### PR TITLE
lxd/db: Refactor storage pool used by to get info on all nodes.

### DIFF
--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -465,6 +466,12 @@ func (c *cmdStorageInfo) Run(cmd *cobra.Command, args []string) error {
 	for _, v := range pool.UsedBy {
 		bytype := string(strings.Split(v[5:], "/")[0])
 		bywhat := string(strings.Split(v[5:], "/")[1])
+
+		u, _ := url.Parse(v)
+		node, ok := u.Query()["target"]
+		if ok {
+			bywhat = fmt.Sprintf("%s (%s)", bywhat, node[0])
+		}
 
 		poolusedby[usedbystring][bytype] = append(poolusedby[usedbystring][bytype], bywhat)
 	}

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -43,7 +43,7 @@ storage_pools_config JOIN storage_pools ON storage_pools.id=storage_pools_config
 }
 
 // GetStoragePoolUsedBy looks up all users of a storage pool.
-func (c *ClusterTx) GetStoragePoolUsedBy(name string) ([]string, error) {
+func (c *ClusterTx) GetStoragePoolUsedBy(name string, allNodes bool) ([]string, error) {
 	usedby := []string{}
 
 	// Get the pool ID.
@@ -81,25 +81,27 @@ func (c *ClusterTx) GetStoragePoolUsedBy(name string) ([]string, error) {
 		return []interface{}{&vols[i].volName, &vols[i].volType, &vols[i].projectName, &vols[i].nodeID}
 	}
 
-	remoteDrivers := StorageRemoteDriverNames()
+	nodePredicate := "node_id=?"
+	if allNodes {
+		nodePredicate = "node_id IS NOT NULL"
+	}
 
 	s := fmt.Sprintf(`
 SELECT storage_volumes.name, storage_volumes.type, projects.name, storage_volumes.node_id
   FROM storage_volumes
   JOIN projects ON projects.id=storage_volumes.project_id
   JOIN storage_pools ON storage_pools.id=storage_volumes.storage_pool_id
-  WHERE storage_pool_id=? AND ((node_id=? OR node_id IS NULL AND storage_pools.driver IN %s) OR storage_volumes.type == 2)
-  ORDER BY storage_volumes.type ASC, projects.name ASC, storage_volumes.name ASC, storage_volumes.node_id ASC`, query.Params(len(remoteDrivers)))
+  WHERE storage_pool_id=? AND ((%s OR node_id IS NULL) OR storage_volumes.type == 2)
+  ORDER BY storage_volumes.type ASC, projects.name ASC, storage_volumes.name ASC, storage_volumes.node_id ASC`, nodePredicate)
 
 	stmt, err := c.tx.Prepare(s)
 	if err != nil {
 		return nil, err
 	}
 
-	args := []interface{}{id, c.nodeID}
-
-	for _, driver := range remoteDrivers {
-		args = append(args, driver)
+	args := []interface{}{id}
+	if !allNodes {
+		args = append(args, c.nodeID)
 	}
 
 	err = query.SelectObjects(stmt, dest, args...)
@@ -111,9 +113,17 @@ SELECT storage_volumes.name, storage_volumes.type, projects.name, storage_volume
 		// Handle instances.
 		if r.volType == StoragePoolVolumeTypeContainer || r.volType == StoragePoolVolumeTypeVM {
 			if r.projectName == "default" {
-				usedby = append(usedby, fmt.Sprintf("/1.0/instances/%s", r.volName))
+				if allNodes && r.nodeID != nil && nodesName[*r.nodeID] != "none" {
+					usedby = append(usedby, fmt.Sprintf("/1.0/instances/%s?target=%s", r.volName, nodesName[*r.nodeID]))
+				} else {
+					usedby = append(usedby, fmt.Sprintf("/1.0/instances/%s", r.volName))
+				}
 			} else {
-				usedby = append(usedby, fmt.Sprintf("/1.0/instances/%s?project=%s", r.volName, r.projectName))
+				if allNodes && r.nodeID != nil && nodesName[*r.nodeID] != "none" {
+					usedby = append(usedby, fmt.Sprintf("/1.0/instances/%s?project=%s&target=%s", r.volName, r.projectName, nodesName[*r.nodeID]))
+				} else {
+					usedby = append(usedby, fmt.Sprintf("/1.0/instances/%s?project=%s", r.volName, r.projectName))
+				}
 			}
 		}
 
@@ -128,9 +138,17 @@ SELECT storage_volumes.name, storage_volumes.type, projects.name, storage_volume
 
 			for _, project := range projects {
 				if project == "default" {
-					usedby = append(usedby, fmt.Sprintf("/1.0/images/%s", r.volName))
+					if allNodes && r.nodeID != nil && nodesName[*r.nodeID] != "none" {
+						usedby = append(usedby, fmt.Sprintf("/1.0/images/%s?target=%s", r.volName, nodesName[*r.nodeID]))
+					} else {
+						usedby = append(usedby, fmt.Sprintf("/1.0/images/%s", r.volName))
+					}
 				} else {
-					usedby = append(usedby, fmt.Sprintf("/1.0/images/%s?project=%s", r.volName, project))
+					if allNodes && r.nodeID != nil && nodesName[*r.nodeID] != "none" {
+						usedby = append(usedby, fmt.Sprintf("/1.0/images/%s?project=%s&target=%s", r.volName, project, nodesName[*r.nodeID]))
+					} else {
+						usedby = append(usedby, fmt.Sprintf("/1.0/images/%s?project=%s", r.volName, project))
+					}
 				}
 			}
 		}
@@ -740,7 +758,7 @@ func (c *Cluster) getStoragePool(onlyCreated bool, where string, args ...interfa
 	storagePool.Config = config
 	storagePool.Status = StoragePoolStateToAPIStatus(state)
 
-	nodes, err := c.storagePoolNodes(poolID)
+	nodes, err := c.StoragePoolNodes(poolID)
 	if err != nil {
 		return -1, nil, nil, err
 	}
@@ -766,8 +784,8 @@ func StoragePoolStateToAPIStatus(state StoragePoolState) string {
 	}
 }
 
-// storagePoolNodes returns the nodes keyed by node ID that the given storage pool is defined on.
-func (c *Cluster) storagePoolNodes(poolID int64) (map[int64]StoragePoolNode, error) {
+// StoragePoolNodes returns the nodes keyed by node ID that the given storage pool is defined on.
+func (c *Cluster) StoragePoolNodes(poolID int64) (map[int64]StoragePoolNode, error) {
 	var nodes map[int64]StoragePoolNode
 	var err error
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -192,7 +192,7 @@ func (b *lxdBackend) IsUsed() (bool, error) {
 	var err error
 	poolUsedBy := []string{}
 	err = b.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		poolUsedBy, err = tx.GetStoragePoolUsedBy(b.name)
+		poolUsedBy, err = tx.GetStoragePoolUsedBy(b.name, false)
 		return err
 	})
 	if err != nil {

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -160,7 +160,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 			// Get all users of the storage pool.
 			poolUsedBy := []string{}
 			err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-				poolUsedBy, err = tx.GetStoragePoolUsedBy(pool)
+				poolUsedBy, err = tx.GetStoragePoolUsedBy(pool, true)
 				return err
 			})
 			if err != nil {
@@ -568,7 +568,7 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 	// Get all users of the storage pool.
 	poolUsedBy := []string{}
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		poolUsedBy, err = tx.GetStoragePoolUsedBy(poolName)
+		poolUsedBy, err = tx.GetStoragePoolUsedBy(poolName, false)
 		return err
 	})
 	if err != nil {

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -559,6 +559,12 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 
 	poolName := mux.Vars(r)["name"]
 
+	targetNode := queryParam(r, "target")
+	allNodes := false
+	if targetNode == "" {
+		allNodes = true
+	}
+
 	// Get the existing storage pool.
 	_, pool, _, err := d.cluster.GetStoragePoolInAnyState(poolName)
 	if err != nil {
@@ -568,15 +574,13 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 	// Get all users of the storage pool.
 	poolUsedBy := []string{}
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		poolUsedBy, err = tx.GetStoragePoolUsedBy(poolName, false)
+		poolUsedBy, err = tx.GetStoragePoolUsedBy(poolName, allNodes)
 		return err
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 	pool.UsedBy = project.FilterUsedBy(r, poolUsedBy)
-
-	targetNode := queryParam(r, "target")
 
 	clustered, err := cluster.Enabled(d.db)
 	if err != nil {


### PR DESCRIPTION
This allows `lxc storage list` to display "used by" for all nodes (not
only the node receiving the request) whilst preserving existing
functionality.

Closes #9842 