### PR TITLE
NIC: Enable IP forwarding on routed NIC veth host_name interface 

### DIFF
--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -317,6 +317,12 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 			if err != nil {
 				return nil, fmt.Errorf("Failed adding host gateway IP %q: %w", addr.Address, err)
 			}
+
+			// Enable IP forwarding on host_name.
+			err = util.SysctlSet(fmt.Sprintf("net/%s/conf/%s/forwarding", keyPrefix, saveData["host_name"]), "1")
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		// Perform per-address host-side configuration (static routes and neighbour proxy entries).

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -11,7 +11,7 @@ test_container_devices_nic_routed() {
   ipRand=$(shuf -i 0-9 -n 1)
 
   # These special values are needed to be enabled in kernel.
-  sysctl net.ipv4.conf.all.forwarding=1
+  # No need to enable IPv4 forwarding, as LXD will do this on the veth host_name interface automatically.
   sysctl net.ipv6.conf.all.forwarding=1
   sysctl net.ipv6.conf.all.proxy_ndp=1
 


### PR DESCRIPTION
Fixes regression caused by https://github.com/lxc/lxd/pull/9528

Fixes #9678