### PR TITLE
doc/metrics: stop tuning job's scrape_interval now that results are c…

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -2,7 +2,8 @@
 LXD provides metrics for all running instances. Those covers CPU, memory, network, disk and process usage and are meant to be consumed by Prometheus and likely graphed in Grafana.
 In cluster environments, LXD will only return the values for instances running on the server being accessed. It's expected that each cluster member will be scraped separately.
 The instance metrics are updated when calling the `/1.0/metrics` endpoint.
-They are cached for 15s to handle multiple scrapers. Fetching metrics is a relatively expensive operation for LXD to perform so we would recommend scraping at a 30s or 60s rate to limit impact.
+They are cached for 8s to handle multiple scrapers. Fetching metrics is a relatively expensive operation for LXD to perform so consider scraping at a higher than default interval (15s)
+if the impact is too high.
 
 ## Create metrics certificate
 The `/1.0/metrics` endpoint is a special one as it also accepts a `metrics` type certificate.
@@ -58,7 +59,6 @@ scrape_configs:
   - job_name: lxd
     metrics_path: '/1.0/metrics'
     scheme: 'https'
-    scrape_interval: 30s
     static_configs:
       - targets: ['127.0.0.1:8443']
     tls_config:


### PR DESCRIPTION
…ached 8s only

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>