### PR TITLE
doc/metrics: use secp384r1 curve with SHA384 signature

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -12,7 +12,7 @@ This kind of certificate is meant for metrics only, and won't work for interacti
 Here's how to create a new certificate (this is not specific to metrics):
 
 ```bash
-openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -keyout metrics.key -nodes -out metrics.crt -days 3650 -subj "/CN=metrics.local"
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -sha384 -keyout metrics.key -nodes -out metrics.crt -days 3650 -subj "/CN=metrics.local"
 ```
 
 Now, this certificate needs to be added to the list of trusted clients:


### PR DESCRIPTION
This aligns with the type of key/signature used by LXD itself.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>