### PR TITLE
Fix recent regressions (qemu & db)

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -545,5 +545,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (58, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (59, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -98,6 +98,20 @@ var updates = map[int]schema.Update{
 	56: updateFromV55,
 	57: updateFromV56,
 	58: updateFromV57,
+	59: updateFromV58,
+}
+
+func updateFromV58(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+UPDATE sqlite_sequence SET seq = (
+    SELECT max(
+        (SELECT coalesce(max(storage_volumes.id), 0) FROM storage_volumes),
+        (SELECT coalesce(max(storage_volumes_snapshots.id), 0)
+    FROM storage_volumes_snapshots)))
+WHERE name='storage_volumes';
+`)
+
+	return err
 }
 
 func updateFromV57(tx *sql.Tx) error {
@@ -110,6 +124,7 @@ WHERE name='storage_volumes';
 
 	return err
 }
+
 func updateFromV56(tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (


### PR DESCRIPTION
QEMU crashes on MSR related errors with 5.4 kernels, 5.10 and higher all
seem fine, so let's test for that.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>