### PR TITLE
Add documentation about /etc/resolv.conf

### DIFF
--- a/doc/networks.md
+++ b/doc/networks.md
@@ -159,6 +159,10 @@ actual domain name is, you should prefix it with `~`.  Also,
 since the shell may expand the `~` character, you may need to
 include it in quotes.
 
+Note that the `/etc/resolv.conf` file must have `nameserver 127.0.0.53` on top
+in order for this to work. This can either be done by editing the file manually
+or using a tool like [resolvconf](https://wiki.debian.org/resolv.conf).
+
 In newer releases of systemd, the `systemd-resolve` command has been
 deprecated, however it is still provided for backwards compatibility
 (as of this writing).  The newer method to notify resolved is using


### PR DESCRIPTION
I've spend all day today figuring out why my DNS lookup wasn't working. Finally figured out how to do it, by adding `nameserver 127.0.0.53` to the top of `/etc/resolv.conf`.

Would it be useful to add this to the documentation like this?