### PR TITLE
lxd: Uses api.NewURL and sets project when querying other nodes.

### DIFF
--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -427,8 +427,8 @@ func doInstancesGet(d *Daemon, r *http.Request) (interface{}, error) {
 				} else if strings.HasPrefix(mux.CurrentRoute(r).GetName(), "vm") {
 					instancePath = "virtual-machines"
 				}
-				url := fmt.Sprintf("/%s/%s/%s", version.APIVersion, instancePath, projectInstance[1])
-				resultString = append(resultString, url)
+				url := api.NewURL().Path(version.APIVersion, instancePath, projectInstance[1]).Project(projectInstance[0])
+				resultString = append(resultString, url.String())
 			}
 		} else {
 			threads := 4
@@ -494,8 +494,8 @@ func doInstancesGet(d *Daemon, r *http.Request) (interface{}, error) {
 				} else if strings.HasPrefix(mux.CurrentRoute(r).GetName(), "vm") {
 					instancePath = "virtual-machines"
 				}
-				url := fmt.Sprintf("/%s/%s/%s", version.APIVersion, instancePath, container.Name)
-				resultString = append(resultString, url)
+				url := api.NewURL().Path(version.APIVersion, instancePath, container.Name).Project(container.Project)
+				resultString = append(resultString, url.String())
 			}
 		}
 		return resultString, nil


### PR DESCRIPTION
This was noticed during review of #9698. When querying instances for all project, the project query parameter should be set on requests to other nodes if the project is not the default.