### PR TITLE
doc/metrics: don't assume any default scrape_interval value

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -2,7 +2,7 @@
 LXD provides metrics for all running instances. Those covers CPU, memory, network, disk and process usage and are meant to be consumed by Prometheus and likely graphed in Grafana.
 In cluster environments, LXD will only return the values for instances running on the server being accessed. It's expected that each cluster member will be scraped separately.
 The instance metrics are updated when calling the `/1.0/metrics` endpoint.
-They are cached for 8s to handle multiple scrapers. Fetching metrics is a relatively expensive operation for LXD to perform so consider scraping at a higher than default interval (15s)
+They are cached for 8s to handle multiple scrapers. Fetching metrics is a relatively expensive operation for LXD to perform so consider scraping at a higher than default interval
 if the impact is too high.
 
 ## Create metrics certificate


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>