### PR TITLE
Fix overriding public property by auto-update

### DIFF
--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -42,6 +42,7 @@ type ImageDownloadArgs struct {
 	SetCached         bool
 	PreferCached      bool
 	AutoUpdate        bool
+	Public            bool
 	StoragePool       string
 	Budget            int64
 	SourceProjectName string
@@ -178,7 +179,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 			}
 
 			// We need to insert the database entry for this project, including the node ID entry.
-			err = d.cluster.CreateImage(args.ProjectName, imgInfo.Fingerprint, imgInfo.Filename, imgInfo.Size, false, imgInfo.AutoUpdate, imgInfo.Architecture, imgInfo.CreatedAt, imgInfo.ExpiresAt, imgInfo.Properties, imgInfo.Type)
+			err = d.cluster.CreateImage(args.ProjectName, imgInfo.Fingerprint, imgInfo.Filename, imgInfo.Size, args.Public, imgInfo.AutoUpdate, imgInfo.Architecture, imgInfo.CreatedAt, imgInfo.ExpiresAt, imgInfo.Properties, imgInfo.Type)
 			if err != nil {
 				return nil, err
 			}
@@ -457,7 +458,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 	}
 
 	// Override visiblity
-	info.Public = false
+	info.Public = args.Public
 
 	// We want to enable auto-update only if we were passed an
 	// alias name, so we can figure when the associated

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -390,6 +390,7 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 		Alias:             hash,
 		Type:              req.Source.ImageType,
 		AutoUpdate:        req.AutoUpdate,
+		Public:            req.Public,
 		ProjectName:       project,
 		Budget:            budget,
 		SourceProjectName: req.Source.Project,
@@ -471,6 +472,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 		Protocol:    "direct",
 		Alias:       hash,
 		AutoUpdate:  req.AutoUpdate,
+		Public:      req.Public,
 		ProjectName: project,
 		Budget:      budget,
 	})
@@ -1866,6 +1868,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 			Alias:       source.Alias,
 			Type:        info.Type,
 			AutoUpdate:  true,
+			Public:      info.Public,
 			StoragePool: poolName,
 			ProjectName: projectName,
 			Budget:      -1,

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -109,6 +109,7 @@ func createFromImage(d *Daemon, r *http.Request, projectName string, req *api.In
 				SetCached:    true,
 				Type:         imgType,
 				AutoUpdate:   autoUpdate,
+				Public:       false,
 				PreferCached: true,
 				ProjectName:  projectName,
 				Budget:       budget,


### PR DESCRIPTION
public value was hardcoded in two places in `ImageDownload` method:
https://github.com/lxc/lxd/blob/7973ab78af5fba6fa6610174ffb3c0bc7328f76e/lxd/daemon_images.go#L181
https://github.com/lxc/lxd/blob/7973ab78af5fba6fa6610174ffb3c0bc7328f76e/lxd/daemon_images.go#L460
I added new field `Public` to ImageDownloadArgs, so now information can be passed from outside method.
I hardcoded public value in one place:
https://github.com/lxc/lxd/blob/7973ab78af5fba6fa6610174ffb3c0bc7328f76e/lxd/instances_post.go#L102-L114

but I don't see case where image should be public during instance creation.

I also wonder can we use `Secret` field from `ImageDownloadsArgs` to distinguish is image public or not. @stgraber, What do you think?

Fixes  #9730