### PR TITLE
lxd/network: Fixes misspelling of interface.

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -312,7 +312,7 @@ func (n *bridge) Validate(config map[string]string) error {
 				rules[k] = validate.Optional(validate.IsNetworkAddress)
 			case "id":
 				rules[k] = validate.Optional(validate.IsInt64)
-			case "inteface":
+			case "interface":
 				rules[k] = validate.IsInterfaceName
 			case "ttl":
 				rules[k] = validate.Optional(validate.IsUint8)


### PR DESCRIPTION
Previously, the `tunnel.NAME.interface` config value will not have
been validated (as there is no default case in the containing switch
statement to catch invalid values).