### PR TITLE
Fix progress indicator for 'lxc export'

### DIFF
--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -305,7 +305,7 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 			CompressionAlgorithm: req.CompressionAlgorithm,
 		}
 
-		err := backupCreate(d.State(), args, inst)
+		err := backupCreate(d.State(), args, inst, op)
 		if err != nil {
 			return errors.Wrap(err, "Create backup")
 		}


### PR DESCRIPTION
`lxc export` uses two progress indicators. One for backing up instance and one for exporting the backup. The first one was broken. I added support for progress indicator directly in `backupCreate` method but I think there is other approach to solve this issue. We can pass `Operation` to: https://github.com/lxc/lxd/blob/e2fe2f8b74aa32d1fbcb50dfcd5f4143ade76008/lxd/backup.go#L168 as the last parameter. But then we need to implement support for progress indicator for every driver. Most of them uses: https://github.com/lxc/lxd/blob/e2fe2f8b74aa32d1fbcb50dfcd5f4143ade76008/lxd/storage/drivers/generic_vfs.go#L448 but there are two exceptions. I think this solution will be more complex so this is why I decided for first one.

Fixes #9711