### PR TITLE
Events: Add event-hub cluster member role

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1618,3 +1618,6 @@ It adds the `token` field to `POST /1.0/certificates`.
 This adds the ability to disable the `routed` NIC IP neighbor probing for availability on the parent network.
 
 Adds the `ipv4.neighbor_probe` and `ipv6.neighbor_probe` NIC settings. Defaulting to `true` if not specified.
+
+## event\_hub
+This adds support for `event-hub` cluster member role and the `ServerEventMode` environment field.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4848,6 +4848,13 @@ definitions:
         example: false
         type: boolean
         x-go-name: ServerClustered
+      server_event_mode:
+        description: |-
+          Mode that the event distribution subsystem is operating in on this server.
+          Either "full-mesh", "hub-server" or "hub-client".
+        example: full-mesh
+        type: string
+        x-go-name: ServerEventMode
       server_name:
         description: Server hostname
         example: castiana

--- a/lxd-agent/daemon.go
+++ b/lxd-agent/daemon.go
@@ -12,7 +12,7 @@ type Daemon struct {
 
 // newDaemon returns a new Daemon object with the given configuration.
 func newDaemon(debug, verbose bool) *Daemon {
-	lxdEvents := events.NewServer(debug, verbose)
+	lxdEvents := events.NewServer(debug, verbose, nil)
 
 	return &Daemon{
 		events: lxdEvents,

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -45,7 +45,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 	defer c.Close() // This ensures the go routine below is ended when this function ends.
 
 	// As we don't know which project we are in, subscribe to events from all projects.
-	listener, err := d.events.AddListener("", true, c, strings.Split(typeStr, ","), nil, nil)
+	listener, err := d.events.AddListener("", true, c, strings.Split(typeStr, ","), nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -312,6 +312,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		ServerPid:              os.Getpid(),
 		ServerVersion:          version.Version,
 		ServerClustered:        clustered,
+		ServerEventMode:        string(cluster.ServerEventMode()),
 		ServerName:             serverName,
 		Firewall:               fmt.Sprintf("%s", d.firewall),
 	}

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -363,6 +363,10 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 	for _, removedAddress := range removedAddresses {
 		logger.Info("Removed old member event listener client", log.Ctx{"local": localAddress, "remote": removedAddress})
 	}
+
+	if len(members) > 1 && len(keepListeners) <= 0 {
+		logger.Error("No active cluster event listener clients")
+	}
 }
 
 // Establish a client connection to get events from the given node.

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -92,6 +92,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 				Address:       dbMember.Address,
 				LastHeartbeat: dbMember.Heartbeat,
 				Online:        !dbMember.IsOffline(offlineThreshold),
+				Roles:         dbMember.Roles,
 			}
 		}
 	}

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -370,7 +370,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 	}
 
 	if len(members) > 1 && len(keepListeners) <= 0 {
-		logger.Error("No active cluster event listener clients")
+		logger.Error("No active cluster event listener clients", log.Ctx{"local": localAddress})
 	}
 }
 

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -16,6 +16,11 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
+// eventHubMinHosts is the minimum number of members that must have the event-hub role to trigger switching into
+// event-hub mode (where cluster members will only connect to event-hub members rather than all members when
+// operating in the normal full-mesh mode).
+const eventHubMinHosts = 2
+
 var listeners = map[string]*lxd.EventListener{}
 var listenersNotify = map[chan struct{}][]string{}
 var listenersLock sync.Mutex

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -40,6 +40,14 @@ var listenersNotify = map[chan struct{}][]string{}
 var listenersLock sync.Mutex
 var listenersUpdateLock sync.Mutex
 
+// ServerEventMode returns the event distribution mode that this local server is operating in.
+func ServerEventMode() EventMode {
+	listenersLock.Lock()
+	defer listenersLock.Unlock()
+
+	return eventMode
+}
+
 // EventListenerWait waits for there to be listener connected to the specified address, or one of the event hubs
 // if operating in event hub mode.
 func EventListenerWait(ctx context.Context, address string) error {

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/logging"
 )
 
 // eventHubMinHosts is the minimum number of members that must have the event-hub role to trigger switching into
@@ -35,9 +36,22 @@ const EventModeHubServer EventMode = "hub-server"
 // client, meaning that it is expected to connect to the event-hub members.
 const EventModeHubClient EventMode = "hub-client"
 
+// eventListenerClient stores both the event listener and its associated client.
+type eventListenerClient struct {
+	*lxd.EventListener
+
+	client lxd.InstanceServer
+}
+
+// Disconnect disconnects both the listener and the client.
+func (lc *eventListenerClient) Disconnect() {
+	lc.EventListener.Disconnect()
+	lc.client.Disconnect()
+}
+
 var eventMode EventMode = EventModeFullMesh
 var eventHubAddresses []string
-var listeners = map[string]*lxd.EventListener{}
+var listeners = map[string]*eventListenerClient{}
 var listenersNotify = map[chan struct{}][]string{}
 var listenersLock sync.Mutex
 var listenersUpdateLock sync.Mutex
@@ -218,6 +232,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 			// might be something waiting for a future connection.
 			listener.Disconnect()
 			delete(listeners, member.Address)
+
 			logger.Info("Removed inactive member event listener client", log.Ctx{"local": networkAddress, "remote": member.Address})
 		}
 		listenersLock.Unlock()
@@ -227,10 +242,12 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 		// Connect to remote concurrently and add to active listeners if successful.
 		wg.Add(1)
 		go func(m APIHeartbeatMember) {
+			logger := logging.AddContext(logger.Log, log.Ctx{"local": networkAddress, "remote": m.Address})
+
 			defer wg.Done()
 			listener, err := eventsConnect(m.Address, endpoints.NetworkCert(), serverCert())
 			if err != nil {
-				logger.Warn("Failed adding member event listener client", log.Ctx{"local": networkAddress, "remote": m.Address, "err": err})
+				logger.Warn("Failed adding member event listener client", log.Ctx{"err": err})
 				return
 			}
 
@@ -247,7 +264,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 				}
 			}
 
-			logger.Info("Added member event listener client", log.Ctx{"local": networkAddress, "remote": m.Address})
+			logger.Info("Added member event listener client")
 			listenersLock.Unlock()
 		}(member)
 	}
@@ -260,6 +277,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 		if _, found := keepListeners[address]; !found {
 			listener.Disconnect()
 			delete(listeners, address)
+
 			logger.Info("Removed old member event listener client", log.Ctx{"local": networkAddress, "remote": address})
 		}
 	}
@@ -267,7 +285,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 }
 
 // Establish a client connection to get events from the given node.
-func eventsConnect(address string, networkCert *shared.CertInfo, serverCert *shared.CertInfo) (*lxd.EventListener, error) {
+func eventsConnect(address string, networkCert *shared.CertInfo, serverCert *shared.CertInfo) (*eventListenerClient, error) {
 	client, err := Connect(address, networkCert, serverCert, nil, true)
 	if err != nil {
 		return nil, err
@@ -284,5 +302,11 @@ func eventsConnect(address string, networkCert *shared.CertInfo, serverCert *sha
 	}
 
 	revert.Success()
-	return listener, nil
+
+	lc := &eventListenerClient{
+		EventListener: listener,
+		client:        client,
+	}
+
+	return lc, nil
 }

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -21,6 +21,20 @@ import (
 // operating in the normal full-mesh mode).
 const eventHubMinHosts = 2
 
+// EventMode indicates the event distribution mode.
+type EventMode string
+
+// EventModeFullMesh is when every cluster member connects to every other cluster member to pull events.
+const EventModeFullMesh EventMode = "full-mesh"
+
+// EventModeHubServer is when the cluster is operating in event-hub mode and this server is designated as a hub
+// server, meaning that it will only connect to the other event-hub members and not other members.
+const EventModeHubServer EventMode = "hub-server"
+
+// EventModeHubClient is when the cluster is operating in event-hub mode and this member is designated as a hub
+// client, meaning that it is expected to connect to the event-hub members.
+const EventModeHubClient EventMode = "hub-client"
+
 var listeners = map[string]*lxd.EventListener{}
 var listenersNotify = map[chan struct{}][]string{}
 var listenersLock sync.Mutex

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -48,6 +48,17 @@ func ServerEventMode() EventMode {
 	return eventMode
 }
 
+// RoleInSlice returns whether or not the rule is within the roles list.
+func RoleInSlice(role db.ClusterRole, roles []db.ClusterRole) bool {
+	for _, r := range roles {
+		if r == role {
+			return true
+		}
+	}
+
+	return false
+}
+
 // EventListenerWait waits for there to be listener connected to the specified address, or one of the event hubs
 // if operating in event hub mode.
 func EventListenerWait(ctx context.Context, address string) error {

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -34,14 +34,15 @@ const (
 
 // APIHeartbeatMember contains specific cluster node info.
 type APIHeartbeatMember struct {
-	ID            int64     // ID field value in nodes table.
-	Address       string    // Host and Port of node.
-	Name          string    // Name of cluster member.
-	RaftID        uint64    // ID field value in raft_nodes table, zero if non-raft node.
-	RaftRole      int       // Node role in the raft cluster, from the raft_nodes table
-	LastHeartbeat time.Time // Last time we received a successful response from node.
-	Online        bool      // Calculated from offline threshold and LastHeatbeat time.
-	updated       bool      // Has node been updated during this heartbeat run. Not sent to nodes.
+	ID            int64            // ID field value in nodes table.
+	Address       string           // Host and Port of node.
+	Name          string           // Name of cluster member.
+	RaftID        uint64           // ID field value in raft_nodes table, zero if non-raft node.
+	RaftRole      int              // Node role in the raft cluster, from the raft_nodes table
+	LastHeartbeat time.Time        // Last time we received a successful response from node.
+	Online        bool             // Calculated from offline threshold and LastHeatbeat time.
+	Roles         []db.ClusterRole // Supplementary non-database roles the member has.
+	updated       bool             // Has node been updated during this heartbeat run. Not sent to nodes.
 }
 
 // APIHeartbeatVersion contains max versions for all nodes in cluster.
@@ -97,6 +98,7 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 			Name:          node.Name,
 			LastHeartbeat: node.Heartbeat,
 			Online:        !node.IsOffline(offlineThreshold),
+			Roles:         node.Roles,
 		}
 
 		if raftNode, exists := raftNodeMap[member.Address]; exists {

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -622,7 +622,7 @@ func NotifyHeartbeat(state *state.State, gateway *Gateway) {
 	// Refresh local event listeners.
 	wg.Add(1)
 	go func() {
-		EventsUpdateListeners(state.Endpoints, state.Cluster, state.ServerCert, hbState.Members, state.Events.Forward)
+		EventsUpdateListeners(state.Endpoints, state.Cluster, state.ServerCert, hbState.Members, state.Events.Inject)
 		wg.Done()
 	}()
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -179,7 +179,7 @@ func (m *IdentityClientWrapper) DeclaredIdentity(ctx context.Context, declared m
 
 // newDaemon returns a new Daemon object with the given configuration.
 func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
-	lxdEvents := events.NewServer(daemon.Debug, daemon.Verbose)
+	lxdEvents := events.NewServer(daemon.Debug, daemon.Verbose, cluster.EventHubPush)
 	devlxdEvents := events.NewDevLXDServer(daemon.Debug, daemon.Verbose)
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1447,7 +1447,7 @@ func (d *Daemon) init() error {
 func (d *Daemon) startClusterTasks() {
 	// Add initial event listeners from global database members.
 	// Run asynchronously so that connecting to remote members doesn't delay starting up other cluster tasks.
-	go cluster.EventsUpdateListeners(d.endpoints, d.cluster, d.serverCert, nil, d.events.Forward)
+	go cluster.EventsUpdateListeners(d.endpoints, d.cluster, d.serverCert, nil, d.events.Inject)
 
 	// Heartbeats
 	d.taskClusterHeartbeat = d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
@@ -2107,7 +2107,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 
 	wg.Add(1)
 	go func() {
-		cluster.EventsUpdateListeners(d.endpoints, d.cluster, d.serverCert, heartbeatData.Members, d.events.Forward)
+		cluster.EventsUpdateListeners(d.endpoints, d.cluster, d.serverCert, heartbeatData.Members, d.events.Inject)
 		wg.Done()
 	}()
 

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -653,54 +653,6 @@ func (c *ClusterTx) UpdateNodeConfig(id int64, config map[string]string) error {
 	return nil
 }
 
-// CreateNodeRole adds a role to the node.
-func (c *ClusterTx) CreateNodeRole(id int64, role ClusterRole) error {
-	// Translate role names to ids
-	roleID := -1
-	for k, v := range ClusterRoles {
-		if v == role {
-			roleID = k
-			break
-		}
-	}
-
-	if roleID < 0 {
-		return fmt.Errorf("Invalid role: %v", role)
-	}
-
-	// Update the database record
-	_, err := c.tx.Exec("INSERT INTO nodes_roles (node_id, role) VALUES (?, ?)", id, roleID)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// RemoveNodeRole removes a role from the node.
-func (c *ClusterTx) RemoveNodeRole(id int64, role ClusterRole) error {
-	// Translate role names to ids
-	roleID := -1
-	for k, v := range ClusterRoles {
-		if v == role {
-			roleID = k
-			break
-		}
-	}
-
-	if roleID < 0 {
-		return fmt.Errorf("Invalid role: %v", role)
-	}
-
-	// Update the database record
-	_, err := c.tx.Exec("DELETE FROM nodes_roles WHERE node_id=? AND role=?", id, roleID)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // UpdateNodeRoles changes the list of roles on a member.
 func (c *ClusterTx) UpdateNodeRoles(id int64, roles []ClusterRole) error {
 	getRoleID := func(role ClusterRole) (int, error) {

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -667,7 +667,7 @@ func (c *ClusterTx) UpdateNodeRoles(id int64, roles []ClusterRole) error {
 			}
 		}
 
-		return -1, fmt.Errorf("Invalid cluster role '%s'", role)
+		return -1, fmt.Errorf("Invalid cluster role %q", role)
 	}
 
 	// Translate role names to ids

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -33,12 +33,17 @@ const ClusterRoleDatabaseStandBy = ClusterRole("database-standby")
 // ClusterRoleDatabaseLeader represents the database leader role in a cluster.
 const ClusterRoleDatabaseLeader = ClusterRole("database-leader")
 
+// ClusterRoleEventHub represents a cluster member who operates as an event hub.
+const ClusterRoleEventHub = ClusterRole("event-hub")
+
 // ClusterRoles maps role ids into human-readable names.
 //
 // Note: the database role is currently stored directly in the raft
 // configuration which acts as single source of truth for it. This map should
 // only contain LXD-specific cluster roles.
-var ClusterRoles = map[int]ClusterRole{}
+var ClusterRoles = map[int]ClusterRole{
+	1: ClusterRoleEventHub,
+}
 
 // Numeric type codes identifying different cluster member states.
 const (

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -10,8 +10,10 @@ import (
 	"github.com/lxc/lxd/lxd/events"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rbac"
+	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
 
 var eventTypes = []string{"logging", "operation", "lifecycle"}
@@ -110,15 +112,38 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 		return err
 	}
 
+	var recvFunc events.EventHandler
 	var excludeSources []events.EventSource
+	var excludeLocations []string
 
 	if isClusterNotification(r) {
 		// If client is another cluster member, it will already be pulling events from other cluster
 		// members so no need to also deliver forwarded events that this member receives.
 		excludeSources = append(excludeSources, events.EventSourcePull)
+
+		recvFunc = func(event api.Event) {
+			// Inject event received via push from event listener client so its forwarded to
+			// other event hub members (if operating in event hub mode).
+			d.events.Inject(event, events.EventSourcePush)
+		}
+
+		ctx := r.Context()
+
+		// Try and match cluster member certificate fingerprint to member name.
+		fingerprint, found := ctx.Value(request.CtxUsername).(string)
+		if found {
+			cert, err := d.State().Cluster.GetCertificate(fingerprint)
+			if err != nil {
+				return fmt.Errorf("Failed matching client certificate to cluster member: %w", err)
+			}
+
+			// Add the cluster member client's name to the excluded locations so that we can avoid
+			// looping the event back to them when they send us an event via recvFunc.
+			excludeLocations = append(excludeLocations, cert.Name)
+		}
 	}
 
-	listener, err := d.events.AddListener(projectName, allProjects, c, types, excludeSources, nil)
+	listener, err := d.events.AddListener(projectName, allProjects, c, types, excludeSources, recvFunc, excludeLocations)
 	if err != nil {
 		return err
 	}

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -26,6 +26,9 @@ const EventSourcePull = 1
 // EventSourcePush indicates the event was received from an event listener client connected to us.
 const EventSourcePush = 2
 
+// InjectFunc is used to inject an event received by a listener into the local events dispatcher.
+type InjectFunc func(event api.Event, eventSource EventSource)
+
 // Server represents an instance of an event server.
 type Server struct {
 	serverCommon

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -84,6 +84,13 @@ type ServerEnvironment struct {
 	// API extension: clustering
 	ServerClustered bool `json:"server_clustered" yaml:"server_clustered"`
 
+	// Mode that the event distribution subsystem is operating in on this server.
+	// Either "full-mesh", "hub-server" or "hub-client".
+	// Example: full-mesh
+	//
+	// API extension: event_hub
+	ServerEventMode string `json:"server_event_mode" yaml:"server_event_mode"`
+
 	// Server hostname
 	// Example: castiana
 	//

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -318,6 +318,7 @@ var APIExtensions = []string{
 	"instance_snapshot_never",
 	"certificate_token",
 	"instance_nic_routed_neighbor_probe",
+	"event_hub",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2120,7 +2120,7 @@ test_clustering_handover() {
   echo "Launched member 4"
 
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
-  LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node4 | grep -q "\- database-standby"
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -Fc "database-standby" | grep -Fx 1
 
   # Shutdown the first node.
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown


### PR DESCRIPTION
Currently in a cluster, event distribution is done as a full-mesh with every member connecting to every other member in the cluster. In larger clusters this causes a lot of unnecessary connections, go routines and interrupts.

The intention of this PR is to provide the ability to specify which cluster members should be responsible for collecting and relaying cluster event messages from other cluster members. 

So by introducing some control over which cluster members will handle the connections from other members, it is expected this will provide the ability to better isolate and control event messaging flows.

This PR includes:

- Adds the concept of an event-hub cluster member role.
- Adds cluster member roles to the heartbeat payload.
- Adding the ability to specify the `event-hub` cluster member role using `lxc cluster edit` which will then trigger a cluster heartbeat notification (distributing the role info to all members) when it changes.
- On receipt of a full-state heartbeat, the event connections on a LXD server are checked for freshness and accuracy, and if 2 or more cluster members have the event-hub role, then all members switch into "event-hub mode" which means that non-hub members will only connect to hub members, and hub members will only connect to other hub members. 
- Adds the `SendEvent` function to the client-initiated outbound event listener connection so that events can be sent back along the existing connection to an event-hub server. 
- An associated event handler option for incoming event request handlers to allow them to receive the events sent from clients. 
- Adds the `ServerEventMode` to the `lxc info` output to allow detecting what event mode a server is in.