### PR TITLE
Event: Add Project field to Event and rename group concept to projectName

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1555,3 +1555,6 @@ the `MIG-` prefix can be omitted
 
 This extension supersedes old `mig.gi` and `mig.ci` parameters which are kept for compatibility with old drivers and
 cannot be set together.
+
+## event\_project
+Expose the project an API event belongs to.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -499,6 +499,11 @@ definitions:
           source: /1.0/instances/c1
         type: object
         x-go-name: Metadata
+      project:
+        description: Project the event belongs to.
+        example: default
+        type: string
+        x-go-name: Project
       timestamp:
         description: Time at which the event was sent
         example: "2021-02-24T19:00:45.452649098-05:00"

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -44,10 +44,8 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 	}
 	defer c.Close() // This ensures the go routine below is ended when this function ends.
 
-	// If this request is an internal one initiated by another node wanting
-	// to watch the events on this node, set the listener to broadcast only
-	// local events.
-	listener, err := d.events.AddListener("default", false, c, strings.Split(typeStr, ","), "lxd-agent", false)
+	// As we don't know which project we are in, subscribe to events from all projects.
+	listener, err := d.events.AddListener("", true, c, strings.Split(typeStr, ","), "", true)
 	if err != nil {
 		return err
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -81,7 +81,7 @@ type Daemon struct {
 	cluster     *db.Cluster
 
 	// Event servers
-	devlxdEvents *events.Server
+	devlxdEvents *events.DevLXDServer
 	events       *events.Server
 
 	// Tasks registry for long-running background tasks
@@ -187,7 +187,7 @@ func (m *IdentityClientWrapper) DeclaredIdentity(ctx context.Context, declared m
 // newDaemon returns a new Daemon object with the given configuration.
 func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 	lxdEvents := events.NewServer(daemon.Debug, daemon.Verbose)
-	devlxdEvents := events.NewServer(daemon.Debug, daemon.Verbose)
+	devlxdEvents := events.NewDevLXDServer(daemon.Debug, daemon.Verbose)
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 
 	d := &Daemon{

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -118,7 +118,7 @@ var devlxdEventsGet = devLxdHandler{"/1.0/events", func(d *Daemon, c instance.In
 	}
 	defer conn.Close() // This ensures the go routine below is ended when this function ends.
 
-	listener, err := d.devlxdEvents.AddListener(strconv.Itoa(c.ID()), false, conn, strings.Split(typeStr, ","), "", false)
+	listener, err := d.devlxdEvents.AddListener(c.ID(), conn, strings.Split(typeStr, ","))
 	if err != nil {
 		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
 	}

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -1,0 +1,136 @@
+package events
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	log "gopkg.in/inconshreveable/log15.v2"
+
+	"github.com/gorilla/websocket"
+	"github.com/lxc/lxd/shared/logger"
+)
+
+// serverCommon represents an instance of a comon event server.
+type serverCommon struct {
+	debug   bool
+	verbose bool
+	lock    sync.Mutex
+}
+
+// listenerCommon describes a common event listener.
+type listenerCommon struct {
+	*websocket.Conn
+
+	messageTypes []string
+	ctx          context.Context
+	ctxCancel    func()
+	id           string
+	lock         sync.Mutex
+	location     string
+	pongsPending uint
+
+	// If true, this listener won't get events forwarded from other
+	// nodes. It only used by listeners created internally by LXD nodes
+	// connecting to other LXD nodes to get their local events only.
+	localOnly bool
+}
+
+func (e *listenerCommon) heartbeat() {
+	logger.Debug("Event listener server handler started", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
+
+	defer e.Close()
+
+	pingInterval := time.Second * 5
+	e.pongsPending = 0
+
+	e.SetPongHandler(func(msg string) error {
+		e.lock.Lock()
+		e.pongsPending = 0
+		e.lock.Unlock()
+		return nil
+	})
+
+	// Run a blocking reader to detect if the remote side is closed.
+	// We don't expect to get anything from the remote side, so this should remain blocked until disconnected.
+	go func() {
+		e.Conn.NextReader()
+		e.Close()
+	}()
+
+	for {
+		if e.IsClosed() {
+			return
+		}
+
+		e.lock.Lock()
+		if e.pongsPending > 2 {
+			e.lock.Unlock()
+			logger.Warn("Hearbeat for event listener handler timed out", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
+			return
+		}
+		err := e.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
+		if err != nil {
+			e.lock.Unlock()
+			return
+		}
+
+		e.pongsPending++
+		e.lock.Unlock()
+
+		select {
+		case <-time.After(pingInterval):
+		case <-e.ctx.Done():
+			return
+		}
+	}
+}
+
+// IsClosed returns true if the listener is closed.
+func (e *listenerCommon) IsClosed() bool {
+	return e.ctx.Err() != nil
+}
+
+// ID returns the listener ID.
+func (e *listenerCommon) ID() string {
+	return e.id
+}
+
+// Wait waits for a message on its active channel or the context is cancelled, then returns.
+func (e *listenerCommon) Wait(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-e.ctx.Done():
+	}
+}
+
+// Close Disconnects the listener.
+func (e *listenerCommon) Close() {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if e.IsClosed() {
+		return
+	}
+
+	logger.Debug("Event listener server handler stopped", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
+
+	e.Conn.Close()
+	e.ctxCancel()
+}
+
+// WriteJSON message to the connection.
+func (e *listenerCommon) WriteJSON(v interface{}) error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	return e.Conn.WriteJSON(v)
+}
+
+// WriteMessage to the connection.
+func (e *listenerCommon) WriteMessage(messageType int, data []byte) error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	return e.Conn.WriteMessage(messageType, data)
+}

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -27,7 +27,6 @@ type listenerCommon struct {
 	ctxCancel    func()
 	id           string
 	lock         sync.Mutex
-	location     string
 	pongsPending uint
 
 	// If true, this listener won't get events forwarded from other

--- a/lxd/events/devlxdEvents.go
+++ b/lxd/events/devlxdEvents.go
@@ -1,0 +1,141 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pborman/uuid"
+
+	"github.com/gorilla/websocket"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// DevLXDServer represents an instance of an devlxd event server.
+type DevLXDServer struct {
+	serverCommon
+
+	listeners map[string]*DevLXDListener
+}
+
+// NewDevLXDServer returns a new devlxd event server.
+func NewDevLXDServer(debug bool, verbose bool) *DevLXDServer {
+	server := &DevLXDServer{
+		serverCommon: serverCommon{
+			debug:   debug,
+			verbose: verbose,
+		},
+		listeners: map[string]*DevLXDListener{},
+	}
+
+	return server
+}
+
+// AddListener creates and returns a new event listener.
+func (s *DevLXDServer) AddListener(projectName string, allProjects bool, connection *websocket.Conn, messageTypes []string, location string, localOnly bool) (*DevLXDListener, error) {
+	if allProjects && projectName != "" {
+		return nil, fmt.Errorf("Cannot specify project name when listening for events on all projects")
+	}
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	listener := &DevLXDListener{
+		listenerCommon: listenerCommon{
+			Conn:         connection,
+			messageTypes: messageTypes,
+			location:     location,
+			localOnly:    localOnly,
+			ctx:          ctx,
+			ctxCancel:    ctxCancel,
+			id:           uuid.New(),
+		},
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.listeners[listener.id] != nil {
+		return nil, fmt.Errorf("A listener with ID %q already exists", listener.id)
+	}
+
+	s.listeners[listener.id] = listener
+
+	go listener.heartbeat()
+
+	return listener, nil
+}
+
+// Send broadcasts a custom event.
+func (s *DevLXDServer) Send(projectName string, eventType string, eventMessage interface{}) error {
+	encodedMessage, err := json.Marshal(eventMessage)
+	if err != nil {
+		return err
+	}
+	event := api.Event{
+		Type:      eventType,
+		Timestamp: time.Now(),
+		Metadata:  encodedMessage,
+		Project:   projectName,
+	}
+
+	return s.broadcast(event, false)
+}
+
+func (s *DevLXDServer) broadcast(event api.Event, isForward bool) error {
+	s.lock.Lock()
+	listeners := s.listeners
+	for _, listener := range listeners {
+		if isForward && listener.localOnly {
+			continue
+		}
+
+		if !shared.StringInSlice(event.Type, listener.messageTypes) {
+			continue
+		}
+
+		go func(listener *DevLXDListener, event api.Event) {
+			// Check that the listener still exists
+			if listener == nil {
+				return
+			}
+
+			// Make sure we're not done already
+			if listener.IsClosed() {
+				return
+			}
+
+			// Set the Location to the expected serverName
+			if event.Location == "" {
+				eventCopy := api.Event{}
+				err := shared.DeepCopy(&event, &eventCopy)
+				if err != nil {
+					return
+				}
+				eventCopy.Location = listener.location
+
+				event = eventCopy
+			}
+
+			listener.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			err := listener.WriteJSON(event)
+			if err != nil {
+				// Remove the listener from the list
+				s.lock.Lock()
+				delete(s.listeners, listener.id)
+				s.lock.Unlock()
+
+				listener.Close()
+			}
+		}(listener, event)
+	}
+	s.lock.Unlock()
+
+	return nil
+}
+
+// DevLXDListener describes a devlxd event listener.
+type DevLXDListener struct {
+	listenerCommon
+}

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -46,13 +46,13 @@ func (s *Server) AddListener(projectName string, allProjects bool, connection *w
 		listenerCommon: listenerCommon{
 			Conn:         connection,
 			messageTypes: messageTypes,
-			location:     location,
 			localOnly:    localOnly,
 			ctx:          ctx,
 			ctxCancel:    ctxCancel,
 			id:           uuid.New(),
 		},
 
+		location:    location,
 		allProjects: allProjects,
 		projectName: projectName,
 	}
@@ -178,6 +178,7 @@ func (s *Server) broadcast(event api.Event, isForward bool) error {
 type Listener struct {
 	listenerCommon
 
+	location    string
 	allProjects bool
 	projectName string
 }

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -86,9 +86,10 @@ func (s *Server) Send(projectName string, eventType string, eventMessage interfa
 		Type:      eventType,
 		Timestamp: time.Now(),
 		Metadata:  encodedMessage,
+		Project:   projectName,
 	}
 
-	return s.broadcast(projectName, event, false)
+	return s.broadcast(event, false)
 }
 
 // Forward to the local events dispatcher an event received from another node.
@@ -110,18 +111,18 @@ func (s *Server) Forward(id int64, event api.Event) {
 		}
 	}
 
-	err := s.broadcast("", event, true)
+	err := s.broadcast(event, true)
 	if err != nil {
 		logger.Warnf("Failed to forward event from member %d: %v", id, err)
 	}
 }
 
-func (s *Server) broadcast(projectName string, event api.Event, isForward bool) error {
+func (s *Server) broadcast(event api.Event, isForward bool) error {
 	s.lock.Lock()
 	listeners := s.listeners
 	for _, listener := range listeners {
 		// If the event is project specific, check if the listener is requesting events from that project.
-		if projectName != "" && !listener.allProjects && projectName != listener.projectName {
+		if event.Project != "" && !listener.allProjects && event.Project != listener.projectName {
 			continue
 		}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1374,7 +1374,7 @@ func (d *lxc) devlxdEventSend(eventType string, eventMessage map[string]interfac
 	event["timestamp"] = time.Now()
 	event["metadata"] = eventMessage
 
-	return d.state.DevlxdEvents.Send(strconv.Itoa(d.ID()), eventType, eventMessage)
+	return d.state.DevlxdEvents.Send(d.ID(), eventType, eventMessage)
 }
 
 // RegisterDevices calls the Register() function on all of the instance's devices.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1368,7 +1368,7 @@ func (d *lxc) IdmappedStorage(path string) idmap.IdmapStorageType {
 	return mode
 }
 
-func (d *lxc) devlxdEventSend(eventType string, eventMessage interface{}) error {
+func (d *lxc) devlxdEventSend(eventType string, eventMessage map[string]interface{}) error {
 	event := shared.Jmap{}
 	event["type"] = eventType
 	event["timestamp"] = time.Now()
@@ -4571,7 +4571,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				continue
 			}
 
-			msg := map[string]string{
+			msg := map[string]interface{}{
 				"key":       key,
 				"old_value": oldExpandedConfig[key],
 				"value":     d.expandedConfig[key],

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4123,7 +4123,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 				continue
 			}
 
-			msg := map[string]string{
+			msg := map[string]interface{}{
 				"key":       key,
 				"old_value": oldExpandedConfig[key],
 				"value":     d.expandedConfig[key],
@@ -5635,7 +5635,7 @@ func (d *qemu) cpuTopology(limit string) (int, int, int, map[uint64]uint64, map[
 	return nrSockets, nrCores, nrThreads, vcpus, numaNodes, nil
 }
 
-func (d *qemu) devlxdEventSend(eventType string, eventMessage interface{}) error {
+func (d *qemu) devlxdEventSend(eventType string, eventMessage map[string]interface{}) error {
 	event := shared.Jmap{}
 	event["type"] = eventType
 	event["timestamp"] = time.Now()

--- a/lxd/lifecycle/instance.go
+++ b/lxd/lifecycle/instance.go
@@ -2,11 +2,10 @@ package lifecycle
 
 import (
 	"fmt"
-	"net/url"
 
 	"github.com/lxc/lxd/lxd/operations"
-	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 )
 
 // Internal copy of the instance interface.
@@ -44,11 +43,7 @@ const (
 // Event creates the lifecycle event for an action on an instance.
 func (a InstanceAction) Event(inst instance, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("instance-%s", a)
-	u := fmt.Sprintf("/1.0/instances/%s", url.PathEscape(inst.Name()))
-
-	if inst.Project() != project.Default {
-		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(inst.Project()))
-	}
+	url := api.NewURL().Path(version.APIVersion, "instances", inst.Name()).Project(inst.Project())
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {
@@ -57,7 +52,7 @@ func (a InstanceAction) Event(inst instance, ctx map[string]interface{}) api.Eve
 
 	return api.EventLifecycle{
 		Action:    eventType,
-		Source:    u,
+		Source:    url.String(),
 		Context:   ctx,
 		Requestor: requestor,
 	}

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -49,7 +49,7 @@ type State struct {
 	Endpoints *endpoints.Endpoints
 
 	// Event server
-	DevlxdEvents *events.Server
+	DevlxdEvents *events.DevLXDServer
 	Events       *events.Server
 
 	// Firewall instance

--- a/shared/api/event.go
+++ b/shared/api/event.go
@@ -27,6 +27,12 @@ type Event struct {
 	//
 	// API extension: event_location
 	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+
+	// Project the event belongs to.
+	// Example: default
+	//
+	// API extension: event_project
+	Project string `yaml:"project,omitempty" json:"project,omitempty"`
 }
 
 // ToLogging creates log record for the event

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -303,6 +303,7 @@ var APIExtensions = []string{
 	"instance_get_full",
 	"qemu_metrics",
 	"gpu_mig_uuid",
+	"event_project",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Fixes #9718

- Adds `Project` field to `Event` struct to allow project info to be relayed between cluster members.
- Adds new `events.DevLXDServer` and `events.DevLXDListener` types and splits external event listeners from devlxd listeners (whilst sharing common logic).
- Updates VM lxd-agent devlxd listener to listen for events from all projects (and thus rely on LXD to only post it the correct events), rather than only accepting non-project events as it did previously.
- Tightens up the devlxd `devlxdEventSend` `eventMessage` type.
- Removes "lxd-agent" `Location` field value from VM devlxd events (to align with container devlxd events).

Example devlxd events:

Container:
```
root@c1:~# ./devlxd-client monitor
metadata:
  key: user.foo
  old_value: bar
  value: foobar
timestamp: null
type: config
```

VM:
```
root@v1:~# ./devlxd-client monitor
metadata:
  key: user.foo
  old_value: bar
  value: foobar
timestamp: null
type: config
```