### PR TITLE
Fix incorrect type of ceph.rbd.clone_copy in docs

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -251,7 +251,7 @@ ceph.osd.data\_pool\_name     | string                        | -               
 ceph.osd.force\_reuse         | bool                          | false                                   | Force using an osd storage pool that is already in use by another LXD instance
 ceph.osd.pg\_num              | string                        | 32                                      | Number of placement groups for the osd storage pool
 ceph.osd.pool\_name           | string                        | name of the pool                        | Name of the osd storage pool
-ceph.rbd.clone\_copy          | string                        | true                                    | Whether to use RBD lightweight clones rather than full dataset copies
+ceph.rbd.clone\_copy          | bool                          | true                                    | Whether to use RBD lightweight clones rather than full dataset copies
 ceph.rbd.du                   | bool                          | true                                    | Whether to use rbd du to obtain disk usage data for stopped instances.
 ceph.rbd.features             | string                        | layering                                | Comma separate list of RBD features to enable on the volumes
 ceph.user.name                | string                        | admin                                   | The ceph user to use when creating storage pools and volumes


### PR DESCRIPTION
The type of the `ceph.rbd.clone_copy` config key was listed as `string` in the storage docs, but in the codebase it's validated and used as a `bool` value.