### PR TITLE
Cluster: Heartbeat improvements

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -125,7 +125,7 @@ type Gateway struct {
 	HeartbeatOfflineThreshold time.Duration
 	heartbeatCancel           context.CancelFunc
 	heartbeatCancelLock       sync.Mutex
-	heartbeatLock             sync.Mutex
+	HeartbeatLock             sync.Mutex
 
 	// NodeStore wrapper.
 	store *dqliteNodeStore

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -455,7 +455,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 				if !node.updated {
 					// If member has not been updated during this heartbeat round it means
 					// they are currently unreachable or rejecting heartbeats due to being
-					// in the process of shutting down. Eitherway we do not want to use this
+					// in the process of shutting down. Either way we do not want to use this
 					// member as a candidate for role promotion.
 					unavailableMembers = append(unavailableMembers, node.Address)
 					continue

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -185,9 +185,11 @@ func (hbState *APIHeartbeat) Send(ctx context.Context, networkCert *shared.CertI
 		} else {
 			logger.Warn("Failed heartbeat", log.Ctx{"remote": address, "err": err})
 
-			err = hbState.cluster.UpsertWarningLocalNode("", cluster.TypeNode, int(nodeID), db.WarningOfflineClusterMember, err.Error())
-			if err != nil {
-				logger.Warn("Failed to create warning", log.Ctx{"err": err})
+			if ctx.Err() == nil {
+				err = hbState.cluster.UpsertWarningLocalNode("", cluster.TypeNode, int(nodeID), db.WarningOfflineClusterMember, err.Error())
+				if err != nil {
+					logger.Warn("Failed to create warning", log.Ctx{"err": err})
+				}
 			}
 		}
 	}

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -290,8 +290,8 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	// Avoid concurent heartbeat loops.
 	// This is possible when both the regular task and the out of band heartbeat round from a dqlite
 	// connection or notification restart both kick in at the same time.
-	g.heartbeatLock.Lock()
-	defer g.heartbeatLock.Unlock()
+	g.HeartbeatLock.Lock()
+	defer g.HeartbeatLock.Unlock()
 
 	// Acquire the cancellation lock and populate it so that this heartbeat round can be cancelled if a
 	// notification cancellation request arrives during the round. Also setup a defer so that the cancellation

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -402,57 +402,48 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, allNodes, spreadDuration)
 	}
 
-	// If the context has been cancelled, return immediately.
-	err = ctx.Err()
-	if err != nil {
-		logger.Warn("Aborting heartbeat round", log.Ctx{"err": err, "mode": modeStr, "local": localAddress})
-		return
-	}
+	// Check if context has been cancelled.
+	ctxErr := ctx.Err()
 
 	// Look for any new node which appeared since sending last heartbeat.
-	var currentNodes []db.NodeInfo
-	err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		var err error
-		currentNodes, err = tx.GetNodes()
+	if ctxErr == nil {
+		var currentNodes []db.NodeInfo
+		err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
+			var err error
+			currentNodes, err = tx.GetNodes()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
 		if err != nil {
-			return err
+			logger.Warn("Failed to get current cluster members", log.Ctx{"err": err, "mode": modeStr, "local": localAddress})
+			return
 		}
 
-		return nil
-	})
-	if err != nil {
-		logger.Warn("Failed to get current cluster members", log.Ctx{"err": err, "mode": modeStr, "local": localAddress})
-		return
-	}
+		newNodes := []db.NodeInfo{}
+		for _, currentNode := range currentNodes {
+			existing := false
+			for _, node := range allNodes {
+				if node.Address == currentNode.Address && node.ID == currentNode.ID {
+					existing = true
+					break
+				}
+			}
 
-	newNodes := []db.NodeInfo{}
-	for _, currentNode := range currentNodes {
-		existing := false
-		for _, node := range allNodes {
-			if node.Address == currentNode.Address && node.ID == currentNode.ID {
-				existing = true
-				break
+			if !existing {
+				// We found a new node
+				allNodes = append(allNodes, currentNode)
+				newNodes = append(newNodes, currentNode)
 			}
 		}
 
-		if !existing {
-			// We found a new node
-			allNodes = append(allNodes, currentNode)
-			newNodes = append(newNodes, currentNode)
+		// If any new nodes found, send heartbeat to just them (with full node state).
+		if len(newNodes) > 0 {
+			hbState.Update(true, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
+			hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, newNodes, 0)
 		}
-	}
-
-	// If any new nodes found, send heartbeat to just them (with full node state).
-	if len(newNodes) > 0 {
-		hbState.Update(true, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
-		hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, newNodes, 0)
-	}
-
-	// If the context has been cancelled, return immediately.
-	err = ctx.Err()
-	if err != nil {
-		logger.Warn("Aborting heartbeat round", log.Ctx{"err": err, "mode": modeStr, "local": localAddress})
-		return
 	}
 
 	// Initialise slice to indicate to HeartbeatNodeHook that its being called from leader.
@@ -481,6 +472,12 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	})
 	if err != nil {
 		logger.Error("Failed updating cluster heartbeats", log.Ctx{"err": err})
+		return
+	}
+
+	// If the context has been cancelled, return prematurely after saving the members we did manage to ping.
+	if ctxErr != nil {
+		logger.Warn("Aborting heartbeat round", log.Ctx{"err": ctxErr, "mode": modeStr, "local": localAddress})
 		return
 	}
 

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -568,6 +568,10 @@ func NotifyHeartbeat(state *state.State, gateway *Gateway) {
 	heartbeatCancel := gateway.HearbeatCancelFunc()
 	if heartbeatCancel != nil {
 		heartbeatCancel()
+
+		// Wait for heartbeat to finish and then release.
+		gateway.HeartbeatLock.Lock()
+		gateway.HeartbeatLock.Unlock()
 	}
 
 	hbState := NewAPIHearbeat(state.Cluster)


### PR DESCRIPTION
I found that when a notification heartbeat was being triggered on the leader, it would cancel the ongoing heartbeat round and discard any node state it had recorded, then retrieve the previous state from the db and broadcast that to all the nodes triggering them to consider nodes offline incorrectly (due to old last heartbeat times) which in turn caused the event listeners to those nodes to be closed  causing missed events.

The fix is to not abruptly cancel the heartbeat round but instead ask it to abort its spread mode  and switch to immediate to finish quickly.

- Don't abruptly end ongoing heartbeat when asked to cancel, instead immediately ping any remaining members and save the state. This is so we don't end up sending out-of-date member info when a notification heartbeat causes an ongoing heartbeat round to be cancelled prematurely. Instead now the cancellation requests that the ongoing heartbeat round "hurry up" rather than "kill itself".
- Notification heartbeat waits for any ongoing heartbeat round to finish up before starting to ensure out-of-date member info isn't broadcast to all members.