### PR TITLE
Automatically attempt live migration during evacuation

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1558,3 +1558,7 @@ cannot be set together.
 
 ## event\_project
 Expose the project an API event belongs to.
+
+## clustering\_evacuation\_live
+This adds `live-migrate` as a config option to `cluster.evacuate`, which forces live-migration
+of instances during cluster evacuation.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -50,7 +50,7 @@ boot.stop.priority                          | integer   | 0                 | n/
 cloud-init.network-config                   | string    | DHCP on eth0      | no            | -                         | Cloud-init network-config, content is used as seed value
 cloud-init.user-data                        | string    | #cloud-config     | no            | -                         | Cloud-init user-data, content is used as seed value
 cloud-init.vendor-data                      | string    | #cloud-config     | no            | -                         | Cloud-init vendor-data, content is used as seed value
-cluster.evacuate                            | string    | auto              | n/a           | -                         | What to do when evacuating the instance (auto, migrate, or stop)
+cluster.evacuate                            | string    | auto              | n/a           | -                         | What to do when evacuating the instance (auto, migrate, live-migrate, or stop)
 environment.\*                              | string    | -                 | yes (exec)    | -                         | key/value environment variables to export to the instance and set on exec
 limits.cpu                                  | string    | -                 | yes           | -                         | Number or range of CPUs to expose to the instance (defaults to 1 CPU for VMs)
 limits.cpu.allowance                        | string    | 100%              | yes           | container                 | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6699,7 +6699,7 @@ func (d *lxc) IsRunning() bool {
 }
 
 // CanMigrate returns whether the instance can be migrated.
-func (d *lxc) CanMigrate() bool {
+func (d *lxc) CanMigrate() (bool, bool) {
 	return d.canMigrate(d)
 }
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5364,7 +5364,7 @@ func (d *qemu) IsFrozen() bool {
 }
 
 // CanMigrate returns whether the instance can be migrated.
-func (d *qemu) CanMigrate() bool {
+func (d *qemu) CanMigrate() (bool, bool) {
 	return d.canMigrate(d)
 }
 

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -146,7 +146,7 @@ type Instance interface {
 	StoragePool() (string, error)
 
 	// Migration.
-	CanMigrate() bool
+	CanMigrate() (bool, bool)
 	Migrate(args *CriuMigrationArgs) error
 
 	// Progress reporting.

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -87,7 +87,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	"cloud-init.user-data":      validate.Optional(validate.IsAny),
 	"cloud-init.vendor-data":    validate.Optional(validate.IsAny),
 
-	"cluster.evacuate": validate.Optional(validate.IsOneOf("auto", "migrate", "stop")),
+	"cluster.evacuate": validate.Optional(validate.IsOneOf("auto", "migrate", "live-migrate", "stop")),
 
 	"limits.cpu": func(value string) error {
 		if value == "" {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -304,6 +304,7 @@ var APIExtensions = []string{
 	"qemu_metrics",
 	"gpu_mig_uuid",
 	"event_project",
+	"clustering_evacuation_live",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Resolves #9489.

I had some questions that I left as a comment on the issue, but I think I've mostly figured them out. Here's a couple of the assumptions I made in this implementation:

- `canMigrate(instance)` in lxd/instance/drivers/driver_common.go will only return true for the new `live-migrate` option if all of the instance's devices can migrate (this is the same behavior as `auto`)
- If live-migration (i.e. stateful stop) of an instance fails during evacuation when `live-migrate` is the evacuation mode then we fail with the error "Failed to stop instance [name]," but if `auto` is set then we will attempt the normal non-stateful stop procedure

Should the clustering.sh test suite be updated to test the new `live-migrate` option?