### PR TITLE
test: Ensure ebtables is legacy when driver is xtables.

### DIFF
--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -9,6 +9,13 @@ test_container_devices_nic_bridged_filtering() {
     false
   fi
 
+  if [ "$firewallDriver" = "xtables" ]; then
+    if readlink -f "$(command -v ebtables)" | grep -q nft; then
+      echo "==> SKIP: ebtables must be legacy version (try update-alternatives --set ebtables /usr/sbin/ebtables-legacy)"
+      return
+    fi
+  fi
+
   # Record how many nics we started with.
   startNicCount=$(find /sys/class/net | wc -l)
 


### PR DESCRIPTION
PR for #9666.

#9793 did not address this because the testing error was initially not reproducible. This was because the nftables driver was still being used (`nftables` must be uninstalled to force `xtables` if `xtables` is using the `nf_table` wrapper, i.e. `nft flush ruleset` does not work).

There is only one test in which this is required, and only `ebtables` needs to be legacy (`iptables` etc can be `nf_table`).