### PR TITLE
Adds lxd-agent option to apply name and MTU to nic devices

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1621,3 +1621,7 @@ Adds the `ipv4.neighbor_probe` and `ipv6.neighbor_probe` NIC settings. Defaultin
 
 ## event\_hub
 This adds support for `event-hub` cluster member role and the `ServerEventMode` environment field.
+
+## agent\_rename\_interfaces
+If set to true, on start-up the lxd-agent will rename the network interfaces to match the names of the instances network
+devices.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -42,6 +42,7 @@ The currently supported keys are:
 
 Key                                         | Type      | Default           | Live update   | Condition                 | Description
 :--                                         | :---      | :------           | :----------   | :----------               | :----------
+agent.rename_interfaces                     | boolean   | false             | n/a           | virtual-machine           | Set the name and MTU of the default network interfaces to be the same as the instance devices (this is automatic for containers). 
 boot.autostart                              | boolean   | -                 | n/a           | -                         | Always start the instance when LXD starts (if not set, restore last state)
 boot.autostart.delay                        | integer   | 0                 | n/a           | -                         | Number of seconds to wait after the instance started before starting the next one
 boot.autostart.priority                     | integer   | 0                 | n/a           | -                         | What order to start the instances in (starting with highest)

--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -106,6 +106,8 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 		time.Sleep(300 * time.Second)
 	}
 
+	reconfigureNetworkInterfaces()
+
 	// Load the kernel driver.
 	logger.Info("Loading vsock module")
 	err = util.LoadModule("vsock")

--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -55,3 +55,9 @@ type RunConfig struct {
 	PCIDevice        []RunConfigItem  // PCI device configuration settings.
 	Revert           *revert.Reverter // Revert setup of device on post-setup error.
 }
+
+// NICConfig contains network interface configuration to be passed into a VM and applied by the agent.
+type NICConfig struct {
+	MACAddress string `json:"mac_address"`
+	MTU        uint32 `json:"mtu"`
+}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -631,10 +631,25 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	if d.inst.Type() == instancetype.VM {
+		var mtu uint32
+		if d.config["mtu"] != "" {
+			mtu64, err := strconv.ParseUint(d.config["mtu"], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			mtu = uint32(mtu64)
+		} else if d.config["parent"] != "" {
+			mtu, err = network.GetDevMTU(d.config["parent"])
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
 				{Key: "hwaddr", Value: d.config["hwaddr"]},
+				{Key: "mtu", Value: strconv.Itoa(int(mtu))},
 			}...)
 	}
 
@@ -1577,15 +1592,9 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 		addresses = append(addresses, addr)
 	}
 
-	// Get MTU of host interface if exists.
-	iface, err := net.InterfaceByName(d.config["host_name"])
+	mtu, err := d.getHostMTU()
 	if err != nil {
 		d.logger.Warn("Failed getting host interface state for MTU", log.Ctx{"host_name": d.config["host_name"], "err": err})
-	}
-
-	mtu := -1
-	if iface != nil {
-		mtu = iface.MTU
 	}
 
 	// Retrieve the host counters, as we report the values from the instance's point of view,
@@ -1611,6 +1620,21 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 	}
 
 	return &network, nil
+}
+
+func (d *nicBridged) getHostMTU() (int, error) {
+	// Get MTU of host interface if exists.
+	iface, err := net.InterfaceByName(d.config["host_name"])
+	if err != nil {
+		return 0, err
+	}
+
+	mtu := -1
+	if iface != nil {
+		mtu = iface.MTU
+	}
+
+	return mtu, nil
 }
 
 // Register sets up anything needed on LXD startup.

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -276,6 +276,8 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 
 	"security.agent.metrics": validate.Optional(validate.IsBool),
 	"security.secureboot":    validate.Optional(validate.IsBool),
+
+	"agent.rename_interfaces": validate.Optional(validate.IsBool),
 }
 
 // ConfigKeyChecker returns a function that will check whether or not

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -319,6 +319,7 @@ var APIExtensions = []string{
 	"certificate_token",
 	"instance_nic_routed_neighbor_probe",
 	"event_hub",
+	"agent_rename_interfaces",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Adds information about expected nic devices to the VM config share. The lxd-agent reads and applies the configuration on startup.

Closes #7233 