### PR TITLE
Adds State function to network interface

### DIFF
--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/network/acl"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -1055,4 +1056,8 @@ func (n *common) peerUsedBy(peerName string, firstOnly bool) ([]string, error) {
 	}
 
 	return usedBy, nil
+}
+
+func (n *common) State() (*api.NetworkState, error) {
+	return resources.GetNetworkState(n.name)
 }

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -54,6 +54,7 @@ type Network interface {
 	handleDependencyChange(netName string, netConfig map[string]string, changedKeys []string) error
 
 	// Status.
+	State() (*api.NetworkState, error)
 	Leases(projectName string, clientType request.ClientType) ([]api.NetworkLease, error)
 
 	// Address Forwards.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1488,11 +1488,26 @@ func networkStateGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	name := mux.Vars(r)["name"]
+	networkName := mux.Vars(r)["name"]
 
-	state, err := resources.GetNetworkState(name)
-	if err != nil {
-		return response.SmartError(err)
+	projectName := queryParam(r, "project")
+	if projectName == "" {
+		projectName = project.Default
+	}
+
+	var state *api.NetworkState
+	var err error
+	n, networkLoadError := network.LoadByName(d.State(), projectName, networkName)
+	if networkLoadError == nil {
+		state, err = n.State()
+		if err != nil {
+			return response.SmartError(err)
+		}
+	} else {
+		state, err = resources.GetNetworkState(networkName)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.SyncResponse(true, state)


### PR DESCRIPTION
On `GET /1.0/networks/<name>/state` we currently call `resources.GetNetworkState` for all networks. This doesn't work for OVN networks. 

This change attempts loads the network on `GET /1.0/networks/<name>/state` and calls `network.State` instead, allowing for driver specific implemenations.

Partially addresses #9232 and along with #9813.