### PR TITLE
Cluster: Heartbeat system rework to allow for full-state member change notifications

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -65,7 +65,7 @@ func restServer(d *Daemon) *http.Server {
 		response.SyncResponse(true, []string{"/1.0"}).Render(w)
 	})
 
-	for endpoint, f := range d.gateway.HandlerFuncs(d.NodeRefreshTask, d.getTrustedCertificates) {
+	for endpoint, f := range d.gateway.HandlerFuncs(d.heartbeatHandler, d.getTrustedCertificates) {
 		mux.HandleFunc(endpoint, f)
 	}
 
@@ -110,7 +110,7 @@ func metricsServer(d *Daemon) *http.Server {
 		response.SyncResponse(true, []string{"/1.0"}).Render(w)
 	})
 
-	for endpoint, f := range d.gateway.HandlerFuncs(d.NodeRefreshTask, d.getTrustedCertificates) {
+	for endpoint, f := range d.gateway.HandlerFuncs(d.heartbeatHandler, d.getTrustedCertificates) {
 		mux.HandleFunc(endpoint, f)
 	}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2161,7 +2161,7 @@ again:
 			break
 		}
 
-		logger.Info("Demoting offline member", log.Ctx{"candidateAddress": node.Address})
+		logger.Info("Demoting offline member during rebalance", log.Ctx{"candidateAddress": node.Address})
 		err := d.gateway.DemoteOfflineNode(node.ID)
 		if err != nil {
 			return errors.Wrapf(err, "Demote offline node %s", node.Address)
@@ -2171,7 +2171,7 @@ again:
 	}
 
 	// Tell the node to promote itself.
-	logger.Info("Promoting member", log.Ctx{"candidateAddress": address})
+	logger.Info("Promoting member during rebalance", log.Ctx{"candidateAddress": address})
 	err = changeMemberRole(d, r, address, nodes)
 	if err != nil {
 		return err
@@ -2376,7 +2376,7 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 		goto out
 	}
 
-	logger.Info("Promoting member", log.Ctx{"address": address, "losingAddress": req.Address, "candidateAddress": target})
+	logger.Info("Promoting member during handover", log.Ctx{"address": address, "losingAddress": req.Address, "candidateAddress": target})
 	err = changeMemberRole(d, r, target, nodes)
 	if err != nil {
 		return response.SmartError(err)
@@ -2389,7 +2389,7 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	logger.Info("Demoting member", log.Ctx{"address": address, "losingAddress": req.Address})
+	logger.Info("Demoting member during handover", log.Ctx{"address": address, "losingAddress": req.Address})
 	err = changeMemberRole(d, r, req.Address, nodes)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -124,12 +124,12 @@ type Gateway struct {
 	HeartbeatOfflineThreshold time.Duration
 	heartbeatCancel           context.CancelFunc
 	heartbeatCancelLock       sync.Mutex
+	heartbeatLock             sync.Mutex
 
 	// NodeStore wrapper.
 	store *dqliteNodeStore
 
-	lock          sync.RWMutex
-	heartbeatLock sync.Mutex
+	lock sync.RWMutex
 
 	// Abstract unix socket that the local dqlite task is listening to.
 	bindAddress string

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -195,15 +195,15 @@ func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts f
 		if r.Method == "PUT" {
 			if g.shutdownCtx.Err() != nil {
 				logger.Warn("Rejecting heartbeat request as shutting down")
-				http.Error(w, "503 shutting down", http.StatusServiceUnavailable)
+				http.Error(w, "503 Shutting down", http.StatusServiceUnavailable)
 				return
 			}
 
 			var heartbeatData APIHeartbeat
 			err := json.NewDecoder(r.Body).Decode(&heartbeatData)
 			if err != nil {
-				logger.Error("Error decoding heartbeat body", log.Ctx{"err": err})
-				http.Error(w, "400 invalid heartbeat payload", http.StatusBadRequest)
+				logger.Error("Failed decoding heartbeat", log.Ctx{"err": err})
+				http.Error(w, "400 Failed decoding heartbeat", http.StatusBadRequest)
 				return
 			}
 

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/util"
-	"github.com/lxc/lxd/lxd/warnings"
 	"github.com/lxc/lxd/shared"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
@@ -75,6 +74,9 @@ func NewGateway(shutdownCtx context.Context, db *db.Node, networkCert *shared.Ce
 
 // HeartbeatHook represents a function that can be called as the heartbeat hook.
 type HeartbeatHook func(heartbeatData *APIHeartbeat, isLeader bool, unavailableMembers []string)
+
+// HeartbeatHandler represents a function that can be called when a heartbeat request arrives.
+type HeartbeatHandler func(w http.ResponseWriter, r *http.Request, isLeader bool, hbData *APIHeartbeat)
 
 // Gateway mediates access to the dqlite cluster using a gRPC SQL client, and
 // possibly runs a dqlite replica on this LXD node (if we're configured to do
@@ -133,9 +135,6 @@ type Gateway struct {
 
 	// Abstract unix socket that the local dqlite task is listening to.
 	bindAddress string
-
-	// Keep track of skews
-	timeSkew bool
 }
 
 // Current dqlite protocol version.
@@ -155,7 +154,7 @@ func setDqliteVersionHeader(request *http.Request) {
 // These handlers might return 404, either because this LXD node is a
 // non-clustered node not available over the network or because it is not a
 // database node part of the dqlite cluster.
-func (g *Gateway) HandlerFuncs(nodeRefreshTask HeartbeatHook, trustedCerts func() map[db.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
+func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts func() map[db.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
 	database := func(w http.ResponseWriter, r *http.Request) {
 		g.lock.RLock()
 		defer g.lock.RUnlock()
@@ -208,90 +207,19 @@ func (g *Gateway) HandlerFuncs(nodeRefreshTask HeartbeatHook, trustedCerts func(
 				return
 			}
 
-			// Look for time skews.
-			now := time.Now().UTC()
-
-			if heartbeatData.Time.Add(5*time.Second).Before(now) || heartbeatData.Time.Add(-5*time.Second).After(now) {
-				if !g.timeSkew {
-					logger.Warn("Time skew detected between leader and local", log.Ctx{"leaderTime": heartbeatData.Time, "localTime": now})
-
-					if g.Cluster != nil {
-						err := g.Cluster.UpsertWarningLocalNode("", -1, -1, db.WarningClusterTimeSkew, fmt.Sprintf("leaderTime: %s, localTime: %s", heartbeatData.Time, now))
-						if err != nil {
-							logger.Warn("Failed to create cluster time skew warning", log.Ctx{"err": err})
-						}
-					}
-				}
-				g.timeSkew = true
-			} else {
-				if g.timeSkew {
-					logger.Warn("Time skew resolved")
-
-					if g.Cluster != nil {
-						err := warnings.ResolveWarningsByLocalNodeAndType(g.Cluster, db.WarningClusterTimeSkew)
-						if err != nil {
-							logger.Warn("Failed to resolve cluster time skew warning", log.Ctx{"err": err})
-						}
-					}
-
-					g.timeSkew = false
-				}
+			isLeader, err := g.isLeader()
+			if err != nil {
+				logger.Error("Failed checking if leader", log.Ctx{"err": err})
+				http.Error(w, "500 Failed checking if leader", http.StatusInternalServerError)
+				return
 			}
 
-			raftNodes := make([]db.RaftNode, 0)
-			for _, node := range heartbeatData.Members {
-				if node.RaftID > 0 {
-					raftNodes = append(raftNodes, db.RaftNode{
-						NodeInfo: client.NodeInfo{
-							ID:      node.RaftID,
-							Address: node.Address,
-							Role:    db.RaftRole(node.RaftRole),
-						},
-						Name: node.Name,
-					})
-				}
+			if heartbeatHandler == nil {
+				logger.Error("No heartbeat handler", log.Ctx{"err": err})
+				return
 			}
 
-			heartbeatRestarted := false
-
-			// Check we have been sent at least 1 raft node before wiping our set.
-			if len(raftNodes) > 0 {
-				// Accept Raft node updates from any node (joining nodes just send raft nodes heartbeat data).
-				logger.Debugf("Replace current raft nodes with %+v", raftNodes)
-				err = g.db.Transaction(func(tx *db.NodeTx) error {
-					return tx.ReplaceRaftNodes(raftNodes)
-				})
-				if err != nil {
-					logger.Error("Error updating raft members", log.Ctx{"err": err})
-					http.Error(w, "500 failed to update raft nodes", http.StatusInternalServerError)
-					return
-				}
-
-				// If there is an ongoing heartbeat round (and by implication this is the leader),
-				// then this could be a problem because it could be broadcasting the stale member
-				// state information which in turn could lead to incorrect decisions being made.
-				// So calling heartbeatRestart will request any ongoing heartbeat round to cancel
-				// itself prematurely and restart another one. If there is no ongoing heartbeat
-				// round then this function call is a no-op.
-				heartbeatRestarted = g.heartbeatRestart()
-			} else {
-				logger.Error("Empty raft member set received")
-			}
-
-			// Only perform heartbeat refresh task if we have received a full state list from leader.
-			if !heartbeatData.FullStateList {
-				logger.Info("Partial member list heartbeat received, skipping full update")
-			} else if nodeRefreshTask != nil && !heartbeatRestarted {
-				// Perform heartbeat refresh task async if an ongoing heartbeat wasn't restarted.
-				// As this task will be run at the end of the heartbeat task anyway.
-				isLeader, err := g.isLeader()
-				if err != nil {
-					logger.Error("Failed checking if leader", log.Ctx{"err": err})
-					return
-				}
-
-				go nodeRefreshTask(&heartbeatData, isLeader, nil)
-			}
+			heartbeatHandler(w, r, isLeader, &heartbeatData)
 
 			return
 		}

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -253,10 +253,10 @@ func (g *Gateway) HearbeatCancelFunc() func() {
 	return g.heartbeatCancel
 }
 
-// heartbeatRestart restarts cancels any ongoing heartbeat and restarts it.
+// HeartbeatRestart restarts cancels any ongoing heartbeat and restarts it.
 // If there is no ongoing heartbeat then this is a no-op.
 // Returns true if new heartbeat round was started.
-func (g *Gateway) heartbeatRestart() bool {
+func (g *Gateway) HeartbeatRestart() bool {
 	heartbeatCancel := g.HearbeatCancelFunc()
 
 	// There is a cancellable heartbeat round ongoing.

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -49,6 +49,13 @@ type APIHeartbeatVersion struct {
 	APIExtensions int
 }
 
+// NewAPIHearbeat returns initialised APIHeartbeat.
+func NewAPIHearbeat(cluster *db.Cluster) *APIHeartbeat {
+	return &APIHeartbeat{
+		cluster: cluster,
+	}
+}
+
 // APIHeartbeat contains data sent to nodes in heartbeat.
 type APIHeartbeat struct {
 	sync.Mutex // Used to control access to Members maps.
@@ -359,7 +366,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	heartbeatInterval := g.heartbeatInterval()
 
 	// Cumulative set of node states (will be written back to database once done).
-	hbState := &APIHeartbeat{cluster: g.Cluster}
+	hbState := NewAPIHearbeat(g.Cluster)
 
 	// If we are doing a normal heartbeat round then spread the requests over the heartbeatInterval in order
 	// to reduce load on the cluster.

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -438,7 +438,8 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		return
 	}
 
-	var unavailableMembers []string
+	// Initialise slice to indicate to HeartbeatNodeHook that its being called from leader.
+	unavailableMembers := make([]string, 0)
 
 	err = query.Retry(func() error {
 		return g.Cluster.Transaction(func(tx *db.ClusterTx) error {

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -217,14 +217,16 @@ func HeartbeatTask(gateway *Gateway) (task.Func, task.Schedule) {
 	// Since the database APIs are blocking we need to wrap the core logic
 	// and run it in a goroutine, so we can abort as soon as the context expires.
 	heartbeatWrapper := func(ctx context.Context) {
-		ch := make(chan struct{})
-		go func() {
-			gateway.heartbeat(ctx, hearbeatNormal)
-			ch <- struct{}{}
-		}()
-		select {
-		case <-ch:
-		case <-ctx.Done():
+		if gateway.HearbeatCancelFunc() == nil {
+			ch := make(chan struct{})
+			go func() {
+				gateway.heartbeat(ctx, hearbeatNormal)
+				close(ch)
+			}()
+			select {
+			case <-ch:
+			case <-ctx.Done():
+			}
 		}
 	}
 

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -245,26 +245,29 @@ func (g *Gateway) heartbeatInterval() time.Duration {
 	return threshold / 2
 }
 
+// HearbeatCancelFunc returns the function that can be used to cancel an ongoing heartbeat.
+// Returns nil if no ongoing heartbeat.
+func (g *Gateway) HearbeatCancelFunc() func() {
+	g.heartbeatCancelLock.Lock()
+	defer g.heartbeatCancelLock.Unlock()
+	return g.heartbeatCancel
+}
+
 // heartbeatRestart restarts cancels any ongoing heartbeat and restarts it.
 // If there is no ongoing heartbeat then this is a no-op.
 // Returns true if new heartbeat round was started.
 func (g *Gateway) heartbeatRestart() bool {
-	g.heartbeatCancelLock.Lock() // Make sure we're the only ones inspecting the g.heartbeatCancel var.
+	heartbeatCancel := g.HearbeatCancelFunc()
 
 	// There is a cancellable heartbeat round ongoing.
-	if g.heartbeatCancel != nil {
-		g.heartbeatCancel()            // Request ongoing hearbeat round cancel itself.
-		g.heartbeatCancel = nil        // Indicate there is no further cancellable heartbeat round.
-		g.heartbeatCancelLock.Unlock() // Release lock ready for g.heartbeat to acquire it.
+	if heartbeatCancel != nil {
+		g.heartbeatCancel() // Request ongoing hearbeat round cancel itself.
 
 		// Start a new heartbeat round async that will run as soon as ongoing heartbeat round exits.
 		go g.heartbeat(g.ctx, hearbeatImmediate)
 
 		return true
 	}
-
-	// No cancellable heartbeat round, release lock.
-	g.heartbeatCancelLock.Unlock()
 
 	return false
 }
@@ -282,12 +285,11 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	g.heartbeatCancelLock.Lock()
 	ctx, g.heartbeatCancel = context.WithCancel(ctx)
 	defer func() {
-		g.heartbeatCancelLock.Lock()
-		if g.heartbeatCancel != nil {
+		heartbeatCancel := g.HearbeatCancelFunc()
+		if heartbeatCancel != nil {
 			g.heartbeatCancel()
 			g.heartbeatCancel = nil
 		}
-		g.heartbeatCancelLock.Unlock()
 	}()
 	g.heartbeatCancelLock.Unlock()
 

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -540,6 +540,13 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 			return errors.Wrapf(err, "Failed to unmark the node as pending")
 		}
 
+		// Set last heartbeat time to now, as member is clearly online as it just successfully joined,
+		// that way when we send the notification to all members below it will consider this member online.
+		err = tx.SetNodeHeartbeat(node.Address, time.Now().UTC())
+		if err != nil {
+			return errors.Wrapf(err, "Failed setting last heartbeat time for member")
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 	liblxc "gopkg.in/lxc/go-lxc.v2"
 
+	client "github.com/canonical/go-dqlite/client"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
@@ -133,6 +134,9 @@ type Daemon struct {
 
 	// Device monitor for watching filesystem events
 	devmonitor devmonitor.FSMonitor
+
+	// Keep track of skews.
+	timeSkew bool
 }
 
 type externalAuth struct {
@@ -1024,7 +1028,7 @@ func (d *Daemon) init() error {
 	if err != nil {
 		return err
 	}
-	d.gateway.HeartbeatNodeHook = d.NodeRefreshTask
+	d.gateway.HeartbeatNodeHook = d.nodeRefreshTask
 
 	/* Setup some mounts (nice to have) */
 	if !d.os.MockMode {
@@ -1959,13 +1963,107 @@ func (d *Daemon) hasMemberStateChanged(heartbeatData *cluster.APIHeartbeat) bool
 	return false
 }
 
-// NodeRefreshTask is run when a full state heartbeat is sent (on the leader) or received (by a non-leader member).
+// heartbeatHandler handles heartbeat requests from other cluster members.
+func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLeader bool, hbData *cluster.APIHeartbeat) {
+	var err error
+
+	// Look for time skews.
+	now := time.Now().UTC()
+
+	if hbData.Time.Add(5*time.Second).Before(now) || hbData.Time.Add(-5*time.Second).After(now) {
+		if !d.timeSkew {
+			logger.Warn("Time skew detected between leader and local", log.Ctx{"leaderTime": hbData.Time, "localTime": now})
+
+			if d.cluster != nil {
+				err := d.cluster.UpsertWarningLocalNode("", -1, -1, db.WarningClusterTimeSkew, fmt.Sprintf("leaderTime: %s, localTime: %s", hbData.Time, now))
+				if err != nil {
+					logger.Warn("Failed to create cluster time skew warning", log.Ctx{"err": err})
+				}
+			}
+		}
+		d.timeSkew = true
+	} else {
+		if d.timeSkew {
+			logger.Warn("Time skew resolved")
+
+			if d.cluster != nil {
+				err := warnings.ResolveWarningsByLocalNodeAndType(d.cluster, db.WarningClusterTimeSkew)
+				if err != nil {
+					logger.Warn("Failed to resolve cluster time skew warning", log.Ctx{"err": err})
+				}
+			}
+
+			d.timeSkew = false
+		}
+	}
+
+	// Extract the raft nodes from the heartbeat info.
+	raftNodes := make([]db.RaftNode, 0)
+	for _, node := range hbData.Members {
+		if node.RaftID > 0 {
+			raftNodes = append(raftNodes, db.RaftNode{
+				NodeInfo: client.NodeInfo{
+					ID:      node.RaftID,
+					Address: node.Address,
+					Role:    db.RaftRole(node.RaftRole),
+				},
+				Name: node.Name,
+			})
+		}
+	}
+
+	// Check we have been sent at least 1 raft node before wiping our set.
+	if len(raftNodes) <= 0 {
+		logger.Error("Empty raft member set received")
+		http.Error(w, "400 Empty raft member set received", http.StatusBadRequest)
+		return
+	}
+
+	// Accept raft node list from any heartbeat type so that we get freshest data quickly.
+	logger.Debug("Replace current raft nodes", log.Ctx{"raftMembers": raftNodes})
+	err = d.db.Transaction(func(tx *db.NodeTx) error {
+		return tx.ReplaceRaftNodes(raftNodes)
+	})
+	if err != nil {
+		logger.Error("Error updating raft members", log.Ctx{"err": err})
+		http.Error(w, "500 failed to update raft nodes", http.StatusInternalServerError)
+		return
+	}
+
+	localAddress, _ := node.ClusterAddress(d.db)
+
+	if hbData.FullStateList {
+		// If there is an ongoing heartbeat round (and by implication this is the leader), then this could
+		// be a problem because it could be broadcasting the stale member state information which in turn
+		// could lead to incorrect decisions being made. So calling heartbeatRestart will request any
+		// ongoing heartbeat round to cancel itself prematurely and restart another one. If there is no
+		// ongoing heartbeat round or this member isn't the leader then this function call is a no-op and
+		// will return false. If the heartbeat is restarted, then the heartbeat refresh task will be called
+		// at the end of the heartbeat so no need to do it here.
+		if !isLeader || !d.gateway.HeartbeatRestart() {
+			// Run heartbeat refresh task async so heartbeat response is sent to leader straight away.
+			go d.nodeRefreshTask(hbData, isLeader, nil)
+		}
+	} else {
+		if isLeader {
+			logger.Error("Partial heartbeat should not be sent to leader")
+			http.Error(w, "400 Partial heartbeat should not be sent to leader", http.StatusBadRequest)
+			return
+		}
+
+		logger.Info("Partial heartbeat received", log.Ctx{"local": localAddress})
+	}
+
+	return
+}
+
+// nodeRefreshTask is run when a full state heartbeat is sent (on the leader) or received (by a non-leader member).
 // Is is used to check for member state changes and trigger refreshes of the certificate cache and forkdns peers.
 // It also triggers member role promotion when run on the isLeader is true.
 // When run on the leader, it accepts a list of unavailableMembers that have not responded to the current heartbeat
 // round (but may not be considered actually offline at this stage). These unavailable members will not be used for
 // role rebalancing.
-func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader bool, unavailableMembers []string) {
+func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader bool, unavailableMembers []string) {
 	// Don't process the heartbeat until we're fully online.
 	if d.cluster == nil || d.cluster.GetNodeID() == 0 {
 		return

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2110,8 +2110,10 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		d.lastNodeList = heartbeatData
 	}
 
-	// If we are the leader and there are other members in the cluster, then check if we need to update roles.
-	if isLeader && len(heartbeatData.Members) > 1 {
+	// If we are leader and called from the leader heartbeat send function (unavailbleMembers != nil) and there
+	// are other members in the cluster, then check if we need to update roles. We do not want to do this if
+	// we are called on the leader as part of a notification heartbeat being received from another member.
+	if isLeader && unavailableMembers != nil && len(heartbeatData.Members) > 1 {
 		isDegraded := false
 		hasNodesNotPartOfRaft := false
 		onlineVoters := 0

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -1232,7 +1232,7 @@ func (c *ClusterTx) SetNodeVersion(id int64, version [2]int) error {
 }
 
 func nodeIsOffline(threshold time.Duration, heartbeat time.Time) bool {
-	offlineTime := time.Now().Add(-threshold)
+	offlineTime := time.Now().UTC().Add(-threshold)
 
 	return heartbeat.Before(offlineTime) || heartbeat.Equal(offlineTime)
 }


### PR DESCRIPTION
This lays the groundwork to allow triggering a full-state notification heartbeat to all members for distributing event hub role changes.

So now there are the following "types" of heartbeat:

1. Partial state - this is only ever sent as part of the 1st phase of the initial heartbeat generated when a leader is elected.
2. Full state - this is sent during the 2nd phase of the initial leader heartbeat, during scheduled and immediate leader heartbeats, and it is sent from non-leader members to all other members for member state change notifications.

When a full-state heartbeat is sent from the leader or received any member, it will run the heartbeat refresh task. 
However when the heartbeat refresh task is run on the leader after sending a full-state heartbeat, the heartbeat task may perform additional member role change detection.