### PR TITLE
NIC: Adds ipv{n}.neighbor_probe settings to routed NIC

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1613,3 +1613,8 @@ Adds a `@never` option to `snapshots.schedule` which allows disabling inheritanc
 This adds token-based certificate addition to the trust store as a safer alternative to a trust password.
 
 It adds the `token` field to `POST /1.0/certificates`.
+
+## instance\_nic\_routed\_neighbor\_probe
+This adds the ability to disable the `routed` NIC IP neighbor probing for availability on the parent network.
+
+Adds the `ipv4.neighbor_probe` and `ipv6.neighbor_probe` NIC settings. Defaulting to `true` if not specified.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -640,11 +640,13 @@ ipv4.routes             | string  | -                 | no       | Comma delimit
 ipv4.gateway            | string  | auto              | no       | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
 ipv4.host\_address      | string  | 169.254.0.1       | no       | The IPv4 address to add to the host-side veth interface
 ipv4.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table)
+ipv4.neighbor\_probe    | boolean | true              | no       | Whether to probe the parent network for IP address availability.
 ipv6.address            | string  | -                 | no       | Comma delimited list of IPv6 static addresses to add to the instance
 ipv6.routes             | string  | -                 | no       | Comma delimited list of IPv6 static routes to add on host to NIC (without L2 ARP/NDP proxy)
 ipv6.gateway            | string  | auto              | no       | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
 ipv6.host\_address      | string  | fe80::1           | no       | The IPv6 address to add to the host-side veth interface
 ipv6.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table)
+ipv6.neighbor\_probe    | boolean | true              | no       | Whether to probe the parent network for IP address availability.
 vlan                    | integer | -                 | no       | The VLAN ID to attach to
 gvrp                    | boolean | false             | no       | Register VLAN using GARP VLAN Registration Protocol
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -85,6 +85,8 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 	rules["ipv4.address"] = validate.Optional(validate.IsNetworkAddressV4List)
 	rules["ipv6.address"] = validate.Optional(validate.IsNetworkAddressV6List)
 	rules["gvrp"] = validate.Optional(validate.IsBool)
+	rules["ipv4.neighbor_probe"] = validate.Optional(validate.IsBool)
+	rules["ipv6.neighbor_probe"] = validate.Optional(validate.IsBool)
 
 	err = d.config.Validate(rules)
 	if err != nil {
@@ -213,17 +215,16 @@ func (d *nicRouted) validateEnvironment() error {
 // checkIPAvailability checks using ARP and NDP neighbour probes whether any of the NIC's IPs are already in use.
 func (d *nicRouted) checkIPAvailability(parent string) error {
 	var addresses []net.IP
-	ipv4AddrStr, ok := d.config["ipv4.address"]
-	if ok {
-		ipv4Addrs := util.SplitNTrimSpace(ipv4AddrStr, ",", -1, true)
+
+	if !shared.IsFalse(d.config["ipv4.neighbor_probe"]) {
+		ipv4Addrs := util.SplitNTrimSpace(d.config["ipv4.address"], ",", -1, true)
 		for _, addr := range ipv4Addrs {
 			addresses = append(addresses, net.ParseIP(addr))
 		}
 	}
 
-	ipv6AddrStr, ok := d.config["ipv6.address"]
-	if ok {
-		ipv6Addrs := util.SplitNTrimSpace(ipv6AddrStr, ",", -1, true)
+	if !shared.IsFalse(d.config["ipv6.neighbor_probe"]) {
+		ipv6Addrs := util.SplitNTrimSpace(d.config["ipv6.address"], ",", -1, true)
 		for _, addr := range ipv6Addrs {
 			addresses = append(addresses, net.ParseIP(addr))
 		}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -317,6 +317,7 @@ var APIExtensions = []string{
 	"metrics_cpu_seconds",
 	"instance_snapshot_never",
 	"certificate_token",
+	"instance_nic_routed_neighbor_probe",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2477,7 +2477,7 @@ test_clustering_failure_domains() {
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
   sleep 3
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -q "database: false"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node5 | grep -q "database: true"
 

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -127,5 +127,6 @@ test_container_devices_nic_macvlan() {
   # Cleanup.
   lxc delete "${ctName}" -f
   lxc delete "${ctName}2" -f
+  lxc profile delete "${ctName}"
   ip link delete "${ctName}" type dummy
 }


### PR DESCRIPTION
Fixes #9940

Allows disabling IP availability probe checks.
Also adds missing tests for IP availability checks.