### PR TITLE
Cluster: Heartbeat ordering

### DIFF
--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -89,7 +89,7 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 			Address:       node.Address,
 			Name:          node.Name,
 			LastHeartbeat: node.Heartbeat,
-			Online:        !node.Heartbeat.Before(time.Now().Add(-offlineThreshold)),
+			Online:        !node.IsOffline(offlineThreshold),
 		}
 
 		if raftNode, exists := raftNodeMap[member.Address]; exists {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1986,7 +1986,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 
 	stateChangeTaskFailure := false // Records whether any of the state change tasks failed.
 	if d.hasMemberStateChanged(heartbeatData) {
-		logger.Debug("Cluster member state has changed")
+		logger.Info("Cluster member state has changed")
 
 		// Refresh cluster certificates cached.
 		updateCertificateCache(d)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1980,6 +1980,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		}
 	}
 
+	stateChangeTaskFailure := false // Records whether any of the state change tasks failed.
 	if d.hasMemberStateChanged(heartbeatData) {
 		logger.Debug("Cluster member state has changed")
 
@@ -1989,14 +1990,16 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		// Refresh forkdns peers.
 		err := networkUpdateForkdnsServersTask(d.State(), heartbeatData)
 		if err != nil {
+			stateChangeTaskFailure = true
 			logger.Error("Error refreshing forkdns", log.Ctx{"err": err})
-			return
 		}
 	}
 
-	// Only update the node list if the task succeeded.
-	// If it fails then it will get to run again next heartbeat.
-	d.lastNodeList = heartbeatData
+	// Only update the node list if there are no state change task failures.
+	// If there are failures, then we leave the old state so that we can re-try the tasks again next heartbeat.
+	if !stateChangeTaskFailure {
+		d.lastNodeList = heartbeatData
+	}
 
 	// If there are offline members that have voter or stand-by database
 	// roles, let's see if we can replace them with spare ones. Also, if we

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1961,6 +1961,11 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		return
 	}
 
+	if !heartbeatData.FullStateList || len(heartbeatData.Members) <= 0 {
+		logger.Error("Heartbeat member refresh task called with partial state list")
+		return
+	}
+
 	// If the max version of the cluster has changed, check whether we need to upgrade.
 	if d.lastNodeList == nil || d.lastNodeList.Version.APIExtensions != heartbeatData.Version.APIExtensions || d.lastNodeList.Version.Schema != heartbeatData.Version.Schema {
 		err := cluster.MaybeUpdate(d.State())
@@ -1975,40 +1980,37 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 	voters := 0
 	standbys := 0
 
-	// Only refresh forkdns peers if the full state list has been generated.
-	if heartbeatData.FullStateList && len(heartbeatData.Members) > 0 {
-		for i, node := range heartbeatData.Members {
-			role := db.RaftRole(node.RaftRole)
-			// Exclude nodes that the leader considers offline.
-			// This is to avoid forkdns delaying results by querying an offline node.
-			if !node.Online {
-				if role != db.RaftSpare {
-					isDegraded = true
-				}
-				logger.Warn("Excluding offline member from refresh", log.Ctx{"address": node.Address, "ID": node.ID, "raftID": node.RaftID, "lastHeartbeat": node.LastHeartbeat})
-				delete(heartbeatData.Members, i)
+	for i, node := range heartbeatData.Members {
+		role := db.RaftRole(node.RaftRole)
+		// Exclude nodes that the leader considers offline.
+		// This is to avoid forkdns delaying results by querying an offline node.
+		if !node.Online {
+			if role != db.RaftSpare {
+				isDegraded = true
 			}
-			switch role {
-			case db.RaftVoter:
-				voters++
-			case db.RaftStandBy:
-				standbys++
-			}
-			if node.RaftID == 0 {
-				hasNodesNotPartOfRaft = true
-			}
+			logger.Warn("Excluding offline member from refresh", log.Ctx{"address": node.Address, "ID": node.ID, "raftID": node.RaftID, "lastHeartbeat": node.LastHeartbeat})
+			delete(heartbeatData.Members, i)
 		}
+		switch role {
+		case db.RaftVoter:
+			voters++
+		case db.RaftStandBy:
+			standbys++
+		}
+		if node.RaftID == 0 {
+			hasNodesNotPartOfRaft = true
+		}
+	}
 
-		nodeListChanged := d.hasNodeListChanged(heartbeatData)
-		if nodeListChanged {
-			logger.Debug("Member list has changed")
-			updateCertificateCache(d)
+	nodeListChanged := d.hasNodeListChanged(heartbeatData)
+	if nodeListChanged {
+		logger.Debug("Member list has changed")
+		updateCertificateCache(d)
 
-			err := networkUpdateForkdnsServersTask(d.State(), heartbeatData)
-			if err != nil {
-				logger.Error("Error refreshing forkdns", log.Ctx{"err": err})
-				return
-			}
+		err := networkUpdateForkdnsServersTask(d.State(), heartbeatData)
+		if err != nil {
+			logger.Error("Error refreshing forkdns", log.Ctx{"err": err})
+			return
 		}
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2001,31 +2001,29 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		d.lastNodeList = heartbeatData
 	}
 
-	// If there are offline members that have voter or stand-by database
-	// roles, let's see if we can replace them with spare ones. Also, if we
-	// don't have enough voters or standbys, let's see if we can upgrade
-	// some member.
+	// If we are the leader and there are other members in the cluster, then check if we need to update roles.
 	if isLeader && len(heartbeatData.Members) > 1 {
 		isDegraded := false
 		hasNodesNotPartOfRaft := false
-		voters := 0
-		standbys := 0
+		onlineVoters := 0
+		onlineStandbys := 0
 
 		for _, node := range heartbeatData.Members {
 			role := db.RaftRole(node.RaftRole)
-			if !node.Online && role != db.RaftSpare {
-				isDegraded = true
-			}
+			if node.Online {
+				// Count online members that have voter or stand-by raft role.
+				switch role {
+				case db.RaftVoter:
+					onlineVoters++
+				case db.RaftStandBy:
+					onlineStandbys++
+				}
 
-			switch role {
-			case db.RaftVoter:
-				voters++
-			case db.RaftStandBy:
-				standbys++
-			}
-
-			if node.RaftID == 0 {
-				hasNodesNotPartOfRaft = true
+				if node.RaftID == 0 {
+					hasNodesNotPartOfRaft = true
+				}
+			} else if role != db.RaftSpare {
+				isDegraded = true // Offline member that has voter or stand-by raft role.
 			}
 		}
 
@@ -2047,9 +2045,12 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 			return
 		}
 
-		if isDegraded || voters < int(maxVoters) || standbys < int(maxStandBy) {
+		// If there are offline members that have voter or stand-by database roles, let's see if we can
+		// replace them with spare ones. Also, if we don't have enough voters or standbys, let's see if we
+		// can upgrade some member.
+		if isDegraded || onlineVoters < int(maxVoters) || onlineStandbys < int(maxStandBy) {
 			d.clusterMembershipMutex.Lock()
-			logger.Info("Rebalancing member roles in heartbeat", log.Ctx{"address": address})
+			logger.Debug("Rebalancing member roles in heartbeat", log.Ctx{"address": address})
 			err := rebalanceMemberRoles(d, nil, unavailableMembers)
 			if err != nil && errors.Cause(err) != cluster.ErrNotLeader {
 				logger.Warnf("Could not rebalance cluster member roles: %v", err)
@@ -2059,7 +2060,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 
 		if hasNodesNotPartOfRaft {
 			d.clusterMembershipMutex.Lock()
-			logger.Info("Upgrading members without raft role in heartbeat", log.Ctx{"address": address})
+			logger.Debug("Upgrading members without raft role in heartbeat", log.Ctx{"address": address})
 			err := upgradeNodesWithoutRaftRole(d)
 			if err != nil && errors.Cause(err) != cluster.ErrNotLeader {
 				logger.Warnf("Failed upgrade raft roles: %v", err)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1984,16 +1984,12 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 	voters := 0
 	standbys := 0
 
-	for i, node := range heartbeatData.Members {
+	for _, node := range heartbeatData.Members {
 		role := db.RaftRole(node.RaftRole)
-		// Exclude nodes that the leader considers offline.
-		// This is to avoid forkdns delaying results by querying an offline node.
 		if !node.Online {
 			if role != db.RaftSpare {
 				isDegraded = true
 			}
-			logger.Warn("Excluding offline member from refresh", log.Ctx{"address": node.Address, "ID": node.ID, "raftID": node.RaftID, "lastHeartbeat": node.LastHeartbeat})
-			delete(heartbeatData.Members, i)
 		}
 		switch role {
 		case db.RaftVoter:
@@ -2026,7 +2022,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 	// roles, let's see if we can replace them with spare ones. Also, if we
 	// don't have enough voters or standbys, let's see if we can upgrade
 	// some member.
-	if isLeader && len(heartbeatData.Members) > 2 {
+	if isLeader && len(heartbeatData.Members) > 1 {
 		address, _ := node.ClusterAddress(d.State().Node)
 
 		var maxVoters int64

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1958,8 +1958,12 @@ func (d *Daemon) hasMemberStateChanged(heartbeatData *cluster.APIHeartbeat) bool
 	return false
 }
 
-// NodeRefreshTask is run each time a fresh node is generated.
-// This can be used to trigger actions when the node list changes.
+// NodeRefreshTask is run when a full state heartbeat is sent (on the leader) or received (by a non-leader member).
+// Is is used to check for member state changes and trigger refreshes of the certificate cache and forkdns peers.
+// It also triggers member role promotion when run on the isLeader is true.
+// When run on the leader, it accepts a list of unavailableMembers that have not responded to the current heartbeat
+// round (but may not be considered actually offline at this stage). These unavailable members will not be used for
+// role rebalancing.
 func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader bool, unavailableMembers []string) {
 	// Don't process the heartbeat until we're fully online
 	if d.cluster == nil || d.cluster.GetNodeID() == 0 {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1943,9 +1943,13 @@ func (d *Daemon) hasNodeListChanged(heartbeatData *cluster.APIHeartbeat) bool {
 		return true
 	}
 
-	// Check for node address changes.
+	// Check for member address or state changes.
 	for lastMemberID, lastMember := range d.lastNodeList.Members {
 		if heartbeatData.Members[lastMemberID].Address != lastMember.Address {
+			return true
+		}
+
+		if heartbeatData.Members[lastMemberID].Online != lastMember.Online {
 			return true
 		}
 	}

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -1217,7 +1217,9 @@ func (c *ClusterTx) SetNodeVersion(id int64, version [2]int) error {
 }
 
 func nodeIsOffline(threshold time.Duration, heartbeat time.Time) bool {
-	return heartbeat.Before(time.Now().Add(-threshold))
+	offlineTime := time.Now().Add(-threshold)
+
+	return heartbeat.Before(offlineTime) || heartbeat.Equal(offlineTime)
 }
 
 // LocalNodeIsEvacuated returns whether the local node is in the evacuated state.

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1922,6 +1922,11 @@ func (n *bridge) HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error {
 			continue
 		}
 
+		if !node.Online {
+			n.logger.Warn("Excluding offline member from DNS peers refresh", log.Ctx{"address": node.Address, "ID": node.ID, "raftID": node.RaftID, "lastHeartbeat": node.LastHeartbeat})
+			continue
+		}
+
 		client, err := cluster.Connect(node.Address, networkCert, n.state.ServerCert(), nil, true)
 		if err != nil {
 			return err

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2351,8 +2351,8 @@ test_clustering_remove_raft_node() {
       return 1
   fi
 
-  # Check node4 is still standby first, as it could be promoted at any time.
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node4 | grep -q "\- database-standby"
+  # Let the heartbeats catch up.
+  sleep 12
 
   # The node does not appear anymore in the cluster list.
   ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -q "node2" || false
@@ -2361,6 +2361,7 @@ test_clustering_remove_raft_node() {
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "\- database-leader$"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node3 | grep -q "\- database$"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node4 | grep -q "\- database$"
 
   # The second node is still in the raft_nodes table.
   LXD_DIR="${LXD_ONE_DIR}" lxd sql local "SELECT * FROM raft_nodes" | grep -q "10.1.1.102"
@@ -2369,7 +2370,7 @@ test_clustering_remove_raft_node() {
   LXD_DIR="${LXD_ONE_DIR}" lxd cluster remove-raft-node -q "10.1.1.102"
 
   # Wait for a heartbeat to propagate and a rebalance to be performed.
-  sleep 15
+  sleep 12
 
   # We're back to 3 database nodes.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list


### PR DESCRIPTION
- Cleans up the heartbeat handler to be more explicit and less prone to error when being changed.
- Changes member offline detection to fix an off-by-one error (this should make the tests more reliable).
- Keeps all heartbeat members state in global variable to detect future state changes (rather than just keeping online ones) - this way each consumer of the list can decide if they want to consider offline members or not.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>