### PR TITLE
lxc/config/file: allow overriding default remote by env variable

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -21,6 +21,7 @@ Name                            | Description
 `VISUAL`                        | What text editor to use (if `EDITOR` isn't set)
 `LXD_CONF`                      | Path to the LXC configuration directory
 `LXD_GLOBAL_CONF`               | Path to the global LXC configuration directory
+`LXC_REMOTE`                    | Name of the remote to use (overrides configured default remote)
 
 ## Server environment variable
 Name                            | Description

--- a/lxc/config/file.go
+++ b/lxc/config/file.go
@@ -64,8 +64,12 @@ func LoadConfig(path string) (*Config, error) {
 		c.Remotes[k] = v
 	}
 
-	// Set default remote if not defined.
-	if c.DefaultRemote == "" {
+	// If the environment specifies a remote this takes priority over what
+	// is defined in the configuration
+	envDefaultRemote := os.Getenv("LXC_REMOTE")
+	if len(envDefaultRemote) > 0 {
+		c.DefaultRemote = envDefaultRemote
+	} else if c.DefaultRemote == "" {
 		c.DefaultRemote = DefaultConfig.DefaultRemote
 	}
 


### PR DESCRIPTION
In some cases it's useful to override the default remote for a single
lxc command invocation instead of switch the default remote statically
in the configuration. Specifically in automated environments where you
deal with different remotes and parallel lxc command invocations happen
this is extremely helpful.

Signed-off-by: Simon Fels <simon.fels@canonical.com>