### PR TITLE
lxd: Only patch dnsmasq for networks in the db.

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -191,21 +191,9 @@ func patchesApply(d *Daemon, stage patchStage) error {
 // Patches begin here
 
 func patchDnsmasqEntriesIncludeDeviceName(name string, d *Daemon) error {
-	f, err := os.Open(shared.VarPath("networks"))
+	err := network.UpdateDNSMasqStatic(d.State(), "")
 	if err != nil {
 		return err
-	}
-
-	entries, err := f.ReadDir(-1)
-	if err != nil {
-		return err
-	}
-
-	for _, entry := range entries {
-		err := network.UpdateDNSMasqStatic(d.State(), entry.Name())
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
network.UpdateDNSMasqStatic will update all networks in the database if
passed an empty string. The previous implementation failed if any
directories were listed under $LXD_DIR/networks that were not managed by
LXD (maybe due to failed cluster setup) because the migration attempted
to load the network by it's directory name.

See https://discuss.linuxcontainers.org/t/error-applying-patch-dnsmasq-entries-include/13205