### PR TITLE
NIC: Don't attempt to configure IPv6 reverse path filter on routed NIC if IPv6 not enabled

### DIFF
--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -1281,10 +1281,12 @@ func (d Xtables) InstanceSetupRPFilter(projectName string, instanceName string, 
 		return err
 	}
 
-	// IPv6 filter.
-	err = d.iptablesPrepend(6, comment, "raw", "PREROUTING", args...)
-	if err != nil {
-		return err
+	// IPv6 filter if IPv6 is enabled.
+	if shared.PathExists("/proc/sys/net/ipv6") {
+		err = d.iptablesPrepend(6, comment, "raw", "PREROUTING", args...)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Reported from https://discuss.linuxcontainers.org/t/network-routed-odd-ip6-error-host-has-no-ipv6/

Also don't attempt to disable IPv6 on OVN uplink host interfaces if IPv6 not loaded.