### PR TITLE
Allow inconsistent rsync copies with flag

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -534,6 +534,9 @@ type InstanceCopyArgs struct {
 	// API extension: container_incremental_copy
 	// Perform an incremental copy
 	Refresh bool
+
+	// API extension: instance_allow_inconsistent_copy
+	AllowInconsistent bool
 }
 
 // The InstanceSnapshotCopyArgs struct is used to pass additional options during instance copy.

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -500,6 +500,12 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 			}
 		}
 
+		if args.AllowInconsistent {
+			if !r.HasExtension("instance_allow_inconsistent_copy") {
+				return nil, fmt.Errorf("The source server is missing the required \"instance_allow_inconsistent_copy\" API extension")
+			}
+		}
+
 		// Allow overriding the target name
 		if args.Name != "" {
 			req.Name = args.Name
@@ -509,6 +515,7 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 		req.Source.InstanceOnly = args.InstanceOnly
 		req.Source.ContainerOnly = args.InstanceOnly // For legacy servers.
 		req.Source.Refresh = args.Refresh
+		req.Source.AllowInconsistent = args.AllowInconsistent
 	}
 
 	if req.Source.Live {

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1562,3 +1562,7 @@ Expose the project an API event belongs to.
 ## clustering\_evacuation\_live
 This adds `live-migrate` as a config option to `cluster.evacuate`, which forces live-migration
 of instances during cluster evacuation.
+
+## instance\_allow\_inconsistent\_copy
+Adds `allow_inconsistent` field to instance source on `POST /1.0/instances`. If true, rsync will ignore the 
+`Partial transfer due to vanished source files` (code 24) error when creating an instance from a copy. 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1714,6 +1714,11 @@ definitions:
         example: ubuntu/20.04
         type: string
         x-go-name: Alias
+      allow_inconsistent:
+        description: Whether to ignore errors when copying (e.g. for volatile files)
+        example: false
+        type: boolean
+        x-go-name: AllowInconsistent
       base-image:
         description: Base image fingerprint (for faster migration)
         example: ed56997f7c5b48e8d78986d2467a26109be6fb9f2d92e8c7b08eb8b6cec7629a

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -18,18 +18,19 @@ import (
 type cmdCopy struct {
 	global *cmdGlobal
 
-	flagNoProfiles    bool
-	flagProfile       []string
-	flagConfig        []string
-	flagDevice        []string
-	flagEphemeral     bool
-	flagInstanceOnly  bool
-	flagMode          string
-	flagStateless     bool
-	flagStorage       string
-	flagTarget        string
-	flagTargetProject string
-	flagRefresh       bool
+	flagNoProfiles        bool
+	flagProfile           []string
+	flagConfig            []string
+	flagDevice            []string
+	flagEphemeral         bool
+	flagInstanceOnly      bool
+	flagMode              string
+	flagStateless         bool
+	flagStorage           string
+	flagTarget            string
+	flagTargetProject     string
+	flagRefresh           bool
+	flagAllowInconsistent bool
 }
 
 func (c *cmdCopy) Command() *cobra.Command {
@@ -53,6 +54,7 @@ func (c *cmdCopy) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().BoolVar(&c.flagNoProfiles, "no-profiles", false, i18n.G("Create the instance with no profiles applied"))
 	cmd.Flags().BoolVar(&c.flagRefresh, "refresh", false, i18n.G("Perform an incremental copy"))
+	cmd.Flags().BoolVar(&c.flagAllowInconsistent, "allow-inconsistent", false, i18n.G("Ignore copy errors for volatile files"))
 
 	return cmd
 }
@@ -245,11 +247,12 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 	} else {
 		// Prepare the instance creation request
 		args := lxd.InstanceCopyArgs{
-			Name:         destName,
-			Live:         stateful,
-			InstanceOnly: instanceOnly,
-			Mode:         mode,
-			Refresh:      c.flagRefresh,
+			Name:              destName,
+			Live:              stateful,
+			InstanceOnly:      instanceOnly,
+			Mode:              mode,
+			Refresh:           c.flagRefresh,
+			AllowInconsistent: c.flagAllowInconsistent,
 		}
 
 		// Copy of an instance into a new instance

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -17,16 +17,17 @@ import (
 type cmdMove struct {
 	global *cmdGlobal
 
-	flagNoProfiles    bool
-	flagProfile       []string
-	flagConfig        []string
-	flagInstanceOnly  bool
-	flagDevice        []string
-	flagMode          string
-	flagStateless     bool
-	flagStorage       string
-	flagTarget        string
-	flagTargetProject string
+	flagNoProfiles        bool
+	flagProfile           []string
+	flagConfig            []string
+	flagInstanceOnly      bool
+	flagDevice            []string
+	flagMode              string
+	flagStateless         bool
+	flagStorage           string
+	flagTarget            string
+	flagTargetProject     string
+	flagAllowInconsistent bool
 }
 
 func (c *cmdMove) Command() *cobra.Command {
@@ -57,6 +58,7 @@ lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>
 	cmd.Flags().StringVarP(&c.flagStorage, "storage", "s", "", i18n.G("Storage pool name")+"``")
 	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
+	cmd.Flags().BoolVar(&c.flagAllowInconsistent, "allow-inconsistent", false, i18n.G("Ignore copy errors for volatile files"))
 
 	return cmd
 }
@@ -224,6 +226,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 	cpy.flagDevice = c.flagDevice
 	cpy.flagProfile = c.flagProfile
 	cpy.flagNoProfiles = c.flagNoProfiles
+	cpy.flagAllowInconsistent = c.flagAllowInconsistent
 
 	instanceOnly := c.flagInstanceOnly
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -188,6 +188,7 @@ type instanceCreateAsCopyOpts struct {
 	instanceOnly         bool              // Only copy the instance and not it's snapshots.
 	refresh              bool              // Refresh an existing target instance.
 	applyTemplateTrigger bool              // Apply deferred TemplateTriggerCopy.
+	allowInconsistent    bool              // Ignore some copy errors
 }
 
 // instanceCreateAsCopy create a new instance by copying from an existing instance.
@@ -363,7 +364,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			return nil, errors.Wrap(err, "Refresh instance")
 		}
 	} else {
-		err = pool.CreateInstanceFromCopy(inst, opts.sourceInstance, !opts.instanceOnly, op)
+		err = pool.CreateInstanceFromCopy(inst, opts.sourceInstance, !opts.instanceOnly, opts.allowInconsistent, op)
 		if err != nil {
 			return nil, errors.Wrap(err, "Create instance from copy")
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -570,6 +570,7 @@ func createFromCopy(d *Daemon, r *http.Request, projectName string, req *api.Ins
 			instanceOnly:         req.Source.InstanceOnly || req.Source.ContainerOnly,
 			refresh:              req.Source.Refresh,
 			applyTemplateTrigger: true,
+			allowInconsistent:    req.Source.AllowInconsistent,
 		}, op)
 		if err != nil {
 			return err

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -19,14 +19,15 @@ type Type struct {
 
 // VolumeSourceArgs represents the arguments needed to setup a volume migration source.
 type VolumeSourceArgs struct {
-	Name          string
-	Snapshots     []string
-	MigrationType Type
-	TrackProgress bool
-	MultiSync     bool
-	FinalSync     bool
-	Data          interface{} // Optional store to persist storage driver state between MultiSync phases.
-	ContentType   string
+	Name              string
+	Snapshots         []string
+	MigrationType     Type
+	TrackProgress     bool
+	MultiSync         bool
+	FinalSync         bool
+	Data              interface{} // Optional store to persist storage driver state between MultiSync phases.
+	ContentType       string
+	AllowInconsistent bool
 }
 
 // VolumeTargetArgs represents the arguments needed to setup a volume migration sink.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -795,7 +795,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 }
 
 // CreateInstanceFromCopy copies an instance volume and optionally its snapshots to new volume(s).
-func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
 	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name(), "src": src.Name(), "snapshots": snapshots})
 	logger.Debug("CreateInstanceFromCopy started")
 	defer logger.Debug("CreateInstanceFromCopy finished")
@@ -922,10 +922,11 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		bEndErrCh := make(chan error, 1)
 		go func() {
 			err := srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
-				Name:          src.Name(),
-				Snapshots:     snapshotNames,
-				MigrationType: migrationTypes[0],
-				TrackProgress: true, // Do use a progress tracker on sender.
+				Name:              src.Name(),
+				Snapshots:         snapshotNames,
+				MigrationType:     migrationTypes[0],
+				TrackProgress:     true, // Do use a progress tracker on sender.
+				AllowInconsistent: allowInconsistent,
 			}, op)
 
 			if err != nil {

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -101,7 +101,7 @@ func (b *mockBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io
 	return nil, nil, nil
 }
 
-func (b *mockBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, op *operations.Operation) error {
+func (b *mockBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -170,7 +170,14 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol Volume, conn io.ReadW
 		path := shared.AddSlash(mountPath)
 
 		d.Logger().Debug("Sending filesystem volume", log.Ctx{"volName": vol.name, "path": path, "bwlimit": bwlimit, "rsyncArgs": rsyncArgs})
-		return rsync.Send(vol.name, path, conn, wrapper, volSrcArgs.MigrationType.Features, bwlimit, s.OS.ExecPath, rsyncArgs...)
+		err := rsync.Send(vol.name, path, conn, wrapper, volSrcArgs.MigrationType.Features, bwlimit, s.OS.ExecPath, rsyncArgs...)
+
+		status, _ := shared.ExitStatus(err)
+		if volSrcArgs.AllowInconsistent && status == 24 {
+			return nil
+		}
+
+		return err
 	}
 
 	// Define function to send a block volume.

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -45,7 +45,7 @@ type Pool interface {
 	FillInstanceConfig(inst instance.Instance, config map[string]string) error
 	CreateInstance(inst instance.Instance, op *operations.Operation) error
 	CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error)
-	CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, op *operations.Operation) error
+	CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error
 	CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error
 	CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
 	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -538,11 +538,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -552,7 +552,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1084,8 +1084,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1128,7 +1128,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1138,7 +1138,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1204,7 +1204,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1214,7 +1214,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1524,8 +1524,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1533,7 +1533,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1666,15 +1666,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1837,11 +1837,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Flüchtiger Container"
@@ -1869,11 +1869,11 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 #, fuzzy
 msgid ""
 "Execute commands in instances\n"
@@ -1968,7 +1968,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1978,7 +1978,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 #, fuzzy
 msgid "Failed to get the new instance name"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2014,7 +2014,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2253,6 +2253,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2354,7 +2358,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3069,11 +3073,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -3227,7 +3231,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3237,7 +3241,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3420,7 +3424,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3499,7 +3503,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3567,7 +3571,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Pause instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3654,12 +3658,12 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3780,7 +3784,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -4536,7 +4540,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4615,35 +4619,35 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 #, fuzzy
 msgid "The --mode flag can't be used with --storage"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 #, fuzzy
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4681,7 +4685,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4745,7 +4749,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4763,11 +4767,11 @@ msgstr "unbekannter entfernter Instanz Name: %q"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4776,7 +4780,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4863,7 +4867,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -4969,7 +4973,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -5040,21 +5044,21 @@ msgstr "Zustand des laufenden Containers sichern oder nicht"
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 #, fuzzy
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 #, fuzzy
 msgid "You must specify a destination instance name when using --target"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5459,7 +5463,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
@@ -5521,7 +5525,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6006,7 +6010,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -6245,7 +6249,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -334,11 +334,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -721,7 +721,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -831,8 +831,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -883,7 +883,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -930,7 +930,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1242,8 +1242,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1251,7 +1251,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1375,15 +1375,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1537,11 +1537,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1563,11 +1563,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1654,7 +1654,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1695,7 +1695,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1856,7 +1856,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1926,6 +1926,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2686,11 +2690,11 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2831,7 +2835,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2839,7 +2843,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3020,7 +3024,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3096,7 +3100,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3163,7 +3167,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3250,11 +3254,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4080,7 +4084,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4155,31 +4159,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4215,7 +4219,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4275,7 +4279,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4293,11 +4297,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4306,7 +4310,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4392,7 +4396,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4491,7 +4495,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4553,19 +4557,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4764,7 +4768,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4793,7 +4797,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5039,7 +5043,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5246,7 +5250,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -531,12 +531,12 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -545,7 +545,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -926,7 +926,7 @@ msgstr "Cacheado: %s"
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1038,8 +1038,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1091,7 +1091,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1458,8 +1458,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1467,7 +1467,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1592,15 +1592,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1754,11 +1754,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1781,11 +1781,11 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1884,7 +1884,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 #, fuzzy
 msgid "Failed to get the new instance name"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1917,7 +1917,7 @@ msgstr "Huella dactilar: %s"
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2150,6 +2150,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2250,7 +2254,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -2919,11 +2923,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -3074,7 +3078,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -3082,7 +3086,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3261,7 +3265,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3337,7 +3341,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3404,7 +3408,7 @@ msgstr "Contraseña admin para %s:"
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3491,12 +3495,12 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -3611,7 +3615,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4331,7 +4335,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4406,33 +4410,33 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 #, fuzzy
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4468,7 +4472,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4528,7 +4532,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4546,11 +4550,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4559,7 +4563,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4647,7 +4651,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4747,7 +4751,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4809,19 +4813,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -5067,7 +5071,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5102,7 +5106,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5405,7 +5409,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5619,7 +5623,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -532,11 +532,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -860,7 +860,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -955,7 +955,7 @@ msgstr "Créé : %s"
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1070,8 +1070,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1131,7 +1131,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiez le conteneur sans ses instantanés"
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
@@ -1207,7 +1207,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr "Créé : %s"
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1539,8 +1539,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1548,7 +1548,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1675,15 +1675,15 @@ msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr "Désactiver l'allocation pseudo-terminal"
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
@@ -1848,11 +1848,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
@@ -1883,11 +1883,11 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Event type to listen for"
 msgstr "Type d'évènements à surveiller"
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 #, fuzzy
 msgid ""
 "Execute commands in instances\n"
@@ -1990,7 +1990,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2000,7 +2000,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to create alias %s"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 #, fuzzy
 msgid "Failed to get the new instance name"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2035,7 +2035,7 @@ msgstr "Empreinte : %s"
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
@@ -2204,7 +2204,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2281,6 +2281,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2387,7 +2391,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3139,12 +3143,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 #, fuzzy
 msgid "Migration API failure"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -3301,7 +3305,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -3311,7 +3315,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -3496,7 +3500,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -3585,7 +3589,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
@@ -3654,7 +3658,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Pause instances"
 msgstr "Création du conteneur"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3742,12 +3746,12 @@ msgstr "Profil %s supprimé de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -3870,7 +3874,7 @@ msgstr "Copie de l'image : %s"
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -4654,7 +4658,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -4735,31 +4739,31 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4804,7 +4808,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4868,7 +4872,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4886,11 +4890,11 @@ msgstr "Transfert de l'image : %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4899,7 +4903,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -4987,7 +4991,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -5096,7 +5100,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr "Publié : %s"
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -5164,21 +5168,21 @@ msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur
 msgid "YES"
 msgstr "OUI"
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr "Il est impossible de passer -t et -T simultanément"
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 #, fuzzy
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 #, fuzzy
 msgid "You must specify a destination instance name when using --target"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -5628,7 +5632,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
@@ -5702,7 +5706,7 @@ msgstr ""
 "lxc publish [<remote>:]<container>[/<snapshot>] [<remote>:] [--"
 "alias=ALIAS...] [prop-key=prop-value...]"
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6220,7 +6224,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -6482,7 +6486,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
@@ -7964,7 +7968,7 @@ msgstr "oui"
 #~ msgstr ""
 #~ "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid ""
 #~ "List instances\n"
 #~ "\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -524,11 +524,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -536,7 +536,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -822,7 +822,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -916,7 +916,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,8 +1027,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1126,7 +1126,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1446,8 +1446,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1455,7 +1455,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1580,15 +1580,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1742,11 +1742,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1769,11 +1769,11 @@ msgstr "Il nome del container è: %s"
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1862,7 +1862,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1904,7 +1904,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2135,6 +2135,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2235,7 +2239,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -2909,11 +2913,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -3062,7 +3066,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3249,7 +3253,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3325,7 +3329,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3393,7 +3397,7 @@ msgstr "Password amministratore per %s: "
 msgid "Pause instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3480,11 +3484,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -3599,7 +3603,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
@@ -4319,7 +4323,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4396,31 +4400,31 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4517,7 +4521,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4535,11 +4539,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4548,7 +4552,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -4635,7 +4639,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -4733,7 +4737,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4795,20 +4799,20 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 #, fuzzy
 msgid "You must specify a destination instance name when using --target"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -5055,7 +5059,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "Creazione del container in corso"
@@ -5090,7 +5094,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -5393,7 +5397,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
@@ -5607,7 +5611,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -522,11 +522,11 @@ msgstr "--empty はイメージ名と同時に指定できません"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only はコピー元がスナップショットの場合は指定できません"
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles と --refresh は同時に指定できません"
 
@@ -534,7 +534,7 @@ msgstr "--no-profiles と --refresh は同時に指定できません"
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
@@ -834,7 +834,7 @@ msgstr "バックアップ:"
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -845,7 +845,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -928,7 +928,7 @@ msgstr "キャッシュ済: %s"
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -1040,8 +1040,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr "デバイス %s が %s から削除されました"
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1088,7 +1088,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `none`)"
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
@@ -1096,7 +1096,7 @@ msgstr "新しいインスタンスに適用するキー/値の設定"
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
@@ -1123,7 +1123,7 @@ msgstr "ストレージボリュームのタイプ、block もしくは filesyst
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
@@ -1147,7 +1147,7 @@ msgstr ""
 "自動更新フラグは、このイメージを最新に保つようにサーバに指示します。\n"
 "ソースはエイリアスで、かつパブリックである必要があります。"
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr "LXD サーバ内で、またはサーバ間でインスタンスをコピーします"
 
@@ -1163,7 +1163,7 @@ msgstr "プロファイルをコピーします"
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
@@ -1171,7 +1171,7 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1312,7 +1312,7 @@ msgstr "プロジェクトを作成します"
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
@@ -1465,8 +1465,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1474,7 +1474,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1603,15 +1603,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr "擬似端末の割り当てを無効にします"
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
@@ -1774,11 +1774,11 @@ msgstr ""
 "  これは 'lxc config get core.https_address' コマンドでチェックできます。\n"
 "  まだ使用可能でない場合は、アドレスを設定することもできます。"
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
@@ -1800,11 +1800,11 @@ msgstr "クラスターメンバーを待避させています: %s"
 msgid "Event type to listen for"
 msgstr "Listenするイベントタイプ"
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr "インスタンス内でコマンドを実行します"
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1906,7 +1906,7 @@ msgstr "FIRST SEEN"
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr "クラスタメンバへの接続に失敗しました"
 
@@ -1915,7 +1915,7 @@ msgstr "クラスタメンバへの接続に失敗しました"
 msgid "Failed to create alias %s"
 msgstr "エイリアス %s の作成に失敗しました"
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr "新しいインスタンス名が取得できません"
 
@@ -1947,7 +1947,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
@@ -2119,7 +2119,7 @@ msgstr "ストレージプールの設定値を取得します"
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
 
@@ -2192,6 +2192,10 @@ msgstr "設定されている自動でのインスタンスの有効期限設定
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
+msgstr ""
 
 #: lxc/action.go:117
 msgid "Ignore the instance state"
@@ -2295,7 +2299,7 @@ msgstr "インスタンスのみ"
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3118,11 +3122,11 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr "マイグレーション API が失敗しました"
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr "マイグレーションが失敗しました"
 
@@ -3268,7 +3272,7 @@ msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
@@ -3276,7 +3280,7 @@ msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動�
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
@@ -3457,7 +3461,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -3534,7 +3538,7 @@ msgstr "最適化されたストレージ"
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
@@ -3601,7 +3605,7 @@ msgstr "%s のパスワード: "
 msgid "Pause instances"
 msgstr "インスタンスを一時停止します"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
@@ -3690,11 +3694,11 @@ msgstr "プロファイル %s が %s から削除されました"
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
@@ -3807,7 +3811,7 @@ msgstr "既存のストレージボリュームのコピーの再読込と更新
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
@@ -4573,7 +4577,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -4648,31 +4652,31 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr "--mode と --storage は同時に指定できません"
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--mode と --target-project は同時に指定できません"
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr "--storage と --target は同時に指定できません"
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr "--target-project と --target は同時に指定できません"
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
@@ -4713,7 +4717,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
@@ -4790,7 +4794,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:20.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -4810,11 +4814,11 @@ msgstr "トランシーバータイプ: %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -4823,7 +4827,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -4910,7 +4914,7 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
@@ -5007,7 +5011,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr "使用済: %v"
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
@@ -5073,20 +5077,20 @@ msgstr "インスタンスの稼動状態のスナップショットを取得す
 msgid "YES"
 msgstr "YES"
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr "-t と -T は同時に指定できません"
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -5287,7 +5291,7 @@ msgstr "[<remote>:]<instance> [<snapshot name>]"
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 
@@ -5317,7 +5321,7 @@ msgstr "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
@@ -5572,7 +5576,7 @@ msgstr "[<remote>:]<project> <key>=<value>..."
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
@@ -5860,7 +5864,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8001,7 +8005,6 @@ msgstr "yes"
 #~ "lxc launch ubuntu:18.04 u1 < config.yaml\n"
 #~ "    config.yaml の設定を使ってインスタンスを作成し、起動します"
 
-#, c-format
 #~ msgid ""
 #~ "List instances\n"
 #~ "\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-01-04 13:30-0500\n"
+        "POT-Creation-Date: 2022-01-11 18:58+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -313,11 +313,11 @@ msgstr  ""
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid   "--instance-only can't be passed when the source is a snapshot"
 msgstr  ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid   "--no-profiles cannot be used with --refresh"
 msgstr  ""
 
@@ -325,7 +325,7 @@ msgstr  ""
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
@@ -598,7 +598,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179 lxc/storage.go:126 lxc/storage_volume.go:565
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179 lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -608,7 +608,7 @@ msgstr  ""
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid   "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
@@ -690,7 +690,7 @@ msgstr  ""
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -799,7 +799,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339 lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757 lxc/storage_volume.go:336 lxc/storage_volume.go:524 lxc/storage_volume.go:603 lxc/storage_volume.go:845 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1402 lxc/storage_volume.go:1434 lxc/storage_volume.go:1550 lxc/storage_volume.go:1641 lxc/storage_volume.go:1734 lxc/storage_volume.go:1771 lxc/storage_volume.go:1865 lxc/storage_volume.go:1937 lxc/storage_volume.go:2076
+#: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55 lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339 lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757 lxc/storage_volume.go:336 lxc/storage_volume.go:524 lxc/storage_volume.go:603 lxc/storage_volume.go:845 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1402 lxc/storage_volume.go:1434 lxc/storage_volume.go:1550 lxc/storage_volume.go:1641 lxc/storage_volume.go:1734 lxc/storage_volume.go:1771 lxc/storage_volume.go:1865 lxc/storage_volume.go:1937 lxc/storage_volume.go:2076
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -826,7 +826,7 @@ msgstr  ""
 msgid   "Compression algorithm to use (`none` for uncompressed)"
 msgstr  ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
@@ -834,7 +834,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
@@ -856,7 +856,7 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
@@ -875,7 +875,7 @@ msgid   "Copy images between servers\n"
         "It requires the source to be an alias and for it to be public."
 msgstr  ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid   "Copy instances within or in between LXD servers"
 msgstr  ""
 
@@ -891,7 +891,7 @@ msgstr  ""
 msgid   "Copy storage volumes"
 msgstr  ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
@@ -899,7 +899,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1034,7 +1034,7 @@ msgstr  ""
 msgid   "Create storage pools"
 msgstr  ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
@@ -1161,7 +1161,7 @@ msgstr  ""
 msgid   "Deletes a new cluster groups"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:117 lxc/cluster.go:199 lxc/cluster.go:248 lxc/cluster.go:295 lxc/cluster.go:347 lxc/cluster.go:376 lxc/cluster.go:426 lxc/cluster.go:509 lxc/cluster.go:594 lxc/cluster.go:745 lxc/cluster.go:807 lxc/cluster.go:905 lxc/cluster.go:984 lxc/cluster.go:1090 lxc/cluster.go:1109 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166 lxc/storage_volume.go:241 lxc/storage_volume.go:332 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:676 lxc/storage_volume.go:758 lxc/storage_volume.go:839 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1214 lxc/storage_volume.go:1398 lxc/storage_volume.go:1431 lxc/storage_volume.go:1544 lxc/storage_volume.go:1632 lxc/storage_volume.go:1731 lxc/storage_volume.go:1765 lxc/storage_volume.go:1863 lxc/storage_volume.go:1930 lxc/storage_volume.go:2071 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:117 lxc/cluster.go:199 lxc/cluster.go:248 lxc/cluster.go:295 lxc/cluster.go:347 lxc/cluster.go:376 lxc/cluster.go:426 lxc/cluster.go:509 lxc/cluster.go:594 lxc/cluster.go:745 lxc/cluster.go:807 lxc/cluster.go:905 lxc/cluster.go:984 lxc/cluster.go:1090 lxc/cluster.go:1109 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166 lxc/storage_volume.go:241 lxc/storage_volume.go:332 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:676 lxc/storage_volume.go:758 lxc/storage_volume.go:839 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1214 lxc/storage_volume.go:1398 lxc/storage_volume.go:1431 lxc/storage_volume.go:1544 lxc/storage_volume.go:1632 lxc/storage_volume.go:1731 lxc/storage_volume.go:1765 lxc/storage_volume.go:1863 lxc/storage_volume.go:1930 lxc/storage_volume.go:2071 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1234,15 +1234,15 @@ msgstr  ""
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid   "Disable pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
@@ -1384,11 +1384,11 @@ msgid   "Enable clustering on a single non-clustered LXD server\n"
         "  for the address if not yet set."
 msgstr  ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid   "Ephemeral instance"
 msgstr  ""
 
@@ -1410,11 +1410,11 @@ msgstr  ""
 msgid   "Event type to listen for"
 msgstr  ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid   "Execute commands in instances"
 msgstr  ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid   "Execute commands in instances\n"
         "\n"
         "The command is executed directly using exec, so there is no shell and\n"
@@ -1497,7 +1497,7 @@ msgstr  ""
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid   "Failed to connect to cluster member"
 msgstr  ""
 
@@ -1506,7 +1506,7 @@ msgstr  ""
 msgid   "Failed to create alias %s"
 msgstr  ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid   "Failed to get the new instance name"
 msgstr  ""
 
@@ -1537,7 +1537,7 @@ msgstr  ""
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
@@ -1683,7 +1683,7 @@ msgstr  ""
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid   "Group ID to run the command as (default 0)"
 msgstr  ""
 
@@ -1751,6 +1751,10 @@ msgstr  ""
 
 #: lxc/storage_volume.go:1769
 msgid   "Ignore any configured auto-expiry for the storage volume"
+msgstr  ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
 #: lxc/action.go:117
@@ -1847,7 +1851,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2489,11 +2493,11 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid   "Migration API failure"
 msgstr  ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid   "Migration operation failure"
 msgstr  ""
 
@@ -2597,7 +2601,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid   "Move instances within or in between LXD servers"
 msgstr  ""
 
@@ -2605,7 +2609,7 @@ msgstr  ""
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
@@ -2777,7 +2781,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -2853,7 +2857,7 @@ msgstr  ""
 msgid   "Override the source project"
 msgstr  ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
@@ -2920,7 +2924,7 @@ msgstr  ""
 msgid   "Pause instances"
 msgstr  ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid   "Perform an incremental copy"
 msgstr  ""
 
@@ -3002,11 +3006,11 @@ msgstr  ""
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
@@ -3119,7 +3123,7 @@ msgstr  ""
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
@@ -3796,7 +3800,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -3869,31 +3873,31 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid   "The --mode flag can't be used with --storage"
 msgstr  ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid   "The --mode flag can't be used with --target-project"
 msgstr  ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid   "The --storage flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid   "The --target-project flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
@@ -3927,7 +3931,7 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
@@ -3980,7 +3984,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:20.04\n"
         "Or for a virtual machine: lxc launch ubuntu:20.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655 lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655 lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -3998,11 +4002,11 @@ msgstr  ""
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -4011,7 +4015,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -4091,7 +4095,7 @@ msgstr  ""
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
@@ -4182,7 +4186,7 @@ msgstr  ""
 msgid   "Used: %v"
 msgstr  ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
@@ -4239,19 +4243,19 @@ msgstr  ""
 msgid   "YES"
 msgstr  ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid   "You can't pass -t and -T at the same time"
 msgstr  ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid   "You must specify a destination instance name when using --target"
 msgstr  ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -4443,7 +4447,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr  ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid   "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr  ""
 
@@ -4471,7 +4475,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -4703,7 +4707,7 @@ msgstr  ""
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
@@ -4887,7 +4891,7 @@ msgid   "lxc monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
         "    Move an instance between two hosts, renaming it if destination name differs.\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,11 +515,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -819,7 +819,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1011,8 +1011,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1110,7 +1110,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -1126,7 +1126,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1270,7 +1270,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1421,8 +1421,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1430,7 +1430,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1553,15 +1553,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1710,11 +1710,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1736,11 +1736,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2095,6 +2095,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2192,7 +2196,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2852,11 +2856,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2996,7 +3000,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -3004,7 +3008,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3183,7 +3187,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3259,7 +3263,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3326,7 +3330,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3413,11 +3417,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3530,7 +3534,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4236,7 +4240,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4311,31 +4315,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4371,7 +4375,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4431,7 +4435,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4449,11 +4453,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4462,7 +4466,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4547,7 +4551,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4641,7 +4645,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4703,19 +4707,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4914,7 +4918,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4943,7 +4947,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5189,7 +5193,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5396,7 +5400,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -545,11 +545,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -838,7 +838,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -931,7 +931,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1041,8 +1041,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1120,7 +1120,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1140,7 +1140,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1451,8 +1451,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1460,7 +1460,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1583,15 +1583,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1740,11 +1740,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1766,11 +1766,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1857,7 +1857,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2125,6 +2125,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2222,7 +2226,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2882,11 +2886,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -3026,7 +3030,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -3034,7 +3038,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3213,7 +3217,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3289,7 +3293,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3356,7 +3360,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3443,11 +3447,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3560,7 +3564,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4266,7 +4270,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4341,31 +4345,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4401,7 +4405,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4461,7 +4465,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4479,11 +4483,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4492,7 +4496,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4577,7 +4581,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4671,7 +4675,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4733,19 +4737,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4944,7 +4948,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4973,7 +4977,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5219,7 +5223,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5426,7 +5430,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -537,12 +537,12 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh só pode ser usado com containers"
@@ -552,7 +552,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -848,7 +848,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -859,7 +859,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
@@ -942,7 +942,7 @@ msgstr "Em cache: %s"
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1054,8 +1054,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1104,7 +1104,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1113,7 +1113,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiar imagens entre servidores"
@@ -1178,7 +1178,7 @@ msgstr "Copiar perfis"
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr "Criar projetos"
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1496,8 +1496,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1505,7 +1505,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1632,15 +1632,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr "Desabilitar alocação de pseudo-terminal"
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
@@ -1802,11 +1802,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1829,11 +1829,11 @@ msgstr "Nome de membro do cluster"
 msgid "Event type to listen for"
 msgstr "Tipo de evento a escutar"
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1920,7 +1920,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2197,6 +2197,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2296,7 +2300,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2971,11 +2975,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -3123,7 +3127,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -3131,7 +3135,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3310,7 +3314,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3386,7 +3390,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3453,7 +3457,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3540,12 +3544,12 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -3662,7 +3666,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
@@ -4402,7 +4406,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4478,35 +4482,35 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 #, fuzzy
 msgid "The --mode flag can't be used with --storage"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 #, fuzzy
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4542,7 +4546,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4602,7 +4606,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4620,11 +4624,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -4720,7 +4724,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -4826,7 +4830,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4888,19 +4892,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -5120,7 +5124,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -5149,7 +5153,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5413,7 +5417,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5621,7 +5625,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -539,11 +539,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -863,7 +863,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -947,7 +947,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1058,8 +1058,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1110,7 +1110,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1488,8 +1488,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1497,7 +1497,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1622,15 +1622,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1787,11 +1787,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1817,11 +1817,11 @@ msgstr "Копирование образа: %s"
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1913,7 +1913,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1922,7 +1922,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1954,7 +1954,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2186,6 +2186,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2289,7 +2293,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -2972,11 +2976,11 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -3126,7 +3130,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -3135,7 +3139,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3316,7 +3320,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3393,7 +3397,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3460,7 +3464,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3547,11 +3551,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3666,7 +3670,7 @@ msgstr "Копирование образа: %s"
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4399,7 +4403,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4475,31 +4479,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4535,7 +4539,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4595,7 +4599,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4613,11 +4617,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4626,7 +4630,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4713,7 +4717,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4813,7 +4817,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4875,19 +4879,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -5274,7 +5278,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
@@ -5331,7 +5335,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -5805,7 +5809,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -6040,7 +6044,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -425,11 +425,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -437,7 +437,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -729,7 +729,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -921,8 +921,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -965,7 +965,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1180,7 +1180,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1331,8 +1331,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1340,7 +1340,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1463,15 +1463,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1620,11 +1620,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1646,11 +1646,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1737,7 +1737,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1746,7 +1746,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1778,7 +1778,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -2005,6 +2005,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2102,7 +2106,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2762,11 +2766,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2906,7 +2910,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2914,7 +2918,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3093,7 +3097,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3169,7 +3173,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3236,7 +3240,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3323,11 +3327,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3440,7 +3444,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4221,31 +4225,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4281,7 +4285,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4341,7 +4345,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4359,11 +4363,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4372,7 +4376,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4551,7 +4555,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4613,19 +4617,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4824,7 +4828,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4853,7 +4857,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5099,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5306,7 +5310,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-01-04 13:30-0500\n"
+"POT-Creation-Date: 2022-01-11 18:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:156
+#: lxc/copy.go:158
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:85
+#: lxc/copy.go:87
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:167
+#: lxc/copy.go:169
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
+#: lxc/copy.go:128 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
 #: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:137
+#: lxc/copy.go:139
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -827,8 +827,8 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617
-#: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
-#: lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
+#: lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:55
+#: lxc/move.go:59 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764
 #: lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:49
+#: lxc/copy.go:45 lxc/init.go:49
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:51 lxc/move.go:57
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
+#: lxc/copy.go:50
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
+#: lxc/copy.go:54 lxc/move.go:60 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:56
+#: lxc/copy.go:55 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1237,8 +1237,8 @@ msgstr ""
 #: lxc/config_template.go:153 lxc/config_template.go:239
 #: lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79
 #: lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368
-#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
+#: lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111
 #: lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476
 #: lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
 #: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
@@ -1369,15 +1369,15 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:60
+#: lxc/exec.go:62
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/exec.go:56
+#: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:57
+#: lxc/exec.go:59
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -1526,11 +1526,11 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/exec.go:53
+#: lxc/exec.go:55
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:51
+#: lxc/copy.go:48 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -1552,11 +1552,11 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/exec.go:39
+#: lxc/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: lxc/exec.go:40
+#: lxc/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/move.go:275 lxc/move.go:349 lxc/move.go:401
+#: lxc/move.go:278 lxc/move.go:352 lxc/move.go:404
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:409
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: lxc/exec.go:55
+#: lxc/exec.go:57
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/exec.go:59
+#: lxc/exec.go:61
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
@@ -1911,6 +1911,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1769
 msgid "Ignore any configured auto-expiry for the storage volume"
+msgstr ""
+
+#: lxc/copy.go:57 lxc/move.go:61
+msgid "Ignore copy errors for volatile files"
 msgstr ""
 
 #: lxc/action.go:117
@@ -2008,7 +2012,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:415 lxc/init.go:364
+#: lxc/copy.go:418 lxc/init.go:364
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:293 lxc/move.go:363 lxc/move.go:415
+#: lxc/move.go:296 lxc/move.go:366 lxc/move.go:418
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:368 lxc/move.go:420
+#: lxc/move.go:319 lxc/move.go:371 lxc/move.go:423
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2812,7 +2816,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2999,7 +3003,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "Override the source project"
 msgstr ""
 
-#: lxc/exec.go:54
+#: lxc/exec.go:56
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -3142,7 +3146,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:56
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -3229,11 +3233,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:50
+#: lxc/copy.go:47 lxc/init.go:50
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:376
+#: lxc/copy.go:379
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:53 lxc/move.go:57
+#: lxc/copy.go:52 lxc/import.go:36 lxc/init.go:53 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -4127,31 +4131,31 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/move.go:159
+#: lxc/move.go:161
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:196
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:173
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:212
+#: lxc/move.go:214
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
-#: lxc/move.go:163
+#: lxc/move.go:165
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:169
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:183
+#: lxc/move.go:185
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -4187,7 +4191,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:280
+#: lxc/move.go:283
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -4247,7 +4251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
-#: lxc/copy.go:119 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
+#: lxc/copy.go:121 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:428
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -4265,11 +4269,11 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/image.go:155
+#: lxc/copy.go:49 lxc/image.go:155
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:335
+#: lxc/move.go:56 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4278,7 +4282,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:342 lxc/move.go:298
+#: lxc/copy.go:345 lxc/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -4363,7 +4367,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -4457,7 +4461,7 @@ msgstr ""
 msgid "Used: %v"
 msgstr ""
 
-#: lxc/exec.go:58
+#: lxc/exec.go:60
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
@@ -4519,19 +4523,19 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:92
+#: lxc/exec.go:94
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:96
+#: lxc/exec.go:98
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:80
+#: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:264 lxc/move.go:338 lxc/move.go:390
+#: lxc/copy.go:77 lxc/move.go:267 lxc/move.go:341 lxc/move.go:393
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: lxc/exec.go:38
+#: lxc/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -5212,7 +5216,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -317,4 +317,10 @@ type InstanceSource struct {
 	// Source project name (for copy and local image)
 	// Example: blah
 	Project string `json:"project,omitempty" yaml:"project,omitempty"`
+
+	// Whether to ignore errors when copying (e.g. for volatile files)
+	// Example: false
+	//
+	// API extension: instance_allow_inconsistent_copy
+	AllowInconsistent bool `json:"allow_inconsistent" yaml:"allow_inconsistent"`
 }

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -305,6 +305,7 @@ var APIExtensions = []string{
 	"gpu_mig_uuid",
 	"event_project",
 	"clustering_evacuation_live",
+	"instance_allow_inconsistent_copy",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds an `--allow-inconsistent` flag to both `lxc copy` and `lxc move`. This is plumbed through the API client, daemon, storage pool interface and storage drivers so that the rsync error code 24 (`Partial transfer due to vanished source files`) can be optionally ignored.

Closes #9706 