### PR TITLE
Migration: Enable TCP_USER_TIMEOUT and TCP keep alives on migration connections

### DIFF
--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -22,8 +22,10 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/idmap"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -174,6 +176,16 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 	c, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return err
+	}
+
+	remoteTCP, err := util.ExtractTCPConn(c.UnderlyingConn())
+	if err != nil {
+		logger.Error("Failed extracting TCP connection from remote connection", log.Ctx{"err": err})
+	} else {
+		err := util.SetTCPTimeouts(remoteTCP)
+		if err != nil {
+			logger.Error("Failed setting TCP timeouts on remote connection", log.Ctx{"err": err})
+		}
 	}
 
 	*conn = c

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -133,7 +133,7 @@ func (c *migrationFields) controlChannel() <-chan *migration.MigrationControl {
 type migrationSourceWs struct {
 	migrationFields
 
-	allConnected chan bool
+	allConnected chan struct{}
 }
 
 func (s *migrationSourceWs) Metadata() interface{} {
@@ -191,7 +191,7 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 		return nil
 	}
 
-	s.allConnected <- true
+	close(s.allConnected)
 
 	return nil
 }
@@ -249,7 +249,7 @@ func (s *migrationSourceWs) ConnectTarget(certificate string, operation string, 
 		*conn = wsConn
 	}
 
-	s.allConnected <- true
+	close(s.allConnected)
 
 	return nil
 }

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -264,7 +264,7 @@ type migrationSink struct {
 
 	url          string
 	dialer       websocket.Dialer
-	allConnected chan bool
+	allConnected chan struct{}
 	push         bool
 	refresh      bool
 }
@@ -360,7 +360,7 @@ func (s *migrationSink) Connect(op *operations.Operation, r *http.Request, w htt
 		return nil
 	}
 
-	s.allConnected <- true
+	close(s.allConnected)
 
 	return nil
 }

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -747,7 +747,7 @@ func newMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {
 	}
 
 	if sink.push {
-		sink.allConnected = make(chan bool, 1)
+		sink.allConnected = make(chan struct{})
 	}
 
 	var ok bool

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -351,6 +351,8 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 
 	logger.Info("Migration channels connected")
 
+	defer s.disconnect()
+
 	var poolMigrationTypes []migration.Type
 
 	pool, err := storagePools.GetPoolByInstance(state, s.instance)

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -34,7 +34,10 @@ import (
 )
 
 func newMigrationSource(inst instance.Instance, stateful bool, instanceOnly bool) (*migrationSourceWs, error) {
-	ret := migrationSourceWs{migrationFields{instance: inst}, make(chan bool, 1)}
+	ret := migrationSourceWs{
+		migrationFields: migrationFields{instance: inst},
+		allConnected:    make(chan struct{}),
+	}
 	ret.instanceOnly = instanceOnly
 
 	var err error

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -180,7 +180,7 @@ func newStorageMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {
 	}
 
 	if sink.push {
-		sink.allConnected = make(chan bool, 1)
+		sink.allConnected = make(chan struct{})
 	}
 
 	var ok bool

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -18,7 +18,10 @@ import (
 )
 
 func newStorageMigrationSource(volumeOnly bool) (*migrationSourceWs, error) {
-	ret := migrationSourceWs{migrationFields{}, make(chan bool, 1)}
+	ret := migrationSourceWs{
+		migrationFields: migrationFields{},
+		allConnected:    make(chan struct{}),
+	}
 	ret.volumeOnly = volumeOnly
 
 	var err error

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"reflect"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 
@@ -301,6 +303,56 @@ func SysctlSet(parts ...string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// ExtractTCPConn tries to extract the underlying net.TCPConn from a tls.Conn.
+func ExtractTCPConn(conn net.Conn) (*net.TCPConn, error) {
+	// Go doesn't currently expose the underlying TCP connection of a TLS connection, but we need it in order
+	// to set timeout properties on the connection. We use some reflect/unsafe magic to extract the private
+	// remote.conn field, which is indeed the underlying TCP connection.
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return nil, fmt.Errorf("Connection is not a tls.Conn")
+	}
+
+	field := reflect.ValueOf(tlsConn).Elem().FieldByName("conn")
+	field = reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+	c := field.Interface()
+
+	tcpConn, ok := c.(*net.TCPConn)
+	if !ok {
+		return tcpConn, fmt.Errorf("Connection is not a net.TCPConn")
+	}
+
+	return tcpConn, nil
+}
+
+// SetTCPTimeouts sets TCP_USER_TIMEOUT and TCP keep alive timeouts on a connection.
+func SetTCPTimeouts(conn *net.TCPConn) error {
+	// Set TCP_USER_TIMEOUT option to limit the maximum amount of time in ms that transmitted data may remain
+	// unacknowledged before TCP will forcefully close the corresponding connection and return ETIMEDOUT to the
+	// application. This combined with the TCP keepalive options on the socket will ensure that should the
+	// remote side of the connection disappear abruptly that LXD will detect this and close the socket quickly.
+	// Decreasing the user timeouts allows applications to "fail fast" if so desired. Otherwise it may take
+	// up to 20 minutes with the current system defaults in a normal WAN environment if there are packets in
+	// the send queue that will prevent the keepalive timer from working as the retransmission timers kick in.
+	// See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dca43c75e7e545694a9dd6288553f55c53e2a3a3
+	err := SetTCPUserTimeout(conn, time.Second*30)
+	if err != nil {
+		return err
+	}
+
+	err = conn.SetKeepAlive(true)
+	if err != nil {
+		return err
+	}
+
+	err = conn.SetKeepAlivePeriod(3 * time.Second)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This way they will gracefully close rather than hanging if a network problem occurs.