### PR TITLE
lxd/storage/btrfs: Add volume delete shortcut

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -156,6 +156,12 @@ func (d *btrfs) deleteSubvolume(rootPath string, recursion bool) error {
 		return errors.Wrapf(err, "Failed setting subvolume writable %q", rootPath)
 	}
 
+	// Attempt to delete the root subvol itself (short path).
+	err = destroy(rootPath)
+	if err == nil {
+		return nil
+	}
+
 	// Delete subsubvols.
 	if recursion {
 		// Get the subvolumes list.


### PR DESCRIPTION
Most people don't have nested subvolumes and recursively deleting
subvolumes can be time consuming and has additional restrictions on path
traversal that's caused issues to some users.

Closes #9479

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>