### PR TITLE
Record net.Conn in request context

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/project"
+	lxdRequest "github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -92,7 +93,10 @@ func restServer(d *Daemon) *http.Server {
 		response.NotFound(nil).Render(w)
 	})
 
-	return &http.Server{Handler: &lxdHttpServer{r: mux, d: d}}
+	return &http.Server{
+		Handler:     &lxdHttpServer{r: mux, d: d},
+		ConnContext: lxdRequest.SaveConnectionInContext,
+	}
 }
 
 func metricsServer(d *Daemon) *http.Server {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -316,7 +316,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	// Local unix socket queries.
 	if r.RemoteAddr == "@" {
 		if w != nil {
-			cred, err := ucred.GetCredFromWriter(w)
+			cred, err := ucred.GetCredFromContext(r.Context())
 			if err != nil {
 				return false, "", "", err
 			}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/ucred"
 	"github.com/lxc/lxd/lxd/util"
@@ -31,8 +32,9 @@ import (
 // /dev/lxd Unix socket endpoint created inside containers.
 func devLxdServer(d *Daemon) *http.Server {
 	return &http.Server{
-		Handler:   devLxdAPI(d),
-		ConnState: pidMapper.ConnStateHandler,
+		Handler:     devLxdAPI(d),
+		ConnState:   pidMapper.ConnStateHandler,
+		ConnContext: request.SaveConnectionInContext,
 	}
 }
 

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -161,7 +161,7 @@ var handlers = []devLxdHandler{
 
 func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) *devLxdResponse, d *Daemon) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		conn := ucred.GetConnFromWriter(w)
+		conn := ucred.GetConnFromContext(r.Context())
 		cred, ok := pidMapper.m[conn.(*net.UnixConn)]
 		if !ok {
 			http.Error(w, pidNotInContainerErr.Error(), 500)

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -1,8 +1,13 @@
 package request
 
+type requestCtxKey string
+
 const (
 	// CtxAccess is the access field in request context.
 	CtxAccess = "access"
+
+	// CtxConn is the access field in the request context
+	CtxConn requestCtxKey = "conn"
 
 	// CtxAddress is the address field in request context.
 	CtxAddress = "address"

--- a/lxd/request/request.go
+++ b/lxd/request/request.go
@@ -1,6 +1,8 @@
 package request
 
 import (
+	"context"
+	"net"
 	"net/http"
 
 	"github.com/lxc/lxd/shared/api"
@@ -40,4 +42,10 @@ func CreateRequestor(r *http.Request) *api.EventLifecycleRequestor {
 		requestor.Address = val
 	}
 	return requestor
+}
+
+// SaveConnectionInContext can be set as the ConnContext field of a http.Server to set the connection
+// in the request context for later use.
+func SaveConnectionInContext(ctx context.Context, connection net.Conn) context.Context {
+	return context.WithValue(ctx, CtxConn, connection)
 }


### PR DESCRIPTION
The connection was previously obtained via reflection. With golang >= 1.13 we can use `ConnContext` on the `http.Server` instead.

Fixes #9650. 