### PR TITLE
Add TLS over Unix Socket support

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -314,7 +314,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	}
 
 	// Local unix socket queries.
-	if r.RemoteAddr == "@" {
+	if r.RemoteAddr == "@" && r.TLS == nil {
 		if w != nil {
 			cred, err := ucred.GetCredFromContext(r.Context())
 			if err != nil {

--- a/lxd/endpoints/endpoints.go
+++ b/lxd/endpoints/endpoints.go
@@ -192,6 +192,11 @@ func (e *Endpoints) up(config *Config) error {
 		}
 	}
 
+	// Setup STARTTLS layer on local listener.
+	if e.listeners[local] != nil {
+		e.listeners[local] = networkSTARTTLSListener(e.listeners[local], e.cert)
+	}
+
 	// Start the devlxd listener
 	e.listeners[devlxd], err = createDevLxdlListener(config.Dir)
 	if err != nil {

--- a/lxd/endpoints/socket.go
+++ b/lxd/endpoints/socket.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Bind to the given unix socket path.
-func socketUnixListen(path string) (net.Listener, error) {
+func socketUnixListen(path string) (*net.UnixListener, error) {
 	addr, err := net.ResolveUnixAddr("unix", path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve socket address: %v", err)
@@ -28,7 +28,6 @@ func socketUnixListen(path string) (net.Listener, error) {
 	}
 
 	return listener, err
-
 }
 
 // CheckAlreadyRunning checks if the socket at the given path is already

--- a/lxd/endpoints/starttls.go
+++ b/lxd/endpoints/starttls.go
@@ -1,0 +1,99 @@
+package endpoints
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+)
+
+// A variation of the standard tls.Listener that supports atomically swapping
+// the underlying TLS configuration. Requests served before the swap will
+// continue using the old configuration.
+type starttlsListener struct {
+	net.Listener
+	mu     sync.RWMutex
+	config *tls.Config
+}
+
+func networkSTARTTLSListener(inner net.Listener, cert *shared.CertInfo) *starttlsListener {
+	listener := &starttlsListener{
+		Listener: inner,
+	}
+
+	listener.Config(cert)
+	return listener
+}
+
+// Accept waits for and returns the next incoming TLS connection then use the
+// current TLS configuration to handle it.
+func (l *starttlsListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup bufferred connection.
+	bufConn := BufferedUnixConn{bufio.NewReader(c), c.(*net.UnixConn)}
+
+	// Peak to see if STARTTLS.
+	header, err := bufConn.Peek(8)
+	if err == nil && string(header) == "STARTTLS" {
+		discarded, err := bufConn.Discard(9)
+		if err != nil {
+			return nil, err
+		}
+
+		if discarded < 9 {
+			return nil, fmt.Errorf("Bad STARTTLS header on connection")
+		}
+
+		l.mu.RLock()
+		defer l.mu.RUnlock()
+
+		config := l.config
+		return tls.Server(bufConn, config), nil
+	}
+
+	return bufConn, nil
+}
+
+// Config safely swaps the underlying TLS configuration.
+func (l *starttlsListener) Config(cert *shared.CertInfo) {
+	config := util.ServerTLSConfig(cert)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.config = config
+}
+
+// BufferedUnixConn is a UnixConn wrapped in a Bufio Reader
+type BufferedUnixConn struct {
+	r *bufio.Reader
+	*net.UnixConn
+}
+
+// Discard allows discarding some bytes from the buffer.
+func (b BufferedUnixConn) Discard(n int) (int, error) {
+	return b.r.Discard(n)
+}
+
+// Peek allows reading some bytes without moving the read pointer.
+func (b BufferedUnixConn) Peek(n int) ([]byte, error) {
+	return b.r.Peek(n)
+}
+
+// Read allows normal reads on the buffered connection.
+func (b BufferedUnixConn) Read(p []byte) (int, error) {
+	return b.r.Read(p)
+}
+
+// Unix returns the inner UnixConn.
+func (b BufferedUnixConn) Unix() *net.UnixConn {
+	return b.UnixConn
+}

--- a/lxd/ucred/ucred.go
+++ b/lxd/ucred/ucred.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/lxc/lxd/lxd/endpoints"
 	"github.com/lxc/lxd/lxd/request"
 )
 
@@ -46,7 +47,12 @@ func GetCredFromContext(ctx context.Context) (*unix.Ucred, error) {
 	conn := GetConnFromContext(ctx)
 	unixConnPtr, ok := conn.(*net.UnixConn)
 	if !ok {
-		return nil, ErrNotUnixSocket
+		bufferedUnixConnPtr, ok := conn.(endpoints.BufferedUnixConn)
+		if !ok {
+			return nil, ErrNotUnixSocket
+		}
+
+		unixConnPtr = bufferedUnixConnPtr.Unix()
 	}
 
 	return GetCred(unixConnPtr)


### PR DESCRIPTION
This allows using STARTTLS to run a TLS authenticated session of the local LXD unix socket.

Other than potentially helping for local testing of authentication mechanism, this will be used by an upcoming `lxd-user` daemon which will allow unprivileged users interacting with LXD by dynamically creating and managing LXD projects.

This daemon required the ability to restrict a particular connection to a specific project. Rather than re-inventing the wheel, we'll have it use per-user trust certificates restricted to their respective project and have that daemon establish individual TLS connections to LXD for authentication.

This PR makes it possible to do all that locally without having to expose LXD to the network and so retaining our current socket-activation support at the same time.