### PR TITLE
Events: Replaces listener level server location with server level location

### DIFF
--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -45,7 +45,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 	defer c.Close() // This ensures the go routine below is ended when this function ends.
 
 	// As we don't know which project we are in, subscribe to events from all projects.
-	listener, err := d.events.AddListener("", true, c, strings.Split(typeStr, ","), "", nil, nil)
+	listener, err := d.events.AddListener("", true, c, strings.Split(typeStr, ","), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -19,6 +19,7 @@ import (
 var listeners = map[string]*lxd.EventListener{}
 var listenersNotify = map[chan struct{}][]string{}
 var listenersLock sync.Mutex
+var listenersUpdateLock sync.Mutex
 
 // EventListenerWait waits for there to be listener connected to the specified address, or one of the event hubs
 // if operating in event hub mode.
@@ -55,6 +56,9 @@ func EventListenerWait(ctx context.Context, address string) error {
 
 // EventsUpdateListeners refreshes the cluster event listener connections.
 func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func() *shared.CertInfo, members map[int64]APIHeartbeatMember, f func(int64, api.Event)) {
+	listenersUpdateLock.Lock()
+	defer listenersUpdateLock.Unlock()
+
 	// If no heartbeat members provided, populate from global database.
 	if members == nil {
 		var dbMembers []db.NodeInfo

--- a/test/main.sh
+++ b/test/main.sh
@@ -196,6 +196,7 @@ if [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_autotarget "clustering autotarget member"
     # run_test test_clustering_upgrade "clustering upgrade"
     run_test test_clustering_groups "clustering groups"
+    run_test test_clustering_events "clustering events"
 fi
 
 if [ "${1:-"all"}" != "cluster" ]; then

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3269,3 +3269,81 @@ test_clustering_groups() {
 
   lxc remote rm cluster
 }
+
+test_clustering_events() {
+  # shellcheck disable=2039
+  local LXD_DIR
+
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_ONE_DIR}"
+  ns1="${prefix}1"
+  spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+  # Add a newline at the end of each line. YAML has weird rules...
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+  # Spawn a second node.
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_TWO_DIR}"
+  ns2="${prefix}2"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
+
+  # Spawn a third node.
+  setup_clustering_netns 3
+  LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_THREE_DIR}"
+  ns3="${prefix}3"
+  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
+
+  ensure_import_testimage
+
+  # c1 should go to node1.
+  LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c1
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node1"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc monitor --type=lifecycle > "${TEST_DIR}/node1.log" &
+  monitorNode1PID=$!
+  LXD_DIR="${LXD_TWO_DIR}" lxc monitor --type=lifecycle > "${TEST_DIR}/node2.log" &
+  monitorNode2PID=$!
+  LXD_DIR="${LXD_THREE_DIR}" lxc monitor --type=lifecycle > "${TEST_DIR}/node3.log" &
+  monitorNode3PID=$!
+
+  # Delete instance generating stop and delete lifecycle events.
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete -f c1
+  sleep 1 # Wait for event to be distributed.
+
+  # Kill monitors.
+  kill -9 ${monitorNode1PID}
+  kill -9 ${monitorNode2PID}
+  kill -9 ${monitorNode3PID}
+
+  # Check events were distributed.
+  for i in 1 2 3; do
+    grep "instance-stopped" "${TEST_DIR}/node${i}.log" -c | grep -F 1
+    grep "instance-deleted" "${TEST_DIR}/node${i}.log" -c | grep -F 1
+  done
+
+  # Cleanup.
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  sleep 0.5
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_THREE_DIR}"
+}


### PR DESCRIPTION
Replaces listener location with event server location as it makes more logical sense and avoids the need for a deep copy of the event.

Also includes fix for an intermittent event duplication caused by a joining member running `EventsUpdateListeners` concurrently both as part of its joining process whist at the same time receiving a heartbeat which also triggers `EventsUpdateListeners`.

Includes tests from https://github.com/lxc/lxd/pull/9905