### PR TITLE
Cluster: Fix non-leader transaction errors when leader shuts down cleanly

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -407,7 +407,7 @@ func (g *Gateway) raftDial() client.DialFunc {
 
 		listener.Close()
 
-		go dqliteProxy("raftDial", g.stopCh, conn, goUnix)
+		go dqliteProxy("raft", g.stopCh, conn, goUnix)
 
 		return cUnix, nil
 	}
@@ -1075,7 +1075,7 @@ func runDqliteProxy(stopCh chan struct{}, bindAddress string, acceptCh chan net.
 			continue
 		}
 
-		go dqliteProxy("runDqliteProxy", stopCh, remote, local)
+		go dqliteProxy("dqlite", stopCh, remote, local)
 	}
 }
 


### PR DESCRIPTION
There appears to be an issue in dqlite/go-dqlite that means that a connection established via `dqliteNetworkDial` is not closed down cleanly when the remote member becomes unreachable. This sometimes (approx 50:50) leaves the connection in close-wait state with data in the send queue for circa 15mins until the OS releases the connection.

This causes DB transactions on the non-leader members to fail with errors like:

```
lxc cluster ls
Error: failed to begin transaction: call exec-sql (budget 9.999963394s): receive: header: EOF
```

This only seems to happen if the remote member is shutdown cleanly, so that the remote end is cleanly closed, and then the OS is waiting for dqlite/go-dqlite to close the local end of the connection (which it never does) and instead continues to use it resulting in every write failing with an EOF error.

This PR works around the issue by limiting the amount of time an outbound dqlite/raft connection can have data waiting to be sent (similar to https://github.com/lxc/lxd/pull/9416 for inbound dqlite connections). This in turn ensures a stalled connection caused by a network interruption is closed locally after 30s so its not used by dqlite causing queries to fail with EOF error.

The error above still occurs, but is now limited to 30s rather than 15mins.
