### PR TITLE
doc/storage: fix 2 typos

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -314,7 +314,7 @@ lxc storage create pool1 ceph source=rpl-pool ceph.osd.data_pool_name=ecpool
    written they end up in new extents and the old ones remain until all of its data is dereferenced or rewritten.
    This means that a quota can be reached even if the total amount of space used by the current files in the
    subvolume is smaller than the quota. This is seen most often when using VMs on BTRFS due to the random I/O
-   nature of using aw disk image files ontop of a btrfs subvolume. Our recommendation is to not use VMs with btrfs
+   nature of using raw disk image files on top of a btrfs subvolume. Our recommendation is to not use VMs with btrfs
    storage pools, but if you insist then please ensure that the instance root disk's `size.state` property is set
    to 2x the size of the root disk's size to allow all blocks in the disk image file to be rewritten without
    reaching the qgroup quota. You may also find that using the `btrfs.mount_options=compress-force` storage pool


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>