### PR TITLE
doc: use customized Furo theme

### DIFF
--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -1,73 +1,81 @@
+/** Fix the font weight (300 for normal, 400 for slightly bold) **/
 
-/** Fix for issue #28 **/
-footer {
-    color: #666
+div.page, h1, h2, h3, h4, h5, h6, .sidebar-tree .current-page>.reference, button, input, optgroup, select, textarea, th.head {
+    font-weight: 300
 }
 
-footer::before {
-    border-top: 1px #ebebeb solid;
-    content: "";
-    display: inherit;
-    padding-bottom: 10px;
+.toc-tree li.scroll-current>.reference, dl.glossary dt, dl.simple dt, dl:not([class]) dt {
+    font-weight: 400;
 }
 
-/** Fix for issue #26 **/
+/** Table styling **/
 
-td p:first-child, th p:first-child {
-    padding-top: 0
+th.head {
+    text-transform: uppercase;
+    font-size: var(--font-size--small);
 }
 
-td p:last-child, th p:last-child {
-    margin-bottom: 0
+table.docutils {
+    border: 0;
+    box-shadow: none;
+    width:100%;
 }
 
-/** Fix for issue #24 **/
-.caption[role="heading"] {
-    font-size: 2rem;
-    line-height: 2.5rem;
-    font-weight: 100;
+table.docutils td, table.docutils th, table.docutils td:last-child, table.docutils th:last-child, table.docutils td:first-child, table.docutils th:first-child {
+    border-right: none;
+    border-left: none;
+}
+
+/** No rounded corners **/
+
+.admonition, code.literal, .sphinx-tabs-tab, .sphinx-tabs-panel, .highlight {
+    border-radius: 0;
+}
+
+/** Admonition styling **/
+
+.admonition {
+    border-top: 1px solid #d9d9d9;
+    border-right: 1px solid #d9d9d9;
+    border-bottom: 1px solid #d9d9d9;
+}
+
+/** Color for the "copy link" symbol next to headings **/
+
+a.headerlink {
+    color: var(--color-brand-primary);
+}
+
+/** Line to the left of the current navigation entry **/
+
+.sidebar-tree li.current-page {
+    border-left: 2px solid var(--color-brand-primary);
 }
 
 /** Some tweaks for issue #16 **/
 
 [role="tablist"] {
-    border-bottom: 1px solid #d9d9d9;
+    border-bottom: 1px solid var(--color-sidebar-item-background--hover);
 }
 
 .sphinx-tabs-tab[aria-selected="true"] {
     border: 0;
-    border-bottom: 2px solid #111;
-    background-color: #ebebeb;
+    border-bottom: 2px solid var(--color-brand-primary);
+    background-color: var(--color-sidebar-item-background--current);
     font-weight:300;
 }
 
 .sphinx-tabs-tab{
-    color: #111;
+    color: var(--color-brand-primary);
     font-weight:300;
-    border-radius: 0;
 }
 
 .sphinx-tabs-panel {
     border: 0;
-    border-bottom: 1px solid #d9d9d9;
-    border-radius: 0;
+    border-bottom: 1px solid var(--color-sidebar-item-background--hover);
+    background: var(--color-background-primary);
 }
 
 button.sphinx-tabs-tab:hover {
-    background-color: #f7f7f7;
-}
-
-/** Fix for issue #14 **/
-
-ol.lowerroman li {
-    list-style: lower-roman;
-}
-ol.upperroman li {
-    list-style: upper-roman;
-}
-ol.loweralpha li {
-    list-style: lower-alpha;
-}
-ol.upperalpha li {
-    list-style: upper-alpha;
+    background-color: var(--color-sidebar-item-background--hover);
 }

--- a/.sphinx/_static/header-nav.js
+++ b/.sphinx/_static/header-nav.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+    $(document).on("click", function () {
+        $(".more-links-dropdown").hide();
+    });
+
+    $('.nav-more-links').click(function(event) {
+        $('.more-links-dropdown').toggle();
+        event.stopPropagation();
+    });
+})

--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -1,0 +1,66 @@
+{# ru-fu: copied from Furo, with modifications as stated below #}
+
+<div class="related-pages">
+  {% if next -%}
+    <a class="next-page" href="{{ next.link }}">
+      <div class="page-info">
+        <div class="context">
+          <span>{{ _("Next") }}</span>
+        </div>
+        <div class="title">{{ next.title }}</div>
+      </div>
+      <svg><use href="#svg-arrow-right"></use></svg>
+    </a>
+  {%- endif %}
+  {% if prev -%}
+    <a class="prev-page" href="{{ prev.link }}">
+      <svg><use href="#svg-arrow-right"></use></svg>
+      <div class="page-info">
+        <div class="context">
+          <span>{{ _("Previous") }}</span>
+        </div>
+        {% if prev.link == pathto(master_doc) %}
+        <div class="title">{{ _("Home") }}</div>
+        {% else %}
+        <div class="title">{{ prev.title }}</div>
+        {% endif %}
+      </div>
+    </a>
+  {%- endif %}
+</div>
+
+<div class="related-information">
+  {%- if show_copyright %}
+    {%- if hasdoc('copyright') %}
+      {% trans path=pathto('copyright'), copyright=copyright|e -%}
+        <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}.
+      {%- endtrans %}
+    {%- else %}
+      {% trans copyright=copyright|e -%}
+        Copyright &#169; {{ copyright }}
+      {%- endtrans %}
+    {%- endif %}
+  {%- endif %}
+  {%- if last_updated %}
+    {%- if show_copyright %} | {%- endif %}
+    {% trans last_updated=last_updated|e -%}
+      Last updated on {{ last_updated }}.
+    {%- endtrans %}
+  {%- endif %}
+
+  {# ru-fu: removed "created using" #}
+
+  {%- if show_source and has_source and sourcename %}
+    | <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
+       rel="nofollow">
+      {{ _('Show Source') }}
+    </a>
+  {%- endif %}
+
+  {# ru-fu: added Edit on GitHub #}
+
+  {% if github_url and github_version and github_folder and github_filetype %}
+     {%- if show_copyright or last_updated or show_sphinx or show_source %} | {%- endif %}
+     <a class="muted-link" href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}.{{ github_filetype }}">Edit on GitHub</a>
+  {% endif %}
+</div>

--- a/.sphinx/_templates/header.html
+++ b/.sphinx/_templates/header.html
@@ -1,0 +1,115 @@
+<header id="header">
+
+  <style>
+    ul.p-navigation__links {
+        display: flex;
+        list-style: none;
+        margin-left: 0;
+        margin-top: auto;
+        margin-bottom: auto;
+        width: 60%;
+    }
+    ul.p-navigation__links li {
+        padding: 0 5px;
+        margin: 0 auto;
+        padding-top: 0.8rem;
+        border-left: 1px solid #cdcdcd;
+        text-align: center;
+        width: 100%;
+    }
+    ul.p-navigation__links li:first-child {
+        padding-top: 5px;
+        padding-bottom: 2px;
+        border-left: none;
+    }
+    ul.p-navigation__links li a {
+        color: var(--color-brand-primary);
+        font-weight: 300;
+    }
+    .p-navigation__logo img {
+        width: 40px;
+    }
+    .p-navigation__nav {
+        border-bottom: 1px solid #cdcdcd;
+    }
+    ul.more-links-dropdown {
+        display: none;
+        overflow-x: visible;
+        height: 0px;
+        z-index: 55;
+        position: relative;
+        list-style: none;
+        margin-bottom: 0;
+        margin-top: 0.8rem;
+    }
+    ul.p-navigation__links ul.more-links-dropdown li {
+        background-color: var(--color-background-primary);
+        border-left: 1px solid #cdcdcd;
+        border-right: 1px solid #cdcdcd;
+    }
+    ul.p-navigation__links ul.more-links-dropdown li:first-child {
+        border-top: 1px solid #cdcdcd;
+        padding-top: 10px;
+    }
+    ul.p-navigation__links ul.more-links-dropdown li:last-child {
+        border-bottom: 1px solid #cdcdcd;
+        padding-bottom: 10px;
+    }
+  </style>
+
+  <div class="p-navigation__nav" role="menubar">
+
+    <ul class="p-navigation__links" role="menu">
+
+      <li>
+        <a class="p-navigation__logo" href="/">
+          <img src="https://linuxcontainers.org/static/img/containers.small.png" alt="Linux containers logo" border="0" />
+        </a>
+      </li>
+
+      <li>
+        <a href="/">Home</a>
+      </li>
+
+      <li>
+        <a href="/lxd/try-it/">Demo</a>
+      </li>
+
+
+      <li>
+        <a href="#" class="nav-more-links">More resources</a>
+        <ul class="more-links-dropdown">
+          <li>
+            <a href="/lxd/introduction/"  class="p-navigation__sub-link p-dropdown__link">Introduction</a>
+          </li>
+
+          <li>
+            <a href="/lxd/news/"  class="p-navigation__sub-link p-dropdown__link">News</a>
+          </li>
+
+          <li>
+            <a href="/lxd/getting-started-cli/"  class="p-navigation__sub-link is-selected p-dropdown__link">Getting started</a>
+          </li>
+
+          <li>
+            <a href="/lxd/third-party-integrations/"  class="p-navigation__sub-link p-dropdown__link">Third-party integrations</a>
+          </li>
+
+          <li>
+            <a href="/lxd/advanced-guide/"  class="p-navigation__sub-link p-dropdown__link">Advanced guide</a>
+          </li>
+
+          <li>
+            <a href="https://discuss.linuxcontainers.org"  class="p-navigation__sub-link p-dropdown__link">Forum</a>
+          </li>
+
+          <li>
+            <a href="https://github.com/lxc/lxd"  class="p-navigation__sub-link p-dropdown__link">GitHub</a>
+          </li>
+
+        </ul>
+      </li>
+
+    </ul>
+  </div>
+</header>

--- a/.sphinx/_templates/page.html
+++ b/.sphinx/_templates/page.html
@@ -3,3 +3,8 @@
 {% block footer %}
    {% include "footer.html" %}
 {% endblock footer %}
+
+{% block body -%}
+   {% include "header.html" %}
+   {{ super() }}
+{%- endblock body %}

--- a/.sphinx/_templates/page.html
+++ b/.sphinx/_templates/page.html
@@ -1,0 +1,5 @@
+{% extends "furo/page.html" %}
+
+{% block footer %}
+   {% include "footer.html" %}
+{% endblock footer %}

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -28,8 +28,7 @@ if os.path.exists("doc/substitutions.yaml"):
         myst_substitutions = yaml.load(fd.read())
 
 # Setup theme.
-html_theme_path = ["themes"]
-html_theme = "vanilla"
+html_theme = "furo"
 html_show_sphinx = False
 html_last_updated_fmt = ""
 html_favicon = "https://linuxcontainers.org/static/img/favicon.ico"
@@ -38,12 +37,59 @@ html_static_path = ['_static']
 html_css_files = ['custom.css']
 html_extra_path = ['_extra']
 
-
-# Uses global TOC for side nav instead of default local TOC.
-html_sidebars = {
-    "**": [
-        "globaltoc.html",
-    ]
+html_theme_options = {
+    "sidebar_hide_name": True,
+    "light_css_variables": {
+        "font-stack": "Ubuntu, -apple-system, Segoe UI, Roboto, Oxygen, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif",
+        "font-stack--monospace": "Ubuntu Mono, Consolas, Monaco, Courier, monospace",
+        "color-foreground-primary": "#111",
+        "color-foreground-secondary": "var(--color-foreground-primary)",
+        "color-foreground-muted": "#333",
+        "color-background-secondary": "#FFF",
+        "color-background-hover": "#f2f2f2",
+        "color-brand-primary": "#111",
+        "color-brand-content": "#06C",
+        "color-api-background": "#cdcdcd",
+        "color-inline-code-background": "rgba(0,0,0,.03)",
+        "color-sidebar-link-text": "#111",
+        "color-sidebar-item-background--current": "#ebebeb",
+        "color-sidebar-item-background--hover": "#f2f2f2",
+        "toc-font-size": "var(--font-size--small)",
+        "color-admonition-title-background--note": "var(--color-background-primary)",
+        "color-admonition-title-background--tip": "var(--color-background-primary)",
+        "color-admonition-title-background--important": "var(--color-background-primary)",
+        "color-admonition-title-background--caution": "var(--color-background-primary)",
+        "color-admonition-title--note": "#24598F",
+        "color-admonition-title--tip": "#24598F",
+        "color-admonition-title--important": "#C7162B",
+        "color-admonition-title--caution": "#F99B11",
+        "color-highlighted-background": "#EbEbEb",
+        "color-link-underline": "var(--color-background-primary)",
+        "color-link-underline--hover": "var(--color-background-primary)",
+    },
+    "dark_css_variables": {
+        "color-foreground-secondary": "var(--color-foreground-primary)",
+        "color-foreground-muted": "#CDCDCD",
+        "color-background-secondary": "var(--color-background-primary)",
+        "color-background-hover": "#666",
+        "color-brand-primary": "#fff",
+        "color-brand-content": "#06C",
+        "color-sidebar-link-text": "#f7f7f7",
+        "color-sidebar-item-background--current": "#666",
+        "color-sidebar-item-background--hover": "#333",
+        "color-admonition-background": "transparent",
+        "color-admonition-title-background--note": "var(--color-background-primary)",
+        "color-admonition-title-background--tip": "var(--color-background-primary)",
+        "color-admonition-title-background--important": "var(--color-background-primary)",
+        "color-admonition-title-background--caution": "var(--color-background-primary)",
+        "color-admonition-title--note": "#24598F",
+        "color-admonition-title--tip": "#24598F",
+        "color-admonition-title--important": "#C7162B",
+        "color-admonition-title--caution": "#F99B11",
+        "color-highlighted-background": "#666",
+        "color-link-underline": "var(--color-background-primary)",
+        "color-link-underline--hover": "var(--color-background-primary)",
+    },
 }
 
 source_suffix = ".md"

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -34,9 +34,9 @@ html_theme = "furo"
 html_show_sphinx = False
 html_last_updated_fmt = ""
 html_favicon = "https://linuxcontainers.org/static/img/favicon.ico"
-html_logo = "https://linuxcontainers.org/static/img/containers.small.png"
 html_static_path = ['_static']
 html_css_files = ['custom.css']
+html_js_files = ['header-nav.js']
 html_extra_path = ['_extra']
 
 html_theme_options = {

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -28,6 +28,8 @@ if os.path.exists("doc/substitutions.yaml"):
         myst_substitutions = yaml.load(fd.read())
 
 # Setup theme.
+templates_path = ["_templates"]
+
 html_theme = "furo"
 html_show_sphinx = False
 html_last_updated_fmt = ""
@@ -90,6 +92,13 @@ html_theme_options = {
         "color-link-underline": "var(--color-background-primary)",
         "color-link-underline--hover": "var(--color-background-primary)",
     },
+}
+
+html_context = {
+    "github_url": "https://github.com/lxc/lxd",
+    "github_version": "master",
+    "github_folder": "/doc/",
+    "github_filetype": "md"
 }
 
 source_suffix = ".md"

--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -30,3 +30,4 @@ myst-parser
 sphinx-tabs
 sphinx-reredirects
 linkify-it-py
+furo

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,6 @@ doc:
 	python3 -m venv .sphinx/venv
 	. $(SPHINXENV) ; pip install --upgrade -r .sphinx/requirements.txt
 	mkdir -p .sphinx/deps/ .sphinx/themes/
-	git -C .sphinx/deps/vanilla pull || git clone --depth 1 https://github.com/evildmp/vanilla-sphinx-test .sphinx/deps/vanilla
-	ln -sf ../deps/vanilla/vanilla .sphinx/themes/vanilla
 	git -C .sphinx/deps/swagger-ui pull || git clone --depth 1 https://github.com/swagger-api/swagger-ui.git .sphinx/deps/swagger-ui
 	ln -sf ../deps/swagger-ui/dist .sphinx/_static/swagger-ui
 	rm -Rf doc/html


### PR DESCRIPTION
Switch to a customized version of the Furo theme.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>

To do:

- [x] Fix colors for dark mode
- [x] Add a header, then remove the logo in the navigation on the left
- [ ] ~~Check colors in code blocks~~ Can be done by setting ``pygments_style = "sphinx"``, but it doesn't really make it better
- [x] Fix the footer (double hr, "Created using", edit on GitHub)
- [x] Check which parts of the original custom.css we actually need
- [x] Clean up Vanilla theme download from Makefile
- [x] Different color for hover and selected in navigation, black left border for selected
- [x] Get rid of rounded corners (for code blocks and inline code, maybe more)