### PR TITLE
Add support for UUID selection of NVIDIA MIG devices

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1548,3 +1548,10 @@ all instance structs, including the state, snapshots and backup structs.
 ## qemu\_metrics
 This adds a new `security.agent.metrics` boolean which defaults to `true`.
 When set to `false`, it doesn't connect to the lxd-agent for metrics and other state information, but relies on stats from QEMU.
+
+## gpu\_mig\_uuid
+Adds support for the new MIG UUID format used by Nvidia `470+` drivers (eg. `MIG-74c6a31a-fde5-5c61-973b-70e12346c202`),
+the `MIG-` prefix can be omitted
+
+This extension supersedes old `mig.gi` and `mig.ci` parameters which are kept for compatibility with old drivers and
+cannot be set together.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -904,8 +904,11 @@ vendorid    | string    | -                 | no        | The vendor id of the G
 productid   | string    | -                 | no        | The product id of the GPU device
 id          | string    | -                 | no        | The card id of the GPU device
 pci         | string    | -                 | no        | The pci address of the GPU device
-mig.ci      | int       | -                 | yes       | Existing MIG compute instance ID
-mig.gi      | int       | -                 | yes       | Existing MIG GPU instance ID
+mig.ci      | int       | -                 | no        | Existing MIG compute instance ID
+mig.gi      | int       | -                 | no        | Existing MIG GPU instance ID
+mig.uuid    | string    | -                 | no        | Existing MIG device UUID ("MIG-" prefix can be omitted)
+
+Note: Either "mig.uuid" (Nvidia drivers 470+) or both "mig.ci" and "mig.gi" (old Nvidia drivers) must be set.
 
 ##### gpu: sriov
 

--- a/lxd/device/device_utils_gpu.go
+++ b/lxd/device/device_utils_gpu.go
@@ -1,0 +1,14 @@
+package device
+
+import (
+	"github.com/lxc/lxd/shared/validate"
+	"strings"
+)
+
+// gpuValidMigUUID validates Nvidia MIG (Multi Instance GPU) UUID with or without "MIG-" prefix.
+func gpuValidMigUUID(value string) error {
+	if value == "" {
+		return nil
+	}
+	return validate.IsUUID(strings.TrimPrefix(value, "MIG-"))
+}

--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -14,6 +14,7 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 		"mode":      unixValidOctalFileMode,
 		"mig.gi":    validate.IsUint8,
 		"mig.ci":    validate.IsUint8,
+		"mig.uuid":  gpuValidMigUUID,
 		"mdev":      validate.IsAny,
 	}
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -302,6 +302,7 @@ var APIExtensions = []string{
 	"ceph_rbd_du",
 	"instance_get_full",
 	"qemu_metrics",
+	"gpu_mig_uuid",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Introduce a new parameter `mig.uuid` which reflects the new MIG UUID format used by Nvidia `470+` drivers (eg. `MIG-74c6a31a-fde5-5c61-973b-70e12346c202`), the `MIG-` prefix can be omitted.

This extension supersedes old `mig.gi` and `mig.ci` parameters which are kept for compatibility with old drivers and
cannot be set together.

Resolves #9518.

Signed-off-by: Vincent KHERBACHE <v.kherbache@titandc.fr>
