### PR TITLE
Implement server-side API filtering for storage volumes 

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1571,3 +1571,6 @@ Adds `allow_inconsistent` field to instance source on `POST /1.0/instances`. If 
 This adds an "ovn" section to the /1.0/networks/NAME/state API which contains additional state information relevant to 
 OVN networks:
 - chassis
+
+## storage\_volume\_api\_filtering
+Adds support for filtering the result of a GET request for storage volumes.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -153,7 +153,7 @@ by the object itself.
 To filter your results on certain values, filter is implemented for collections.
 A `filter` argument can be passed to a GET query against a collection.
 
-Filtering is available for the instance and image endpoints.
+Filtering is available for the instance, image and storage volume endpoints.
 
 There is no default value for filter which means that all results found will
 be returned. The following is the language used for the filter argument:

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -11594,6 +11594,11 @@ paths:
         in: query
         name: target
         type: string
+      - description: Collection filter
+        example: default
+        in: query
+        name: filter
+        type: string
       produces:
       - application/json
       responses:
@@ -12656,6 +12661,11 @@ paths:
         example: lxd01
         in: query
         name: target
+        type: string
+      - description: Collection filter
+        example: default
+        in: query
+        name: filter
         type: string
       produces:
       - application/json

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -307,6 +307,7 @@ var APIExtensions = []string{
 	"clustering_evacuation_live",
 	"instance_allow_inconsistent_copy",
 	"network_state_ovn",
+	"storage_volume_api_filtering",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
@stgraber, this PR adds server-side API filtering for storage volumes but I'm a little bit confused about filtering snapshots.
Default behavior allow us to filter by e.g. name, type, content_type but I don't see possibility to filter by snapshots.
Am I missing something? Should we implement additional behavior? E.g. by checking "/" in storage volume name?

Closes #9798