### PR TITLE
lxc/alias: Allows users to reference specific arguments.

### DIFF
--- a/lxc/main_aliases.go
+++ b/lxc/main_aliases.go
@@ -7,12 +7,16 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/lxc/lxd/lxc/config"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/i18n"
 )
+
+var numberedArgRegex = regexp.MustCompile(`@ARG(\d+)@`)
 
 // defaultAliases contains LXC's built-in command line aliases.  The built-in
 // aliases are checked only if no user-defined alias was found.
@@ -44,7 +48,7 @@ func findAlias(aliases map[string]string, origArgs []string) ([]string, []string
 	return aliasKey, aliasValue, foundAlias
 }
 
-func expandAlias(conf *config.Config, args []string) ([]string, bool) {
+func expandAlias(conf *config.Config, args []string) ([]string, bool, error) {
 	var newArgs []string
 	var origArgs []string
 
@@ -62,30 +66,89 @@ func expandAlias(conf *config.Config, args []string) ([]string, bool) {
 	if !foundAlias {
 		aliasKey, aliasValue, foundAlias = findAlias(defaultAliases, origArgs)
 		if !foundAlias {
-			return []string{}, false
+			return []string{}, false, nil
 		}
 	}
 
 	if !strings.HasPrefix(aliasValue[0], "/") {
 		newArgs = append([]string{origArgs[0]}, newArgs...)
 	}
-	hasReplacedArgsVar := false
 
+	// The @ARGS@ are initially any arguments given after the alias key.
+	var atArgs []string
+	if len(origArgs) > len(aliasKey)+1 {
+		atArgs = origArgs[len(aliasKey)+1:]
+	}
+
+	// Find the arguments that have been referenced directly e.g. @ARG1@.
+	numberedArgsMap := map[int]string{}
 	for _, aliasArg := range aliasValue {
-		if aliasArg == "@ARGS@" && len(origArgs) > 2 {
-			newArgs = append(newArgs, origArgs[2:]...)
-			hasReplacedArgsVar = true
-		} else {
-			newArgs = append(newArgs, aliasArg)
+		matches := numberedArgRegex.FindAllStringSubmatch(aliasArg, -1)
+		if len(matches) == 0 {
+			continue
+		}
+
+		for _, match := range matches {
+			argNoStr := match[1]
+			argNo, err := strconv.Atoi(argNoStr)
+			if err != nil {
+				return nil, false, fmt.Errorf("Invalid argument %q", match[0])
+			}
+
+			if argNo > len(atArgs) {
+				return nil, false, fmt.Errorf("Found alias %q references an argument outside the given number", strings.Join(aliasKey, " "))
+			}
+
+			numberedArgsMap[argNo] = atArgs[argNo-1]
 		}
 	}
 
-	if !hasReplacedArgsVar {
-		// Add the rest of the arguments
-		newArgs = append(newArgs, origArgs[len(aliasKey)+1:]...)
+	// Remove directly referenced arguments from @ARGS@
+	for i := len(atArgs) - 1; i >= 0; i-- {
+		_, ok := numberedArgsMap[i+1]
+		if ok {
+			atArgs = append(atArgs[:i], atArgs[i+1:]...)
+		}
 	}
 
-	return newArgs, true
+	// Replace arguments
+	hasReplacedArgsVar := false
+	for _, aliasArg := range aliasValue {
+
+		// Only replace all @ARGS@ when it is not part of another string
+		if aliasArg == "@ARGS@" {
+			newArgs = append(newArgs, atArgs...)
+			hasReplacedArgsVar = true
+			continue
+		}
+
+		// Replace @ARG1@, @ARG2@ etc. as substrings
+		matches := numberedArgRegex.FindAllStringSubmatch(aliasArg, -1)
+		if len(matches) > 0 {
+			newArg := aliasArg
+			for _, match := range matches {
+				argNoStr := match[1]
+				argNo, err := strconv.Atoi(argNoStr)
+				if err != nil {
+					return nil, false, fmt.Errorf("Invalid argument %q", match[0])
+				}
+
+				replacement := numberedArgsMap[argNo]
+				newArg = strings.Replace(newArg, match[0], replacement, -1)
+			}
+			newArgs = append(newArgs, newArg)
+			continue
+		}
+
+		newArgs = append(newArgs, aliasArg)
+	}
+
+	// Add the rest of the arguments only if @ARGS@ wasn't used.
+	if !hasReplacedArgsVar {
+		newArgs = append(newArgs, atArgs...)
+	}
+
+	return newArgs, true, nil
 }
 
 func execIfAliases() error {
@@ -126,8 +189,10 @@ func execIfAliases() error {
 	}
 
 	// Expand the aliases
-	newArgs, expanded := expandAlias(conf, args)
-	if !expanded {
+	newArgs, expanded, err := expandAlias(conf, args)
+	if err != nil {
+		return err
+	} else if !expanded {
 		return nil
 	}
 


### PR DESCRIPTION
Previously, users could use `@ARGS@` to pass arguments from the command
line into their alias. In addition to this, users can now reference
`@ARG1@`, `@ARG2@` etc. from their argument list. The value of `@ARG1@` is
removed from the list of `@ARGS@`.

Signed-off-by: Mark Laing <mark.laing@canonical.com>