### PR TITLE
lxc/exec: Don't send SIGWINCH when non-interactive

### DIFF
--- a/lxc/exec_unix.go
+++ b/lxc/exec_unix.go
@@ -42,6 +42,11 @@ func (c *cmdExec) controlSocketHandler(control *websocket.Conn) {
 		sig := <-ch
 		switch sig {
 		case unix.SIGWINCH:
+			if !c.interactive {
+				// Don't send SIGWINCH to non-interactive, this can lead to console corruption/crashes.
+				return
+			}
+
 			logger.Debugf("Received '%s signal', updating window geometry.", sig)
 			err := c.sendTermSize(control)
 			if err != nil {


### PR DESCRIPTION
Fixes a regression caused by 138387fc99a26b228ff117a1ed4bc9a7bcbb09e4