### PR TITLE
Instance migration consistency

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -854,6 +854,49 @@ func (d *btrfs) RenameVolume(vol Volume, newVolName string, op *operations.Opera
 	return genericVFSRenameVolume(d, vol, newVolName, op)
 }
 
+func (d *btrfs) readonlySnapshot(vol Volume) (string, *revert.Reverter, error) {
+	reverter := revert.New()
+
+	sourcePath := vol.MountPath()
+	poolPath := GetPoolMountPath(d.name)
+	tmpDir, err := ioutil.TempDir(poolPath, "backup.")
+	if err != nil {
+		return "", nil, err
+	}
+
+	reverter.Add(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	err = os.Chmod(tmpDir, 0100)
+	if err != nil {
+		reverter.Fail()
+		return "", nil, err
+	}
+
+	mountPath := filepath.Join(tmpDir, vol.name)
+
+	err = d.snapshotSubvolume(sourcePath, mountPath, true)
+	if err != nil {
+		reverter.Fail()
+		return "", nil, err
+	}
+
+	reverter.Add(func() {
+		d.deleteSubvolume(mountPath, true)
+	})
+
+	err = d.setSubvolumeReadonlyProperty(mountPath, true)
+	if err != nil {
+		reverter.Fail()
+		return "", nil, err
+	}
+
+	d.logger.Debug("Created read-only backup snapshot", log.Ctx{"sourcePath": sourcePath, "path": mountPath})
+
+	return mountPath, reverter, nil
+}
+
 // MigrateVolume sends a volume for migration.
 func (d *btrfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	// Handle simple rsync and block_and_rsync through generic.
@@ -1022,37 +1065,16 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 		// as they are copied to the tarball, as BTRFS allows us to take a quick snapshot without impacting
 		// the parent volume we do so here to ensure the backup taken is consistent.
 		if vol.contentType == ContentTypeFS {
-			sourcePath := vol.MountPath()
-			poolPath := GetPoolMountPath(d.name)
-			tmpDir, err := ioutil.TempDir(poolPath, "backup.")
-			if err != nil {
-				return errors.Wrapf(err, "Failed to create temporary directory under %q", poolPath)
-			}
-			defer os.RemoveAll(tmpDir)
-
-			err = os.Chmod(tmpDir, 0100)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to chmod %q", tmpDir)
-			}
-
-			// Override volume's mount path with location of snapshot so genericVFSBackupVolume reads
-			// from there instead of main volume.
-			vol.mountCustomPath = filepath.Join(tmpDir, vol.name)
-
-			// Create the read-only snapshot.
-			mountPath := vol.MountPath()
-			err = d.snapshotSubvolume(sourcePath, mountPath, true)
+			snapshotPath, reverter, err := d.readonlySnapshot(vol)
 			if err != nil {
 				return err
 			}
 
-			err = d.setSubvolumeReadonlyProperty(mountPath, true)
-			if err != nil {
-				return err
-			}
+			// Clean up the snapshot.
+			defer reverter.Fail()
 
-			d.logger.Debug("Created read-only backup snapshot", log.Ctx{"sourcePath": sourcePath, "path": mountPath})
-			defer d.deleteSubvolume(mountPath, true)
+			// Set the path of the volume to the path of the fast snapshot so the migration reads from there instead.
+			vol.mountCustomPath = snapshotPath
 		}
 
 		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -95,7 +95,7 @@ func (d *lvm) Info() Info {
 		Remote:            d.isRemote(),
 		VolumeTypes:       []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
 		BlockBacking:      true,
-		RunningCopyFreeze: false,
+		RunningCopyFreeze: true,
 		DirectIO:          true,
 		MountedRoot:       false,
 	}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1468,6 +1468,59 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 	return nil
 }
 
+func (d *zfs) readonlySnapshot(vol Volume) (string, *revert.Reverter, error) {
+	reverter := revert.New()
+
+	poolPath := GetPoolMountPath(d.name)
+	tmpDir, err := ioutil.TempDir(poolPath, "backup.")
+	if err != nil {
+		return "", nil, err
+	}
+	reverter.Add(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	err = os.Chmod(tmpDir, 0100)
+	if err != nil {
+		reverter.Fail()
+		return "", nil, err
+	}
+
+	// Create a temporary snapshot.
+	srcSnapshot := fmt.Sprintf("%s@backup-%s", d.dataset(vol, false), uuid.New())
+	_, err = shared.RunCommand("zfs", "snapshot", srcSnapshot)
+	if err != nil {
+		reverter.Fail()
+		return "", nil, err
+	}
+	reverter.Add(func() {
+		shared.RunCommand("zfs", "destroy", srcSnapshot)
+	})
+	d.logger.Debug("Created backup snapshot", log.Ctx{"dev": srcSnapshot})
+
+	// Mount the snapshot directly (not possible through ZFS tools), so that the volume is
+	// already mounted by the time genericVFSBackupVolume tries to mount it below,
+	// thus preventing it from trying to unmount it at the end, as this is a custom snapshot,
+	// the normal mount and unmount logic will fail.
+	err = TryMount(srcSnapshot, tmpDir, "zfs", 0, "")
+	if err != nil {
+		reverter.Fail()
+		return "", nil, err
+	}
+	d.logger.Debug("Mounted ZFS snapshot dataset", log.Ctx{"dev": srcSnapshot, "path": vol.MountPath()})
+
+	reverter.Add(func() {
+		_, err := forceUnmount(tmpDir)
+		if err != nil {
+			return
+		}
+
+		d.logger.Debug("Unmounted ZFS snapshot dataset", log.Ctx{"dev": srcSnapshot, "path": tmpDir})
+	})
+
+	return tmpDir, reverter, nil
+}
+
 // BackupVolume creates an exported version of a volume.
 func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	// Handle the non-optimized tarballs through the generic packer.
@@ -1476,49 +1529,16 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 		// as they are copied to the tarball, as ZFS allows us to take a quick snapshot without impacting
 		// the parent volume we do so here to ensure the backup taken is consistent.
 		if vol.contentType == ContentTypeFS {
-			poolPath := GetPoolMountPath(d.name)
-			tmpDir, err := ioutil.TempDir(poolPath, "backup.")
-			if err != nil {
-				return errors.Wrapf(err, "Failed to create temporary directory under %q", poolPath)
-			}
-			defer os.RemoveAll(tmpDir)
-
-			err = os.Chmod(tmpDir, 0100)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to chmod %q", tmpDir)
-			}
-
-			// Create a temporary snapshot.
-			srcSnapshot := fmt.Sprintf("%s@backup-%s", d.dataset(vol, false), uuid.New())
-			_, err = shared.RunCommand("zfs", "snapshot", srcSnapshot)
+			snapshotPath, reverter, err := d.readonlySnapshot(vol)
 			if err != nil {
 				return err
 			}
-			defer shared.RunCommand("zfs", "destroy", srcSnapshot)
-			d.logger.Debug("Created backup snapshot", log.Ctx{"dev": srcSnapshot})
 
-			// Override volume's mount path with location of snapshot so genericVFSBackupVolume reads
-			// from there instead of main volume.
-			vol.mountCustomPath = tmpDir
+			// Clean up the snapshot.
+			defer reverter.Fail()
 
-			// Mount the snapshot directly (not possible through ZFS tools), so that the volume is
-			// already mounted by the time genericVFSBackupVolume tries to mount it below,
-			// thus preventing it from trying to unmount it at the end, as this is a custom snapshot,
-			// the normal mount and unmount logic will fail.
-			err = TryMount(srcSnapshot, vol.MountPath(), "zfs", 0, "")
-			if err != nil {
-				return err
-			}
-			d.logger.Debug("Mounted ZFS snapshot dataset", log.Ctx{"dev": srcSnapshot, "path": vol.MountPath()})
-
-			defer func(dataset string, mountPath string) {
-				_, err := forceUnmount(mountPath)
-				if err != nil {
-					return
-				}
-
-				d.logger.Debug("Unmounted ZFS snapshot dataset", log.Ctx{"dev": dataset, "path": mountPath})
-			}(srcSnapshot, vol.MountPath())
+			// Set the path of the volume to the path of the fast snapshot so the migration reads from there instead.
+			vol.mountCustomPath = snapshotPath
 		}
 
 		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1382,6 +1382,19 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	// Handle simple rsync and block_and_rsync through generic.
 	if volSrcArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSrcArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
+		// If volume is filesystem type, create a fast snapshot to ensure migration is consistent.
+		if vol.contentType == ContentTypeFS && !vol.IsSnapshot() {
+			snapshotPath, reverter, err := d.readonlySnapshot(vol)
+			if err != nil {
+				return err
+			}
+
+			// Clean up the snapshot.
+			defer reverter.Fail()
+
+			// Set the path of the volume to the path of the fast snapshot so the migration reads from there instead.
+			vol.mountCustomPath = snapshotPath
+		}
 		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
 	} else if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_ZFS {
 		return ErrNotSupported


### PR DESCRIPTION
* For `zfs` and `btrfs` takes a fast snapshot for use as the source of the volume migration. 
* In storage pool `MigrateInstance` method, only freezes the instance during the migration if `RunningCopyFreeze` is true *and* `AllowInconsistent` is false (so instance is never frozen with supported drivers, and optionally frozen for users invoking copy/migrate with and without the `--allow-inconsistent` flag.
* Sets `RunningCopyFreeze` to true for the `lvm` driver.

Closes #9789 