### PR TITLE
Remove state.State dependency from apparmor package 

### DIFF
--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -67,7 +67,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 `))
 
 // dnsmasqProfile generates the AppArmor profile template from the given network.
-func dnsmasqProfile(state *state.State, n network) (string, error) {
+func dnsmasqProfile(sysOS *sys.OS, n network) (string, error) {
 	rootPath := ""
 	if shared.InSnap() {
 		rootPath = "/var/lib/snapd/hostfs"

--- a/lxd/apparmor/network_forkdns.go
+++ b/lxd/apparmor/network_forkdns.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 )
@@ -55,7 +55,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 `))
 
 // forkdnsProfile generates the AppArmor profile template from the given network.
-func forkdnsProfile(state *state.State, n network) (string, error) {
+func forkdnsProfile(sysOS *sys.OS, n network) (string, error) {
 	rootPath := ""
 	if shared.InSnap() {
 		rootPath = "/var/lib/snapd/hostfs"

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -215,7 +215,7 @@ func (d *proxy) Start() (*deviceConfig.RunConfig, error) {
 			logPath := filepath.Join(d.inst.LogPath(), logFileName)
 
 			// Load the apparmor profile
-			err = apparmor.ForkproxyLoad(d.state, d.inst, d)
+			err = apparmor.ForkproxyLoad(d.state.OS, d.inst, d)
 			if err != nil {
 				return fmt.Errorf("Failed to start device %q: %w", d.name, err)
 			}
@@ -340,7 +340,7 @@ func (d *proxy) Stop() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Unload apparmor profile.
-	err = apparmor.ForkproxyUnload(d.state, d.inst, d)
+	err = apparmor.ForkproxyUnload(d.state.OS, d.inst, d)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +572,7 @@ func (d *proxy) Remove() error {
 	}
 
 	// Delete apparmor profile.
-	err = apparmor.ForkproxyDelete(d.state, d.inst, d)
+	err = apparmor.ForkproxyDelete(d.state.OS, d.inst, d)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -656,7 +656,7 @@ func (d *qemu) onStop(target string) error {
 	}
 
 	// Unload the apparmor profile
-	err = apparmor.InstanceUnload(d.state, d)
+	err = apparmor.InstanceUnload(d.state.OS, d)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -1399,7 +1399,7 @@ func (d *qemu) Start(stateful bool) error {
 	}
 
 	// Load the AppArmor profile
-	err = apparmor.InstanceLoad(d.state, d)
+	err = apparmor.InstanceLoad(d.state.OS, d)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -4060,7 +4060,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 
 	// If apparmor changed, re-validate the apparmor profile (even if not running).
 	if shared.StringInSlice("raw.apparmor", changedConfig) {
-		err = apparmor.InstanceValidate(d.state, d)
+		err = apparmor.InstanceValidate(d.state.OS, d)
 		if err != nil {
 			return errors.Wrap(err, "Parse AppArmor profile")
 		}
@@ -4463,7 +4463,7 @@ func (d *qemu) cleanup() {
 	d.removeDiskDevices()
 
 	// Remove the security profiles
-	apparmor.InstanceDelete(d.state, d)
+	apparmor.InstanceDelete(d.state.OS, d)
 
 	// Remove the devices path
 	os.Remove(d.DevicesPath())

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -512,7 +512,7 @@ func (n *bridge) Delete(clientType request.ClientType) error {
 	}
 
 	// Delete apparmor profiles.
-	err = apparmor.NetworkDelete(n.state, n)
+	err = apparmor.NetworkDelete(n.state.OS, n)
 	if err != nil {
 		return err
 	}
@@ -1479,7 +1479,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 	}
 
 	// Generate and load apparmor profiles.
-	err = apparmor.NetworkLoad(n.state, n)
+	err = apparmor.NetworkLoad(n.state.OS, n)
 	if err != nil {
 		return err
 	}
@@ -1760,7 +1760,7 @@ func (n *bridge) Stop() error {
 	}
 
 	// Unload apparmor profiles.
-	err = apparmor.NetworkUnload(n.state, n)
+	err = apparmor.NetworkUnload(n.state.OS, n)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR removes the `state.State` dependency from `apparmor` package, so now it's dependent from `sys.OS`. This way its clearer what actually `apparmor` package depend on. This change is based on conversation from #9906.