### PR TITLE
Discard TLS errors caused by early connect termination for trusted proxies.

### DIFF
--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"strings"
 	"time"
@@ -171,6 +172,11 @@ func (e *Endpoints) NetworkUpdateTrustedProxy(trustedProxy string) {
 	listener, ok = e.listeners[cluster]
 	if ok && listener != nil {
 		listener.(*listeners.FancyTLSListener).TrustedProxy(proxies)
+	}
+
+	server, ok := e.servers[network]
+	if ok && server != nil {
+		server.ErrorLog = log.New(networkServerErrorLogWriter{proxies: proxies}, "", 0)
 	}
 }
 

--- a/lxd/endpoints/network_util.go
+++ b/lxd/endpoints/network_util.go
@@ -1,0 +1,63 @@
+package endpoints
+
+import (
+	"bytes"
+	"net"
+	"regexp"
+
+	"github.com/lxc/lxd/shared/logger"
+)
+
+type networkServerErrorLogWriter struct {
+	proxies []net.IP
+}
+
+// Regex for the log we want to ignore.
+var unwantedLogRegex = regexp.MustCompile(`^http: TLS handshake error from ([^\[:]+?|\[([^\]]+?)\]):[0-9]+: .+write: connection reset by peer$`)
+
+func (d networkServerErrorLogWriter) Write(p []byte) (int, error) {
+	strippedLog := d.stripLog(p)
+	if strippedLog == "" {
+		return 0, nil
+	}
+
+	logger.Info(strippedLog)
+	return len(p), nil
+}
+
+func (d networkServerErrorLogWriter) stripLog(p []byte) string {
+	// Strip the beginning of the log until we reach "http:".
+	for string(p[0:5]) != "http:" && len(p) > 0 {
+		p = bytes.TrimLeftFunc(p, func(r rune) bool {
+			return r != 'h'
+		})
+	}
+
+	// Strip the newline from the end.
+	p = bytes.TrimRightFunc(p, func(r rune) bool {
+		return r == '\n'
+	})
+
+	// Get the source IP address.
+	match := unwantedLogRegex.FindSubmatch(p)
+	var sourceIP string
+	if match != nil {
+		if match[2] != nil {
+			// Inner match omits parentheses of ipv6 address.
+			sourceIP = string(match[2])
+		} else if match[1] != nil {
+			sourceIP = string(match[1])
+		}
+	}
+
+	// Discard the log if the source is in our list of trusted proxies.
+	if sourceIP != "" {
+		for _, ip := range d.proxies {
+			if ip.String() == sourceIP {
+				return ""
+			}
+		}
+	}
+
+	return string(p)
+}

--- a/lxd/endpoints/network_util_test.go
+++ b/lxd/endpoints/network_util_test.go
@@ -1,0 +1,55 @@
+package endpoints
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_networkServerErrorLogWriter_shouldDiscard(t *testing.T) {
+	tests := []struct {
+		name    string
+		proxies []net.IP
+		log     []byte
+		want    string
+	}{
+		{
+			name:    "ipv4 trusted proxy",
+			proxies: []net.IP{net.ParseIP("10.24.0.32")},
+			log:     []byte("Sep 17 04:58:30 abydos lxd.daemon[21884]: 2021/09/17 04:58:30 http: TLS handshake error from 10.24.0.32:55672: write tcp 10.24.0.22:8443->10.24.0.32:55672: write: connection reset by peer\n"),
+			want:    "",
+		},
+		{
+			name:    "ipv4 non-trusted proxy",
+			proxies: []net.IP{net.ParseIP("10.24.0.33")},
+			log:     []byte("Sep 17 04:58:30 abydos lxd.daemon[21884]: 2021/09/17 04:58:30 http: TLS handshake error from 10.24.0.32:55672: write tcp 10.24.0.22:8443->10.24.0.32:55672: write: connection reset by peer\n"),
+			want:    "http: TLS handshake error from 10.24.0.32:55672: write tcp 10.24.0.22:8443->10.24.0.32:55672: write: connection reset by peer",
+		},
+		{
+			name:    "ipv6 trusted proxy",
+			proxies: []net.IP{net.ParseIP("2602:fd23:8:1003:216:3eff:fefa:7670")},
+			log:     []byte("Sep 17 04:58:30 abydos lxd.daemon[21884]: 2021/09/17 04:58:30 http: TLS handshake error from [2602:fd23:8:1003:216:3eff:fefa:7670]:55672: write tcp [2602:fd23:8:101::100]:8443->[2602:fd23:8:1003:216:3eff:fefa:7670]:55672: write: connection reset by peer\n"),
+			want:    "",
+		},
+		{
+			name:    "ipv6 non-trusted proxy",
+			proxies: []net.IP{net.ParseIP("2602:fd23:8:1003:216:3eff:fefa:7671")},
+			log:     []byte("Sep 17 04:58:30 abydos lxd.daemon[21884]: 2021/09/17 04:58:30 http: TLS handshake error from [2602:fd23:8:1003:216:3eff:fefa:7670]:55672: write tcp [2602:fd23:8:101::100]:8443->[2602:fd23:8:1003:216:3eff:fefa:7670]:55672: write: connection reset by peer\n"),
+			want:    "http: TLS handshake error from [2602:fd23:8:1003:216:3eff:fefa:7670]:55672: write tcp [2602:fd23:8:101::100]:8443->[2602:fd23:8:1003:216:3eff:fefa:7670]:55672: write: connection reset by peer",
+		},
+		{
+			name:    "unrelated",
+			proxies: []net.IP{},
+			log:     []byte("Sep 17 04:58:30 abydos lxd.daemon[21884]: 2021/09/17 04:58:30 http: response.WriteHeader on hijacked connection from yourfunction (yourfile.go:80)\n"),
+			want:    "http: response.WriteHeader on hijacked connection from yourfunction (yourfile.go:80)",
+		},
+	}
+	for i, tt := range tests {
+		t.Logf("Case %d: %s", i, tt.name)
+		d := networkServerErrorLogWriter{
+			proxies: tt.proxies,
+		}
+		assert.Equal(t, tt.want, d.stripLog(tt.log))
+	}
+}


### PR DESCRIPTION
Adds a `networkServerErrorLogWriter` which discards logs matching a regex (which contain the IP of the trusted proxy). Sets the writer in the network server logger.

Closes #9237 