### PR TITLE
Cluster: Make event listener refresh event driven

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -639,14 +639,14 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			nodes[i].Role = db.RaftRole(node.Role)
 		}
 
-		// Start clustering tasks
-		d.startClusterTasks()
-		revert.Add(func() { d.stopClusterTasks() })
-
 		err = cluster.Join(d.State(), d.gateway, networkCert, serverCert, req.ServerName, nodes)
 		if err != nil {
 			return err
 		}
+
+		// Start clustering tasks.
+		d.startClusterTasks()
+		revert.Add(func() { d.stopClusterTasks() })
 
 		// Handle optional service integration on cluster join
 		var clusterConfig *cluster.Config

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2123,6 +2123,10 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 		return response.SmartError(err)
 	}
 
+	// Refresh event listeners from global database members.
+	// Run asynchronously so that connecting to remote members doesn't delay rebalance notification.
+	go cluster.EventsUpdateListeners(d.endpoints, d.cluster, d.serverCert, nil, d.events.Forward)
+
 	return response.SyncResponse(true, nil)
 }
 

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -16,7 +16,8 @@ import (
 var listeners = map[string]*lxd.EventListener{}
 var listenersLock sync.Mutex
 
-func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func() *shared.CertInfo, members map[int64]APIHeartbeatMember, f func(int64, api.Event)) {
+// EventsUpdateListeners refreshes the cluster event listener connections.
+func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func() *shared.CertInfo, members map[int64]APIHeartbeatMember, f func(int64, api.Event)) {
 	// If no heartbeat members provided, populate from global database.
 	if members == nil {
 		var dbMembers []db.NodeInfo

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -30,7 +30,7 @@ func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func
 	update := func(ctx context.Context) {
 		ch := make(chan struct{})
 		go func() {
-			eventsUpdateListeners(endpoints, cluster, serverCert, f)
+			eventsUpdateListeners(endpoints, cluster, serverCert, nil, f)
 			ch <- struct{}{}
 		}()
 		select {
@@ -44,7 +44,7 @@ func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func
 	return update, schedule
 }
 
-func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func() *shared.CertInfo, f func(int64, api.Event)) {
+func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func() *shared.CertInfo, members map[int64]APIHeartbeatMember, f func(int64, api.Event)) {
 	// Get the current cluster nodes.
 	var nodes []db.NodeInfo
 	var offlineThreshold time.Duration

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1443,9 +1443,6 @@ func (d *Daemon) startClusterTasks() {
 	// Heartbeats
 	d.taskClusterHeartbeat = d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
 
-	// Events
-	d.clusterTasks.Add(cluster.Events(d.endpoints, d.cluster, d.serverCert, d.events.Forward))
-
 	// Auto-sync images across the cluster (hourly)
 	d.clusterTasks.Add(autoSyncImagesTask(d))
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1440,6 +1440,10 @@ func (d *Daemon) init() error {
 }
 
 func (d *Daemon) startClusterTasks() {
+	// Add initial event listeners from global database members.
+	// Run asynchronously so that connecting to remote members doesn't delay starting up other cluster tasks.
+	go cluster.EventsUpdateListeners(d.endpoints, d.cluster, d.serverCert, nil, d.events.Forward)
+
 	// Heartbeats
 	d.taskClusterHeartbeat = d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1996,6 +1996,10 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		}
 	}
 
+	// Refresh event listeners from heartbeat members (after certificates refreshed if needed).
+	// Run asynchronously so that connecting to remote members doesn't delay other heartbeat tasks.
+	go cluster.EventsUpdateListeners(d.endpoints, d.cluster, d.serverCert, heartbeatData.Members, d.events.Forward)
+
 	// Only update the node list if there are no state change task failures.
 	// If there are failures, then we leave the old state so that we can re-try the tasks again next heartbeat.
 	if !stateChangeTaskFailure {


### PR DESCRIPTION
Moves event listener refresh to be event driven (triggered on cluster task startup, heartbeat and member rebalance notification) rather than have every member polling the global database for a list of members continuously every 1 second.

For the heartbeat triggered event, it uses the member list sent with the heartbeat to further avoid additional leader DB traffic from other members.

This reduces network traffic significantly, here is an example in an idle 4-member cluster, with vnstat run on the leader member.

Before:
```
vnstat -tr -tr 60 -i enp5s0
12774 packets sampled in 60 seconds
Traffic average for enp5s0

      rx       101.49 kbit/s           120 packets/s
      tx       150.31 kbit/s            92 packets/s
```

After:
```
vnstat -tr 60 -i enp5s0
4058 packets sampled in 60 seconds
Traffic average for enp5s0

      rx        32.79 kbit/s            34 packets/s
      tx        59.92 kbit/s            33 packets/s
```

Also changes how the last applied heartbeat member list is stored in all members. Previously it only contained online members, but now it stores all online members so it can be selectively filtered for online members by each user of the list (forkdns peer refresh for example).

This work lays the ground work for event-hub roles, getting the event listeners refresh function to use the member list from the heartbeat payload.

Also connects to remove servers concurrently, so that if one server is unreachable it doesn't delay setting up the event stream for the reachable servers.