### PR TITLE
lxd/metrics: add EOL marker

### DIFF
--- a/lxd/metrics/metrics.go
+++ b/lxd/metrics/metrics.go
@@ -119,6 +119,11 @@ func (m *MetricSet) String() string {
 		}
 	}
 
+	_, err := out.WriteString("# EOF\n")
+	if err != nil {
+		return ""
+	}
+
 	return out.String()
 }
 


### PR DESCRIPTION
This allow detecting partial scrapes.

https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily-metadata

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>