### PR TITLE
Events: Make Connect use an event driven wait approach for waiting until the event stream is connected

### DIFF
--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -38,7 +38,6 @@ type APIHeartbeatMember struct {
 	Name          string    // Name of cluster member.
 	RaftID        uint64    // ID field value in raft_nodes table, zero if non-raft node.
 	RaftRole      int       // Node role in the raft cluster, from the raft_nodes table
-	Raft          bool      // Deprecated, use non-zero RaftID instead to indicate raft node.
 	LastHeartbeat time.Time // Last time we received a successful response from node.
 	Online        bool      // Calculated from offline threshold and LastHeatbeat time.
 	updated       bool      // Has node been updated during this heartbeat run. Not sent to nodes.
@@ -93,7 +92,6 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 		}
 
 		if raftNode, exists := raftNodeMap[member.Address]; exists {
-			member.Raft = true // Deprecated
 			member.RaftID = raftNode.ID
 			member.RaftRole = int(raftNode.Role)
 			delete(raftNodeMap, member.Address) // Used to check any remaining later.

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -112,7 +112,7 @@ func (s *Server) Forward(id int64, event api.Event) {
 
 	err := s.broadcast("", event, true)
 	if err != nil {
-		logger.Warnf("Failed to forward event from node %d: %v", id, err)
+		logger.Warnf("Failed to forward event from member %d: %v", id, err)
 	}
 }
 

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -61,7 +61,7 @@ func (s *Server) AddListener(group string, allGroups bool, connection *websocket
 	defer s.lock.Unlock()
 
 	if s.listeners[listener.id] != nil {
-		return nil, fmt.Errorf("A listener with id '%s' already exists", listener.id)
+		return nil, fmt.Errorf("A listener with ID %q already exists", listener.id)
 	}
 
 	s.listeners[listener.id] = listener


### PR DESCRIPTION
No need to keep polling unnecessarily.