### PR TITLE
Events: Replaces isLocal concept with event source

### DIFF
--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -45,7 +45,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 	defer c.Close() // This ensures the go routine below is ended when this function ends.
 
 	// As we don't know which project we are in, subscribe to events from all projects.
-	listener, err := d.events.AddListener("", true, c, strings.Split(typeStr, ","), "", true, nil)
+	listener, err := d.events.AddListener("", true, c, strings.Split(typeStr, ","), "", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -33,15 +33,10 @@ type listenerCommon struct {
 	lock         sync.Mutex
 	pongsPending uint
 	recvFunc     EventHandler
-
-	// If true, this listener won't get events forwarded from other
-	// nodes. It only used by listeners created internally by LXD nodes
-	// connecting to other LXD nodes to get their local events only.
-	localOnly bool
 }
 
 func (e *listenerCommon) heartbeat() {
-	logger.Debug("Event listener server handler started", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
+	logger.Debug("Event listener server handler started", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr()})
 
 	defer e.Close()
 
@@ -85,7 +80,7 @@ func (e *listenerCommon) heartbeat() {
 		e.lock.Lock()
 		if e.pongsPending > 2 {
 			e.lock.Unlock()
-			logger.Warn("Hearbeat for event listener handler timed out", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
+			logger.Warn("Hearbeat for event listener handler timed out", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr()})
 			return
 		}
 		err := e.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
@@ -132,7 +127,7 @@ func (e *listenerCommon) Close() {
 		return
 	}
 
-	logger.Debug("Event listener server handler stopped", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr(), "localOnly": e.localOnly})
+	logger.Debug("Event listener server handler stopped", log.Ctx{"listener": e.ID(), "local": e.Conn.LocalAddr(), "remote": e.Conn.RemoteAddr()})
 
 	e.Conn.Close()
 	e.ctxCancel()

--- a/lxd/events/devlxdEvents.go
+++ b/lxd/events/devlxdEvents.go
@@ -41,7 +41,6 @@ func (s *DevLXDServer) AddListener(instanceID int, connection *websocket.Conn, m
 		listenerCommon: listenerCommon{
 			Conn:         connection,
 			messageTypes: messageTypes,
-			localOnly:    true,
 			ctx:          ctx,
 			ctxCancel:    ctxCancel,
 			id:           uuid.New(),

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -14,6 +14,18 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
+// EventSource indicates the source of an event.
+type EventSource uint8
+
+// EventSourceLocal indicates the event was generated locally.
+const EventSourceLocal = 0
+
+// EventSourcePull indicates the event was received from an outbound event listener stream.
+const EventSourcePull = 1
+
+// EventSourcePush indicates the event was received from an event listener client connected to us.
+const EventSourcePush = 2
+
 // Server represents an instance of an event server.
 type Server struct {
 	serverCommon


### PR DESCRIPTION
This will be needed for the event-hub feature (by utilising the `EventSourcePush` source type for pushed events from non-hub members).