### PR TITLE
Cluster: Move notifyNodesUpdate call out of transaction in Join

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -540,14 +540,14 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 			return errors.Wrapf(err, "Failed to unmark the node as pending")
 		}
 
-		// Generate partial heartbeat request containing just a raft node list.
-		notifyNodesUpdate(raftNodes, info, networkCert, serverCert)
-
 		return nil
 	})
 	if err != nil {
 		return errors.Wrap(err, "Cluster database initialization failed")
 	}
+
+	// Generate partial heartbeat request containing just a raft node list.
+	notifyNodesUpdate(raftNodes, info, networkCert, serverCert)
 
 	return nil
 }


### PR DESCRIPTION
Othewise when the other members get the notification heartbeat, the member state in the DB will still be set to pending.
This is what generates the "Cluster member info not found" warning messages, and its not good keeping that transaction open whilst we make a network request to each and every member of the cluster.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>