### PR TITLE
Report ovn network state

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1566,3 +1566,8 @@ of instances during cluster evacuation.
 ## instance\_allow\_inconsistent\_copy
 Adds `allow_inconsistent` field to instance source on `POST /1.0/instances`. If true, rsync will ignore the 
 `Partial transfer due to vanished source files` (code 24) error when creating an instance from a copy. 
+
+## network\_state\_ovn
+This adds an "ovn" section to the /1.0/networks/NAME/state API which contains additional state information relevant to 
+OVN networks:
+- chassis

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2697,6 +2697,8 @@ definitions:
         format: int64
         type: integer
         x-go-name: Mtu
+      ovn:
+        $ref: '#/definitions/NetworkStateOVN'
       state:
         description: Link state
         example: up
@@ -2851,6 +2853,15 @@ definitions:
         format: int64
         type: integer
         x-go-name: PacketsSent
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  NetworkStateOVN:
+    description: NetworkStateOVN represents OVN specific state
+    properties:
+      chassis:
+        description: OVN network chassis name
+        type: string
+        x-go-name: Chassis
     type: object
     x-go-package: github.com/lxc/lxd/shared/api
   NetworkStateVLAN:

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -352,3 +352,18 @@ func (o *OVS) HardwareOffloadingEnabled() bool {
 
 	return offload == "true"
 }
+
+// OVNSouthboundDBRemoteAddress gets the address of the southbound ovn database.
+func (o *OVS) OVNSouthboundDBRemoteAddress() (string, error) {
+	result, err := shared.RunCommand("ovs-vsctl", "get", "open_vswitch", ".", "external_ids:ovn-remote")
+	if err != nil {
+		return "", err
+	}
+
+	addr, err := unquote(strings.TrimSuffix(result, "\n"))
+	if err != nil {
+		return "", err
+	}
+
+	return addr, nil
+}

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -174,6 +174,11 @@ type NetworkState struct {
 	//
 	// API extension: network_state_vlan
 	VLAN *NetworkStateVLAN `json:"vlan" yaml:"vlan"`
+
+	// Additional OVN network information
+	//
+	// API extension: network_state_ovn
+	OVN *NetworkStateOVN `json:"ovn" yaml:"ovn"`
 }
 
 // NetworkStateAddress represents a network address
@@ -297,4 +302,14 @@ type NetworkStateVLAN struct {
 	// VLAN ID
 	// Example: 100
 	VID uint64 `json:"vid" yaml:"vid"`
+}
+
+// NetworkStateOVN represents OVN specific state
+//
+// swagger:model
+//
+// API extension: network_state_ovn
+type NetworkStateOVN struct {
+	// OVN network chassis name
+	Chassis string `json:"chassis" yaml:"chassis"`
 }

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -306,6 +306,7 @@ var APIExtensions = []string{
 	"event_project",
 	"clustering_evacuation_live",
 	"instance_allow_inconsistent_copy",
+	"network_state_ovn",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Implements `network.State` for the `OVN` network driver. 

Fixes #9232 when paired with #9817.