### PR TITLE
github: Update for current min Go version (1.16)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.13.x
           - 1.16.x
           - 1.17.x
         os:


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>