### PR TITLE
Agent-less VM metrics

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1544,3 +1544,7 @@ disabling the use of the potentially slow `rbd du` calls.
 ## instance\_get\_full
 This introduces a new recursion=1 mode for `GET /1.0/instances/{name}` which allows for the retrieval of
 all instance structs, including the state, snapshots and backup structs.
+
+## qemu\_metrics
+This adds a new `security.agent.metrics` boolean which defaults to `true`.
+When set to `false`, it doesn't connect to the lxd-agent for metrics and other state information, but relies on stats from QEMU.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1541,6 +1541,6 @@ This introduces the following new endpoints:
 Adds a new `ceph.rbd.du` boolean on Ceph storage pools which allows
 disabling the use of the potentially slow `rbd du` calls.
 
-##instance\_get\_full
+## instance\_get\_full
 This introduces a new recursion=1 mode for `GET /1.0/instances/{name}` which allows for the retrieval of
 all instance structs, including the state, snapshots and backup structs.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -89,6 +89,7 @@ security.nesting                            | boolean   | false             | ye
 security.privileged                         | boolean   | false             | no            | container                 | Runs the instance in privileged mode
 security.protection.delete                  | boolean   | false             | yes           | -                         | Prevents the instance from being deleted
 security.protection.shift                   | boolean   | false             | yes           | container                 | Prevents the instance's filesystem from being uid/gid shifted on startup
+security.agent.metrics                      | boolean   | true              | no            | virtual-machine           | Controls whether the lxd-agent is queried for state information and metrics
 security.secureboot                         | boolean   | true              | no            | virtual-machine           | Controls whether UEFI secure boot is enabled with the default Microsoft keys
 security.syscalls.allow                     | string    | -                 | no            | container                 | A '\n' separated list of syscalls to allow (mutually exclusive with security.syscalls.deny\*)
 security.syscalls.deny                      | string    | -                 | no            | container                 | A '\n' separated list of syscalls to deny

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5800,3 +5800,13 @@ func (d *qemu) getNetworkState() (map[string]api.InstanceStateNetwork, error) {
 
 	return networks, nil
 }
+
+func (d *qemu) agentMetricsEnabled() bool {
+	val := d.expandedConfig["security.agent.metrics"]
+
+	if val == "" || shared.IsTrue(val) {
+		return true
+	}
+
+	return false
+}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5737,6 +5737,14 @@ func (d *qemu) Info() instance.Info {
 }
 
 func (d *qemu) Metrics() (*metrics.MetricSet, error) {
+	if d.agentMetricsEnabled() {
+		return d.getAgentMetrics()
+	}
+
+	return d.getQemuMetrics()
+}
+
+func (d *qemu) getAgentMetrics() (*metrics.MetricSet, error) {
 	client, err := d.getAgentClient()
 	if err != nil {
 		return nil, err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5219,15 +5219,24 @@ func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error
 	pid, _ := d.pid()
 
 	if d.isRunningStatusCode(statusCode) {
-		// Try and get state info from agent.
-		status, err = d.agentGetState()
-		if err != nil {
-			if err != errQemuAgentOffline {
-				d.logger.Warn("Could not get VM state from agent", log.Ctx{"err": err})
-			}
+		if d.agentMetricsEnabled() {
+			// Try and get state info from agent.
+			status, err = d.agentGetState()
+			if err != nil {
+				if err != errQemuAgentOffline {
+					d.logger.Warn("Could not get VM state from agent", log.Ctx{"err": err})
+				}
 
-			// Fallback data if agent is not reachable.
-			status = &api.InstanceState{}
+				// Fallback data if agent is not reachable.
+				status = &api.InstanceState{}
+				status.Processes = -1
+
+				status.Network, err = d.getNetworkState()
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
 			status.Processes = -1
 
 			status.Network, err = d.getNetworkState()

--- a/lxd/instance/drivers/driver_qemu_metrics.go
+++ b/lxd/instance/drivers/driver_qemu_metrics.go
@@ -1,0 +1,166 @@
+package drivers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/lxc/lxd/lxd/instance/drivers/qmp"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/metrics"
+	"github.com/lxc/lxd/shared"
+	log "github.com/lxc/lxd/shared/log15"
+)
+
+func (d *qemu) getQemuMetrics() (*metrics.MetricSet, error) {
+	// Connect to the monitor.
+	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
+	if err != nil {
+		return nil, err
+	}
+
+	out := metrics.Metrics{}
+
+	cpuStats, err := d.getQemuCPUMetrics(monitor)
+	if err != nil {
+		d.logger.Warn("Failed to get CPU metrics", log.Ctx{"err": err})
+	} else {
+		out.CPU = cpuStats
+	}
+
+	memoryStats, err := d.getQemuMemoryMetrics(monitor)
+	if err != nil {
+		d.logger.Warn("Failed to get memory metrics", log.Ctx{"err": err})
+	} else {
+		out.Memory = memoryStats
+	}
+
+	diskStats, err := d.getQemuDiskMetrics(monitor)
+	if err != nil {
+		d.logger.Warn("Failed to get memory metrics", log.Ctx{"err": err})
+	} else {
+		out.Disk = diskStats
+	}
+
+	networkState, err := d.getNetworkState()
+	if err != nil {
+		d.logger.Warn("Failed to get network metrics", log.Ctx{"err": err})
+	} else {
+
+		out.Network = make(map[string]metrics.NetworkMetrics)
+
+		for name, state := range networkState {
+			out.Network[name] = metrics.NetworkMetrics{
+				ReceiveBytes:    uint64(state.Counters.BytesReceived),
+				ReceiveDrop:     uint64(state.Counters.PacketsDroppedInbound),
+				ReceiveErrors:   uint64(state.Counters.ErrorsReceived),
+				ReceivePackets:  uint64(state.Counters.PacketsReceived),
+				TransmitBytes:   uint64(state.Counters.BytesSent),
+				TransmitDrop:    uint64(state.Counters.PacketsDroppedOutbound),
+				TransmitErrors:  uint64(state.Counters.ErrorsSent),
+				TransmitPackets: uint64(state.Counters.PacketsSent),
+			}
+		}
+	}
+
+	metricSet, err := metrics.MetricSetFromAPI(&out, map[string]string{"project": d.project, "name": d.name, "type": instancetype.VM.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	return metricSet, nil
+}
+
+func (d *qemu) getQemuDiskMetrics(monitor *qmp.Monitor) (map[string]metrics.DiskMetrics, error) {
+	stats, err := monitor.GetBlockStats()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]metrics.DiskMetrics)
+
+	for dev, stat := range stats {
+		out[dev] = metrics.DiskMetrics{
+			ReadBytes:       uint64(stat.BytesRead),
+			ReadsCompleted:  uint64(stat.ReadsCompleted),
+			WrittenBytes:    uint64(stat.BytesWritten),
+			WritesCompleted: uint64(stat.WritesCompleted),
+		}
+	}
+
+	return out, nil
+}
+
+func (d *qemu) getQemuMemoryMetrics(monitor *qmp.Monitor) (metrics.MemoryMetrics, error) {
+	stats, err := monitor.GetMemoryStats()
+	if err != nil {
+		return metrics.MemoryMetrics{}, err
+	}
+
+	out := metrics.MemoryMetrics{
+		MemAvailableBytes: uint64(stats.AvailableMemory),
+		MemFreeBytes:      uint64(stats.FreeMemory),
+		MemTotalBytes:     uint64(stats.TotalMemory),
+	}
+
+	return out, nil
+}
+
+func (d *qemu) getQemuCPUMetrics(monitor *qmp.Monitor) (map[string]metrics.CPUMetrics, error) {
+	// Get CPU metrics
+	threadIDs, err := monitor.GetCPUs()
+	if err != nil {
+		return nil, err
+	}
+
+	cpuMetrics := map[string]metrics.CPUMetrics{}
+
+	for i, threadID := range threadIDs {
+		pid, err := ioutil.ReadFile(d.pidFilePath())
+		if err != nil {
+			return nil, err
+		}
+
+		statFile := filepath.Join("/proc", strings.TrimSpace(string(pid)), "task", strconv.Itoa(threadID), "stat")
+
+		if !shared.PathExists(statFile) {
+			continue
+		}
+
+		content, err := ioutil.ReadFile(statFile)
+		if err != nil {
+			return nil, err
+		}
+
+		fields := strings.Fields(string(content))
+
+		stats := metrics.CPUMetrics{}
+
+		stats.SecondsUser, err = strconv.ParseUint(fields[13], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse %q: %w", fields[13], err)
+		}
+
+		guestTime, err := strconv.ParseUint(fields[42], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse %q: %w", fields[42], err)
+		}
+
+		// According to proc(5), utime includes guest_time which therefore needs to be subtracted to get the correct time.
+		stats.SecondsUser -= guestTime
+		stats.SecondsUser *= 10
+
+		stats.SecondsSystem, err = strconv.ParseUint(fields[14], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse %q: %w", fields[14], err)
+		}
+
+		stats.SecondsSystem *= 10
+
+		cpuMetrics[fmt.Sprintf("cpu%d", i)] = stats
+	}
+
+	return cpuMetrics, nil
+}

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -274,7 +274,8 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	// Caller is responsible for full validation of any raw.* value.
 	"raw.qemu": validate.IsAny,
 
-	"security.secureboot": validate.Optional(validate.IsBool),
+	"security.agent.metrics": validate.Optional(validate.IsBool),
+	"security.secureboot":    validate.Optional(validate.IsBool),
 }
 
 // ConfigKeyChecker returns a function that will check whether or not

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -301,6 +301,7 @@ var APIExtensions = []string{
 	"clustering_groups",
 	"ceph_rbd_du",
 	"instance_get_full",
+	"qemu_metrics",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This adds a `security.agent.metrics` config key which when set to `false` will have LXD use host-side state information for the VM (CPU, disk, memory, network, ...) rather than relying on the agent.

It applies to both `/1.0/instances/NAME/state` and `/1.0/metrics`.

This is useful for environments where the guest cannot be trusted and where having potentially inflated values from QEMU is preferable to the more detailed values the agent would otherwise provide.