### PR TITLE
lxd/instance/qemu: Always set memory sharing on memory-backend-file

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -253,6 +253,7 @@ qom-type = "memory-backend-file"
 mem-path = "{{$hugepages}}"
 prealloc = "on"
 discard-data = "on"
+share = "on"
 {{- else}}
 qom-type = "memory-backend-memfd"
 {{- end }}


### PR DESCRIPTION
This fixes issues with virtiofs when run on top of hugepages with NUMA pinning.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>