### PR TITLE
Clarify multiple gpu device passthrough

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -850,6 +850,10 @@ required    | boolean   | false             | no        | Whether or not this de
 GPU device entries simply make the requested gpu device appear in the
 instance.
 
+```{note}
+Container devices may match multiple GPUs at once. However, for virtual machines a device can only match a single GPU. 
+```
+
 ##### GPUs Available:
 
 The following GPUs can be specified using the `gputype` property:

--- a/lxd/device/gpu_mig.go
+++ b/lxd/device/gpu_mig.go
@@ -22,7 +22,7 @@ const GPUNvidiaDeviceKey = "nvidia.device"
 
 // validateConfig checks the supplied config for correctness.
 func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
-	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {
+	if !instanceSupported(instConf.Type(), instancetype.Container) {
 		return ErrUnsupportedDevType
 	}
 


### PR DESCRIPTION
Removes VMs from the list of allowed instance types for the `gpu_mig` device. Adds note to docs clarifying multiple device passthrough for GPUs.

Closes #9508 