### PR TITLE
lxd/instance/qemu: Enable HyperV flags on x86_64

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1246,15 +1246,23 @@ func (d *qemu) Start(stateful bool) error {
 		return err
 	}
 
-	// Enable extended topology information if needed.
-	cpuType := "host"
+	// Determine additional CPU flags.
+	cpuExtensions := []string{}
 
-	// Only x86_64 requires the use of topoext when SMT is used.
 	if d.architecture == osarch.ARCH_64BIT_INTEL_X86 {
+		// x86_64 can use hv_time to improve Windows guest performance.
+		cpuExtensions = append(cpuExtensions, "hv_passthrough")
+
 		_, _, nrThreads, _, _, err := d.cpuTopology(d.expandedConfig["limits.cpu"])
 		if err != nil && nrThreads > 1 {
-			cpuType = "host,topoext"
+			// x86_64 requires the use of topoext when SMT is used.
+			cpuExtensions = append(cpuExtensions, "topoext")
 		}
+	}
+
+	cpuType := "host"
+	if len(cpuExtensions) > 0 {
+		cpuType += "," + strings.Join(cpuExtensions, ",")
 	}
 
 	// Start QEMU.


### PR DESCRIPTION
This enables the Windows paravirtualization extensions in QEMU which
makes Windows think it's running on HyperV and therefore provides a good
performance improvement on Windows guests.

For Linux guests, all the VirtIO bits remain active and I've confirmed
that systemd-detect-virt and /proc/cpuinfo in our guests still look the
same.

Reported at: https://discuss.linuxcontainers.org/t/lxd-windows-server-2019-performance-validation/13159

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>