### PR TITLE
test: Add 1s between running non-interactive exec and checking for exit status in operation

### DIFF
--- a/test/suites/exec.sh
+++ b/test/suites/exec.sh
@@ -23,10 +23,12 @@ test_exec() {
 
   # Check non-websocket based exec works.
   opID=$(lxc query -X POST -d '{\"command\":[\"touch\",\"/root/foo1\"],\"record-output\":false}' /1.0/instances/x1/exec | jq -r .id)
+  sleep 1
   lxc query  /1.0/operations/"${opID}" | jq .metadata.return | grep -F "0"
   lxc exec x1 -- stat /root/foo1
 
   opID=$(lxc query -X POST -d '{\"command\":[\"missingcmd\"],\"record-output\":false}' /1.0/instances/x1/exec | jq -r .id)
+  sleep 1
   lxc query  /1.0/operations/"${opID}" | jq .metadata.return | grep -F "127"
 
   echo "hello" | lxc exec x1 -- tee /root/foo1


### PR DESCRIPTION
To give it chance to run.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>