### PR TITLE
Growing a loop backed btrfs pool new note

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -391,7 +391,7 @@ sudo losetup -c <LOOPDEV>
 sudo btrfs filesystem resize max /var/lib/lxd/storage-pools/<POOL>/
 ```
 
-(NOTE: For users of the snap, use `/var/snap/lxd/common/lxd/` instead of `/var/lib/lxd/`)
+(NOTE: For users of the snap, use `/var/snap/lxd/common/mntns/var/snap/lxd/common/lxd/` instead of `/var/lib/lxd/`)
 - LOOPDEV refers to the mounted loop device (e.g. `/dev/loop8`) associated with the storage pool image.
 - The mounted loop devices can be found using the following command:
 ```bash


### PR DESCRIPTION
When lxd is installed via snap, like it happens in Ubuntu 20.04 (focal) the storage is mounted inside the namespace `/run/snapd/ns/lxd.mnt` and the command 
`sudo btrfs filesystem resize max /var/snap/lxd/common/lxd/storage-pools/<POOL>/` with `ERROR: not a btrfs filesystem: ....`.

Here I try to give the command required in this situation.