### PR TITLE
doc/instances: Fix bridged NIC ipv{n}.address docs indicating none is valid value

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -352,10 +352,10 @@ host\_name               | string  | randomly assigned | no       | no      | Th
 limits.ingress           | string  | -                 | no       | no      | I/O limit in bit/s for incoming traffic (various suffixes supported, see below)
 limits.egress            | string  | -                 | no       | no      | I/O limit in bit/s for outgoing traffic (various suffixes supported, see below)
 limits.max               | string  | -                 | no       | no      | Same as modifying both limits.ingress and limits.egress
-ipv4.address             | string  | -                 | no       | no      | An IPv4 address to assign to the instance through DHCP
-ipv6.address             | string  | -                 | no       | no      | An IPv6 address to assign to the instance through DHCP
-ipv4.routes              | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to add on host to NIC (Can be `none` to restrict all IPv4 traffic when security.ipv4\_filtering is set)
-ipv6.routes              | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to add on host to NIC (Can be `none` to restrict all IPv6 traffic when security.ipv6\_filtering is set)
+ipv4.address             | string  | -                 | no       | no      | An IPv4 address to assign to the instance through DHCP (Can be `none` to restrict all IPv4 traffic when security.ipv4\_filtering is set)
+ipv6.address             | string  | -                 | no       | no      | An IPv6 address to assign to the instance through DHCP (Can be `none` to restrict all IPv6 traffic when security.ipv6\_filtering is set)
+ipv4.routes              | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to add on host to NIC
+ipv6.routes              | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to add on host to NIC
 ipv4.routes.external     | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to route to the NIC and publish on uplink network (BGP)
 ipv6.routes.external     | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to route to the NIC and publish on uplink network (BGP)
 security.mac\_filtering  | boolean | false             | no       | no      | Prevent the instance from spoofing another's MAC address


### PR DESCRIPTION

This was missed in the original PR https://github.com/lxc/lxd/pull/9641

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>