### PR TITLE
Take extra precautions when calling tar

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -659,7 +659,7 @@ func (c *cmdImageImport) packImageDir(path string) (string, error) {
 	defer outFile.Close()
 
 	outFileName := outFile.Name()
-	shared.RunCommand("tar", "-C", path, "--numeric-owner", "--xattrs", "-cJf", outFileName, "rootfs", "templates", "metadata.yaml")
+	shared.RunCommand("tar", "-C", path, "--numeric-owner", "--restrict", "--force-local", "--xattrs", "-cJf", outFileName, "rootfs", "templates", "metadata.yaml")
 
 	return outFileName, nil
 }

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3779,7 +3779,7 @@ func patchMoveBackups(name string, d *Daemon) error {
 				// Create the tarball
 				backupPath := shared.VarPath("backups", ct.Name(), backup.Name())
 				path := filepath.Join(poolBackupPath, ct.Name(), backup.Name())
-				args := []string{"-cf", backupPath, "--xattrs", "-C", path, "--transform", "s,^./,backup/,", "."}
+				args := []string{"-cf", backupPath, "--restrict", "--force-local", "--xattrs", "-C", path, "--transform", "s,^./,backup/,", "."}
 				_, err = shared.RunCommand("tar", args...)
 				if err != nil {
 					return err

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -659,6 +659,8 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 			args := append(tarArgs, []string{
 				"-",
 				"--xattrs-include=*",
+				"--restrict",
+				"--force-local",
 				"-C", mountPath,
 			}...)
 

--- a/shared/archive_linux.go
+++ b/shared/archive_linux.go
@@ -31,6 +31,7 @@ func Unpack(file string, path string, blockBackend bool, runningInUserns bool, t
 			args = append(args, "--exclude=rootfs/dev/*")
 			args = append(args, "--exclude=rootfs/./dev/*")
 		}
+		args = append(args, "--restrict", "--force-local")
 		args = append(args, "-C", path, "--numeric-owner", "--xattrs-include=*")
 		args = append(args, extractArgs...)
 		args = append(args, "-")


### PR DESCRIPTION
https://www.gnu.org/software/tar/manual/html_node/Option-Summary.html:

--restrict:
  "[...] disables shell invocation from multi-volume menu."

--force-local:
  "[...] interpret the file name [...] as a local file,
  even if it looks like a remote tape drive name."

--one-file-system:
  "Prevents tar from recursing into directories that are
  on different file systems from the current directory."

The last one is only meaningful when creating archives.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>