### PR TITLE
lxd/db: Fix storage_volumes sequence again

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -545,5 +545,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (57, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (58, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -97,8 +97,19 @@ var updates = map[int]schema.Update{
 	55: updateFromV54,
 	56: updateFromV55,
 	57: updateFromV56,
+	58: updateFromV57,
 }
 
+func updateFromV57(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+UPDATE sqlite_sequence SET seq = (
+    SELECT coalesce(max(max(coalesce(storage_volumes.id, 0)), max(coalesce(storage_volumes_snapshots.id, 0))), 0)
+    FROM storage_volumes, storage_volumes_snapshots)
+WHERE name='storage_volumes';
+`)
+
+	return err
+}
 func updateFromV56(tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (


### PR DESCRIPTION
The previous patch didn't account for both storage_volumes and
storage_volumes_snapshots being potentially empty.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>