### PR TITLE
lxd/device/nic/bridged: Allow ipv{n} filtering when ip is set to none 

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -350,8 +350,8 @@ limits.egress            | string  | -                 | no       | no      | I/
 limits.max               | string  | -                 | no       | no      | Same as modifying both limits.ingress and limits.egress
 ipv4.address             | string  | -                 | no       | no      | An IPv4 address to assign to the instance through DHCP
 ipv6.address             | string  | -                 | no       | no      | An IPv6 address to assign to the instance through DHCP
-ipv4.routes              | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to add on host to NIC
-ipv6.routes              | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to add on host to NIC
+ipv4.routes              | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to add on host to NIC (Can be `none` to restrict all IPv4 traffic when security.ipv4\_filtering is set)
+ipv6.routes              | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to add on host to NIC (Can be `none` to restrict all IPv6 traffic when security.ipv6\_filtering is set)
 ipv4.routes.external     | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to route to the NIC and publish on uplink network (BGP)
 ipv6.routes.external     | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to route to the NIC and publish on uplink network (BGP)
 security.mac\_filtering  | boolean | false             | no       | no      | Prevent the instance from spoofing another's MAC address

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -632,6 +632,15 @@ test_container_devices_nic_bridged_filtering() {
   ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1 || false
   ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1 || false
 
+  # Check IP filtering can be enabled with IP assigned as none in LXD config.
+  lxc config device set "${ctPrefix}A" eth0 ipv4.address=none security.ipv4_filtering=true
+  lxc config device set "${ctPrefix}A" eth0 ipv6.address=none security.ipv6_filtering=true
+  lxc exec "${ctPrefix}A" -- ip a flush dev eth0
+  lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
+  lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1 || false
+
   lxc delete -f "${ctPrefix}A"
   ip link delete "${brName}2"
 


### PR DESCRIPTION
Resolves #9215 