### PR TITLE
lxc/console: Fix double close on channel

### DIFF
--- a/lxc/console.go
+++ b/lxc/console.go
@@ -184,7 +184,6 @@ func (c *cmdConsole) console(d lxd.InstanceServer, name string) error {
 
 	consoleDisconnect := make(chan bool)
 	sendDisconnect := make(chan struct{})
-	defer close(sendDisconnect)
 
 	consoleArgs := lxd.InstanceConsoleArgs{
 		Terminal: &readWriteCloser{stdinMirror{os.Stdin,


### PR DESCRIPTION
This removes a double close on a channel which caused a panic every time
one exited the console.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
