### PR TITLE
doc: improve placement of header

### DIFF
--- a/.sphinx/_templates/header.html
+++ b/.sphinx/_templates/header.html
@@ -9,6 +9,17 @@
         margin-bottom: auto;
         width: 60%;
     }
+    @media only screen and (min-width:1200px) {
+        ul.p-navigation__links {
+            margin-left: calc(50% - 40em);
+        }
+    }
+    @media only screen and (min-width:1370px) {
+        ul.p-navigation__links {
+            margin-left: calc(50% - 47em);
+            max-width: 1600px;
+        }
+    }
     ul.p-navigation__links li {
         padding: 0 5px;
         margin: 0 auto;


### PR DESCRIPTION
Improve the placement of the header a bit by adding a left margin
for wide displays.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>