### PR TITLE
Rework FileResponse

### DIFF
--- a/lxd-agent/file.go
+++ b/lxd-agent/file.go
@@ -90,8 +90,9 @@ func fileGet(path string, r *http.Request) response.Response {
 
 		files[0].Path = f.Name()
 		files[0].Filename = filepath.Base(path)
+		files[0].Cleanup = func() { os.Remove(f.Name()) }
 
-		return response.FileResponse(r, files, headers, true)
+		return response.FileResponse(r, files, headers)
 	} else if fType == "directory" {
 		return response.SyncResponseHeaders(true, dirEnts, headers)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3406,7 +3406,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		files[1].Path = rootfsPath
 		files[1].Filename = filename
 
-		return response.FileResponse(r, files, nil, false)
+		return response.FileResponse(r, files, nil)
 	}
 
 	files := make([]response.FileResponseEntry, 1)
@@ -3417,7 +3417,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	requestor := request.CreateRequestor(r)
 	d.State().Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, projectName, requestor, nil))
 
-	return response.FileResponse(r, files, nil, false)
+	return response.FileResponse(r, files, nil)
 }
 
 // swagger:operation POST /1.0/images/{fingerprint}/export images images_export_post

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -616,5 +616,5 @@ func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 
 	d.State().Events.SendLifecycle(projectName, lifecycle.InstanceBackupRetrieved.Event(name, backup.Instance(), nil))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil, false)
+	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
 }

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -152,8 +152,9 @@ func instanceFileGet(c instance.Instance, path string, r *http.Request) response
 		files[0].Identifier = filepath.Base(path)
 		files[0].Path = temp.Name()
 		files[0].Filename = filepath.Base(path)
+		files[0].Cleanup = func() { os.Remove(temp.Name()) }
 
-		return response.FileResponse(r, files, headers, true)
+		return response.FileResponse(r, files, headers)
 	} else if type_ == "directory" {
 		os.Remove(temp.Name())
 		return response.SyncResponseHeaders(true, dirEnts, headers)

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -227,7 +227,7 @@ func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 
 	d.State().Events.SendLifecycle(projectName, lifecycle.InstanceLogRetrieved.Event(file, inst, request.CreateRequestor(r), nil))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil, false)
+	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
 }
 
 // swagger:operation DELETE /1.0/instances/{name}/logs/{filename} instances instance_log_delete

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -478,10 +478,11 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 	files[0].Identifier = templateName
 	files[0].Path = tempfile.Name()
 	files[0].Filename = templateName
+	files[0].Cleanup = func() { os.Remove(tempfile.Name()) }
 
 	d.State().Events.SendLifecycle(projectName, lifecycle.InstanceMetadataTemplateRetrieved.Event(c, request.CreateRequestor(r), log.Ctx{"path": templateName}))
 
-	return response.FileResponse(r, files, nil, true)
+	return response.FileResponse(r, files, nil)
 }
 
 // swagger:operation POST /1.0/instances/{name}/metadata/templates instances instance_metadata_templates_post

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -575,6 +577,9 @@ func networkACLLogGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	ent := response.FileResponseEntry{}
-	ent.Buffer = []byte(log)
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil, false)
+	ent.File = bytes.NewReader([]byte(log))
+	ent.FileModify = time.Now()
+	ent.FileSize = int64(len(log))
+
+	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
 }

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -782,5 +782,5 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 
 	d.State().Events.SendLifecycle(projectName, lifecycle.StorageVolumeBackupRetrieved.Event(poolName, volumeTypeName, volumeName, projectName, request.CreateRequestor(r), nil))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil, false)
+	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
 }


### PR DESCRIPTION
This is in preparation for the upcoming `forkfile` rework as this adds the ability to stream entire files without ever having to read them into memory or have them be present on disk.