### PR TITLE
API get Instance with more in-depth information

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1540,3 +1540,7 @@ This introduces the following new endpoints:
 ## ceph\_rbd\_du
 Adds a new `ceph.rbd.du` boolean on Ceph storage pools which allows
 disabling the use of the potentially slow `rbd du` calls.
+
+##instance\_get\_full
+This introduces a new recursion=1 mode for `GET /1.0/instances/{name}` which allows for the retrieval of
+all instance structs, including the state, snapshots and backup structs.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -7507,7 +7507,7 @@ paths:
       tags:
       - instances
     get:
-      description: Gets a specific instance.
+      description: Gets a specific instance (basic struct).
       operationId: instance_get
       parameters:
       - description: Project name
@@ -8804,6 +8804,49 @@ paths:
         "500":
           $ref: '#/responses/InternalServerError'
       summary: Change the state
+      tags:
+      - instances
+  /1.0/instances/{name}?recursion=1:
+    get:
+      description: |-
+        Gets a specific instance (full struct).
+
+        recursion=1 also includes information about state, snapshots and backups.
+      operationId: instance_get_recursion1
+      parameters:
+      - description: Project name
+        example: default
+        in: query
+        name: project
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Instance
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                $ref: '#/definitions/Instance'
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: integer
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the instance
       tags:
       - instances
   /1.0/instances?recursion=1:

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -300,6 +300,7 @@ var APIExtensions = []string{
 	"instance_all_projects",
 	"clustering_groups",
 	"ceph_rbd_du",
+	"instance_get_full",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Closes  #9555

This change adds additional information about state, backups and snapshots when
query `GET /1.0/instances/c1?recursion=1` is used.

@stgraber
I used recursion=1 to get full struct (with additional information) because no recursion already
returns basic struct. So this is a little bit different then instances_get where we have:
 - urls for no recursion
 - basic structs for recursion=1
 - full structs for recursion=2

is this ok?