### PR TITLE
Instance: Optimise DB queries during instance creation

### DIFF
--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -153,6 +153,11 @@ func (c *Config) ShutdownTimeout() time.Duration {
 	return time.Duration(n) * time.Minute
 }
 
+// ImagesDefaultArchitecture returns the default architecture.
+func (c *Config) ImagesDefaultArchitecture() string {
+	return c.m.GetString("images.default_architecture")
+}
+
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
 func (c *Config) Dump() map[string]interface{} {

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -566,12 +566,26 @@ func (c *Cluster) GetNetworkInAnyState(projectName string, networkName string) (
 // If stateFilter is -1, then a network can be in any state.
 // Returns network ID, network info, and network cluster member info.
 func (c *Cluster) getNetworkByProjectAndName(projectName string, networkName string, stateFilter NetworkState) (int64, *api.Network, map[int64]NetworkNode, error) {
-	networkID, networkState, networkType, network, err := c.getPartialNetworkByProjectAndName(projectName, networkName, stateFilter)
-	if err != nil {
-		return -1, nil, nil, err
-	}
+	var err error
+	var networkID int64
+	var networkState NetworkState
+	var networkType NetworkType
+	var network *api.Network
+	var nodes map[int64]NetworkNode
 
-	nodes, err := c.networkPopulatePeerInfo(networkID, network, networkState, networkType)
+	err = c.Transaction(func(tx *ClusterTx) error {
+		networkID, networkState, networkType, network, err = c.getPartialNetworkByProjectAndName(tx, projectName, networkName, stateFilter)
+		if err != nil {
+			return err
+		}
+
+		nodes, err = c.networkPopulatePeerInfo(tx, networkID, network, networkState, networkType)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
 		return -1, nil, nil, err
 	}
@@ -582,7 +596,7 @@ func (c *Cluster) getNetworkByProjectAndName(projectName string, networkName str
 // getPartialNetworkByProjectAndName gets the network with the given project, name and state.
 // If stateFilter is -1, then a network can be in any state.
 // Returns network ID, network state, network type, and partially populated network info.
-func (c *Cluster) getPartialNetworkByProjectAndName(projectName string, networkName string, stateFilter NetworkState) (int64, NetworkState, NetworkType, *api.Network, error) {
+func (c *Cluster) getPartialNetworkByProjectAndName(tx *ClusterTx, projectName string, networkName string, stateFilter NetworkState) (int64, NetworkState, NetworkType, *api.Network, error) {
 	var err error
 	var networkID int64 = int64(-1)
 	var network api.Network
@@ -608,19 +622,12 @@ func (c *Cluster) getPartialNetworkByProjectAndName(projectName string, networkN
 
 	q.WriteString(" LIMIT 1")
 
-	err = c.Transaction(func(tx *ClusterTx) error {
-		err = tx.tx.QueryRow(q.String(), args...).Scan(&networkID, &network.Name, &network.Description, &networkState, &networkType)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return api.StatusErrorf(http.StatusNotFound, "Network not found")
-			}
-
-			return err
+	err = tx.tx.QueryRow(q.String(), args...).Scan(&networkID, &network.Name, &network.Description, &networkState, &networkType)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return -1, -1, -1, nil, api.StatusErrorf(http.StatusNotFound, "Network not found")
 		}
 
-		return nil
-	})
-	if err != nil {
 		return -1, -1, -1, nil, err
 	}
 
@@ -629,20 +636,20 @@ func (c *Cluster) getPartialNetworkByProjectAndName(projectName string, networkN
 
 // networkPopulatePeerInfo takes a pointer to partially populated network info struct and enriches it.
 // Returns the network cluster member info.
-func (c *Cluster) networkPopulatePeerInfo(networkID int64, network *api.Network, networkState NetworkState, networkType NetworkType) (map[int64]NetworkNode, error) {
+func (c *Cluster) networkPopulatePeerInfo(tx *ClusterTx, networkID int64, network *api.Network, networkState NetworkState, networkType NetworkType) (map[int64]NetworkNode, error) {
 	var err error
 
 	// Populate Status and Type fields by converting from DB values.
 	network.Status = NetworkStateToAPIStatus(networkState)
 	networkFillType(network, networkType)
 
-	network.Config, err = c.getNetworkConfig(networkID)
+	err = c.getNetworkConfig(tx, networkID, network)
 	if err != nil {
 		return nil, err
 	}
 
 	// Populate Location field.
-	nodes, err := c.NetworkNodes(networkID)
+	nodes, err := tx.NetworkNodes(networkID)
 	if err != nil {
 		return nil, err
 	}
@@ -735,69 +742,50 @@ func (c *Cluster) GetNetworkWithInterface(devName string) (int64, *api.Network, 
 		return -1, nil, fmt.Errorf("No network found for interface: %s", devName)
 	}
 
-	config, err := c.getNetworkConfig(id)
-	if err != nil {
-		return -1, nil, err
-	}
-
 	network := api.Network{
 		Name:    name,
 		Managed: true,
 		Type:    "bridge",
 	}
-	network.Config = config
+
+	err = c.Transaction(func(tx *ClusterTx) error {
+		return c.getNetworkConfig(tx, id, &network)
+	})
+	if err != nil {
+		return -1, nil, err
+	}
 
 	return id, &network, nil
 }
 
-// Return the config map of the network with the given ID.
-func (c *Cluster) getNetworkConfig(id int64) (map[string]string, error) {
-	var key, value string
-	query := `
-        SELECT
-            key, value
+// getNetworkConfig populates the config map of the Network with the given ID.
+func (c *Cluster) getNetworkConfig(tx *ClusterTx, networkID int64, network *api.Network) error {
+	q := `
+        SELECT key, value
         FROM networks_config
 		WHERE network_id=?
-                AND (node_id=? OR node_id IS NULL)`
-	inargs := []interface{}{id, c.nodeID}
-	outfmt := []interface{}{key, value}
-	results, err := queryScan(c, query, inargs, outfmt)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get network '%d'", id)
-	}
+		AND (node_id=? OR node_id IS NULL)
+	`
 
-	if len(results) == 0 {
-		/*
-		 * If we didn't get any rows here, let's check to make sure the
-		 * network really exists; if it doesn't, let's send back a 404.
-		 */
-		query := "SELECT id FROM networks WHERE id=?"
-		var r int
-		results, err := queryScan(c, query, []interface{}{id}, []interface{}{r})
+	network.Config = map[string]string{}
+
+	return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		var key, value string
+
+		err := scan(&key, &value)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		if len(results) == 0 {
-			return nil, ErrNoSuchObject
-		}
-	}
-
-	config := map[string]string{}
-
-	for _, r := range results {
-		key = r[0].(string)
-		value = r[1].(string)
-
-		_, found := config[key]
+		_, found := network.Config[key]
 		if found {
-			return nil, fmt.Errorf("Duplicate config row found for key %q for network ID %d", key, id)
+			return fmt.Errorf("Duplicate config row found for key %q for network ID %d", key, networkID)
 		}
 
-		config[key] = value
-	}
+		network.Config[key] = value
 
-	return config, nil
+		return nil
+	}, networkID, c.nodeID)
 }
 
 // CreateNetwork creates a new network.

--- a/lxd/db/query/retry.go
+++ b/lxd/db/query/retry.go
@@ -31,15 +31,16 @@ func Retry(f func() error) error {
 			}
 
 			// Process actual errors.
-			logger.Debugf("Database error: %#v", err)
 			if IsRetriableError(err) {
 				if i == maxRetries {
-					logger.Warnf("Give up retrying database error: %v", err)
+					logger.Warn("Database error, giving up", "attempt", i, "err", err)
 					break
 				}
-				logger.Debugf("Retry failed db interaction (%v)", err)
+				logger.Debug("Database error, retrying", "attempt", i, "err", err)
 				time.Sleep(jitter.Deviation(nil, 0.8)(100 * time.Millisecond))
 				continue
+			} else {
+				logger.Debug("Database error", "err", err)
 			}
 		}
 		break

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -434,20 +434,6 @@ func (d *common) expandConfig(profiles []api.Profile) error {
 	}
 
 	d.expandedConfig = db.ExpandInstanceConfig(d.localConfig, profiles)
-
-	return nil
-}
-
-// expandDevices applies the devices of each profile in order, followed by the local devices.
-func (d *common) expandDevices(profiles []api.Profile) error {
-	if profiles == nil && len(d.profiles) > 0 {
-		var err error
-		profiles, err = d.state.Cluster.GetProfiles(d.project, d.profiles)
-		if err != nil {
-			return err
-		}
-	}
-
 	d.expandedDevices = db.ExpandInstanceDevices(d.localDevices, profiles)
 
 	return nil

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -366,11 +366,6 @@ func lxcLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (inst
 		return nil, err
 	}
 
-	err = d.(*lxc).expandDevices(profiles)
-	if err != nil {
-		return nil, err
-	}
-
 	return d, nil
 }
 
@@ -638,11 +633,6 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 func (d *lxc) init() error {
 	// Compute the expanded config and device list
 	err := d.expandConfig(nil)
-	if err != nil {
-		return err
-	}
-
-	err = d.expandDevices(nil)
 	if err != nil {
 		return err
 	}
@@ -4064,12 +4054,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	// Expand the config and refresh the LXC config
 	err = d.expandConfig(nil)
 	if err != nil {
-		return errors.Wrap(err, "Expand config")
-	}
-
-	err = d.expandDevices(nil)
-	if err != nil {
-		return errors.Wrap(err, "Expand devices")
+		return err
 	}
 
 	// Diff the configurations

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -197,7 +197,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]str
 		return nil, errors.Wrap(err, "Invalid config")
 	}
 
-	err = instance.ValidDevices(s, s.Cluster, d.Project(), d.Type(), d.expandedDevices, true)
+	err = instance.ValidDevices(s, d.Project(), d.Type(), d.expandedDevices, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "Invalid devices")
 	}
@@ -3950,7 +3950,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Validate the new devices without using expanded devices validation (expensive checks disabled).
-		err = instance.ValidDevices(d.state, d.state.Cluster, d.Project(), d.Type(), args.Devices, false)
+		err = instance.ValidDevices(d.state, d.Project(), d.Type(), args.Devices, false)
 		if err != nil {
 			return errors.Wrap(err, "Invalid devices")
 		}
@@ -4117,7 +4117,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Do full expanded validation of the devices diff.
-		err = instance.ValidDevices(d.state, d.state.Cluster, d.Project(), d.Type(), d.expandedDevices, true)
+		err = instance.ValidDevices(d.state, d.Project(), d.Type(), d.expandedDevices, true)
 		if err != nil {
 			return errors.Wrap(err, "Invalid expanded devices")
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -297,14 +297,9 @@ func lxcCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]str
 		jsonIdmap = "[]"
 	}
 
-	err = d.VolatileSet(map[string]string{"volatile.idmap.next": jsonIdmap})
-	if err != nil {
-		return nil, err
-	}
-
-	err = d.VolatileSet(map[string]string{"volatile.idmap.base": fmt.Sprintf("%v", base)})
-	if err != nil {
-		return nil, err
+	v := map[string]string{
+		"volatile.idmap.next": jsonIdmap,
+		"volatile.idmap.base": fmt.Sprintf("%v", base),
 	}
 
 	// Invalid idmap cache.
@@ -312,10 +307,12 @@ func lxcCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]str
 
 	// Set last_state if not currently set.
 	if d.localConfig["volatile.last_state.idmap"] == "" {
-		err = d.VolatileSet(map[string]string{"volatile.last_state.idmap": "[]"})
-		if err != nil {
-			return nil, err
-		}
+		v["volatile.last_state.idmap"] = "[]"
+	}
+
+	err = d.VolatileSet(v)
+	if err != nil {
+		return nil, err
 	}
 
 	// Re-run init to update the idmap.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -106,11 +106,6 @@ func qemuLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (ins
 		return nil, err
 	}
 
-	err = d.expandDevices(profiles)
-	if err != nil {
-		return nil, err
-	}
-
 	return d, nil
 }
 
@@ -4004,12 +3999,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	// Expand the config.
 	err = d.expandConfig(nil)
 	if err != nil {
-		return errors.Wrap(err, "Expand config")
-	}
-
-	err = d.expandDevices(nil)
-	if err != nil {
-		return errors.Wrap(err, "Expand devices")
+		return err
 	}
 
 	// Diff the configurations.
@@ -4506,11 +4496,6 @@ func (d *qemu) cleanupDevices() {
 func (d *qemu) init() error {
 	// Compute the expanded config and device list.
 	err := d.expandConfig(nil)
-	if err != nil {
-		return err
-	}
-
-	err = d.expandDevices(nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -231,7 +231,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]st
 		return nil, errors.Wrap(err, "Invalid config")
 	}
 
-	err = instance.ValidDevices(s, s.Cluster, d.Project(), d.Type(), d.expandedDevices, true)
+	err = instance.ValidDevices(s, d.Project(), d.Type(), d.expandedDevices, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "Invalid devices")
 	}
@@ -3900,7 +3900,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Validate the new devices without using expanded devices validation (expensive checks disabled).
-		err = instance.ValidDevices(d.state, d.state.Cluster, d.Project(), d.Type(), args.Devices, false)
+		err = instance.ValidDevices(d.state, d.Project(), d.Type(), args.Devices, false)
 		if err != nil {
 			return errors.Wrap(err, "Invalid devices")
 		}
@@ -4057,7 +4057,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Do full expanded validation of the devices diff.
-		err = instance.ValidDevices(d.state, d.state.Cluster, d.Project(), d.Type(), d.expandedDevices, true)
+		err = instance.ValidDevices(d.state, d.Project(), d.Type(), d.expandedDevices, true)
 		if err != nil {
 			return errors.Wrap(err, "Invalid expanded devices")
 		}

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -62,7 +62,7 @@ func load(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instanc
 }
 
 // validDevices validate instance device configs.
-func validDevices(state *state.State, cluster *db.Cluster, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error {
+func validDevices(state *state.State, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error {
 	// Empty device list
 	if devices == nil {
 		return nil

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -38,7 +38,7 @@ import (
 )
 
 // ValidDevices is linked from instance/drivers.validDevices to validate device config.
-var ValidDevices func(state *state.State, cluster *db.Cluster, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error
+var ValidDevices func(state *state.State, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error
 
 // Load is linked from instance/drivers.load to allow different instance types to be loaded.
 var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error)
@@ -926,7 +926,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 	}
 
 	// Validate container devices with the supplied container name and devices.
-	err = ValidDevices(s, s.Cluster, args.Project, args.Type, args.Devices, false)
+	err = ValidDevices(s, args.Project, args.Type, args.Devices, false)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Invalid devices")
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -925,11 +925,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 		return nil, nil, err
 	}
 
-	// Validate container devices with the supplied container name and devices.
-	err = ValidDevices(s, args.Project, args.Type, args.Devices, false)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Invalid devices")
-	}
+	// Leave validating devices to Create function call below.
 
 	// Validate architecture.
 	_, err = osarch.ArchitectureName(args.Architecture)

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -977,15 +977,6 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 			return err
 		}
 
-		// TODO: this check should probably be performed by the db package itself.
-		exists, err := tx.ProjectExists(args.Project)
-		if err != nil {
-			return errors.Wrapf(err, "Check if project %q exists", args.Project)
-		}
-		if !exists {
-			return fmt.Errorf("Project %q does not exist", args.Project)
-		}
-
 		devices, err := db.APIToDevices(args.Devices.CloneNative())
 		if err != nil {
 			return err

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -919,7 +919,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 		args.ExpiryDate = time.Time{}
 	}
 
-	// Validate container config.
+	// Validate instance config.
 	err = ValidConfig(s.OS, args.Config, false, args.Type)
 	if err != nil {
 		return nil, nil, err

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -109,8 +109,13 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return errors.Wrap(err, "Failed to load LXD config")
 			}
 
+			p, err := tx.GetProject(projectName)
+			if err != nil {
+				return fmt.Errorf("Failed loading project: %w", err)
+			}
+
 			// Check if user is allowed to use cluster member targeting
-			err = project.CheckClusterTargetRestriction(tx, r, projectName, targetNode)
+			err = project.CheckClusterTargetRestriction(tx, r, p, targetNode)
 			if err != nil {
 				return err
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -979,12 +979,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// If no storage pool is found, error out.
-	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil || len(pools) == 0 {
-		return response.BadRequest(fmt.Errorf("No storage pool found. Please create a new storage pool"))
-	}
-
 	if req.Devices == nil {
 		req.Devices = map[string]map[string]string{}
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -236,7 +236,7 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// At this point we don't know the instance type, so just use instancetype.Any type for validation.
-	err = instance.ValidDevices(d.State(), d.cluster, projectName, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
+	err = instance.ValidDevices(d.State(), projectName, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -31,7 +31,7 @@ func doProfileUpdate(d *Daemon, projectName string, name string, id int64, profi
 
 	// Profiles can be applied to any instance type, so just use instancetype.Any type for validation so that
 	// instance type specific validation checks are not performed.
-	err = instance.ValidDevices(d.State(), d.cluster, projectName, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
+	err = instance.ValidDevices(d.State(), projectName, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
 	if err != nil {
 		return err
 	}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1404,15 +1404,10 @@ func projectHasRestriction(project *db.Project, restrictionKey string, blockValu
 }
 
 // CheckClusterTargetRestriction check if user is allowed to use cluster member targeting
-func CheckClusterTargetRestriction(tx *db.ClusterTx, r *http.Request, projectName string, targetFlag string) error {
+func CheckClusterTargetRestriction(tx *db.ClusterTx, r *http.Request, project *db.Project, targetFlag string) error {
 	// Allow server administrators to move instances around even when restricted (node evacuation, ...)
 	if rbac.UserIsAdmin(r) {
 		return nil
-	}
-
-	project, err := tx.GetProject(projectName)
-	if err != nil {
-		return fmt.Errorf("Fetch project database object")
 	}
 
 	if projectHasRestriction(project, "restricted.cluster.target", "block") && targetFlag != "" {

--- a/lxd/project/permissions_test.go
+++ b/lxd/project/permissions_test.go
@@ -168,9 +168,12 @@ func TestCheckClusterTargetRestriction_RestrictedTrue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	p, err := tx.GetProject("p1")
+	require.NoError(t, err)
+
 	req := &http.Request{}
 
-	err = project.CheckClusterTargetRestriction(tx, req, "p1", "n1")
+	err = project.CheckClusterTargetRestriction(tx, req, p, "n1")
 	assert.EqualError(t, err, "This project doesn't allow cluster member targeting")
 }
 
@@ -188,8 +191,11 @@ func TestCheckClusterTargetRestriction_RestrictedFalse(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	p, err := tx.GetProject("p1")
+	require.NoError(t, err)
+
 	req := &http.Request{}
 
-	err = project.CheckClusterTargetRestriction(tx, req, "p1", "n1")
+	err = project.CheckClusterTargetRestriction(tx, req, p, "n1")
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This attempts to reduce queries/transactions used when creating an instance in an attempt to better support instance migration on high latency networks.

Related to #9861

This reduces the operation time when used with a 40ms latency by about 3s.

Before:
```
t=2022-02-08T17:08:02+0000 lvl=eror msg="tomp instancesPost" duration=16.465716182s
t=2022-02-08T17:08:46+0000 lvl=eror msg="tomp instancesPost" duration=21.270856828s
t=2022-02-08T17:09:24+0000 lvl=eror msg="tomp instancesPost" duration=16.394522801s
```

After:
```
t=2022-02-08T17:10:59+0000 lvl=eror msg="tomp instancesPost" duration=13.822343883s
t=2022-02-08T17:11:30+0000 lvl=eror msg="tomp instancesPost" duration=18.717397529s
t=2022-02-08T17:11:55+0000 lvl=eror msg="tomp instancesPost" duration=13.731331391s
```

Unfortunately whilst it does strip a few seconds off, it does not yet get it under the 10s limit (after which the migration source gives up).