### PR TITLE
Improve `lxc query` support for metrics

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -34,6 +34,7 @@ type RemoteOperation interface {
 type Server interface {
 	GetConnectionInfo() (info *ConnectionInfo, err error)
 	GetHTTPClient() (client *http.Client, err error)
+	DoHTTP(req *http.Request) (resp *http.Response, err error)
 	Disconnect()
 }
 

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -245,7 +245,7 @@ func (r *ProtocolLXD) rawQuery(method string, url string, data interface{}, ETag
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -103,8 +103,8 @@ func (r *ProtocolLXD) GetHTTPClient() (*http.Client, error) {
 	return r.http, nil
 }
 
-// Do performs a Request, using macaroon authentication if set.
-func (r *ProtocolLXD) do(req *http.Request) (*http.Response, error) {
+// DoHTTP performs a Request, using macaroon authentication if set.
+func (r *ProtocolLXD) DoHTTP(req *http.Request) (*http.Response, error) {
 	// Set the user agent
 	if r.httpUserAgent != "" {
 		req.Header.Set("User-Agent", r.httpUserAgent)

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -115,7 +115,7 @@ func (r *ProtocolLXD) CreateContainerFromBackup(args ContainerBackupArgs) (Opera
 	req.Header.Set("X-LXD-pool", args.PoolName)
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}
@@ -775,7 +775,7 @@ func (r *ProtocolLXD) GetContainerFile(containerName string, path string) (io.Re
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -877,7 +877,7 @@ func (r *ProtocolLXD) CreateContainerFile(containerName string, path string, arg
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return err
 	}
@@ -1342,7 +1342,7 @@ func (r *ProtocolLXD) GetContainerLogfile(name string, filename string) (io.Read
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1437,7 +1437,7 @@ func (r *ProtocolLXD) GetContainerTemplateFile(containerName string, templateNam
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1473,7 +1473,7 @@ func (r *ProtocolLXD) CreateContainerTemplateFile(containerName string, template
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	// Check the return value for a cleaner error
 	if resp.StatusCode != http.StatusOK {
 		_, _, err := lxdParseResponse(resp)
@@ -1590,7 +1590,7 @@ func (r *ProtocolLXD) GetContainerConsoleLog(containerName string, args *Contain
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -493,7 +493,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -324,7 +324,7 @@ func (r *ProtocolLXD) CreateInstanceFromBackup(args InstanceBackupArgs) (Operati
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1061,7 +1061,7 @@ func (r *ProtocolLXD) GetInstanceFile(instanceName string, filePath string) (io.
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1174,7 +1174,7 @@ func (r *ProtocolLXD) CreateInstanceFile(instanceName string, filePath string, a
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return err
 	}
@@ -1735,7 +1735,7 @@ func (r *ProtocolLXD) GetInstanceLogfile(name string, filename string) (io.ReadC
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1855,7 +1855,7 @@ func (r *ProtocolLXD) GetInstanceTemplateFile(instanceName string, templateName 
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1896,7 +1896,7 @@ func (r *ProtocolLXD) CreateInstanceTemplateFile(instanceName string, templateNa
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	// Check the return value for a cleaner error
 	if resp.StatusCode != http.StatusOK {
 		_, _, err := lxdParseResponse(resp)
@@ -2119,7 +2119,7 @@ func (r *ProtocolLXD) GetInstanceConsoleLog(instanceName string, args *InstanceC
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_network_acls.go
+++ b/client/lxd_network_acls.go
@@ -82,7 +82,7 @@ func (r *ProtocolLXD) GetNetworkACLLogfile(name string) (io.ReadCloser, error) {
 	}
 
 	// Send the request
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -846,7 +846,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeFromBackup(pool string, args Storag
 	}
 
 	// Send the request.
-	resp, err := r.do(req)
+	resp, err := r.DoHTTP(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/simplestreams.go
+++ b/client/simplestreams.go
@@ -40,3 +40,13 @@ func (r *ProtocolSimpleStreams) GetHTTPClient() (*http.Client, error) {
 
 	return r.http, nil
 }
+
+// DoHTTP performs a Request, using macaroon authentication if set.
+func (r *ProtocolSimpleStreams) DoHTTP(req *http.Request) (*http.Response, error) {
+	// Set the user agent
+	if r.httpUserAgent != "" {
+		req.Header.Set("User-Agent", r.httpUserAgent)
+	}
+
+	return r.http.Do(req)
+}

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -9129,6 +9129,11 @@ paths:
         in: query
         name: project
         type: string
+      - description: Cluster member name
+        example: lxd01
+        in: query
+        name: target
+        type: string
       produces:
       - text/plain
       responses:

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -83,7 +83,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Prepare response.
-	resp := metrics.NewMetricSet(nil)
+	metricSet := metrics.NewMetricSet(nil)
 
 	// Review the cache.
 	metricsCacheLock.Lock()
@@ -97,13 +97,13 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// If present and valid, merge the existing data.
-		resp.Merge(cache.metrics)
+		metricSet.Merge(cache.metrics)
 	}
 	metricsCacheLock.Unlock()
 
 	// If all valid, return immediately.
 	if len(projectMissing) == 0 {
-		return response.SyncResponsePlain(true, resp.String())
+		return response.SyncResponsePlain(true, metricSet.String())
 	}
 
 	// Acquire update lock.
@@ -122,13 +122,13 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// If present and valid, merge the existing data.
-		resp.Merge(cache.metrics)
+		metricSet.Merge(cache.metrics)
 	}
 	metricsCacheLock.Unlock()
 
 	// If all valid, return immediately.
 	if len(toFetch) == 0 {
-		return response.SyncResponsePlain(true, resp.String())
+		return response.SyncResponsePlain(true, metricSet.String())
 	}
 
 	// Prepare temporary metrics storage.
@@ -186,9 +186,9 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 			metrics: entries,
 		}
 
-		resp.Merge(entries)
+		metricSet.Merge(entries)
 	}
 	metricsCacheLock.Unlock()
 
-	return response.SyncResponsePlain(true, resp.String())
+	return response.SyncResponsePlain(true, metricSet.String())
 }

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -45,6 +45,11 @@ var metricsCmd = APIEndpoint{
 //     description: Project name
 //     type: string
 //     example: default
+//   - in: query
+//     name: target
+//     description: Cluster member name
+//     type: string
+//     example: lxd01
 // responses:
 //   "200":
 //     description: Metrics
@@ -57,6 +62,12 @@ var metricsCmd = APIEndpoint{
 //     $ref: "#/responses/InternalServerError"
 func metricsGet(d *Daemon, r *http.Request) response.Response {
 	projectName := queryParam(r, "project")
+
+	// Forward if requested.
+	resp := forwardedResponseIfTargetIsRemote(d, r)
+	if resp != nil {
+		return resp
+	}
 
 	// Figure out the projects to retrieve.
 	var projectNames []string


### PR DESCRIPTION
With this PR, `lxc query` will work against candid/RBAC authenticated endpoints and will be able to select a specific server by using `?target=XYZ`.