### PR TITLE
doc: enable automatically generated anchors

### DIFF
--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -24,6 +24,7 @@ myst_enable_extensions = [
 ]
 
 myst_linkify_fuzzy_links=False
+myst_heading_anchors = 7
 
 if os.path.exists("../doc/substitutions.yaml"):
     with open("../doc/substitutions.yaml", "r") as fd:

--- a/doc/doc-cheat-sheet.md
+++ b/doc/doc-cheat-sheet.md
@@ -187,30 +187,69 @@ Adhere to the following conventions:
 (a_section_target)=
 #### Referencing a section
 
-To reference a section within the documentation (either on the same page or on another page), add a target to that section and reference that target with MyST syntax.
+To reference a section within the documentation (on the same page or on another page), you can either add a target to it and reference that target, or you can use an automatically generated anchor in combination with the file name.
 
-(a_random_target)=
+Adhere to the following conventions:
+- Add targets for sections that are central and a "typical" place to link to, so you expect they will be linked frequently. For "one-off" links, use the automatically generated anchors.
+- Override the link text only when it is necessary. If you can use the section title as link text, do so, because the text will then update automatically if the title changes.
+- Never "override" the link text with the same text that would be generated automatically.
+
+##### Using a target
 
 You can add targets at any place in the documentation. However, if there is no heading or title for the targeted element, you must specify a link text.
+
+(a_random_target)=
 
 ```{list-table}
    :header-rows: 1
 
 * - Input
   - Output
+  - Output on GitHub
   - Description
 * - `(target_ID)=`
   -
+  - \(target_ID\)=
   - Adds the target ``target_ID``.
 * - `` {ref}`a_section_target` ``
   - {ref}`a_section_target`
+  - \{ref\}`a_section_target`
   - References a target that has a title.
 * - `` {ref}`link text <a_random_target>` ``
   - {ref}`link text <a_random_target>`
+  - \{ref\}`link text <a_random_target>`
   - References a target and specifies a title.
 ```
 
-While it is possible to use Markdown syntax to link to an automatically generated section anchor on a page, you should never do this because it is likely to cause a broken link in the future.
+##### Using an automatically generated anchor
+
+When using MyST syntax, you must always specify the file name, even if the link points to a section in the same file.
+When using Markdown syntax, you can leave out the file name when linking within the same file.
+
+```{list-table}
+   :header-rows: 1
+
+* - Input
+  - Output
+  - Output on GitHub
+  - Description
+* - `` {ref}`doc-cheat-sheet.md#referencing-a-section` ``
+  - {ref}`doc-cheat-sheet.md#referencing-a-section`
+  - \{ref\}`doc-cheat-sheet.md#referencing-a-section`
+  - References an automatically generated anchor.
+* - `[](#referencing-a-section)`
+  - [](#referencing-a-section)
+  -
+  - Do not use.
+* - `[link text](#referencing-a-section)`
+  - [link text](#referencing-a-section)
+  - [link text](#referencing-a-section)
+  - Preferred when overriding the link text.
+* - `` {ref}`link text <doc-cheat-sheet.md#referencing-a-section>` ``
+  - {ref}`link text <doc-cheat-sheet.md#referencing-a-section>`
+  - \{ref\}`link text <doc-cheat-sheet.md#referencing-a-section>`
+  - Alternative when overriding the link text.
+```
 
 ## Navigation
 


### PR DESCRIPTION
TBH, I'm not sure if we want this or not. It has a few advantages (see commit message), but it also makes things more complicated.
It also increases the size of the objects.inv file by a factor of ten (but from 1.3 KiB to 12.6 KiB, so we can probably live with that).

Enable
https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#auto-generated-header-anchors
Not sure if this really is a great improvement, since it adds more
options for linking, which will make it harder to be consistent.
It does allow for simpler links using Markdown syntax, but we can
only use those when overriding the link text (because otherwise,
they won't show up on GitHub at all).
When sticking to MyST syntax, linking gets a bit more complicated,
but we don't have to add manual targets for every link.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>