### PR TITLE
NIC: Don't depend on existance of dnsmasq.pid file to write static DHCP allocation file

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -38,6 +38,10 @@ import (
 	"github.com/lxc/lxd/shared/validate"
 )
 
+type bridgeNetwork interface {
+	UsesDNSMasq() bool
+}
+
 type nicBridged struct {
 	deviceCommon
 
@@ -829,8 +833,9 @@ func (d *nicBridged) Remove() error {
 
 // rebuildDnsmasqEntry rebuilds the dnsmasq host entry if connected to a LXD managed network and reloads dnsmasq.
 func (d *nicBridged) rebuildDnsmasqEntry() error {
-	// Rebuild dnsmasq config if a bridged device has changed and parent is a managed network.
-	if !shared.PathExists(shared.VarPath("networks", d.config["parent"], "dnsmasq.pid")) {
+	// Rebuild dnsmasq config if a bridged device has changed and parent is a managed network using dnsmasq.
+	bridgeNet, ok := d.network.(bridgeNetwork)
+	if !ok || !d.network.IsManaged() || !bridgeNet.UsesDNSMasq() {
 		return nil
 	}
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -820,11 +820,9 @@ func (d *nicBridged) Remove() error {
 		}
 
 		// Reload dnsmasq to apply new settings if dnsmasq is running.
-		if shared.PathExists(shared.VarPath("networks", d.config["parent"], "dnsmasq.pid")) {
-			err = dnsmasq.Kill(d.config["parent"], true)
-			if err != nil {
-				return err
-			}
+		err = dnsmasq.Kill(d.config["parent"], true)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1635,7 +1635,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 			}
 		}
 
-		// And same for our PID file.
+		// Clean up old dnsmasq PID file.
 		pidPath := shared.VarPath("networks", n.name, "dnsmasq.pid")
 		if shared.PathExists(pidPath) {
 			err := os.Remove(pidPath)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1496,7 +1496,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 	}
 
 	// Configure dnsmasq.
-	if n.config["bridge.mode"] == "fan" || !shared.StringInSlice(n.config["ipv4.address"], []string{"", "none"}) || !shared.StringInSlice(n.config["ipv6.address"], []string{"", "none"}) {
+	if n.UsesDNSMasq() {
 		// Setup the dnsmasq domain.
 		dnsDomain := n.config["dns.domain"]
 		if dnsDomain == "" {
@@ -3069,4 +3069,9 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 	}
 
 	return leases, nil
+}
+
+// UsesDNSMasq indicates if network's config indicates if it needs to use dnsmasq.
+func (n *bridge) UsesDNSMasq() bool {
+	return n.config["bridge.mode"] == "fan" || !shared.StringInSlice(n.config["ipv4.address"], []string{"", "none"}) || !shared.StringInSlice(n.config["ipv6.address"], []string{"", "none"})
 }


### PR DESCRIPTION
Instead check network config to indicate if dnsmasq will be used and use that as an indicator instead.
This way if dnsmasq has failed to start for some reason we don't skip writing the static allocation file.