### PR TITLE
lxd/instance/drivers: Specify number of USB ports

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -85,6 +85,9 @@ const qemuDeviceIDPrefix = "dev-lxd_"
 // qemuNetDevIDPrefix used as part of the name given QEMU netdevs generated from user added devices.
 const qemuNetDevIDPrefix = "lxd_"
 
+// qemuSparseUSBPorts is the amount of sparse USB ports for VMs.
+const qemuSparseUSBPorts = 4
+
 var errQemuAgentOffline = fmt.Errorf("LXD VM agent isn't currently running")
 
 var vmConsole = map[int]bool{}
@@ -2443,12 +2446,20 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 
 	// s390x doesn't really have USB.
 	if d.architecture != osarch.ARCH_64BIT_S390_BIG_ENDIAN {
+		// Record the number of USB devices.
+		totalUSBdevs := 0
+
+		for _, runConf := range devConfs {
+			totalUSBdevs += len(runConf.USBDevice)
+		}
+
 		devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 		err = qemuUSB.Execute(sb, map[string]interface{}{
 			"bus":           bus.name,
 			"devBus":        devBus,
 			"devAddr":       devAddr,
 			"multifunction": multi,
+			"ports":         totalUSBdevs + qemuSparseUSBPorts,
 		})
 		if err != nil {
 			return "", nil, err

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -513,6 +513,8 @@ var qemuUSB = template.Must(template.New("qemuUSB").Parse(`
 driver = "qemu-xhci"
 bus = "{{.devBus}}"
 addr = "{{.devAddr}}"
+p2 = "{{.ports}}"
+p3 = "{{.ports}}"
 {{if .multifunction -}}
 multifunction = "on"
 {{- end }}


### PR DESCRIPTION
Specify the number of USB2 and USB3 ports. The total number of ports is
4 + the number of configured USB devices. This fixes issues with some
USB devices which otherwise cannot be passed to the VM.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
