### PR TITLE
doc: fix link to rest-api.yaml

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -10,7 +10,7 @@
 window.onload = function() {
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "/rest-api.yaml",
+    url: "../rest-api.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
The link is different on the server than on a local run, so
use a relative path instead.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>