### PR TITLE
Client: Maintain per-project event listeners and connections

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -15,6 +15,8 @@ type EventListener struct {
 	ctxCancel context.CancelFunc
 	err       error
 
+	// projectName stores which project this event listener is associated with (empty for all projects).
+	projectName string
 	targets     []*EventTarget
 	targetsLock sync.Mutex
 }

--- a/client/events.go
+++ b/client/events.go
@@ -83,11 +83,11 @@ func (e *EventListener) Disconnect() {
 	}
 
 	// Locate and remove it from the global list
-	for i, listener := range e.r.eventListeners {
+	for i, listener := range e.r.eventListeners[e.projectName] {
 		if listener == e {
-			copy(e.r.eventListeners[i:], e.r.eventListeners[i+1:])
-			e.r.eventListeners[len(e.r.eventListeners)-1] = nil
-			e.r.eventListeners = e.r.eventListeners[:len(e.r.eventListeners)-1]
+			copy(e.r.eventListeners[e.projectName][i:], e.r.eventListeners[e.projectName][i+1:])
+			e.r.eventListeners[e.projectName][len(e.r.eventListeners[e.projectName])-1] = nil
+			e.r.eventListeners[e.projectName] = e.r.eventListeners[e.projectName][:len(e.r.eventListeners[e.projectName])-1]
 			break
 		}
 	}

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -25,7 +25,8 @@ type ProtocolLXD struct {
 	server      *api.Server
 	chConnected chan struct{}
 
-	eventConn *websocket.Conn
+	// eventConns contains event listener connections associated to a project name (or empty for all projects).
+	eventConns map[string]*websocket.Conn
 
 	// eventListeners is a slice of event listeners associated to a project name (or empty for all projects).
 	eventListeners     map[string][]*EventListener

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -25,8 +25,10 @@ type ProtocolLXD struct {
 	server      *api.Server
 	chConnected chan struct{}
 
-	eventConn          *websocket.Conn
-	eventListeners     []*EventListener
+	eventConn *websocket.Conn
+
+	// eventListeners is a slice of event listeners associated to a project name (or empty for all projects).
+	eventListeners     map[string][]*EventListener
 	eventListenersLock sync.Mutex
 
 	http            *http.Client

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -3,6 +3,8 @@ package lxd
 import (
 	"fmt"
 
+	"github.com/gorilla/websocket"
+
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -103,6 +105,8 @@ func (r *ProtocolLXD) UseProject(name string) InstanceServer {
 		requireAuthenticated: r.requireAuthenticated,
 		clusterTarget:        r.clusterTarget,
 		project:              name,
+		eventConns:           make(map[string]*websocket.Conn),  // New project specific listener conns.
+		eventListeners:       make(map[string][]*EventListener), // New project specific listeners.
 	}
 }
 
@@ -121,6 +125,8 @@ func (r *ProtocolLXD) UseTarget(name string) InstanceServer {
 		bakeryInteractor:     r.bakeryInteractor,
 		requireAuthenticated: r.requireAuthenticated,
 		project:              r.project,
+		eventConns:           make(map[string]*websocket.Conn),  // New target specific listener conns.
+		eventListeners:       make(map[string][]*EventListener), // New target specific listeners.
 		clusterTarget:        name,
 	}
 }


### PR DESCRIPTION
This fixes an issue where if multiple event listeners were started, they would reuse the same event websocket connection (using the first requested project configuration), and potentially result in either missed events or inappropriate events being received by the event listener. By keying the event listeners and websocket connections by project filter configuration, we can ensure we only re-use an appropriate listener connection.

Fixes #9718