### PR TITLE
Add swagger to doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ doc/html/
 .sphinx/themes/
 .sphinx/venv/
 .sphinx/warnings.txt
+.sphinx/_static/swagger-ui
 
 # For Atom ctags
 .tags

--- a/.sphinx/_extra/rest-api.yaml
+++ b/.sphinx/_extra/rest-api.yaml
@@ -1,0 +1,1 @@
+../../doc/rest-api.yaml

--- a/.sphinx/_static/swagger-override.css
+++ b/.sphinx/_static/swagger-override.css
@@ -1,0 +1,11 @@
+.swagger-ui .markdown p, .swagger-ui .markdown pre, .swagger-ui .renderedMarkdown p, .swagger-ui .renderedMarkdown pre {
+    margin-left: 0em;
+}
+
+.swagger-ui, .swagger-ui textarea, .swagger-ui .info li, .swagger-ui .info a, .swagger-ui .info p, .swagger-ui .info table, .swagger-ui .info .title .swagger-ui .opblock-tag, .swagger-ui .opblock .opblock-summary-description, .swagger-ui .opblock-description-wrapper p, .swagger-ui .opblock-external-docs-wrapper p, .swagger-ui .opblock-title_normal p, .swagger-ui .opblock .opblock-section-header h4, .swagger-ui .opblock-tag:hover, .swagger-ui .opblock-tag small, .swagger-ui .opblock .opblock-section-header>label, .swagger-ui .opblock .opblock-summary-method, .swagger-ui .tab li, .swagger-ui .opblock-description-wrapper,.swagger-ui .opblock-external-docs-wrapper,.swagger-ui .opblock-title_normal, .swagger-ui .opblock-description-wrapper h4,.swagger-ui .opblock-external-docs-wrapper h4,.swagger-ui .opblock-title_normal h4, .swagger-ui .responses-inner h4,.swagger-ui .responses-inner h5, .swagger-ui .response-col_status, .swagger-ui .response-col_links, .swagger-ui .download-contents, .swagger-ui .scheme-container .schemes>label, .swagger-ui .loading-container .loading:after, .swagger-ui section h3, .swagger-ui .btn, .swagger-ui .btn.cancel, .swagger-ui select, .swagger-ui label, .swagger-ui .dialog-ux .modal-ux-content p, .swagger-ui .dialog-ux .modal-ux-content p, .swagger-ui .dialog-ux .modal-ux-content h4, .swagger-ui .dialog-ux .modal-ux-header h3, .swagger-ui section.models h4, .swagger-ui section.models h5, .swagger-ui .model-title, .swagger-ui .servers>label, .swagger-ui .model-deprecated-warning, .swagger-ui table thead tr td,.swagger-ui table thead tr th, .swagger-ui .parameter__name, .swagger-ui .topbar a, .swagger-ui .topbar .download-url-wrapper .download-url-button, .swagger-ui .info h1,.swagger-ui .info h2,.swagger-ui .info h3,.swagger-ui .info h4,.swagger-ui .info h5, .swagger-ui .info .title small pre, .swagger-ui .errors-wrapper hgroup h4 {
+    font-family: "Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.swagger-ui .response-col_description, .swagger-ui .parameters-col_description {
+    width: 85%
+}

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -36,6 +36,7 @@ html_favicon = "https://linuxcontainers.org/static/img/favicon.ico"
 html_logo = "https://linuxcontainers.org/static/img/containers.small.png"
 html_static_path = ['_static']
 html_css_files = ['custom.css']
+html_extra_path = ['_extra']
 
 
 # Uses global TOC for side nav instead of default local TOC.

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ doc:
 	python3 -m venv .sphinx/venv
 	. $(SPHINXENV) ; pip install --upgrade -r .sphinx/requirements.txt
 	mkdir -p .sphinx/deps/ .sphinx/themes/
-	git -C .sphinx/deps/vanilla pull || git clone https://github.com/evildmp/vanilla-sphinx-test .sphinx/deps/vanilla
+	git -C .sphinx/deps/vanilla pull || git clone --depth 1 https://github.com/evildmp/vanilla-sphinx-test .sphinx/deps/vanilla
 	ln -sf ../deps/vanilla/vanilla .sphinx/themes/vanilla
 	git -C .sphinx/deps/swagger-ui pull || git clone --depth 1 https://github.com/swagger-api/swagger-ui.git .sphinx/deps/swagger-ui
 	ln -sf ../deps/swagger-ui/dist .sphinx/_static/swagger-ui

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ doc:
 	mkdir -p .sphinx/deps/ .sphinx/themes/
 	git -C .sphinx/deps/vanilla pull || git clone https://github.com/evildmp/vanilla-sphinx-test .sphinx/deps/vanilla
 	ln -sf ../deps/vanilla/vanilla .sphinx/themes/vanilla
+	git -C .sphinx/deps/swagger-ui pull || git clone --depth 1 https://github.com/swagger-api/swagger-ui.git .sphinx/deps/swagger-ui
+	ln -sf ../deps/swagger-ui/dist .sphinx/_static/swagger-ui
 	rm -Rf doc/html
 	make doc-incremental
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,6 +1,7 @@
 # Main API specification
 
 <link rel="stylesheet" type="text/css" href="../_static/swagger-ui/swagger-ui.css" ></link>
+<link rel="stylesheet" type="text/css" href="../_static/swagger-override.css" ></link>
 <div id="swagger-ui"></div>
 
 <script src="../_static/swagger-ui/swagger-ui-bundle.js" charset="UTF-8"> </script>

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,28 @@
+# Main API specification
+
+<link rel="stylesheet" type="text/css" href="../_static/swagger-ui/swagger-ui.css" ></link>
+<div id="swagger-ui"></div>
+
+<script src="../_static/swagger-ui/swagger-ui-bundle.js" charset="UTF-8"> </script>
+<script src="../_static/swagger-ui/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+<script>
+window.onload = function() {
+  // Begin Swagger UI call region
+  const ui = SwaggerUIBundle({
+    url: "/rest-api.yaml",
+    dom_id: '#swagger-ui',
+    deepLinking: true,
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [],
+    validatorUrl: "none",
+    defaultModelsExpandDepth: -1,
+    supportedSubmitMethods: []
+  })
+  // End Swagger UI call region
+
+  window.ui = ui
+}
+</script>

--- a/doc/restapi_landing.md
+++ b/doc/restapi_landing.md
@@ -4,6 +4,7 @@
 :maxdepth: 1
 
 Main API documentation <rest-api>
+api
 Main API extensions <api-extensions>
 Instance API documentation <dev-lxd>
 Events API documentation <events>


### PR DESCRIPTION
Add the Swagger API to the Sphinx docs.

Not quite happy with the way of downloading the files, but the full repo is huge and it would be overkill to clone it. 