### PR TITLE
doc: use absolute URL for Swagger

### DIFF
--- a/.sphinx/_static/swagger-override.css
+++ b/.sphinx/_static/swagger-override.css
@@ -9,3 +9,7 @@
 .swagger-ui .response-col_description, .swagger-ui .parameters-col_description {
     width: 85%
 }
+
+.swagger-ui .information-container .url {
+    display: none;
+}

--- a/doc/api.md
+++ b/doc/api.md
@@ -10,7 +10,7 @@
 window.onload = function() {
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
-    url: "../rest-api.yaml",
+    url: window.location.pathname +"../rest-api.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
It seems like Swagger has a problem with relative URLs.
Test if using an absolute URL fixes the issue.

If it does, we should find a way to add the full URL automatically.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>