### PR TITLE
Use all-projects parameter in events api

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -205,6 +205,7 @@ type InstanceServer interface {
 
 	// Event handling functions
 	GetEvents() (listener *EventListener, err error)
+	GetEventsAllProjects() (listener *EventListener, err error)
 
 	// Image functions
 	CreateImage(image api.ImagesPost, args *ImageCreateArgs) (op Operation, err error)

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -260,7 +260,7 @@ func (r *ProtocolLXD) setQueryAttributes(uri string) (string, error) {
 	}
 
 	if r.project != "" {
-		if values.Get("project") == "" {
+		if values.Get("project") == "" && values.Get("all-projects") == "" {
 			values.Set("project", r.project)
 		}
 	}

--- a/client/lxd_events.go
+++ b/client/lxd_events.go
@@ -10,8 +10,8 @@ import (
 
 // Event handling functions
 
-// GetEvents connects to the LXD monitoring interface
-func (r *ProtocolLXD) GetEvents() (*EventListener, error) {
+// getEvents connects to the LXD monitoring interface
+func (r *ProtocolLXD) getEvents(allProjects bool) (*EventListener, error) {
 	// Prevent anything else from interacting with the listeners
 	r.eventListenersLock.Lock()
 	defer r.eventListenersLock.Unlock()
@@ -29,7 +29,13 @@ func (r *ProtocolLXD) GetEvents() (*EventListener, error) {
 	}
 
 	// Setup a new connection with LXD
-	url, err := r.setQueryAttributes("/events")
+	var url string
+	var err error
+	if allProjects {
+		url, err = r.setQueryAttributes("/events?all-projects=true")
+	} else {
+		url, err = r.setQueryAttributes("/events")
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -121,4 +127,14 @@ func (r *ProtocolLXD) GetEvents() (*EventListener, error) {
 	}()
 
 	return &listener, nil
+}
+
+// GetEvents gets the events for the project defined on the client.
+func (r *ProtocolLXD) GetEvents() (*EventListener, error) {
+	return r.getEvents(false)
+}
+
+// GetEventsAllProjects gets events for all projects.
+func (r *ProtocolLXD) GetEventsAllProjects() (*EventListener, error) {
+	return r.getEvents(true)
 }

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
+	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -93,11 +94,12 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	var listener *lxd.EventListener
 	if c.flagAllProjects {
-		d = d.UseProject("*")
+		listener, err = d.GetEventsAllProjects()
+	} else {
+		listener, err = d.GetEvents()
 	}
-
-	listener, err := d.GetEvents()
 	if err != nil {
 		return err
 	}

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -48,7 +48,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 	// If this request is an internal one initiated by another node wanting
 	// to watch the events on this node, set the listener to broadcast only
 	// local events.
-	listener, err := d.events.AddListener("default", c, strings.Split(typeStr, ","), "lxd-agent", false)
+	listener, err := d.events.AddListener("default", false, c, strings.Split(typeStr, ","), "lxd-agent", false)
 	if err != nil {
 		return err
 	}

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -139,9 +139,5 @@ func eventsConnect(address string, networkCert *shared.CertInfo, serverCert *sha
 		return nil, err
 	}
 
-	// Set the project to the special wildcard in order to get notified
-	// about all events across all projects.
-	client = client.UseProject("*")
-
-	return client.GetEvents()
+	return client.GetEventsAllProjects()
 }

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -116,7 +116,7 @@ var devlxdEventsGet = devLxdHandler{"/1.0/events", func(d *Daemon, c instance.In
 	}
 	defer conn.Close() // This ensures the go routine below is ended when this function ends.
 
-	listener, err := d.devlxdEvents.AddListener(strconv.Itoa(c.ID()), conn, strings.Split(typeStr, ","), "", false)
+	listener, err := d.devlxdEvents.AddListener(strconv.Itoa(c.ID()), false, conn, strings.Split(typeStr, ","), "", false)
 	if err != nil {
 		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
 	}

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -109,7 +109,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 	// If this request is an internal one initiated by another node wanting
 	// to watch the events on this node, set the listener to broadcast only
 	// local events.
-	listener, err := d.events.AddListener(projectName, c, types, serverName, isClusterNotification(r))
+	listener, err := d.events.AddListener(projectName, allProjects, c, types, serverName, isClusterNotification(r))
 	if err != nil {
 		return err
 	}

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rbac"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
@@ -35,7 +37,31 @@ func (r *eventsServe) String() string {
 }
 
 func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
-	projectName := projectParam(r)
+	allProjects := shared.IsTrue(queryParam(r, "all-projects"))
+	projectQueryParam := queryParam(r, "project")
+	if allProjects && projectQueryParam != "" {
+		response.BadRequest(fmt.Errorf("Cannot specify a project when requesting events for all projects"))
+		return nil
+	}
+
+	var projectName string
+	if !allProjects {
+		if projectQueryParam == "" {
+			projectName = project.Default
+		} else {
+			projectName = projectQueryParam
+
+			_, err := d.cluster.GetProject(projectName)
+			if err != nil {
+				if errors.Is(err, db.ErrNoSuchObject) {
+					response.BadRequest(fmt.Errorf("Project %q not found", projectName)).Render(w)
+				}
+
+				return err
+			}
+		}
+	}
+
 	types := strings.Split(r.FormValue("type"), ",")
 	if len(types) == 1 && types[0] == "" {
 		types = []string{}


### PR DESCRIPTION
Changes the events API to use `all-projects=true` instead of `project=*` query parameters. Adds validation on project parameter if one is passed.

Fixes #9647 