### PR TITLE
automatically add labels to PRs that contain doc changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+Documentation:
+- doc/**/*
+- .sphinx/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull request labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
Not sure if we have a guideline to not add labels to PRs, but if we don't, I think this would be very helpful to spot doc PRs.

Add a labeler that automatically labels pull requests that
contain changes to files in doc/ or .sphinx/.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>