### PR TITLE
Bug static ip on multiple bridged nics

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -814,7 +814,7 @@ func (d *nicBridged) Remove() error {
 		}
 
 		// Remove dnsmasq config if it exists (doesn't return error if file is missing).
-		err := dnsmasq.RemoveStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name())
+		err := dnsmasq.RemoveStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name(), d.Name())
 		if err != nil {
 			return err
 		}
@@ -862,7 +862,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	// If IP filtering is enabled, and no static IP in config, check if there is already a
 	// dynamically assigned static IP in dnsmasq config and write that back out in new config.
 	if (shared.IsTrue(d.config["security.ipv4_filtering"]) && ipv4Address == "") || (shared.IsTrue(d.config["security.ipv6_filtering"]) && ipv6Address == "") {
-		_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d.config["parent"], d.inst.Project(), d.inst.Name())
+		_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d.config["parent"], d.inst.Project(), d.inst.Name(), d.Name(), "")
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -876,7 +876,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 		}
 	}
 
-	err = dnsmasq.UpdateStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name(), netConfig, d.config["hwaddr"], ipv4Address, ipv6Address)
+	err = dnsmasq.UpdateStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name(), d.Name(), netConfig, d.config["hwaddr"], ipv4Address, ipv6Address)
 	if err != nil {
 		return err
 	}
@@ -959,7 +959,7 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) {
 
 	// Read current static DHCP IP allocation configured from dnsmasq host config (if exists).
 	// This covers the case when IPs are not defined in config, but have been assigned in managed DHCP.
-	_, IPv4Alloc, IPv6Alloc, err := dnsmasq.DHCPStaticAllocation(m["parent"], d.inst.Project(), d.inst.Name())
+	_, IPv4Alloc, IPv6Alloc, err := dnsmasq.DHCPStaticAllocation(m["parent"], d.inst.Project(), d.inst.Name(), d.Name(), "")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return
@@ -1017,6 +1017,7 @@ func (d *nicBridged) setFilters() (err error) {
 		opts := &dhcpalloc.Options{
 			ProjectName: d.inst.Project(),
 			HostName:    d.inst.Name(),
+			DeviceName:  d.Name(),
 			HostMAC:     mac,
 			Network:     d.network,
 		}

--- a/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
+++ b/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
@@ -92,6 +92,7 @@ type Network interface {
 type Options struct {
 	ProjectName string
 	HostName    string
+	DeviceName  string
 	HostMAC     net.HardwareAddr
 	Network     Network
 }
@@ -343,7 +344,7 @@ func AllocateTask(opts *Options, f func(*Transaction) error) error {
 	t := &Transaction{opts: opts}
 
 	// Read current static IP allocation configured from dnsmasq host config (if exists).
-	t.currentDHCPMAC, t.currentDHCPv4, t.currentDHCPv6, err = dnsmasq.DHCPStaticAllocation(opts.Network.Name(), opts.ProjectName, opts.HostName)
+	t.currentDHCPMAC, t.currentDHCPv4, t.currentDHCPv6, err = dnsmasq.DHCPStaticAllocation(opts.Network.Name(), opts.ProjectName, opts.HostName, opts.DeviceName, "")
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -392,7 +393,7 @@ func AllocateTask(opts *Options, f func(*Transaction) error) error {
 		}
 
 		// Write out new dnsmasq static host allocation config file.
-		err = dnsmasq.UpdateStaticEntry(opts.Network.Name(), opts.ProjectName, opts.HostName, opts.Network.Config(), opts.HostMAC.String(), IPv4Str, IPv6Str)
+		err = dnsmasq.UpdateStaticEntry(opts.Network.Name(), opts.ProjectName, opts.HostName, opts.DeviceName, opts.Network.Config(), opts.HostMAC.String(), IPv4Str, IPv6Str)
 		if err != nil {
 			return err
 		}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -352,7 +352,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 	entries := map[string][][]string{}
 	for _, inst := range insts {
 		// Go through all its devices (including profiles).
-		for k, d := range inst.ExpandedDevices() {
+		for deviceName, d := range inst.ExpandedDevices() {
 			// Skip uninteresting entries.
 			if d["type"] != "nic" {
 				continue
@@ -374,7 +374,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			}
 
 			// Fill in the hwaddr from volatile.
-			d, err = inst.FillNetworkDevice(k, d)
+			d, err = inst.FillNetworkDevice(deviceName, d)
 			if err != nil {
 				continue
 			}
@@ -386,7 +386,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			}
 
 			if (shared.IsTrue(d["security.ipv4_filtering"]) && d["ipv4.address"] == "") || (shared.IsTrue(d["security.ipv6_filtering"]) && d["ipv6.address"] == "") {
-				_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d["parent"], inst.Project(), inst.Name())
+				_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d["parent"], inst.Project(), inst.Name(), deviceName, "")
 				if err != nil && !os.IsNotExist(err) {
 					return err
 				}
@@ -400,7 +400,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 				}
 			}
 
-			entries[d["parent"]] = append(entries[d["parent"]], []string{d["hwaddr"], inst.Project(), inst.Name(), d["ipv4.address"], d["ipv6.address"]})
+			entries[d["parent"]] = append(entries[d["parent"]], []string{d["hwaddr"], inst.Project(), inst.Name(), d["ipv4.address"], d["ipv6.address"], deviceName})
 		}
 	}
 
@@ -441,6 +441,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			cName := entry[2]
 			ipv4Address := entry[3]
 			ipv6Address := entry[4]
+			deviceName := entry[5]
 			line := hwaddr
 
 			// Look for duplicates.
@@ -477,7 +478,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			}
 
 			// Generate the dhcp-host line.
-			err := dnsmasq.UpdateStaticEntry(network, projectName, cName, config, hwaddr, ipv4Address, ipv6Address)
+			err := dnsmasq.UpdateStaticEntry(network, projectName, cName, deviceName, config, hwaddr, ipv4Address, ipv6Address)
 			if err != nil {
 				return err
 			}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -124,6 +125,7 @@ var patches = []patch{
 	{name: "network_acl_remove_defaults", stage: patchPostDaemonStorage, run: patchNetworkACLRemoveDefaults},
 	{name: "clustering_server_cert_trust", stage: patchPreDaemonStorage, run: patchClusteringServerCertTrust},
 	{name: "warnings_remove_empty_node", stage: patchPostDaemonStorage, run: patchRemoveWarningsWithEmptyNode},
+	{name: "dnsmasq_entries_include_device_name", stage: patchPostDaemonStorage, run: patchDnsmasqEntriesIncludeDeviceName},
 }
 
 type patch struct {
@@ -187,6 +189,30 @@ func patchesApply(d *Daemon, stage patchStage) error {
 }
 
 // Patches begin here
+
+func patchDnsmasqEntriesIncludeDeviceName(name string, d *Daemon) error {
+	nodeId := strconv.Itoa(int(d.cluster.GetNodeID()))
+	return d.cluster.InstanceList(&db.InstanceFilter{Node: &nodeId}, func(inst db.Instance, proj db.Project, profiles []api.Profile) error {
+		for _, device := range inst.Devices {
+			if device.Type == db.TypeNIC && device.Config["nictype"] == "bridged" && device.Config["network"] != "" {
+				network := device.Config["network"]
+				hostsDir := shared.VarPath("networks", network, "dnsmasq.hosts")
+				currentEntryFilePath := path.Join(hostsDir, project.Instance(proj.Name, inst.Name))
+				_, err := os.Stat(currentEntryFilePath)
+				if os.IsNotExist(err) {
+					continue
+				}
+
+				newEntryFilePath := path.Join(hostsDir, project.Instance(proj.Name, strings.Join([]string{inst.Name, device.Name}, ".")))
+				err = os.Rename(currentEntryFilePath, newEntryFilePath)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
 
 func patchRemoveWarningsWithEmptyNode(name string, d *Daemon) error {
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -368,7 +368,7 @@ test_container_devices_nic_bridged() {
   fi
 
   # Check dnsmasq host config file is removed.
-  if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ] ; then
+  if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ] ; then
     echo "dnsmasq host config file not removed"
     false
   fi
@@ -379,24 +379,24 @@ test_container_devices_nic_bridged() {
 
   ls -lR "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/"
 
-  if ! grep "192.0.2.200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ; then
+  if ! grep "192.0.2.200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ; then
     echo "dnsmasq host config not updated with IPv4 address"
     false
   fi
 
-  if ! grep "2001:db8::200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ; then
+  if ! grep "2001:db8::200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ; then
     echo "dnsmasq host config not updated with IPv6 address"
     false
   fi
 
   lxc config device remove "${ctName}" eth0
 
-  if grep "192.0.2.200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ; then
+  if grep "192.0.2.200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ; then
     echo "dnsmasq host config still has old IPv4 address"
     false
   fi
 
-  if grep "2001:db8::200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ; then
+  if grep "2001:db8::200" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ; then
     echo "dnsmasq host config still has old IPv6 address"
     false
   fi
@@ -420,7 +420,7 @@ test_container_devices_nic_bridged() {
 
   lxc config device remove "${ctName}" eth0
   lxc stop -f "${ctName}"
-  if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ] ; then
+  if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ] ; then
     echo "dnsmasq host config file not removed from network"
     false
   fi
@@ -431,7 +431,7 @@ test_container_devices_nic_bridged() {
 
   # Check dnsmasq host file is created on add.
   lxc config device add "${ctName}" eth0 nic nictype=bridged parent="${brName}" name=eth0
-  if [ ! -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ] ; then
+  if [ ! -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ] ; then
     echo "dnsmasq host config file not created"
     false
   fi
@@ -439,7 +439,7 @@ test_container_devices_nic_bridged() {
   # Check connecting device to non-managed bridged.
   ip link add "${ctName}" type dummy
   lxc config device set "${ctName}" eth0 parent "${ctName}"
-  if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ] ; then
+  if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}.eth0" ] ; then
     echo "dnsmasq host config file not removed from old network"
     false
   fi

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -214,17 +214,17 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   # Remove static IP and check IP filter works with previous DHCP lease.
-  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0"
   lxc config device unset "${ctPrefix}A" eth0 ipv4.address
   lxc start "${ctPrefix}A"
-  if ! grep "192.0.2.2" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+  if ! grep "192.0.2.2" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0" ; then
     echo "dnsmasq host config doesnt contain previous lease as static IPv4 config"
     false
   fi
 
   lxc stop -f "${ctPrefix}A"
   lxc config device set "${ctPrefix}A" eth0 security.ipv4_filtering false
-  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0"
 
   # Simulate 192.0.2.2 being used by another container, next free IP is 192.0.2.3
   kill "$(grep ^pid "${LXD_DIR}"/networks/"${brName}"/dnsmasq.pid | cut -d' ' -f2)"
@@ -234,7 +234,7 @@ test_container_devices_nic_bridged_filtering() {
   lxc config device set "${ctPrefix}A" eth0 security.ipv4_filtering true
   lxc start "${ctPrefix}A"
 
-  if ! grep "192.0.2.3" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+  if ! grep "192.0.2.3" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0" ; then
     echo "dnsmasq host config doesnt contain sequentially allocated static IPv4 config"
     false
   fi
@@ -244,7 +244,7 @@ test_container_devices_nic_bridged_filtering() {
   lxc network set "${brName}" ipv4.dhcp.ranges "192.0.2.100-192.0.2.110"
   lxc start "${ctPrefix}A"
 
-  if ! grep "192.0.2.100" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+  if ! grep "192.0.2.100" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0" ; then
     echo "dnsmasq host config doesnt contain sequentially range allocated static IPv4 config"
     false
   fi
@@ -402,17 +402,17 @@ test_container_devices_nic_bridged_filtering() {
   lxc config device unset "${ctPrefix}A" eth0 ipv6.address
   lxc config device set "${ctPrefix}A" eth0 hwaddr 00:16:3e:92:f3:c1
   lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering false
-  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0"
   lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering true
   lxc start "${ctPrefix}A"
-  if ! grep "\\[2001:db8::216:3eff:fe92:f3c1\\]" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+  if ! grep "\\[2001:db8::216:3eff:fe92:f3c1\\]" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0" ; then
     echo "dnsmasq host config doesnt contain dynamically allocated static IPv6 config"
     false
   fi
 
   lxc stop -f "${ctPrefix}A"
   lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering false
-  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0"
 
   # Simulate SLAAC 2001:db8::216:3eff:fe92:f3c1 being used by another container, next free IP is 2001:db8::2
   kill "$(grep ^pid "${LXD_DIR}"/networks/"${brName}"/dnsmasq.pid | cut -d' ' -f2)"
@@ -421,7 +421,7 @@ test_container_devices_nic_bridged_filtering() {
   respawn_lxd "${LXD_DIR}" true
   lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering true
   lxc start "${ctPrefix}A"
-  if ! grep "\\[2001:db8::2\\]" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+  if ! grep "\\[2001:db8::2\\]" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A.eth0" ; then
     echo "dnsmasq host config doesnt contain sequentially allocated static IPv6 config"
     false
   fi

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -59,8 +59,8 @@ test_network() {
   v6_addr="$(lxc network get lxdt$$ ipv6.address | cut -d/ -f1)00"
   lxc config device set nettest eth0 ipv4.address "${v4_addr}"
   lxc config device set nettest eth0 ipv6.address "${v6_addr}"
-  grep -q "${v4_addr}.*nettest" "${LXD_DIR}/networks/lxdt$$/dnsmasq.hosts/nettest"
-  grep -q "${v6_addr}.*nettest" "${LXD_DIR}/networks/lxdt$$/dnsmasq.hosts/nettest"
+  grep -q "${v4_addr}.*nettest" "${LXD_DIR}/networks/lxdt$$/dnsmasq.hosts/nettest.eth0"
+  grep -q "${v6_addr}.*nettest" "${LXD_DIR}/networks/lxdt$$/dnsmasq.hosts/nettest.eth0"
   lxc start nettest
 
   lxc network list-leases lxdt$$ | grep STATIC | grep -q "${v4_addr}"


### PR DESCRIPTION
Appends the device name to files under `networks/<network>/dnsmasq.hosts`. These were previously named solely after the instance (and project) but this caused static IP allocation to break if multiple devices were attached.

Closes #9719 