### PR TITLE
lxd/fsmonitor/drivers: Ignore stale file handle errors.

### DIFF
--- a/lxd/fsmonitor/drivers/driver_fanotify.go
+++ b/lxd/fsmonitor/drivers/driver_fanotify.go
@@ -143,7 +143,10 @@ func (d *fanotify) getEvents(mountFd int) {
 
 		fd, err := unix.OpenByHandleAt(mountFd, fh, 0)
 		if err != nil {
-			d.logger.Error("Failed to open file", log.Ctx{"err": err})
+			errno := err.(unix.Errno)
+			if errno != unix.ESTALE {
+				d.logger.Error("Failed to open file", log.Ctx{"err": err})
+			}
 			continue
 		}
 		unix.CloseOnExec(fd)


### PR DESCRIPTION
Checks the error number of the syscall and logs the error only if it's code is not `ESTALE`.

Closes #9885.