### PR TITLE
Restrict device names

### DIFF
--- a/lxd/device/device_load.go
+++ b/lxd/device/device_load.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lxc/lxd/lxd/device/nictype"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/shared/validate"
 )
 
 // newByType returns a new unitialised device based of the type indicated by the project and device config.
@@ -109,6 +110,11 @@ func load(inst instance.Instance, state *state.State, projectName string, name s
 // not compatible with the instance type then an ErrUnsupportedDevType error is returned.
 // Note: The supplied config may be modified during validation to enrich. If this is not desired, supply a copy.
 func New(inst instance.Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
+	err := validate.IsDeviceName(name)
+	if err != nil {
+		return nil, err
+	}
+
 	dev, err := load(inst, state, inst.Project(), name, conf, volatileGet, volatileSet)
 	if err != nil {
 		return nil, err
@@ -126,6 +132,11 @@ func New(inst instance.Instance, state *state.State, name string, conf deviceCon
 // blown instance to allow profile devices to be validated too.
 // Note: The supplied config may be modified during validation to enrich. If this is not desired, supply a copy.
 func Validate(instConfig instance.ConfigReader, state *state.State, name string, conf deviceConfig.Device) error {
+	err := validate.IsDeviceName(name)
+	if err != nil {
+		return err
+	}
+
 	dev, err := load(nil, state, instConfig.Project(), name, conf, nil, nil)
 	if err != nil {
 		return err

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
+	"github.com/lxc/lxd/shared/validate"
 	"github.com/lxc/lxd/shared/version"
 )
 
@@ -845,7 +846,7 @@ func SuitableArchitectures(s *state.State, project string, req api.InstancesPost
 func ValidName(instanceName string, isSnapshot bool) error {
 	if isSnapshot {
 		parentName, snapshotName, _ := shared.InstanceGetParentAndSnapshotName(instanceName)
-		err := shared.ValidHostname(parentName)
+		err := validate.IsHostname(parentName)
 		if err != nil {
 			return errors.Wrap(err, "Invalid instance name")
 		}
@@ -859,7 +860,7 @@ func ValidName(instanceName string, isSnapshot bool) error {
 			return fmt.Errorf("The character %q is reserved for snapshots", shared.SnapshotDelimiter)
 		}
 
-		err := shared.ValidHostname(instanceName)
+		err := validate.IsHostname(instanceName)
 		if err != nil {
 			return errors.Wrap(err, "Invalid instance name")
 		}

--- a/lxd/network/acl/acl_validation.go
+++ b/lxd/network/acl/acl_validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/validate"
 )
 
 // ValidName checks the ACL name is valid.
@@ -19,7 +20,7 @@ func ValidName(name string) error {
 	}
 
 	// Ensures we can differentiate an ACL name from an IP in rules that reference this ACL.
-	err := shared.ValidHostname(name)
+	err := validate.IsHostname(name)
 	if err != nil {
 		return err
 	}

--- a/shared/util.go
+++ b/shared/util.go
@@ -720,36 +720,6 @@ func RunningInUserNS() bool {
 	return true
 }
 
-// ValidHostname checks the string is valid DNS hostname.
-func ValidHostname(name string) error {
-	// Validate length
-	if len(name) < 1 || len(name) > 63 {
-		return fmt.Errorf("Name must be 1-63 characters long")
-	}
-
-	// Validate first character
-	if strings.HasPrefix(name, "-") {
-		return fmt.Errorf(`Name must not start with "-" character`)
-	}
-
-	if _, err := strconv.Atoi(string(name[0])); err == nil {
-		return fmt.Errorf("Name must not be a number")
-	}
-
-	// Validate last character
-	if strings.HasSuffix(name, "-") {
-		return fmt.Errorf(`Name must not end with "-" character`)
-	}
-
-	// Validate the character set
-	match, _ := regexp.MatchString("^[-a-zA-Z0-9]*$", name)
-	if !match {
-		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
-	}
-
-	return nil
-}
-
 // Spawn the editor with a temporary YAML file for editing configs
 func TextEditor(inPath string, inContent []byte) ([]byte, error) {
 	var f *os.File

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -805,6 +805,37 @@ func ParseNetworkVLANRange(vlan string) (int, int, error) {
 
 // IsHostname checks the string is valid DNS hostname.
 func IsHostname(name string) error {
+	err := isName(name)
+	if err != nil {
+		return err
+	}
+
+	match, _ := regexp.MatchString("^[-a-zA-Z0-9]*$", name)
+	if !match {
+		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
+	}
+
+	return nil
+}
+
+// IsDeviceName performs the same checks as ValidHostname but also allows underscores.
+func IsDeviceName(name string) error {
+	err := isName(name)
+	if err != nil {
+		return err
+	}
+
+	match, _ := regexp.MatchString("^[-_a-zA-Z0-9]*$", name)
+	if !match {
+		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
+	}
+
+	return nil
+}
+
+// isName checks that the given string is 1-63 characters long, does not start or end with a hyphen and does not start
+// with a number.
+func isName(name string) error {
 	// Validate length
 	if len(name) < 1 || len(name) > 63 {
 		return fmt.Errorf("Name must be 1-63 characters long")
@@ -816,18 +847,12 @@ func IsHostname(name string) error {
 	}
 
 	if _, err := strconv.Atoi(string(name[0])); err == nil {
-		return fmt.Errorf("Name must not be a number")
+		return fmt.Errorf("Name must not start with a number")
 	}
 
 	// Validate last character
 	if strings.HasSuffix(name, "-") {
 		return fmt.Errorf(`Name must not end with "-" character`)
-	}
-
-	// Validate the character set
-	match, _ := regexp.MatchString("^[-a-zA-Z0-9]*$", name)
-	if !match {
-		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
 	}
 
 	return nil

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -802,3 +802,33 @@ func ParseNetworkVLANRange(vlan string) (int, int, error) {
 
 	return vlanRangeStart, vlanRangeEnd - vlanRangeStart + 1, nil
 }
+
+// IsHostname checks the string is valid DNS hostname.
+func IsHostname(name string) error {
+	// Validate length
+	if len(name) < 1 || len(name) > 63 {
+		return fmt.Errorf("Name must be 1-63 characters long")
+	}
+
+	// Validate first character
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf(`Name must not start with "-" character`)
+	}
+
+	if _, err := strconv.Atoi(string(name[0])); err == nil {
+		return fmt.Errorf("Name must not be a number")
+	}
+
+	// Validate last character
+	if strings.HasSuffix(name, "-") {
+		return fmt.Errorf(`Name must not end with "-" character`)
+	}
+
+	// Validate the character set
+	match, _ := regexp.MatchString("^[-a-zA-Z0-9]*$", name)
+	if !match {
+		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
+	}
+
+	return nil
+}


### PR DESCRIPTION
In #9790 and #9893 we began using device names for naming files (e.g. `<instance>.<device>` for #9790). This means we can no longer use certain characters in device names such as `/` or `..` which would cause files to written to the wrong place.

This PR limits device names to hostname characters plus underscores.