### PR TITLE
Added --sub-command flag 

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -47,8 +47,10 @@ Examples:
   {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{if .HasSubCommands}}{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-    --{{rpad .Name .NamePadding	}}	{{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  {{rpad .Name .NamePadding }}  {{.Short}}{{if .HasSubCommands}}{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+    {{rpad .Name .NamePadding }}  {{.Short}}{{if .HasSubCommands}}{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+      {{rpad .Name .NamePadding }}  {{.Short}}{{if .HasSubCommands}}{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+        {{rpad .Name .NamePadding }}  {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -448,7 +448,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -622,7 +622,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -744,7 +744,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1030,7 +1030,7 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1064,11 +1064,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Spalten"
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1095,7 +1095,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1198,27 +1198,27 @@ msgstr "Fehler: %v\n"
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1341,7 +1341,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1441,11 +1441,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1464,7 +1464,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1630,11 +1630,11 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1657,7 +1657,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -1737,11 +1737,11 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1770,7 +1770,7 @@ msgstr "Flüchtiger Container"
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -1779,7 +1779,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -1865,7 +1865,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1937,7 +1937,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1950,11 +1950,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1978,7 +1978,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -2160,7 +2160,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2338,7 +2338,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2446,7 +2446,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2772,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2941,17 +2941,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2989,7 +2989,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3156,7 +3156,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3321,7 +3321,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3391,7 +3391,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3453,7 +3453,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -3480,7 +3480,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3493,7 +3493,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3501,7 +3501,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3654,7 +3654,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3735,7 +3735,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3780,7 +3780,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3836,7 +3836,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3860,7 +3860,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3882,7 +3882,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3901,7 +3901,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3930,7 +3930,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3978,7 +3978,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -4164,11 +4164,11 @@ msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -4177,7 +4177,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4213,7 +4213,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4435,7 +4435,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4470,7 +4470,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4569,7 +4569,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4607,7 +4607,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4727,7 +4727,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -4808,12 +4808,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4829,6 +4829,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4838,7 +4842,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4940,7 +4944,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4959,7 +4963,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -4985,7 +4989,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -5126,7 +5130,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -5387,8 +5391,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -5397,7 +5401,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -5406,7 +5410,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -5414,7 +5418,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -5955,7 +5959,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6219,7 +6223,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -253,7 +253,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -402,7 +402,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -517,7 +517,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -815,11 +815,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -941,27 +941,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1069,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1164,11 +1164,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1187,7 +1187,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1344,11 +1344,11 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1371,7 +1371,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1443,11 +1443,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1475,11 +1475,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1557,7 +1557,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1624,7 +1624,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1636,11 +1636,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1664,7 +1664,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2012,7 +2012,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2114,7 +2114,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2564,17 +2564,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2764,7 +2764,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3058,7 +3058,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3084,7 +3084,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3105,7 +3105,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3250,7 +3250,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3329,7 +3329,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3369,7 +3369,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3443,7 +3443,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3462,7 +3462,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3480,7 +3480,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3508,7 +3508,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3554,7 +3554,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -3734,11 +3734,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3746,7 +3746,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3778,7 +3778,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3985,7 +3985,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4020,7 +4020,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4111,7 +4111,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4147,7 +4147,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4227,7 +4227,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4266,7 +4266,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -4341,11 +4341,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4361,6 +4361,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4370,7 +4374,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4463,7 +4467,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4475,7 +4479,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4543,7 +4547,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4667,20 +4671,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4979,7 +4983,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5239,7 +5243,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,7 +441,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -596,7 +596,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -713,7 +713,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -980,7 +980,7 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1005,7 +1005,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1014,11 +1014,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Columnas"
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1144,27 +1144,27 @@ msgstr "Expira: %s"
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1372,11 +1372,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1395,7 +1395,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1552,11 +1552,11 @@ msgstr "Uso del disco:"
 msgid "Disks:"
 msgstr "Uso del disco:"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1651,11 +1651,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1683,12 +1683,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -1769,7 +1769,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1849,11 +1849,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1877,7 +1877,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1942,7 +1942,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2230,7 +2230,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
@@ -2638,7 +2638,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2789,17 +2789,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2837,7 +2837,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2997,7 +2997,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3159,7 +3159,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3227,7 +3227,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -3315,7 +3315,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3328,7 +3328,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3484,7 +3484,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3563,7 +3563,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3603,7 +3603,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3655,7 +3655,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3679,7 +3679,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -3700,7 +3700,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -3718,7 +3718,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
@@ -3747,7 +3747,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3793,7 +3793,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -3973,11 +3973,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3985,7 +3985,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4017,7 +4017,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4225,7 +4225,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4353,7 +4353,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4389,7 +4389,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4471,7 +4471,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4510,7 +4510,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -4585,12 +4585,12 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4606,6 +4606,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4615,7 +4619,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4699,7 +4703,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4712,7 +4716,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4727,7 +4731,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4812,7 +4816,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4965,23 +4969,23 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5338,7 +5342,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5598,7 +5602,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,7 +441,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -612,7 +612,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -734,7 +734,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1044,11 +1044,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonnes"
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 #, fuzzy
 msgid ""
 "Command line client for LXD\n"
@@ -1082,7 +1082,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1186,27 +1186,27 @@ msgstr "erreur : %v"
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1450,11 +1450,11 @@ msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1473,7 +1473,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1633,12 +1633,12 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -1742,11 +1742,11 @@ msgstr "Clé de configuration invalide"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1775,7 +1775,7 @@ msgstr "Conteneur éphémère"
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -1787,7 +1787,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -1880,7 +1880,7 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -1952,7 +1952,7 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1966,11 +1966,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of running instances"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1994,7 +1994,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -2059,7 +2059,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2179,7 +2179,7 @@ msgstr "DATE D'ÉMISSION"
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -2364,7 +2364,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -2432,7 +2432,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias :"
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -3003,17 +3003,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3054,7 +3054,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3224,7 +3224,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3391,7 +3391,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3470,7 +3470,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -3534,7 +3534,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -3561,7 +3561,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3575,7 +3575,7 @@ msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3736,7 +3736,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr "SOURCE"
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3819,7 +3819,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3864,7 +3864,7 @@ msgstr "Création du conteneur"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3919,7 +3919,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3944,7 +3944,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3982,7 +3982,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4001,7 +4001,7 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4030,7 +4030,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr "ÉTAT"
@@ -4080,7 +4080,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4268,11 +4268,11 @@ msgstr "Définir les permissions du fichier lors de l'envoi"
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -4281,7 +4281,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4317,7 +4317,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -4546,7 +4546,7 @@ msgstr "Image copiée avec succès !"
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4583,7 +4583,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4684,7 +4684,7 @@ msgstr "le périphérique indiqué ne correspond pas au réseau"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4722,7 +4722,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
@@ -4806,7 +4806,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr "URL"
 
@@ -4845,7 +4845,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4929,12 +4929,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4950,6 +4950,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, fuzzy, c-format
 msgid "Used: %v"
@@ -4959,7 +4963,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -5058,7 +5062,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -5074,7 +5078,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -5106,7 +5110,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -5259,7 +5263,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -5568,8 +5572,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -5581,7 +5585,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -5593,7 +5597,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -5601,7 +5605,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -6173,7 +6177,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6456,7 +6460,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -434,7 +434,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -586,7 +586,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -703,7 +703,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -968,7 +968,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -993,7 +993,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1002,11 +1002,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonne"
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1030,7 +1030,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1128,27 +1128,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1263,7 +1263,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1359,11 +1359,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1382,7 +1382,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1539,11 +1539,11 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1638,11 +1638,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1670,12 +1670,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -1755,7 +1755,7 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1815,7 +1815,7 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1835,11 +1835,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1863,7 +1863,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2038,7 +2038,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2214,7 +2214,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias:"
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
@@ -2623,7 +2623,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2778,17 +2778,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2825,7 +2825,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3146,7 +3146,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3276,7 +3276,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -3303,7 +3303,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3316,7 +3316,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3324,7 +3324,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3471,7 +3471,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3591,7 +3591,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3643,7 +3643,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3667,7 +3667,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -3706,7 +3706,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
@@ -3735,7 +3735,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -3959,11 +3959,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4003,7 +4003,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4213,7 +4213,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4248,7 +4248,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4377,7 +4377,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4458,7 +4458,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4497,7 +4497,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -4570,12 +4570,12 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4591,6 +4591,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4600,7 +4604,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4686,7 +4690,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4699,7 +4703,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
@@ -4714,7 +4718,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -4799,7 +4803,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "Creazione del container in corso"
@@ -4952,23 +4956,23 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
@@ -5325,7 +5329,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5586,7 +5590,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr "si"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -437,7 +437,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -590,7 +590,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -717,7 +717,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -987,7 +987,7 @@ msgstr "クライアント証明書がサーバに信頼されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -1012,7 +1012,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
@@ -1021,11 +1021,11 @@ msgstr "クラスタリングが有効になりました"
 msgid "Columns"
 msgstr "カラムレイアウト"
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr "LXD のコマンドラインクライアント"
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1053,7 +1053,7 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1155,27 +1155,27 @@ msgstr "コア:"
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
@@ -1289,7 +1289,7 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1385,11 +1385,11 @@ msgstr "警告を削除します"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1408,7 +1408,7 @@ msgstr "警告を削除します"
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1568,11 +1568,11 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
@@ -1597,7 +1597,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -1670,12 +1670,12 @@ msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1712,11 +1712,11 @@ msgstr "Ephemeral インスタンス"
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -1809,7 +1809,7 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
@@ -1868,7 +1868,7 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -1876,7 +1876,7 @@ msgstr "ユーザーの確認なしで強制的に待避させます"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
@@ -1888,11 +1888,11 @@ msgstr "インスタンスを強制シャットダウンします"
 msgid "Force the removal of running instances"
 msgstr "稼働中のインスタンスを強制的に削除します"
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1931,7 +1931,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1996,7 +1996,7 @@ msgstr "イメージのプロパティを取得します"
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
@@ -2107,7 +2107,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2291,7 +2291,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -2359,7 +2359,7 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -2395,7 +2395,7 @@ msgstr "DHCP のリースを一覧表示します"
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
@@ -2836,7 +2836,7 @@ msgstr "MEMORY USAGE"
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
@@ -3004,17 +3004,17 @@ msgstr "VF の最大数: %d"
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -3051,7 +3051,7 @@ msgstr "表示するログメッセージの最小レベル"
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
@@ -3210,7 +3210,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3372,7 +3372,7 @@ msgstr "イメージに新しいエイリアスを追加します"
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3441,7 +3441,7 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
@@ -3503,7 +3503,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -3529,7 +3529,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3544,7 +3544,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
@@ -3552,7 +3552,7 @@ msgstr "ヘルプを表示します"
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
@@ -3697,7 +3697,7 @@ msgstr "仮想マシンイメージを対象にします"
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr "ROLES"
 
@@ -3776,7 +3776,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
@@ -3816,7 +3816,7 @@ msgstr "ACL からルールを削除します"
 msgid "Remove trusted clients"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -3868,7 +3868,7 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
@@ -3894,7 +3894,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -3916,7 +3916,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -3934,7 +3934,7 @@ msgstr "インスタンスのコンソールログを取得します"
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
@@ -3962,7 +3962,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr "STATE"
@@ -4008,7 +4008,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
@@ -4237,11 +4237,11 @@ msgstr "プッシュ時にファイルのパーミションを設定します"
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
@@ -4249,7 +4249,7 @@ msgstr "詳細な情報を出力します"
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -4281,7 +4281,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -4488,7 +4488,7 @@ msgstr "ストレージボリュームの移動が成功しました!"
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
@@ -4523,7 +4523,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr "TOKEN"
 
@@ -4623,7 +4623,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4671,7 +4671,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
@@ -4758,7 +4758,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr "URL"
 
@@ -4797,7 +4797,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
@@ -4870,11 +4870,11 @@ msgstr "ストレージボリュームの設定を削除します"
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4893,6 +4893,10 @@ msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4902,7 +4906,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -4989,7 +4993,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -5000,7 +5004,7 @@ msgstr "[<remote>:]"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
@@ -5012,7 +5016,7 @@ msgstr "[<remote>:] <cert>"
 msgid "[<remote>:] <fingerprint>"
 msgstr "[<remote>:] <fingerprint>"
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -5084,7 +5088,7 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr "[<remote>:]<cluster member>"
 
@@ -5211,22 +5215,22 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
@@ -5540,7 +5544,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5914,7 +5918,7 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr "yes"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-12-01 10:51-0500\n"
+        "POT-Creation-Date: 2021-12-06 16:11-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -380,7 +380,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -491,7 +491,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -751,7 +751,7 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
@@ -760,7 +760,7 @@ msgstr  ""
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid   "Clustering enabled"
 msgstr  ""
 
@@ -768,11 +768,11 @@ msgstr  ""
 msgid   "Columns"
 msgstr  ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid   "Command line client for LXD"
 msgstr  ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid   "Command line client for LXD\n"
         "\n"
         "All of LXD's features can be driven through the various commands below.\n"
@@ -795,7 +795,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444 lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444 lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -887,27 +887,27 @@ msgstr  ""
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
@@ -1014,7 +1014,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490 lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1308
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490 lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1308
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1102,7 +1102,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192 lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369 lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738 lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083 lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166 lxc/storage_volume.go:241 lxc/storage_volume.go:332 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:676 lxc/storage_volume.go:758 lxc/storage_volume.go:839 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1214 lxc/storage_volume.go:1398 lxc/storage_volume.go:1431 lxc/storage_volume.go:1544 lxc/storage_volume.go:1620 lxc/storage_volume.go:1719 lxc/storage_volume.go:1753 lxc/storage_volume.go:1851 lxc/storage_volume.go:1918 lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196 lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373 lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742 lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087 lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166 lxc/storage_volume.go:241 lxc/storage_volume.go:332 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:676 lxc/storage_volume.go:758 lxc/storage_volume.go:839 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1214 lxc/storage_volume.go:1398 lxc/storage_volume.go:1431 lxc/storage_volume.go:1544 lxc/storage_volume.go:1620 lxc/storage_volume.go:1719 lxc/storage_volume.go:1753 lxc/storage_volume.go:1851 lxc/storage_volume.go:1918 lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1204,11 +1204,11 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid   "Don't show progress information"
 msgstr  ""
 
@@ -1229,7 +1229,7 @@ msgstr  ""
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1298,11 +1298,11 @@ msgstr  ""
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1326,11 +1326,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1405,7 +1405,7 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
@@ -1462,7 +1462,7 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -1470,7 +1470,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
@@ -1482,11 +1482,11 @@ msgstr  ""
 msgid   "Force the removal of running instances"
 msgstr  ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -1505,7 +1505,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016 lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938 lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1232 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016 lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938 lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1564,7 +1564,7 @@ msgstr  ""
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
@@ -1670,7 +1670,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -1839,7 +1839,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -1904,7 +1904,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -1940,7 +1940,7 @@ msgstr  ""
 msgid   "List aliases"
 msgstr  ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
@@ -2228,7 +2228,7 @@ msgstr  ""
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid   "MESSAGE"
 msgstr  ""
 
@@ -2374,17 +2374,17 @@ msgstr  ""
 msgid   "Mdev profiles:"
 msgstr  ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -2421,7 +2421,7 @@ msgstr  ""
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -2538,7 +2538,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346 lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143 lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570 lxc/storage_volume.go:1307
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346 lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143 lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570 lxc/storage_volume.go:1307
 msgid   "NAME"
 msgstr  ""
 
@@ -2693,7 +2693,7 @@ msgstr  ""
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
@@ -2761,7 +2761,7 @@ msgstr  ""
 msgid   "Optimized Storage"
 msgstr  ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid   "Override the source project"
 msgstr  ""
 
@@ -2823,7 +2823,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -2849,7 +2849,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675 lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675 lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -2857,7 +2857,7 @@ msgstr  ""
 msgid   "Pretty rendering (short for --format=pretty)"
 msgstr  ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid   "Print help"
 msgstr  ""
 
@@ -2865,7 +2865,7 @@ msgstr  ""
 msgid   "Print the raw response"
 msgstr  ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid   "Print version number"
 msgstr  ""
 
@@ -3010,7 +3010,7 @@ msgstr  ""
 msgid   "RESOURCE"
 msgstr  ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid   "ROLES"
 msgstr  ""
 
@@ -3088,7 +3088,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
@@ -3128,7 +3128,7 @@ msgstr  ""
 msgid   "Remove trusted clients"
 msgstr  ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -3178,7 +3178,7 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -3200,7 +3200,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -3218,7 +3218,7 @@ msgstr  ""
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -3236,7 +3236,7 @@ msgstr  ""
 msgid   "Retrieving image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
@@ -3264,7 +3264,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918 lxc/network_peer.go:143 lxc/storage.go:580
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918 lxc/network_peer.go:143 lxc/storage.go:580
 msgid   "STATE"
 msgstr  ""
 
@@ -3309,7 +3309,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
@@ -3461,11 +3461,11 @@ msgstr  ""
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid   "Show all debug messages"
 msgstr  ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid   "Show all information messages"
 msgstr  ""
 
@@ -3473,7 +3473,7 @@ msgstr  ""
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -3505,7 +3505,7 @@ msgstr  ""
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -3710,7 +3710,7 @@ msgstr  ""
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
@@ -3745,7 +3745,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid   "TOKEN"
 msgstr  ""
 
@@ -3831,7 +3831,7 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote LXD server.\n"
         "\n"
@@ -3863,7 +3863,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid   "To start your first container, try: lxc launch ubuntu:20.04\n"
         "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
 msgstr  ""
@@ -3939,7 +3939,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid   "URL"
 msgstr  ""
 
@@ -3975,7 +3975,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
@@ -4044,11 +4044,11 @@ msgstr  ""
 msgid   "Unsupported instance type: %s"
 msgstr  ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
@@ -4061,6 +4061,10 @@ msgstr  ""
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
+#: lxc/main.go:98
+msgid   "Use with help or --help to view sub-commands"
+msgstr  ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid   "Used: %v"
@@ -4070,7 +4074,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -4147,7 +4151,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285 lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88 lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285 lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88 lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -4155,7 +4159,7 @@ msgstr  ""
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
@@ -4167,7 +4171,7 @@ msgstr  ""
 msgid   "[<remote>:] <fingerprint>"
 msgstr  ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -4235,7 +4239,7 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid   "[<remote>:]<cluster member>"
 msgstr  ""
 
@@ -4355,19 +4359,19 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896 lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900 lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -4651,7 +4655,7 @@ msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -4874,7 +4878,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901 lxc/image.go:1084
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901 lxc/image.go:1084
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -427,7 +427,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -576,7 +576,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -691,7 +691,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -988,11 +988,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1114,27 +1114,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1242,7 +1242,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1336,11 +1336,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1359,7 +1359,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1512,11 +1512,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1539,7 +1539,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1609,11 +1609,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1641,11 +1641,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1723,7 +1723,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1802,11 +1802,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1830,7 +1830,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2174,7 +2174,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2576,7 +2576,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2725,17 +2725,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2772,7 +2772,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3215,7 +3215,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3254,7 +3254,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3262,7 +3262,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3526,7 +3526,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3577,7 +3577,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3619,7 +3619,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3637,7 +3637,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3711,7 +3711,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3887,11 +3887,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3899,7 +3899,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3931,7 +3931,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4136,7 +4136,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4171,7 +4171,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4262,7 +4262,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4298,7 +4298,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4417,7 +4417,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4486,11 +4486,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4506,6 +4506,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4515,7 +4519,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4597,7 +4601,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4608,7 +4612,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4620,7 +4624,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4688,7 +4692,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4812,20 +4816,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5124,7 +5128,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5384,7 +5388,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -453,7 +453,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -602,7 +602,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1005,7 +1005,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1014,11 +1014,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1042,7 +1042,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1140,27 +1140,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1268,7 +1268,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1362,11 +1362,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1385,7 +1385,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1538,11 +1538,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1565,7 +1565,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1635,11 +1635,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1749,7 +1749,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1808,7 +1808,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1816,7 +1816,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1828,11 +1828,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1856,7 +1856,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1921,7 +1921,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2027,7 +2027,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2200,7 +2200,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2751,17 +2751,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2798,7 +2798,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2949,7 +2949,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3111,7 +3111,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3179,7 +3179,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3267,7 +3267,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3280,7 +3280,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3433,7 +3433,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3512,7 +3512,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3552,7 +3552,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3603,7 +3603,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3626,7 +3626,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3645,7 +3645,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3663,7 +3663,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3737,7 +3737,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3913,11 +3913,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3957,7 +3957,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4162,7 +4162,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4197,7 +4197,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4288,7 +4288,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4404,7 +4404,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4443,7 +4443,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4512,11 +4512,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4532,6 +4532,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4541,7 +4545,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4623,7 +4627,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4634,7 +4638,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4646,7 +4650,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4714,7 +4718,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4838,20 +4842,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5150,7 +5154,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5410,7 +5414,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -444,7 +444,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -604,7 +604,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -724,7 +724,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -995,7 +995,7 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
@@ -1029,11 +1029,11 @@ msgstr "Clustering ativado"
 msgid "Columns"
 msgstr "Colunas"
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr "Cliente de linha de comando para LXD"
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1165,27 +1165,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1408,11 +1408,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1431,7 +1431,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1590,11 +1590,11 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1617,7 +1617,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -1698,11 +1698,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1730,12 +1730,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -1813,7 +1813,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1892,11 +1892,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1920,7 +1920,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1986,7 +1986,7 @@ msgstr "Editar propriedades da imagem"
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -2100,7 +2100,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2275,7 +2275,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2377,7 +2377,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
@@ -2679,7 +2679,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2840,17 +2840,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2888,7 +2888,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
@@ -3045,7 +3045,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3207,7 +3207,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3275,7 +3275,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3337,7 +3337,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3363,7 +3363,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3376,7 +3376,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3613,7 +3613,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3656,7 +3656,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3708,7 +3708,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3732,7 +3732,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -3757,7 +3757,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -3775,7 +3775,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
@@ -3804,7 +3804,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3850,7 +3850,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -4035,11 +4035,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -4048,7 +4048,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4084,7 +4084,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4296,7 +4296,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4331,7 +4331,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4462,7 +4462,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4543,7 +4543,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4582,7 +4582,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -4663,12 +4663,12 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4684,6 +4684,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4693,7 +4697,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4776,7 +4780,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
@@ -4802,7 +4806,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4880,7 +4884,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5009,22 +5013,22 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5339,7 +5343,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5599,7 +5603,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -451,7 +451,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -614,7 +614,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -732,7 +732,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1000,7 +1000,7 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1034,11 +1034,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Столбцы"
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1162,27 +1162,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1302,7 +1302,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1401,11 +1401,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1424,7 +1424,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1582,11 +1582,11 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1609,7 +1609,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1683,11 +1683,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1715,7 +1715,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -1723,7 +1723,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -1806,7 +1806,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1885,11 +1885,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1913,7 +1913,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2268,7 +2268,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2334,7 +2334,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2371,7 +2371,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
@@ -2678,7 +2678,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2838,17 +2838,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
@@ -3048,7 +3048,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3281,7 +3281,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3343,7 +3343,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -3369,7 +3369,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3382,7 +3382,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3535,7 +3535,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3616,7 +3616,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3657,7 +3657,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3711,7 +3711,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3735,7 +3735,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -3757,7 +3757,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -3775,7 +3775,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
@@ -3804,7 +3804,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3850,7 +3850,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -4030,11 +4030,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4076,7 +4076,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4291,7 +4291,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4326,7 +4326,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4417,7 +4417,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4534,7 +4534,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4573,7 +4573,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -4648,12 +4648,12 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4669,6 +4669,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4678,7 +4682,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4768,7 +4772,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4787,7 +4791,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -4811,7 +4815,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -4947,7 +4951,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -5191,8 +5195,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -5200,7 +5204,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -5208,7 +5212,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -5216,7 +5220,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -5747,7 +5751,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6007,7 +6011,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr "да"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -333,7 +333,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -482,7 +482,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -860,7 +860,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -894,11 +894,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -922,7 +922,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -1020,27 +1020,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1242,11 +1242,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1265,7 +1265,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1418,11 +1418,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1445,7 +1445,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1515,11 +1515,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1547,11 +1547,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1629,7 +1629,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1696,7 +1696,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1708,11 +1708,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1736,7 +1736,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2080,7 +2080,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2146,7 +2146,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2631,17 +2631,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2678,7 +2678,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2991,7 +2991,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3059,7 +3059,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3121,7 +3121,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3147,7 +3147,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3160,7 +3160,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3392,7 +3392,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3432,7 +3432,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3483,7 +3483,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3506,7 +3506,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3525,7 +3525,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3543,7 +3543,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3617,7 +3617,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3793,11 +3793,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3805,7 +3805,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3837,7 +3837,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4077,7 +4077,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4168,7 +4168,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4204,7 +4204,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4284,7 +4284,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4323,7 +4323,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4392,11 +4392,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4412,6 +4412,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4421,7 +4425,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4503,7 +4507,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4514,7 +4518,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4526,7 +4530,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4594,7 +4598,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4718,20 +4722,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5030,7 +5034,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5290,7 +5294,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-01 10:51-0500\n"
+"POT-Creation-Date: 2021-12-06 16:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:599
+#: lxc/cluster.go:603
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:172 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1139
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:956
+#: lxc/cluster.go:960
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:573
+#: lxc/cluster.go:577
 msgid "Clustering enabled"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:79
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:80
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331
+#: lxc/cluster.go:672 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
@@ -937,27 +937,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1024
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1028
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1029
+#: lxc/cluster.go:1033
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1034
+#: lxc/cluster.go:1038
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1051
+#: lxc/cluster.go:1055
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1159,11 +1159,11 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192
-#: lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369
-#: lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738
-#: lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083
-#: lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196
+#: lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373
+#: lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742
+#: lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087
+#: lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1182,7 +1182,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,11 +1335,11 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:67
+#: lxc/main.go:97
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:586 lxc/cluster.go:587
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:501
+#: lxc/cluster.go:505
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:502
+#: lxc/cluster.go:506
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1082 lxc/cluster.go:1083
+#: lxc/cluster.go:1086 lxc/cluster.go:1087
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1163
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:173
+#: lxc/cluster.go:177
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1110
+#: lxc/cluster.go:1114
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:423
+#: lxc/cluster.go:427
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,11 +1625,11 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:63
+#: lxc/main.go:93
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:431
+#: lxc/cluster.go:435
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1653,7 +1653,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:240
+#: lxc/cluster.go:244
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:341
+#: lxc/main.go:375
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1997,7 +1997,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:431
+#: lxc/main.go:465
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:150 lxc/cluster.go:835 lxc/cluster.go:925 lxc/cluster.go:1016
+#: lxc/cluster.go:150 lxc/cluster.go:839 lxc/cluster.go:929 lxc/cluster.go:1020
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:799 lxc/cluster.go:800
+#: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:176
+#: lxc/cluster.go:180
 msgid "MESSAGE"
 msgstr ""
 
@@ -2548,17 +2548,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:781
+#: lxc/cluster.go:785
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:399
+#: lxc/cluster.go:403
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2595,7 +2595,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:620 lxc/cluster.go:761 lxc/cluster.go:1131
+#: lxc/cluster.go:624 lxc/cluster.go:765 lxc/cluster.go:1135
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/cluster.go:963
+#: lxc/cluster.go:967
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:64
+#: lxc/main.go:94
 msgid "Override the source project"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:309
+#: lxc/main.go:343
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332
+#: lxc/cluster.go:673 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:62
+#: lxc/main.go:92
 msgid "Print help"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:61
+#: lxc/main.go:91
 msgid "Print version number"
 msgstr ""
 
@@ -3230,7 +3230,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:171
+#: lxc/cluster.go:175
 msgid "ROLES"
 msgstr ""
 
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:418 lxc/cluster.go:419
+#: lxc/cluster.go:422 lxc/cluster.go:423
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:368 lxc/cluster.go:369
+#: lxc/cluster.go:372 lxc/cluster.go:373
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:737 lxc/cluster.go:738
+#: lxc/cluster.go:741 lxc/cluster.go:742
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1101 lxc/cluster.go:1102
+#: lxc/cluster.go:1105 lxc/cluster.go:1106
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1157
+#: lxc/cluster.go:1161
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3460,7 +3460,7 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/cluster.go:897
+#: lxc/cluster.go:901
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:287
+#: lxc/cluster.go:291
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -3710,11 +3710,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:65
+#: lxc/main.go:95
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:66
+#: lxc/main.go:96
 msgid "Show all information messages"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:191 lxc/cluster.go:192
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:228 lxc/main.go:229
+#: lxc/main.go:259 lxc/main.go:260
 msgid "Show less common commands"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1056
+#: lxc/cluster.go:1060
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:882
+#: lxc/cluster.go:886
 msgid "TOKEN"
 msgstr ""
 
@@ -4085,7 +4085,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/main.go:247
+#: lxc/main.go:281
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:346
+#: lxc/main.go:380
 msgid ""
 "To start your first container, try: lxc launch ubuntu:20.04\n"
 "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:170 lxc/remote.go:591
+#: lxc/cluster.go:174 lxc/remote.go:591
 msgid "URL"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/cluster.go:339
+#: lxc/cluster.go:343
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4309,11 +4309,11 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/cluster.go:976
+#: lxc/cluster.go:980
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:978
+#: lxc/cluster.go:982
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4329,6 +4329,10 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
+#: lxc/main.go:98
+msgid "Use with help or --help to view sub-commands"
+msgstr ""
+
 #: lxc/info.go:365 lxc/info.go:376 lxc/info.go:380 lxc/info.go:386
 #, c-format
 msgid "Used: %v"
@@ -4338,7 +4342,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:450 lxc/delete.go:48
+#: lxc/cluster.go:454 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:111 lxc/cluster.go:798 lxc/config_trust.go:285
+#: lxc/cluster.go:111 lxc/cluster.go:802 lxc/config_trust.go:285
 #: lxc/monitor.go:30 lxc/network.go:838 lxc/network_acl.go:88
 #: lxc/network_zone.go:79 lxc/operation.go:102 lxc/profile.go:577
 #: lxc/project.go:389 lxc/storage.go:513 lxc/version.go:20 lxc/warning.go:69
@@ -4431,7 +4435,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:974
+#: lxc/cluster.go:978
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:500
+#: lxc/cluster.go:504
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4511,7 +4515,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:585
+#: lxc/cluster.go:589
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4635,20 +4639,20 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/cluster.go:416 lxc/cluster.go:736 lxc/cluster.go:896
-#: lxc/cluster.go:1081 lxc/cluster.go:1100
+#: lxc/cluster.go:194 lxc/cluster.go:420 lxc/cluster.go:740 lxc/cluster.go:900
+#: lxc/cluster.go:1085 lxc/cluster.go:1104
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:239 lxc/cluster.go:338
+#: lxc/cluster.go:243 lxc/cluster.go:342
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:286
+#: lxc/cluster.go:290
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:370
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4947,7 +4951,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:589
+#: lxc/cluster.go:593
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:449 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
+#: lxc/cluster.go:453 lxc/delete.go:47 lxc/image.go:896 lxc/image.go:901
 #: lxc/image.go:1084
 msgid "yes"
 msgstr ""


### PR DESCRIPTION
Feature added in response to issue [#9523](https://github.com/lxc/lxd/issues/9523). 

Issuing 'lxc --sub-command' or 'lxc help --sub-command' or 'lxc --help --sub-command' Will list available sub-commands as well as their descriptions for each top-level command. Adding the '--all' flag will have the same results but includes all commands.

The approach for adding this feature involved creating a separate UsageTemplate that displays the sub-commands, and overriding CobraCommand's default UsageTemplate to use the new one if the '--sub-commands' flag is passed.