### PR TITLE
GetNonPendingNetworkIDs Project Aware

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -485,22 +485,24 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		}
 
 		// Networks.
-		ids, err = tx.GetNonPendingNetworkIDs()
+		netids, err := tx.GetNonPendingNetworkIDs()
 		if err != nil {
 			return errors.Wrap(err, "failed to get cluster network IDs")
 		}
-		for name, id := range ids {
-			config, ok := networks[name]
-			if !ok {
-				return fmt.Errorf("joining node has no config for network %s", name)
-			}
-			err := tx.NetworkNodeJoin(id, node.ID)
-			if err != nil {
-				return errors.Wrap(err, "failed to add joining node's to the network")
-			}
-			err = tx.CreateNetworkConfig(id, node.ID, config)
-			if err != nil {
-				return errors.Wrap(err, "failed to add joining node's network config")
+		for _, network := range netids {
+			for name, id := range network {
+				config, ok := networks[name]
+				if !ok {
+					return fmt.Errorf("joining node has no config for network %s", name)
+				}
+				err := tx.NetworkNodeJoin(id, node.ID)
+				if err != nil {
+					return errors.Wrap(err, "failed to add joining node's to the network")
+				}
+				err = tx.CreateNetworkConfig(id, node.ID, config)
+				if err != nil {
+					return errors.Wrap(err, "failed to add joining node's network config")
+				}
 			}
 		}
 

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -48,7 +48,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 		// Fetch current network address and raft nodes
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
-			return errors.Wrap(err, "failed to fetch node configuration")
+			return errors.Wrap(err, "Failed to fetch node configuration")
 		}
 
 		address = config.ClusterAddress()
@@ -62,7 +62,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 		// Add ourselves as first raft node
 		err = tx.CreateFirstRaftNode(address, serverName)
 		if err != nil {
-			return errors.Wrap(err, "failed to insert first raft node")
+			return errors.Wrap(err, "Failed to insert first raft node")
 		}
 
 		return nil
@@ -107,12 +107,12 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 	// reconfiguring raft.
 	err = state.Cluster.EnterExclusive()
 	if err != nil {
-		return errors.Wrap(err, "failed to acquire cluster database lock")
+		return errors.Wrap(err, "Failed to acquire cluster database lock")
 	}
 
 	err = gateway.Shutdown()
 	if err != nil {
-		return errors.Wrap(err, "failed to shutdown gRPC SQL gateway")
+		return errors.Wrap(err, "Failed to shutdown gRPC SQL gateway")
 	}
 
 	// The cluster CA certificate is a symlink against the regular server CA certificate.
@@ -158,7 +158,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "cluster database initialization failed")
+		return errors.Wrap(err, "Cluster database initialization failed")
 	}
 
 	return nil
@@ -224,10 +224,11 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 
 	// Check parameters
 	if name == "" {
-		return nil, fmt.Errorf("node name must not be empty")
+		return nil, fmt.Errorf("Member name must not be empty")
 	}
+
 	if address == "" {
-		return nil, fmt.Errorf("node address must not be empty")
+		return nil, fmt.Errorf("Member address must not be empty")
 	}
 
 	// Insert the new node into the nodes table.
@@ -246,7 +247,7 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 			return err
 		}
 
-		// Add the new node
+		// Add the new node.
 		id, err = tx.CreateNodeWithArch(name, address, arch)
 		if err != nil {
 			return errors.Wrap(err, "Failed to insert new node into the database")
@@ -313,7 +314,7 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, serverCert *shared.CertInfo, name string, raftNodes []db.RaftNode) error {
 	// Check parameters
 	if name == "" {
-		return fmt.Errorf("node name must not be empty")
+		return fmt.Errorf("Member name must not be empty")
 	}
 
 	var address string
@@ -321,8 +322,9 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		// Fetch current network address and raft nodes
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
-			return errors.Wrap(err, "failed to fetch node configuration")
+			return errors.Wrap(err, "Failed to fetch node configuration")
 		}
+
 		address = config.ClusterAddress()
 
 		// Make sure node-local database state is in order.
@@ -334,7 +336,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		// Set the raft nodes list to the one that was returned by Accept().
 		err = tx.ReplaceRaftNodes(raftNodes)
 		if err != nil {
-			return errors.Wrap(err, "failed to set raft nodes")
+			return errors.Wrap(err, "Failed to set raft nodes")
 		}
 
 		return nil
@@ -357,10 +359,12 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		if err != nil {
 			return err
 		}
+
 		networks, err = tx.GetNetworksLocalConfig()
 		if err != nil {
 			return err
 		}
+
 		nodeID := tx.GetNodeID()
 		filter := db.OperationFilter{NodeID: &nodeID}
 		operations, err = tx.GetOperations(filter)
@@ -378,7 +382,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	// other database code to run while we're reconfiguring raft.
 	err = state.Cluster.EnterExclusive()
 	if err != nil {
-		return errors.Wrap(err, "failed to acquire cluster database lock")
+		return errors.Wrap(err, "Failed to acquire cluster database lock")
 	}
 
 	// Shutdown the gateway and wipe any raft data. This will trash any
@@ -386,11 +390,12 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	// the associated raft instance.
 	err = gateway.Shutdown()
 	if err != nil {
-		return errors.Wrap(err, "failed to shutdown gRPC SQL gateway")
+		return errors.Wrap(err, "Failed to shutdown gRPC SQL gateway")
 	}
+
 	err = os.RemoveAll(state.OS.GlobalDatabaseDir())
 	if err != nil {
-		return errors.Wrap(err, "failed to remove existing raft data")
+		return errors.Wrap(err, "Failed to remove existing raft data")
 	}
 
 	// Re-initialize the gateway. This will create a new raft factory an
@@ -399,7 +404,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	gateway.networkCert = networkCert
 	err = gateway.init(false)
 	if err != nil {
-		return errors.Wrap(err, "failed to re-initialize gRPC SQL gateway")
+		return errors.Wrap(err, "Failed to re-initialize gRPC SQL gateway")
 	}
 
 	// If we are listed among the database nodes, join the raft cluster.
@@ -409,9 +414,11 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 			info = &node
 		}
 	}
+
 	if info == nil {
-		panic("joining node not found")
+		panic("Joining member not found")
 	}
+
 	logger.Info("Joining dqlite raft cluster", log15.Ctx{"id": info.ID, "address": info.Address, "role": info.Role})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -443,25 +450,27 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	err = state.Cluster.ExitExclusive(func(tx *db.ClusterTx) error {
 		node, err := tx.GetPendingNodeByAddress(address)
 		if err != nil {
-			return errors.Wrap(err, "failed to get ID of joining node")
+			return errors.Wrap(err, "Failed to get ID of joining node")
 		}
+
 		state.Cluster.NodeID(node.ID)
 		tx.NodeID(node.ID)
 
 		// Storage pools.
 		ids, err := tx.GetNonPendingStoragePoolsNamesToIDs()
 		if err != nil {
-			return errors.Wrap(err, "failed to get cluster storage pool IDs")
+			return errors.Wrap(err, "Failed to get cluster storage pool IDs")
 		}
+
 		for name, id := range ids {
 			err := tx.UpdateStoragePoolAfterNodeJoin(id, node.ID)
 			if err != nil {
-				return errors.Wrap(err, "failed to add joining node's to the pool")
+				return errors.Wrap(err, "Failed to add joining node's to the pool")
 			}
 
 			driver, err := tx.GetStoragePoolDriver(id)
 			if err != nil {
-				return errors.Wrap(err, "failed to get storage pool driver")
+				return errors.Wrap(err, "Failed to get storage pool driver")
 			}
 
 			if shared.StringInSlice(driver, []string{"ceph", "cephfs"}) {
@@ -469,17 +478,18 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 				// entries for the joining node.
 				err := tx.UpdateCephStoragePoolAfterNodeJoin(id, node.ID)
 				if err != nil {
-					return errors.Wrap(err, "failed to create ceph volumes for joining node")
+					return errors.Wrap(err, "Failed to create ceph volumes for joining node")
 				}
 			} else {
 				// For other pools we add the config provided by the joining node.
 				config, ok := pools[name]
 				if !ok {
-					return fmt.Errorf("joining node has no config for pool %s", name)
+					return fmt.Errorf("Joining member has no config for pool %s", name)
 				}
+
 				err = tx.CreateStoragePoolConfig(id, node.ID, config)
 				if err != nil {
-					return errors.Wrap(err, "failed to add joining node's pool config")
+					return errors.Wrap(err, "Failed to add joining node's pool config")
 				}
 			}
 		}
@@ -487,21 +497,24 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		// Networks.
 		netids, err := tx.GetNonPendingNetworkIDs()
 		if err != nil {
-			return errors.Wrap(err, "failed to get cluster network IDs")
+			return errors.Wrap(err, "Failed to get cluster network IDs")
 		}
+
 		for _, network := range netids {
 			for name, id := range network {
 				config, ok := networks[name]
 				if !ok {
-					return fmt.Errorf("joining node has no config for network %s", name)
+					return fmt.Errorf("Joining member has no config for network %s", name)
 				}
+
 				err := tx.NetworkNodeJoin(id, node.ID)
 				if err != nil {
-					return errors.Wrap(err, "failed to add joining node's to the network")
+					return errors.Wrap(err, "Failed to add joining node's to the network")
 				}
+
 				err = tx.CreateNetworkConfig(id, node.ID, config)
 				if err != nil {
-					return errors.Wrap(err, "failed to add joining node's network config")
+					return errors.Wrap(err, "Failed to add joining node's network config")
 				}
 			}
 		}
@@ -513,9 +526,10 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 				Type:   operation.Type,
 				NodeID: tx.GetNodeID(),
 			}
+
 			_, err := tx.CreateOrReplaceOperation(op)
 			if err != nil {
-				return errors.Wrapf(err, "failed to migrate operation %s", operation.UUID)
+				return errors.Wrapf(err, "Failed to migrate operation %s", operation.UUID)
 			}
 		}
 
@@ -523,7 +537,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		// notifications.
 		err = tx.SetNodePendingFlag(node.ID, false)
 		if err != nil {
-			return errors.Wrapf(err, "failed to unmark the node as pending")
+			return errors.Wrapf(err, "Failed to unmark the node as pending")
 		}
 
 		// Generate partial heartbeat request containing just a raft node list.
@@ -532,7 +546,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		return nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "cluster database initialization failed")
+		return errors.Wrap(err, "Cluster database initialization failed")
 	}
 
 	return nil
@@ -650,7 +664,7 @@ func Assign(state *state.State, gateway *Gateway, nodes []db.RaftNode) error {
 
 	// Ensure that our address was actually included in the given list of raft nodes.
 	if info == nil {
-		return fmt.Errorf("This node is not included in the given list of database nodes")
+		return fmt.Errorf("This member is not included in the given list of database nodes")
 	}
 
 	// Replace our local list of raft nodes with the given one (which
@@ -703,7 +717,7 @@ func Assign(state *state.State, gateway *Gateway, nodes []db.RaftNode) error {
 	// gateway handlers.
 	err = gateway.init(false)
 	if err != nil {
-		return errors.Wrap(err, "failed to re-initialize gRPC SQL gateway")
+		return errors.Wrap(err, "Failed to re-initialize gRPC SQL gateway")
 	}
 
 assign:
@@ -851,8 +865,7 @@ func Leave(state *state.State, gateway *Gateway, name string, force bool) (strin
 	}
 
 	if info == nil {
-		// The node was not part of the raft cluster, nothing left to
-		// do.
+		// The node was not part of the raft cluster, nothing left to do.
 		return address, nil
 	}
 
@@ -1006,6 +1019,7 @@ func Count(state *state.State) (int, error) {
 		count, err = tx.GetNodesCount()
 		return err
 	})
+
 	return count, err
 }
 
@@ -1018,9 +1032,11 @@ func Enabled(node *db.Node) (bool, error) {
 		if err != nil {
 			return err
 		}
+
 		enabled = len(addresses) > 0
 		return nil
 	})
+
 	return enabled, err
 }
 
@@ -1029,7 +1045,7 @@ func Enabled(node *db.Node) (bool, error) {
 func membershipCheckNodeStateForBootstrapOrJoin(tx *db.NodeTx, address string) error {
 	nodes, err := tx.GetRaftNodes()
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch current raft nodes")
+		return errors.Wrap(err, "Failed to fetch current raft nodes")
 	}
 
 	hasClusterAddress := address != ""
@@ -1038,14 +1054,15 @@ func membershipCheckNodeStateForBootstrapOrJoin(tx *db.NodeTx, address string) e
 	// Ensure that we're not in an inconsistent situation, where no cluster address is set, but still there
 	// are entries in the raft_nodes table.
 	if !hasClusterAddress && hasRaftNodes {
-		return fmt.Errorf("inconsistent state: found leftover entries in raft_nodes")
+		return fmt.Errorf("Inconsistent state: found leftover entries in raft_nodes")
 	}
 
 	if !hasClusterAddress {
-		return fmt.Errorf("no cluster.https_address config is set on this node")
+		return fmt.Errorf("No cluster.https_address config is set on this member")
 	}
+
 	if hasRaftNodes {
-		return fmt.Errorf("the node is already part of a cluster")
+		return fmt.Errorf("The member is already part of a cluster")
 	}
 
 	return nil
@@ -1056,11 +1073,13 @@ func membershipCheckNodeStateForBootstrapOrJoin(tx *db.NodeTx, address string) e
 func membershipCheckClusterStateForBootstrapOrJoin(tx *db.ClusterTx) error {
 	nodes, err := tx.GetNodes()
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch current cluster nodes")
+		return errors.Wrap(err, "Failed to fetch current cluster nodes")
 	}
+
 	if len(nodes) != 1 {
-		return fmt.Errorf("inconsistent state: found leftover entries in nodes")
+		return fmt.Errorf("Inconsistent state: found leftover entries in nodes")
 	}
+
 	return nil
 }
 
@@ -1113,8 +1132,9 @@ func membershipCheckClusterStateForLeave(tx *db.ClusterTx, nodeID int64) error {
 		return err
 	}
 	if len(nodes) == 1 {
-		return fmt.Errorf("node is the only node in the cluster")
+		return fmt.Errorf("Member is the only member in the cluster")
 	}
+
 	return nil
 }
 
@@ -1124,9 +1144,10 @@ func membershipCheckNoLeftoverClusterCert(dir string) error {
 	// Ensure that there's no leftover cluster certificate.
 	for _, basename := range []string{"cluster.crt", "cluster.key", "cluster.ca"} {
 		if shared.PathExists(filepath.Join(dir, basename)) {
-			return fmt.Errorf("inconsistent state: found leftover cluster certificate")
+			return fmt.Errorf("Inconsistent state: found leftover cluster certificate")
 		}
 	}
+
 	return nil
 }
 

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -35,31 +35,31 @@ func TestBootstrap_UnmetPreconditions(t *testing.T) {
 				filename := filepath.Join(f.state.OS.VarDir, "cluster.crt")
 				ioutil.WriteFile(filename, []byte{}, 0644)
 			},
-			"inconsistent state: found leftover cluster certificate",
+			"Inconsistent state: found leftover cluster certificate",
 		},
 		{
 			func(*membershipFixtures) {},
-			"no cluster.https_address config is set on this node",
+			"No cluster.https_address config is set on this member",
 		},
 		{
 			func(f *membershipFixtures) {
 				f.ClusterAddress("1.2.3.4:666")
 				f.RaftNode("5.6.7.8:666")
 			},
-			"the node is already part of a cluster",
+			"The member is already part of a cluster",
 		},
 		{
 			func(f *membershipFixtures) {
 				f.RaftNode("5.6.7.8:666")
 			},
-			"inconsistent state: found leftover entries in raft_nodes",
+			"Inconsistent state: found leftover entries in raft_nodes",
 		},
 		{
 			func(f *membershipFixtures) {
 				f.ClusterAddress("1.2.3.4:666")
 				f.ClusterNode("5.6.7.8:666")
 			},
-			"inconsistent state: found leftover entries in nodes",
+			"Inconsistent state: found leftover entries in nodes",
 		},
 	}
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -48,6 +48,7 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]map[string]int64, erro
 		name        string
 		projectName string
 	}{}
+
 	dest := func(i int) []interface{} {
 		networks = append(networks, struct {
 			id          int64
@@ -57,15 +58,18 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]map[string]int64, erro
 		return []interface{}{&networks[i].id, &networks[i].name, &networks[i].projectName}
 
 	}
+
 	stmt, err := c.tx.Prepare("SELECT networks.id, networks.name, projects.name FROM networks JOIN projects on projects.id = networks.project_id WHERE NOT networks.state=?")
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
+
 	err = query.SelectObjects(stmt, dest, networkPending)
 	if err != nil {
 		return nil, err
 	}
+
 	ids := map[string]map[string]int64{}
 	for _, network := range networks {
 		if ids[network.projectName] == nil {
@@ -74,6 +78,7 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]map[string]int64, erro
 
 		ids[network.projectName][network.name] = network.id
 	}
+
 	return ids, nil
 }
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -42,20 +42,22 @@ func (c *ClusterTx) GetNetworksLocalConfig() (map[string]map[string]string, erro
 // GetNonPendingNetworkIDs returns a map associating each network name to its ID.
 //
 // Pending networks are skipped.
-func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]int64, error) {
+func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]map[string]int64, error) {
 	networks := []struct {
-		id   int64
-		name string
+		id          int64
+		name        string
+		projectName string
 	}{}
 	dest := func(i int) []interface{} {
 		networks = append(networks, struct {
-			id   int64
-			name string
+			id          int64
+			name        string
+			projectName string
 		}{})
-		return []interface{}{&networks[i].id, &networks[i].name}
+		return []interface{}{&networks[i].id, &networks[i].name, &networks[i].projectName}
 
 	}
-	stmt, err := c.tx.Prepare("SELECT id, name FROM networks WHERE NOT state=?")
+	stmt, err := c.tx.Prepare("SELECT networks.id, networks.name, projects.name FROM networks JOIN projects on projects.id = networks.project_id WHERE NOT networks.state=?")
 	if err != nil {
 		return nil, err
 	}
@@ -64,9 +66,9 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]int64, error) {
 	if err != nil {
 		return nil, err
 	}
-	ids := map[string]int64{}
+	ids := map[string]map[string]int64{}
 	for _, network := range networks {
-		ids[network.name] = network.id
+		ids[network.projectName][network.name] = network.id
 	}
 	return ids, nil
 }

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -68,6 +68,10 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]map[string]int64, erro
 	}
 	ids := map[string]map[string]int64{}
 	for _, network := range networks {
+		if ids[network.projectName] == nil {
+			ids[network.projectName] = map[string]int64{}
+		}
+
 		ids[network.projectName][network.name] = network.id
 	}
 	return ids, nil


### PR DESCRIPTION
To resolve #9466 

My solution modifies the GetNonPendingNetworkIDs function to pull the project name from the database and add it to map that maps project names to maps of network names to network IDs.

The Join function in cluster/membership.go may not be properly project aware while GetNonPendingNetworkIDs is. Is that something I should look into?