### PR TITLE
NIC: Various routed fixes and improvements

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -909,7 +909,9 @@ func networkSRIOVSetupContainerVFNIC(hostName string, config map[string]string) 
 	return nil
 }
 
-func isIPAvailable(ctx context.Context, address net.IP, parentInterface string) error {
+// isIPAvailable checks if address responds to ARP/NDP neighbour probe on the parentInterface.
+// Returns true if IP is available.
+func isIPAvailable(ctx context.Context, address net.IP, parentInterface string) (bool, error) {
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		// Set default timeout of 500ms if no deadline context provided.
@@ -924,29 +926,33 @@ func isIPAvailable(ctx context.Context, address net.IP, parentInterface string) 
 		timeout := deadline.Sub(time.Now())
 		arping.SetTimeout(timeout)
 		_, _, err := arping.PingOverIfaceByName(address, parentInterface)
-		if err == nil {
-			return fmt.Errorf("ipv4.address %q is already in use", address.String())
+		if err != nil {
+			if errors.Cause(err) == arping.ErrTimeout {
+				return false, nil
+			}
+
+			return false, err
 		}
 
-		return nil
+		return true, nil
 	}
 
 	// Handle IPv6 address.
 	networkInterface, err := net.InterfaceByName(parentInterface)
 	if err != nil {
-		return nil
+		return false, err
 	}
 
 	conn, _, err := ndp.Listen(networkInterface, ndp.LinkLocal)
 	if err != nil {
-		return nil
+		return false, err
 	}
 
 	defer conn.Close()
 
 	solicitedNodeMulticast, err := ndp.SolicitedNodeMulticast(address)
 	if err != nil {
-		return nil
+		return false, err
 	}
 
 	neighbourSolicitationMessage := &ndp.NeighborSolicitation{
@@ -956,21 +962,25 @@ func isIPAvailable(ctx context.Context, address net.IP, parentInterface string) 
 	conn.SetDeadline(deadline)
 	err = conn.WriteTo(neighbourSolicitationMessage, nil, solicitedNodeMulticast)
 	if err != nil {
-		return nil
+		return false, err
 	}
 
 	conn.SetDeadline(deadline)
 	msg, _, _, err := conn.ReadFrom()
 	if err != nil {
-		return nil
+		if cause, ok := err.(net.Error); ok && cause.Timeout() {
+			return false, nil
+		}
+
+		return false, err
 	}
 
 	neighbourAdvertisement, ok := msg.(*ndp.NeighborAdvertisement)
-	if ok {
-		return fmt.Errorf("ipv6.address %q is already in use", neighbourAdvertisement.TargetAddress.String())
+	if ok && neighbourAdvertisement.TargetAddress.Equal(address) {
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 // networkVLANListExpand takes in a list of raw VLAN values (string) that includes

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -105,7 +105,7 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		}
 	}
 
-	// Ensure that address is set if routes is set
+	// Ensure that address is set if routes is set.
 	for _, keyPrefix := range []string{"ipv4", "ipv6"} {
 		if d.config[fmt.Sprintf("%s.routes", keyPrefix)] != "" && d.config[fmt.Sprintf("%s.address", keyPrefix)] == "" {
 			return fmt.Errorf("%s.routes requires %s.address to be set", keyPrefix, keyPrefix)

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -140,7 +140,7 @@ func (d *nicRouted) validateEnvironment() error {
 		// If the effective parent doesn't exist and the vlan option is specified, it means we are going to
 		// create the VLAN parent at start, and we will configure the needed sysctls then, so skip checks
 		// on the effective parent.
-		if d.config["vlan"] != "" && network.InterfaceExists(d.effectiveParentName) {
+		if d.config["vlan"] != "" && !network.InterfaceExists(d.effectiveParentName) {
 			return nil
 		}
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -126,11 +126,6 @@ func (d *nicRouted) validateEnvironment() error {
 		return fmt.Errorf("Requires name property to start")
 	}
 
-	extensions := d.state.OS.LXCFeatures
-	if !extensions["network_veth_router"] || !extensions["network_l2proxy"] {
-		return fmt.Errorf("Requires liblxc has following API extensions: network_veth_router, network_l2proxy")
-	}
-
 	if d.config["parent"] != "" && !network.InterfaceExists(d.config["parent"]) {
 		return fmt.Errorf("Parent device %q doesn't exist", d.config["parent"])
 	}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -270,7 +270,7 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 		saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
 
 		// If we created a VLAN interface, we need to setup the sysctls on that interface.
-		if statusDev == "created" {
+		if shared.IsTrue(saveData["last_state.created"]) {
 			err := d.setupParentSysctls(d.effectiveParentName)
 			if err != nil {
 				return nil, err

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -209,6 +209,7 @@ func (d *nicRouted) validateEnvironment() error {
 	return nil
 }
 
+// checkIPAvailability checks using ARP and NDP neighbour probes whether any of the NIC's IPs are already in use.
 func (d *nicRouted) checkIPAvailability(parent string) error {
 	var addresses []net.IP
 	ipv4AddrStr, ok := d.config["ipv4.address"]

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -28,6 +28,7 @@ var nicRoutedIPGateway = map[string]string{
 
 type nicRouted struct {
 	deviceCommon
+	effectiveParentName string
 }
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running.
@@ -126,77 +127,82 @@ func (d *nicRouted) validateEnvironment() error {
 		return fmt.Errorf("Requires name property to start")
 	}
 
-	if d.config["parent"] != "" && !network.InterfaceExists(d.config["parent"]) {
-		return fmt.Errorf("Parent device %q doesn't exist", d.config["parent"])
-	}
-
-	// Check necessary "all" sysctls are configured for use with l2proxy parent for routed mode.
-	if d.config["parent"] != "" && d.config["ipv6.address"] != "" {
-		// net.ipv6.conf.all.forwarding=1 is required to enable general packet forwarding for IPv6.
-		ipv6FwdPath := fmt.Sprintf("net/ipv6/conf/%s/forwarding", "all")
-		sysctlVal, err := util.SysctlGet(ipv6FwdPath)
-		if err != nil {
-			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6FwdPath, err)
-		}
-		if sysctlVal != "1\n" {
-			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.forwarding=1", "all")
+	if d.config["parent"] != "" {
+		// Check parent interface exists (don't use d.effectiveParentName here as we want to check the
+		// parent of any VLAN interface exists too). The VLAN interface will be created later if needed.
+		if !network.InterfaceExists(d.config["parent"]) {
+			return fmt.Errorf("Parent device %q doesn't exist", d.config["parent"])
 		}
 
-		// net.ipv6.conf.all.proxy_ndp=1 is needed otherwise unicast neighbour solicitations are rejected.
-		// This causes periodic latency spikes every 15-20s as the neighbour has to resort to using
-		// multicast NDP resolution and expires the previous neighbour entry.
-		ipv6ProxyNdpPath := fmt.Sprintf("net/ipv6/conf/%s/proxy_ndp", "all")
-		sysctlVal, err = util.SysctlGet(ipv6ProxyNdpPath)
-		if err != nil {
-			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6ProxyNdpPath, err)
-		}
-		if sysctlVal != "1\n" {
-			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.proxy_ndp=1", "all")
-		}
-	}
+		// Detect the effective parent interface that we will be using (taking into account VLAN setting).
+		d.effectiveParentName = network.GetHostDevice(d.config["parent"], d.config["vlan"])
 
-	// Generate effective parent name, including the VLAN part if option used.
-	effectiveParentName := network.GetHostDevice(d.config["parent"], d.config["vlan"])
-
-	// If the effective parent doesn't exist and the vlan option is specified, it means we are going to create
-	// the VLAN parent at start, and we will configure the needed sysctls so don't need to check them yet.
-	if d.config["vlan"] != "" && network.InterfaceExists(effectiveParentName) {
-		return nil
-	}
-
-	// Check necessary sysctls are configured for use with l2proxy parent for routed mode.
-	if effectiveParentName != "" && d.config["ipv4.address"] != "" {
-		ipv4FwdPath := fmt.Sprintf("net/ipv4/conf/%s/forwarding", effectiveParentName)
-		sysctlVal, err := util.SysctlGet(ipv4FwdPath)
-		if err != nil {
-			return fmt.Errorf("Error reading net sysctl %s: %v", ipv4FwdPath, err)
-		}
-		if sysctlVal != "1\n" {
-			// Replace . in parent name with / for sysctl formatting.
-			return fmt.Errorf("Routed mode requires sysctl net.ipv4.conf.%s.forwarding=1", strings.Replace(effectiveParentName, ".", "/", -1))
-		}
-	}
-
-	// Check necessary devic specific sysctls are configured for use with l2proxy parent for routed mode.
-	if effectiveParentName != "" && d.config["ipv6.address"] != "" {
-		ipv6FwdPath := fmt.Sprintf("net/ipv6/conf/%s/forwarding", effectiveParentName)
-		sysctlVal, err := util.SysctlGet(ipv6FwdPath)
-		if err != nil {
-			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6FwdPath, err)
-		}
-		if sysctlVal != "1\n" {
-			// Replace . in parent name with / for sysctl formatting.
-			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.forwarding=1", strings.Replace(effectiveParentName, ".", "/", -1))
+		// If the effective parent doesn't exist and the vlan option is specified, it means we are going to
+		// create the VLAN parent at start, and we will configure the needed sysctls then, so skip checks
+		// on the effective parent.
+		if d.config["vlan"] != "" && network.InterfaceExists(d.effectiveParentName) {
+			return nil
 		}
 
-		ipv6ProxyNdpPath := fmt.Sprintf("net/ipv6/conf/%s/proxy_ndp", effectiveParentName)
-		sysctlVal, err = util.SysctlGet(ipv6ProxyNdpPath)
-		if err != nil {
-			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6ProxyNdpPath, err)
+		// Check necessary "all" sysctls are configured for use with l2proxy parent for routed mode.
+		if d.config["ipv6.address"] != "" {
+			// net.ipv6.conf.all.forwarding=1 is required to enable general packet forwarding for IPv6.
+			ipv6FwdPath := fmt.Sprintf("net/ipv6/conf/%s/forwarding", "all")
+			sysctlVal, err := util.SysctlGet(ipv6FwdPath)
+			if err != nil {
+				return fmt.Errorf("Error reading net sysctl %s: %v", ipv6FwdPath, err)
+			}
+			if sysctlVal != "1\n" {
+				return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.forwarding=1", "all")
+			}
+
+			// net.ipv6.conf.all.proxy_ndp=1 is needed otherwise unicast neighbour solicitations are .
+			// rejected This causes periodic latency spikes every 15-20s as the neighbour has to resort
+			// to using multicast NDP resolution and expires the previous neighbour entry.
+			ipv6ProxyNdpPath := fmt.Sprintf("net/ipv6/conf/%s/proxy_ndp", "all")
+			sysctlVal, err = util.SysctlGet(ipv6ProxyNdpPath)
+			if err != nil {
+				return fmt.Errorf("Error reading net sysctl %s: %v", ipv6ProxyNdpPath, err)
+			}
+			if sysctlVal != "1\n" {
+				return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.proxy_ndp=1", "all")
+			}
 		}
-		if sysctlVal != "1\n" {
-			// Replace . in parent name with / for sysctl formatting.
-			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.proxy_ndp=1", strings.Replace(effectiveParentName, ".", "/", -1))
+
+		// Check necessary sysctls are configured for use with l2proxy parent for routed mode.
+		if d.config["ipv4.address"] != "" {
+			ipv4FwdPath := fmt.Sprintf("net/ipv4/conf/%s/forwarding", d.effectiveParentName)
+			sysctlVal, err := util.SysctlGet(ipv4FwdPath)
+			if err != nil {
+				return fmt.Errorf("Error reading net sysctl %s: %v", ipv4FwdPath, err)
+			}
+			if sysctlVal != "1\n" {
+				// Replace . in parent name with / for sysctl formatting.
+				return fmt.Errorf("Routed mode requires sysctl net.ipv4.conf.%s.forwarding=1", strings.Replace(d.effectiveParentName, ".", "/", -1))
+			}
+		}
+
+		// Check necessary devic specific sysctls are configured for use with l2proxy parent for routed mode.
+		if d.config["ipv6.address"] != "" {
+			ipv6FwdPath := fmt.Sprintf("net/ipv6/conf/%s/forwarding", d.effectiveParentName)
+			sysctlVal, err := util.SysctlGet(ipv6FwdPath)
+			if err != nil {
+				return fmt.Errorf("Error reading net sysctl %s: %v", ipv6FwdPath, err)
+			}
+			if sysctlVal != "1\n" {
+				// Replace . in parent name with / for sysctl formatting.
+				return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.forwarding=1", strings.Replace(d.effectiveParentName, ".", "/", -1))
+			}
+
+			ipv6ProxyNdpPath := fmt.Sprintf("net/ipv6/conf/%s/proxy_ndp", d.effectiveParentName)
+			sysctlVal, err = util.SysctlGet(ipv6ProxyNdpPath)
+			if err != nil {
+				return fmt.Errorf("Error reading net sysctl %s: %v", ipv6ProxyNdpPath, err)
+			}
+			if sysctlVal != "1\n" {
+				// Replace . in parent name with / for sysctl formatting.
+				return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.proxy_ndp=1", strings.Replace(d.effectiveParentName, ".", "/", -1))
+			}
 		}
 	}
 
@@ -254,10 +260,8 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 	saveData := make(map[string]string)
 
 	// Decide which parent we should use based on VLAN setting.
-	parentName := ""
-	if d.config["parent"] != "" {
-		parentName = network.GetHostDevice(d.config["parent"], d.config["vlan"])
-		statusDev, err := networkCreateVlanDeviceIfNeeded(d.state, d.config["parent"], parentName, d.config["vlan"], shared.IsTrue(d.config["gvrp"]))
+	if d.config["vlan"] != "" {
+		statusDev, err := networkCreateVlanDeviceIfNeeded(d.state, d.config["parent"], d.effectiveParentName, d.config["vlan"], shared.IsTrue(d.config["gvrp"]))
 		if err != nil {
 			return nil, err
 		}
@@ -267,15 +271,15 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 
 		// If we created a VLAN interface, we need to setup the sysctls on that interface.
 		if statusDev == "created" {
-			err := d.setupParentSysctls(parentName)
+			err := d.setupParentSysctls(d.effectiveParentName)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	if parentName != "" {
-		err := d.checkIPAvailability(parentName)
+	if d.effectiveParentName != "" {
+		err := d.checkIPAvailability(d.effectiveParentName)
 		if err != nil {
 			return nil, err
 		}
@@ -399,9 +403,9 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 			}
 
 			// If there is a parent interface, add neighbour proxy entry.
-			if parentName != "" {
+			if d.effectiveParentName != "" {
 				np := ip.NeighProxy{
-					DevName: parentName,
+					DevName: d.effectiveParentName,
 					Addr:    net.ParseIP(addrStr),
 				}
 				err = np.Add()

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -576,9 +576,8 @@ func (d *nicRouted) postStop() error {
 
 	networkVethFillFromVolatile(d.config, v)
 
-	parentName := ""
 	if d.config["parent"] != "" {
-		parentName = network.GetHostDevice(d.config["parent"], d.config["vlan"])
+		d.effectiveParentName = network.GetHostDevice(d.config["parent"], d.config["vlan"])
 	}
 
 	// Delete host-side interface.
@@ -591,11 +590,11 @@ func (d *nicRouted) postStop() error {
 	}
 
 	// Delete IP neighbour proxy entries on the parent.
-	if parentName != "" {
+	if d.effectiveParentName != "" {
 		for _, key := range []string{"ipv4.address", "ipv6.address"} {
 			for _, addr := range util.SplitNTrimSpace(d.config[key], ",", -1, true) {
 				neighProxy := &ip.NeighProxy{
-					DevName: parentName,
+					DevName: d.effectiveParentName,
 					Addr:    net.ParseIP(addr),
 				}
 
@@ -606,7 +605,7 @@ func (d *nicRouted) postStop() error {
 
 	// This will delete the parent interface if we created it for VLAN parent.
 	if shared.IsTrue(v["last_state.created"]) {
-		err := networkRemoveInterfaceIfNeeded(d.state, parentName, d.inst, d.config["parent"], d.config["vlan"])
+		err := networkRemoveInterfaceIfNeeded(d.state, d.effectiveParentName, d.inst, d.config["parent"], d.config["vlan"])
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -112,6 +112,11 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		}
 	}
 
+	// Ensure that VLAN setting is only used with parent setting.
+	if d.config["parent"] == "" && d.config["vlan"] != "" {
+		return fmt.Errorf("The vlan setting can only be used when combined with a parent interface")
+	}
+
 	return nil
 }
 
@@ -128,10 +133,6 @@ func (d *nicRouted) validateEnvironment() error {
 
 	if d.config["parent"] != "" && !network.InterfaceExists(d.config["parent"]) {
 		return fmt.Errorf("Parent device %q doesn't exist", d.config["parent"])
-	}
-
-	if d.config["parent"] == "" && d.config["vlan"] != "" {
-		return fmt.Errorf("The vlan setting can only be used when combined with a parent interface")
 	}
 
 	// Check necessary "all" sysctls are configured for use with l2proxy parent for routed mode.

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -53,8 +53,15 @@ test_container_devices_nic_routed() {
   # Record how many nics we started with.
   startNicCount=$(find /sys/class/net | wc -l)
 
-  # Check that starting routed container.
   lxc init testimage "${ctName}"
+
+  # Check vlan option not allowed without parent option.
+  ! lxc config device add "${ctName}" eth0 nic \
+    name=eth0 \
+    nictype=routed \
+    vlan=1234 || false
+
+  # Check starting routed container.
   lxc config device add "${ctName}" eth0 nic \
     name=eth0 \
     nictype=routed \

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -61,6 +61,18 @@ test_container_devices_nic_routed() {
     nictype=routed \
     vlan=1234 || false
 
+  # Check VLAN parent interface creation and teardown.
+  lxc config device add "${ctName}" eth0 nic \
+    name=eth0 \
+    nictype=routed \
+    parent=${ctName} \
+    vlan=1235
+  lxc start "${ctName}"
+  stat "/sys/class/net/${ctName}.1235"
+  lxc stop -f "${ctName}"
+  ! stat "/sys/class/net/${ctName}.1235" || false
+  lxc config device remove "${ctName}" eth0
+
   # Check starting routed container.
   lxc config device add "${ctName}" eth0 nic \
     name=eth0 \


### PR DESCRIPTION
- Fixes an issue where if `vlan` and `parent` options are set, but VLAN interface doesn't exist, the instance wouldn't start (now it correctly creates the vlan interface on the parent).
- Simplifies the IP in use detection to use socket deadlines rather than go routines and contexts, to avoid leaving go routines behind after context has been cancelled and also to be able to better inspect the resulting error and log warnings for unknown errors, rather than just ignoring them.
- Cleans up parent environmental checks to keep them together and reduce duplicated logic.
- Removes created VLAN interface on error.
- Adds default 500ms timeout to isIPAvailable (which is what the ARP package used as a default anyway), in case `context.Background()` was ever passed to this function, which would then block forever for IPv6 probes.