### PR TITLE
Daemon: Add the trusted cluster member fingerprint to the request context username field

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -296,15 +296,17 @@ func (d *Daemon) getTrustedCertificates() map[db.CertificateType]map[string]x509
 // will validate the TLS certificate or Macaroon.
 //
 // This does not perform authorization, only validates authentication.
+// Returns whether trusted or not, the username (or certificate fingerprint) of the trusted client, and the type of
+// client that has been authenticated (cluster, unix, candid or tls).
 func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, string, string, error) {
 	trustedCerts := d.getTrustedCertificates()
 
 	// Allow internal cluster traffic by checking against the trusted certfificates.
 	if r.TLS != nil {
 		for _, i := range r.TLS.PeerCertificates {
-			trusted, _ := util.CheckTrustState(*i, trustedCerts[db.CertificateTypeServer], d.endpoints.NetworkCert(), false)
+			trusted, fingerprint := util.CheckTrustState(*i, trustedCerts[db.CertificateTypeServer], d.endpoints.NetworkCert(), false)
 			if trusted {
-				return true, "", "cluster", nil
+				return true, fingerprint, "cluster", nil
 			}
 		}
 	}
@@ -508,7 +510,13 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			}
 		}
 
-		logCtx := log.Ctx{"method": r.Method, "url": r.URL.RequestURI(), "ip": r.RemoteAddr, "username": username, "protocol": protocol}
+		logCtx := log.Ctx{"method": r.Method, "url": r.URL.RequestURI(), "ip": r.RemoteAddr, "protocol": protocol}
+		if protocol == "cluster" {
+			logCtx["fingerprint"] = username
+		} else {
+			logCtx["username"] = username
+		}
+
 		untrustedOk := (r.Method == "GET" && c.Get.AllowUntrusted) || (r.Method == "POST" && c.Post.AllowUntrusted)
 		if trusted {
 			logger.Debug("Handling API request", logCtx)

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -151,6 +151,7 @@ type ContextAwareRequest interface {
 // CheckTrustState checks whether the given client certificate is trusted
 // (i.e. it has a valid time span and it belongs to the given list of trusted
 // certificates).
+// Returns whether or not the certificate is trusted, and the fingerprint of the certificate.
 func CheckTrustState(cert x509.Certificate, trustedCerts map[string]x509.Certificate, networkCert *shared.CertInfo, trustCACertificates bool) (bool, string) {
 	// Extra validity check (should have been caught by TLS stack)
 	if time.Now().Before(cert.NotBefore) || time.Now().After(cert.NotAfter) {

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -179,10 +179,10 @@ func CheckTrustState(cert x509.Certificate, trustedCerts map[string]x509.Certifi
 	}
 
 	// Check whether client certificate is in trust store.
-	for k, v := range trustedCerts {
+	for fingerprint, v := range trustedCerts {
 		if bytes.Compare(cert.Raw, v.Raw) == 0 {
-			logger.Debug("Matched trusted cert", log.Ctx{"fingerprint": k, "subject": v.Subject})
-			return true, k
+			logger.Debug("Matched trusted cert", log.Ctx{"fingerprint": fingerprint, "subject": v.Subject})
+			return true, fingerprint
 		}
 	}
 


### PR DESCRIPTION
This allows requests to identify the cluster member from the certificate fingerprint it uses.

Will be used for event-hub feature.