### PR TITLE
doc: fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ find and subscribe to those at: <https://lists.linuxcontainers.org>
 If you prefer live discussions, you can find us in [#lxc](https://kiwiirc.com/client/irc.libera.chat/#lxc) on irc.libera.chat. See [Getting started with IRC](https://discuss.linuxcontainers.org/t/getting-started-with-irc/11920) if needed.
 
 ## Contributing
-Fixes and new features are greatly appreciated. Make sure to read our [contributing guidelines](contributing.md) first!
+Fixes and new features are greatly appreciated. Make sure to read our [contributing guidelines](CONTRIBUTING.md) first!

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,7 +14,9 @@ See [Security](security.md) for more information.
 % Include content from [../README.md](../README.md)
 ```{include} ../README.md
     :start-after: security.md).
+    :end-before: greatly appreciated.
 ```
+See [Contributing](contributing.md) for more information.
 
 ```{toctree}
 :hidden:


### PR DESCRIPTION
We renamed the contributing guide to uppercase - need to fix this
in the Readme as well.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>