### PR TITLE
doc: fix path to image in the header

### DIFF
--- a/.sphinx/_templates/header.html
+++ b/.sphinx/_templates/header.html
@@ -74,7 +74,7 @@
 
       <li>
         <a class="p-navigation__logo" href="/">
-          <img src="_static/download/containers.small.png" alt="Linux containers logo" border="0" />
+          <img src="{{ pathto('_static/download/containers.small.png', 1) }}" alt="Linux containers logo" border="0" />
         </a>
       </li>
 


### PR DESCRIPTION
The image currently displays fine, but if we created subfolders
in doc/, it doesn't.
Make sure the path is adapted accordingly.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>