### PR TITLE
doc: fix broken links

### DIFF
--- a/doc/network-acls.md
+++ b/doc/network-acls.md
@@ -96,6 +96,7 @@ local and external traffic respectively.
 
 E.g. `source=@internal`
 
+(network-acls-bridge-limitations)=
 ## Bridge limitations
 
 Unlike OVN ACLs, `bridge` ACLs are applied *only* on the boundary between the bridge and the LXD host.

--- a/doc/network-forwards.md
+++ b/doc/network-forwards.md
@@ -41,13 +41,14 @@ The following network types support forwards. See each network type section for 
  - [bridge](#network-bridge)
  - [ovn](#network-ovn)
 
-
+(network-forwards-bridge)=
 ### network: bridge
 
 Any non-conflicting listen address is allowed.
 
 The listen address used cannot overlap with a subnet that is in use with another network.
 
+(network-forwards-ovn)=
 ### network: ovn
 
 The allowed listen addresses are those that are defined in the uplink network's `ipv{n}.routes` settings, and the

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -46,7 +46,7 @@ devices:
 
 Network forwards:
 
-Bridge networks support [network forwards](network-forwards.md#network-bridge).
+Bridge networks support {ref}`network forwards <network-forwards-bridge>`.
 
 Network configuration properties:
 
@@ -122,7 +122,7 @@ tunnel.NAME.port                     | integer   | vxlan                 | 0    
 tunnel.NAME.protocol                 | string    | standard mode         | -                         | Tunneling protocol ("vxlan" or "gre")
 tunnel.NAME.remote                   | string    | gre or vxlan          | -                         | Remote address for the tunnel (not necessary for multicast vxlan)
 tunnel.NAME.ttl                      | integer   | vxlan                 | 1                         | Specific TTL to use for multicast routing topologies
-security.acls                        | string    | -                     | -                         | Comma separated list of Network ACLs to apply to NICs connected to this network (see [Limitations](network-acls.md#bridge-limitations))
+security.acls                        | string    | -                     | -                         | Comma separated list of Network ACLs to apply to NICs connected to this network (see {ref}`network-acls-bridge-limitations`)
 security.acls.default.ingress.action | string    | security.acls         | reject                    | Action to use for ingress traffic that doesn't match any ACL rule
 security.acls.default.egress.action  | string    | security.acls         | reject                    | Action to use for egress traffic that doesn't match any ACL rule
 security.acls.default.ingress.logged | boolean   | security.acls         | false                     | Whether to log ingress traffic that doesn't match any ACL rule
@@ -369,7 +369,7 @@ lxc ls
 
 Network forwards:
 
-OVN networks support [network forwards](network-forwards.md#network-ovn).
+OVN networks support {ref}`network forwards <network-forwards-ovn>`.
 
 Network peers:
 


### PR DESCRIPTION
Linking to the automatic ID does not work in Sphinx when appending
the automatic ID to the md file name.
It works within a page because you don't need the file name, but
this is error prone (because the ID depends on the heading and
changes when the heading changes) and should be changed as well in
the future.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>