### PR TITLE
lxd/instance/drivers: Performs disk size check on stateful startup.

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -993,3 +993,26 @@ func (d *common) setCoreSched(pids []int) error {
 	_, err := shared.RunCommand(d.state.OS.ExecPath, args...)
 	return err
 }
+
+// getRootDiskDevice gets the name and configuration of the root disk device of an instance.
+func (d *common) getRootDiskDevice() (string, map[string]string, error) {
+	devices := d.ExpandedDevices()
+	if d.IsSnapshot() {
+		parentName, _, _ := shared.InstanceGetParentAndSnapshotName(d.name)
+
+		// Load the parent.
+		storageInstance, err := instance.LoadByProjectAndName(d.state, d.project, parentName)
+		if err != nil {
+			return "", nil, err
+		}
+		devices = storageInstance.ExpandedDevices()
+	}
+
+	// Retrieve the instance's storage pool.
+	name, configuration, err := shared.GetRootDiskDevice(devices.CloneNative())
+	if err != nil {
+		return "", nil, err
+	}
+
+	return name, configuration, nil
+}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -202,21 +202,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]str
 		return nil, errors.Wrap(err, "Invalid devices")
 	}
 
-	// Retrieve the container's storage pool.
-	var storageInstance instance.Instance
-	if d.IsSnapshot() {
-		parentName, _, _ := shared.InstanceGetParentAndSnapshotName(d.name)
-
-		// Load the parent.
-		storageInstance, err = instance.LoadByProjectAndName(d.state, d.project, parentName)
-		if err != nil {
-			return nil, errors.Wrap(err, "Invalid parent")
-		}
-	} else {
-		storageInstance = d
-	}
-
-	_, rootDiskDevice, err := shared.GetRootDiskDevice(storageInstance.ExpandedDevices().CloneNative())
+	_, rootDiskDevice, err := d.getRootDiskDevice()
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -237,21 +237,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]st
 	}
 
 	// Retrieve the container's storage pool.
-	var storageInstance instance.Instance
-	if d.IsSnapshot() {
-		parentName, _, _ := shared.InstanceGetParentAndSnapshotName(d.name)
-
-		// Load the parent.
-		storageInstance, err = instance.LoadByProjectAndName(d.state, d.project, parentName)
-		if err != nil {
-			return nil, errors.Wrap(err, "Invalid parent")
-		}
-	} else {
-		storageInstance = d
-	}
-
-	// Retrieve the instance's storage pool.
-	_, rootDiskDevice, err := shared.GetRootDiskDevice(storageInstance.ExpandedDevices().CloneNative())
+	_, rootDiskDevice, err := d.getRootDiskDevice()
 	if err != nil {
 		return nil, err
 	}
@@ -5345,7 +5331,7 @@ func (d *qemu) diskState() (map[string]api.InstanceStateDisk, error) {
 	}
 
 	// Get the root disk device config.
-	rootDiskName, _, err := shared.GetRootDiskDevice(d.ExpandedDevices().CloneNative())
+	rootDiskName, _, err := d.getRootDiskDevice()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ensures that disk.state on the instance root disk device is larger than
limits.memory on the instance (when performing a stateful start).

Closes #9723 