### PR TITLE
lxd/certificates: Better handle authentication

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -482,12 +482,16 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	trusted, _, protocol, err := d.Authenticate(nil, r)
+	trusted, _, _, err := d.Authenticate(nil, r)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	if !trusted || (protocol == "candid" && !rbac.UserIsAdmin(r)) {
+	if !rbac.UserIsAdmin(r) {
+		if trusted {
+			return response.BadRequest(fmt.Errorf("Client is already trusted"))
+		}
+
 		if req.Password != "" {
 			// Check if cluster member join token supplied as password.
 			joinToken, err := clusterMemberJoinTokenDecode(req.Password)


### PR DESCRIPTION
rbac.UserIsAdmin will return true if the user is:
 - local user (admin)
 - TLS user (no restriction)
 - candid user
 - RBAC user (with global admin role)

We then need to check again whether the user is considered to be trusted.
If they are, then we can't add them to the trust store.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>