### PR TITLE
`lxc exec` fixes

### DIFF
--- a/lxc/console.go
+++ b/lxc/console.go
@@ -339,6 +339,12 @@ func (c *cmdConsole) vga(d lxd.InstanceServer, name string) error {
 		cmd.Stderr = os.Stderr
 		cmd.Start()
 
+		// Handle the command exitting.
+		go func() {
+			cmd.Wait()
+			sendDisconnect <- true
+		}()
+
 		defer func() {
 			if cmd.Process == nil {
 				return

--- a/lxc/exec_unix.go
+++ b/lxc/exec_unix.go
@@ -40,11 +40,12 @@ func (c *cmdExec) controlSocketHandler(control *websocket.Conn) {
 
 	for {
 		sig := <-ch
+
 		switch sig {
 		case unix.SIGWINCH:
 			if !c.interactive {
 				// Don't send SIGWINCH to non-interactive, this can lead to console corruption/crashes.
-				return
+				continue
 			}
 
 			logger.Debugf("Received '%s signal', updating window geometry.", sig)

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -45,7 +45,7 @@ func (e *listenerCommon) heartbeat() {
 
 	defer e.Close()
 
-	pingInterval := time.Second * 5
+	pingInterval := time.Second * 10
 	e.pongsPending = 0
 
 	e.SetPongHandler(func(msg string) error {

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -227,14 +227,14 @@ func (s *consoleWs) doConsole(op *operations.Operation) error {
 
 			_, r, err := conn.NextReader()
 			if err != nil {
-				logger.Debugf("Got error getting next reader %s", err)
+				logger.Debugf("Got error getting next reader: %v", err)
 				close(consoleDoneCh)
 				return
 			}
 
 			buf, err := ioutil.ReadAll(r)
 			if err != nil {
-				logger.Debugf("Failed to read message %s", err)
+				logger.Debugf("Failed to read message: %v", err)
 				break
 			}
 
@@ -339,7 +339,7 @@ func (s *consoleWs) doVGA(op *operations.Operation) error {
 
 			_, _, err := conn.NextReader()
 			if err != nil {
-				logger.Debugf("Got error getting next reader %s", err)
+				logger.Debugf("Got error getting next reader: %v", err)
 				close(consoleDoneCh)
 				return
 			}


### PR DESCRIPTION
The previous fix for the SIGWINCH issue on non-interactive incorrectly
used "return" rather than "continue", which then caused the websocket to
terminate rather than for the signal to be ignored.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>