### PR TITLE
Generator: Add 'order' tag to generator

### DIFF
--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -130,15 +130,33 @@ func (s *Stmt) objects(buf *file.Buffer) error {
 			}
 		}
 	}
-	nk := mapping.NaturalKey()
-	orderBy := make([]string, len(nk))
-	for i, field := range nk {
-		if field.IsScalar() {
-			orderBy[i] = lex.Plural(lex.Snake(field.Name)) + ".id"
-		} else {
-			orderBy[i] = mapping.FieldColumnName(field.Name, table)
-			if mapping.Type == ReferenceTable || mapping.Type == MapTable {
-				orderBy[i] = strings.Replace(orderBy[i], "reference", "%s", -1)
+	orderBy := []string{}
+	for _, field := range fields {
+		if field.Config.Get("order") != "" {
+			if field.IsScalar() {
+				orderBy = append(orderBy, lex.Plural(lex.Snake(field.Name))+".id")
+			} else {
+				line := mapping.FieldColumnName(field.Name, table)
+				if mapping.Type == ReferenceTable || mapping.Type == MapTable {
+					line = strings.Replace(line, "reference", "%s", -1)
+				}
+
+				orderBy = append(orderBy, line)
+			}
+		}
+	}
+
+	if len(orderBy) < 1 {
+		nk := mapping.NaturalKey()
+		orderBy = make([]string, len(nk))
+		for i, field := range nk {
+			if field.IsScalar() {
+				orderBy[i] = lex.Plural(lex.Snake(field.Name)) + ".id"
+			} else {
+				orderBy[i] = mapping.FieldColumnName(field.Name, table)
+				if mapping.Type == ReferenceTable || mapping.Type == MapTable {
+					orderBy[i] = strings.Replace(orderBy[i], "reference", "%s", -1)
+				}
 			}
 		}
 	}

--- a/lxd/db/instance_profiles.go
+++ b/lxd/db/instance_profiles.go
@@ -22,9 +22,9 @@ import "fmt"
 // InstanceProfile is an association table struct that associates Instances
 // to Profiles.
 type InstanceProfile struct {
-	InstanceID int `db:"primary=yes"`
+	InstanceID int `db:"primary=yes&order=yes"`
 	ProfileID  int
-	ApplyOrder int
+	ApplyOrder int `db:"order=yes"`
 }
 
 // InstanceProfileFilter specifies potential query parameter fields.

--- a/lxd/db/instance_profiles.mapper.go
+++ b/lxd/db/instance_profiles.mapper.go
@@ -18,7 +18,7 @@ var _ = api.ServerEnvironment{}
 var instanceProfileObjects = cluster.RegisterStmt(`
 SELECT instances_profiles.instance_id, instances_profiles.profile_id, instances_profiles.apply_order
   FROM instances_profiles
-  ORDER BY instances_profiles.instance_id
+  ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
 `)
 
 var instanceProfileCreate = cluster.RegisterStmt(`


### PR DESCRIPTION
Closes #9868 

Adds a `db:"order=yes"` tag to the generator, that can be used to override the default behaviour of ordering by the primary key.

Currently being used for `instances_profiles` field `apply_order`.