### PR TITLE
Fix live-migrate during evacuation and restore

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2722,7 +2722,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 				return errors.Wrap(err, "Failed to migrate instance")
 			}
 
-			if !isRunning {
+			if !isRunning || live {
 				continue
 			}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2717,7 +2717,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 
 			// Find the least loaded cluster member which supports the architecture.
 			err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-				targetNodeName, err = tx.GetNodeWithLeastInstances([]int{node.Architecture}, -1, "", nil)
+				targetNodeName, err = tx.GetNodeWithLeastInstances([]int{inst.Architecture()}, -1, "", nil)
 				if err != nil {
 					return err
 				}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4023,11 +4023,50 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 
 	if isRunning {
 		// Only certain keys can be changed on a running VM.
-		liveUpdateKeys := []string{"limits.memory"}
+		liveUpdateKeys := []string{
+			"limits.memory",
+			"security.agent.metrics",
+		}
+
+		isLiveUpdatable := func(key string) bool {
+			if strings.HasPrefix(key, "boot.") {
+				return true
+			}
+
+			if strings.HasPrefix(key, "cloud-init.") {
+				return true
+			}
+
+			if strings.HasPrefix(key, "environment.") {
+				return true
+			}
+
+			if strings.HasPrefix(key, "image.") {
+				return true
+			}
+
+			if strings.HasPrefix(key, "snapshots.") {
+				return true
+			}
+
+			if strings.HasPrefix(key, "user.") {
+				return true
+			}
+
+			if strings.HasPrefix(key, "volatile.") {
+				return true
+			}
+
+			if !shared.StringInSlice(key, liveUpdateKeys) {
+				return true
+			}
+
+			return false
+		}
 
 		// Check only keys that support live update have changed.
 		for _, key := range changedConfig {
-			if !strings.HasPrefix(key, "user.") && !shared.StringInSlice(key, liveUpdateKeys) {
+			if !isLiveUpdatable(key) {
 				return fmt.Errorf("Key %q cannot be updated when VM is running", key)
 			}
 		}

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -141,17 +141,17 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	// Check if the cluster member is evacuated.
-	if d.cluster.LocalNodeIsEvacuated() {
-		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
-	}
-
 	req := api.InstanceStatePut{}
 
 	// We default to -1 (i.e. no timeout) here instead of 0 (instant timeout).
 	req.Timeout = -1
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(err)
+	}
+
+	// Check if the cluster member is evacuated.
+	if d.cluster.LocalNodeIsEvacuated() && req.Action != "stop" {
+		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
 	}
 
 	// Don't mess with containers while in setup mode.


### PR DESCRIPTION
This fixes a number of issue with the evacuation logic especially when it comes to live-migration:

 1. LXD didn't allow the stateful stop of the instance
 2. A live-migrated instance shouldn't be started at the end of migration (it will happen as part of migration already)
 3. We should consider the instance architecture when looking for a compatible server, not for the source's primary architecture
 4. Live-migration should also be done on restore
 5. To allow proper restoration after a live-migration, we need to be able to update the live instance config

This also removes some code duplication, fixes the revert logic which was unfortunately quite broken and allows a lot more configuration keys to be changed live on virtual machines.