### PR TITLE
Storage: Set all ZFS dataset mountpoint settings to legacy

### DIFF
--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -26,7 +26,7 @@ var zfsDirectIO bool
 var zfsTrim bool
 
 var zfsDefaultSettings = map[string]string{
-	"mountpoint": "none",
+	"mountpoint": "legacy",
 	"setuid":     "on",
 	"exec":       "on",
 	"devices":    "on",
@@ -216,7 +216,7 @@ func (d *zfs) Create() error {
 		if strings.Contains(d.config["zfs.pool_name"], "/") {
 			// Handle a dataset.
 			if !d.checkDataset(d.config["zfs.pool_name"]) {
-				err := d.createDataset(d.config["zfs.pool_name"], "mountpoint=none")
+				err := d.createDataset(d.config["zfs.pool_name"], "mountpoint=legacy")
 				if err != nil {
 					return err
 				}
@@ -264,7 +264,7 @@ func (d *zfs) Create() error {
 	// Create the initial datasets.
 	for _, dataset := range d.initialDatasets() {
 
-		properties := []string{"mountpoint=none"}
+		properties := []string{"mountpoint=legacy"}
 		if shared.StringInSlice(dataset, []string{"virtual-machines", "deleted/virtual-machines"}) {
 			if len(zfsVersion) >= 3 && zfsVersion[0:3] == "0.6" {
 				d.logger.Warn("Unable to set volmode on parent virtual-machines datasets due to ZFS being too old")

--- a/lxd/storage/drivers/driver_zfs_patches.go
+++ b/lxd/storage/drivers/driver_zfs_patches.go
@@ -14,7 +14,7 @@ func (d *zfs) patchStorageCreateVM() error {
 			continue
 		}
 
-		err := d.createDataset(filepath.Join(d.config["zfs.pool_name"], dataset), "mountpoint=none", "canmount=noauto")
+		err := d.createDataset(filepath.Join(d.config["zfs.pool_name"], dataset), "mountpoint=legacy", "canmount=noauto")
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ func (d *zfs) patchStorageZFSMount() error {
 		}
 
 		if oldMountPoint != "none" {
-			err := d.setDatasetProperties(filepath.Join(d.config["zfs.pool_name"], dataset), "mountpoint=none", "canmount=noauto")
+			err := d.setDatasetProperties(filepath.Join(d.config["zfs.pool_name"], dataset), "mountpoint=legacy", "canmount=noauto")
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -133,7 +133,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 	if vol.contentType == ContentTypeFS {
 		// Create the filesystem dataset.
-		err := d.createDataset(d.dataset(vol, false), "mountpoint=none", "canmount=noauto")
+		err := d.createDataset(d.dataset(vol, false), "mountpoint=legacy", "canmount=noauto")
 		if err != nil {
 			return err
 		}
@@ -427,7 +427,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 
 		// Re-apply the base mount options.
 		if v.contentType == ContentTypeFS {
-			err := d.setDatasetProperties(d.dataset(v, false), "mountpoint=none", "canmount=noauto")
+			err := d.setDatasetProperties(d.dataset(v, false), "mountpoint=legacy", "canmount=noauto")
 			if err != nil {
 				return nil, nil, err
 			}
@@ -650,7 +650,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 
 	// Apply the properties.
 	if vol.contentType == ContentTypeFS {
-		err := d.setDatasetProperties(d.dataset(vol, false), "mountpoint=none", "canmount=noauto")
+		err := d.setDatasetProperties(d.dataset(vol, false), "mountpoint=legacy", "canmount=noauto")
 		if err != nil {
 			return err
 		}
@@ -772,7 +772,7 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 		}
 
 		// Re-apply the base mount options.
-		err = d.setDatasetProperties(d.dataset(vol, false), "mountpoint=none", "canmount=noauto")
+		err = d.setDatasetProperties(d.dataset(vol, false), "mountpoint=legacy", "canmount=noauto")
 		if err != nil {
 			return err
 		}
@@ -1223,7 +1223,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 	if vol.contentType == ContentTypeFS {
 		mountPath := vol.MountPath()
 		if !filesystem.IsMountPoint(mountPath) {
-			err := d.setDatasetProperties(dataset, "mountpoint=none", "canmount=noauto")
+			err := d.setDatasetProperties(dataset, "mountpoint=legacy", "canmount=noauto")
 			if err != nil {
 				return err
 			}
@@ -1406,7 +1406,7 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 
 	// Ensure the volume has correct mountpoint settings.
 	if vol.contentType == ContentTypeFS {
-		err = d.setDatasetProperties(d.dataset(newVol, false), "mountpoint=none", "canmount=noauto")
+		err = d.setDatasetProperties(d.dataset(newVol, false), "mountpoint=legacy", "canmount=noauto")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is in relation to https://github.com/lxc/lxd-pkg-snap/issues/61 and trying to avoid
the ZFS tooling running inside the snap mount namspace from trying to mount/unmount the
datasets as it can get confused and fail to find the mounts.

Our experimentation in earier iterations of these changes suggest that using the legacy
mount/umount commands fair better than getting the ZFS tooling do it.

We previously set mountpoint=none but have seen that this is causing ZFS tooling to
try and unmount volumes which is still causing problems.

This is an attempt to try and further avoid ZFS from trying to mount/unmount datasets.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>