### PR TITLE
Cluster: Event listener socket cleanup and logging improvements

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -71,13 +71,13 @@ func (e *EventListener) RemoveHandler(target *EventTarget) error {
 
 // Disconnect must be used once done listening for events
 func (e *EventListener) Disconnect() {
-	if e.disconnected {
-		return
-	}
-
 	// Handle locking
 	e.r.eventListenersLock.Lock()
 	defer e.r.eventListenersLock.Unlock()
+
+	if e.disconnected {
+		return
+	}
 
 	// Locate and remove it from the global list
 	for i, listener := range e.r.eventListeners {

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -25,6 +25,7 @@ type ProtocolLXD struct {
 	server      *api.Server
 	chConnected chan struct{}
 
+	eventConn          *websocket.Conn
 	eventListeners     []*EventListener
 	eventListenersLock sync.Mutex
 

--- a/client/lxd_events.go
+++ b/client/lxd_events.go
@@ -1,6 +1,7 @@
 package lxd
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -16,10 +17,13 @@ func (r *ProtocolLXD) getEvents(allProjects bool) (*EventListener, error) {
 	r.eventListenersLock.Lock()
 	defer r.eventListenersLock.Unlock()
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	// Setup a new listener
 	listener := EventListener{
-		r:        r,
-		chActive: make(chan bool),
+		r:         r,
+		ctx:       ctx,
+		ctxCancel: cancel,
 	}
 
 	if r.eventListeners != nil {
@@ -84,8 +88,7 @@ func (r *ProtocolLXD) getEvents(allProjects bool) (*EventListener, error) {
 				// Tell all the current listeners about the failure
 				for _, listener := range r.eventListeners {
 					listener.err = err
-					listener.disconnected = true
-					close(listener.chActive)
+					listener.ctxCancel()
 				}
 
 				// And remove them all from the list

--- a/client/operations.go
+++ b/client/operations.go
@@ -211,7 +211,7 @@ func (op *operation) setupListener() error {
 
 		// Wait for the listener or operation to be done
 		select {
-		case <-listener.chActive:
+		case <-listener.ctx.Done():
 			op.handlerLock.Lock()
 			if op.listener != nil {
 				op.Err = fmt.Sprintf("%v", listener.err)

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
-	"github.com/lxc/lxd/shared/logger"
 )
 
 var eventsCmd = APIEndpoint{
@@ -53,9 +52,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 		return err
 	}
 
-	logger.Debugf("New event listener: %s (%v)", listener.ID(), typeStr)
 	listener.Wait(r.Context())
-	logger.Debugf("Event listener finished: %s", listener.ID())
 
 	return nil
 }

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -39,7 +39,7 @@ func Connect(address string, networkCert *shared.CertInfo, serverCert *shared.Ce
 	if !notify {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10)*time.Second)
 		defer cancel()
-		_, err := EventListenerWait(ctx, address)
+		err := EventListenerWait(ctx, address)
 		if err != nil {
 			return nil, fmt.Errorf("Missing event connection with target cluster member")
 		}

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -117,7 +117,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 			// might be something waiting for a future connection.
 			listener.Disconnect()
 			delete(listeners, member.Address)
-			logger.Info("Removed inactive member event listener", log.Ctx{"local": networkAddress, "remote": member.Address})
+			logger.Info("Removed inactive member event listener client", log.Ctx{"local": networkAddress, "remote": member.Address})
 		}
 		listenersLock.Unlock()
 
@@ -129,7 +129,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 			defer wg.Done()
 			listener, err := eventsConnect(m.Address, endpoints.NetworkCert(), serverCert())
 			if err != nil {
-				logger.Warn("Failed adding member event listener", log.Ctx{"local": networkAddress, "remote": m.Address, "err": err})
+				logger.Warn("Failed adding member event listener client", log.Ctx{"local": networkAddress, "remote": m.Address, "err": err})
 				return
 			}
 
@@ -146,7 +146,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 				}
 			}
 
-			logger.Info("Added member event listener", log.Ctx{"local": networkAddress, "remote": m.Address})
+			logger.Info("Added member event listener client", log.Ctx{"local": networkAddress, "remote": m.Address})
 			listenersLock.Unlock()
 		}(member)
 	}
@@ -159,7 +159,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 		if _, found := keepListeners[address]; !found {
 			listener.Disconnect()
 			delete(listeners, address)
-			logger.Info("Removed old member event listener", log.Ctx{"local": networkAddress, "remote": address})
+			logger.Info("Removed old member event listener client", log.Ctx{"local": networkAddress, "remote": address})
 		}
 	}
 	listenersLock.Unlock()

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -107,7 +107,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 		// If the member already has a listener associated to it, check that the listener is still active.
 		// If it is, just move on to next member, but if not then we'll try to connect again.
 		if ok {
-			if listeners[member.Address].IsActive() {
+			if listener.IsActive() {
 				keepListeners[member.Address] = struct{}{} // Add to current listeners list.
 				listenersLock.Unlock()
 				continue

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lxc/lxd/lxd/rbac"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
-	"github.com/lxc/lxd/shared/logger"
 )
 
 var eventTypes = []string{"logging", "operation", "lifecycle"}
@@ -114,9 +113,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 		return err
 	}
 
-	logger.Debugf("New event listener: %s", listener.ID())
 	listener.Wait(r.Context())
-	logger.Debugf("Event listener finished: %s", listener.ID())
 
 	return nil
 }

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -193,6 +193,8 @@ type Listener struct {
 }
 
 func (e *Listener) heartbeat() {
+	logger.Debug("Event listener server handler started", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
+
 	defer e.Close()
 
 	pingInterval := time.Second * 5
@@ -220,7 +222,7 @@ func (e *Listener) heartbeat() {
 		e.lock.Lock()
 		if e.pongsPending > 2 {
 			e.lock.Unlock()
-			logger.Warn("Hearbeat for event listener timed out", log.Ctx{"listener": e.ID()})
+			logger.Warn("Hearbeat for event listener handler timed out", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
 			return
 		}
 		err := e.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
@@ -272,7 +274,7 @@ func (e *Listener) Close() {
 		return
 	}
 
-	logger.Debug("Disconnected event listener", log.Ctx{"listener": e.id})
+	logger.Debug("Event listener server handler stopped", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
 
 	e.Conn.Close()
 	e.ctxCancel()


### PR DESCRIPTION
Also lays the ground work for allowing a server-initiated client connection to another server to be considered active if there is an events connection to either the specific server being connected to, or, in the future, one or more event hub servers.