### PR TITLE
lxd: ensure file descriptors are closed before starting container

### DIFF
--- a/lxd/main_forkstart.go
+++ b/lxd/main_forkstart.go
@@ -53,6 +53,11 @@ func (c *cmdForkstart) Run(cmd *cobra.Command, args []string) error {
 	lxcpath := args[1]
 	configPath := args[2]
 
+	err := shared.CloseRange(uint32(os.Stderr.Fd())+1, ^uint32(0), shared.CLOSE_RANGE_CLOEXEC)
+	if err != nil {
+		return fmt.Errorf("Aborting attach to prevent leaking file descriptors into container")
+	}
+
 	d, err := liblxc.NewContainer(name, lxcpath)
 	if err != nil {
 		return fmt.Errorf("Error initializing container for start: %q", err)


### PR DESCRIPTION
LXC will check inherited fds again and close them but make sure we don't
even leak any and abort if we failed to close them.

Signed-off-by: Christian Brauner <brauner@kernel.org>