### PR TITLE
lxc/copy: Replaces profiles when -p is set.

### DIFF
--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -174,9 +174,9 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 			return err
 		}
 
-		// Allow adding additional profiles
+		// Overwrite profiles.
 		if c.flagProfile != nil {
-			entry.Profiles = append(entry.Profiles, c.flagProfile...)
+			entry.Profiles = c.flagProfile
 		} else if c.flagNoProfiles {
 			entry.Profiles = []string{}
 		}
@@ -264,9 +264,9 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 			start = true
 		}
 
-		// Allow adding additional profiles
+		// Overwrite profiles.
 		if c.flagProfile != nil {
-			entry.Profiles = append(entry.Profiles, c.flagProfile...)
+			entry.Profiles = c.flagProfile
 		} else if c.flagNoProfiles {
 			entry.Profiles = []string{}
 		}


### PR DESCRIPTION
Previously, profiles provided using -p flag were appended to the
instance profiles. This brings the behaviour of copy in line with that
of launch.

Fixes #9554 