### PR TITLE
lxd/storage: Switch to deviceConfig.DefaultVMBlockFilesystemSize

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -772,7 +772,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				// filesystem volume as well, allowing a former quota to be removed from both
 				// volumes.
 				if vmStateSize == "" && size != "" {
-					vmStateSize = drivers.DefaultVMBlockFilesystemSize
+					vmStateSize = deviceConfig.DefaultVMBlockFilesystemSize
 				}
 
 				logger.Debug("Applying filesystem volume quota from root disk config", log.Ctx{"size.state": vmStateSize})


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
