### PR TITLE
Allow ipv{4,6} routes when using bridged security.ipv{4,6}_filtering

### DIFF
--- a/lxd/firewall/drivers/drivers_consts.go
+++ b/lxd/firewall/drivers/drivers_consts.go
@@ -2,12 +2,6 @@ package drivers
 
 import "net"
 
-// FilterIPv6All used to indicate to firewall package to filter all IPv6 traffic.
-const FilterIPv6All = "::"
-
-// FilterIPv4All used to indicate to firewall package to filter all IPv4 traffic.
-const FilterIPv4All = "0.0.0.0"
-
 // FeatureOpts specify how firewall features are setup.
 type FeatureOpts struct {
 	ICMPDHCPDNSAccess bool // Add rules to allow ICMP, DHCP and DNS access.

--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -188,24 +188,31 @@ chain in{{.chainSeparator}}{{.deviceLabel}} {
 	iifname "{{.hostName}}" ether saddr != {{.hwAddr}} drop
 	iifname "{{.hostName}}" ether type arp arp saddr ether != {{.hwAddr}} drop
 	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,528,48 != {{.hwAddrHex}} drop
+	{{if .ipv4Nets -}}
+	iifname "{{.hostName}}" ether type ip ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp dport 67 accept
+	{{range .ipv4Nets -}}
+	iifname "{{$.hostName}}" ether type arp arp saddr ip {{.}} accept
+	iifname "{{$.hostName}}" ether type ip ip saddr {{.}} accept
+	{{end}}
+	iifname "{{.hostName}}" ether type arp drop
+	iifname "{{.hostName}}" ether type ip drop
+	{{- end}}
 	{{if .ipv4FilterAll -}}
 	iifname "{{.hostName}}" ether type arp drop
 	iifname "{{.hostName}}" ether type ip drop
 	{{- end}}
-	{{if .ipv4Addr -}}
-	iifname "{{.hostName}}" ether type arp arp saddr ip != {{.ipv4Addr}} drop
-	iifname "{{.hostName}}" ether type ip ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp dport 67 accept
-	iifname "{{.hostName}}" ether type ip ip saddr != {{.ipv4Addr}} drop
+	{{if .ipv6Nets -}}
+	iifname "{{.hostName}}" ether type ip6 ip6 saddr fe80::/10 ip6 daddr ff02::1:2 udp dport 547 accept
+	iifname "{{.hostName}}" ether type ip6 ip6 saddr fe80::/10 ip6 daddr ff02::2 icmpv6 type 133 accept
+	iifname "{{.hostName}}" ether type ip6 icmpv6 type 134 drop
+	{{ range .ipv6Nets -}}
+	iifname "{{$.hostName}}" ether type ip6 icmpv6 type 136 @nh,384,{{.nBits}} {{.hexPrefix}} accept
+	iifname "{{$.hostName}}" ether type ip6 ip6 saddr {{.net}} accept
+	{{end}}
+	iifname "{{.hostName}}" ether type ip6 drop
 	{{- end}}
 	{{if .ipv6FilterAll -}}
 	iifname "{{.hostName}}" ether type ip6 drop
-	{{- end}}
-	{{if .ipv6Addr -}}
-	iifname "{{.hostName}}" ether type ip6 ip6 saddr fe80::/10 ip6 daddr ff02::1:2 udp dport 547 accept
-	iifname "{{.hostName}}" ether type ip6 ip6 saddr fe80::/10 ip6 daddr ff02::2 icmpv6 type 133 accept
-	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,384,128 != {{.ipv6AddrHex}} drop
-	iifname "{{.hostName}}" ether type ip6 ip6 saddr != {{.ipv6Addr}} drop
-	iifname "{{.hostName}}" ether type ip6 icmpv6 type 134 drop
 	{{- end}}
 	{{if .filterUnwantedFrames -}}
 	iifname "{{.hostName}}" ether type != {arp, ip, ip6} drop
@@ -217,21 +224,28 @@ chain fwd{{.chainSeparator}}{{.deviceLabel}} {
 	iifname "{{.hostName}}" ether saddr != {{.hwAddr}} drop
 	iifname "{{.hostName}}" ether type arp arp saddr ether != {{.hwAddr}} drop
 	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,528,48 != {{.hwAddrHex}} drop
+	{{if .ipv4Nets -}}
+	{{range .ipv4Nets -}}
+	iifname "{{$.hostName}}" ether type arp arp saddr ip {{.}} accept
+	iifname "{{$.hostName}}" ether type ip ip saddr {{.}} accept
+	{{end}}
+	iifname "{{.hostName}}" ether type arp drop
+	iifname "{{.hostName}}" ether type ip drop
+	{{end}}
 	{{if .ipv4FilterAll -}}
 	iifname "{{.hostName}}" ether type arp drop
 	iifname "{{.hostName}}" ether type ip drop
 	{{- end}}
-	{{if .ipv4Addr -}}
-	iifname "{{.hostName}}" ether type arp arp saddr ip != {{.ipv4Addr}} drop
-	iifname "{{.hostName}}" ether type ip ip saddr != {{.ipv4Addr}} drop
+	{{if .ipv6Nets -}}
+	iifname "{{.hostName}}" ether type ip6 icmpv6 type 134 drop
+	{{range .ipv6Nets}}
+	iifname "{{$.hostName}}" ether type ip6 ip6 saddr {{.net}} accept
+	iifname "{{$.hostName}}" ether type ip6 icmpv6 type 136 @nh,384,{{.nBits}} {{.hexPrefix}} accept
+	{{end}}
+	iifname "{{.hostName}}" ether type ip6 drop
 	{{- end}}
 	{{if .ipv6FilterAll -}}
 	iifname "{{.hostName}}" ether type ip6 drop
-	{{- end}}
-	{{if .ipv6Addr -}}
-	iifname "{{.hostName}}" ether type ip6 ip6 saddr != {{.ipv6Addr}} drop
-	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,384,128 != {{.ipv6AddrHex}} drop
-	iifname "{{.hostName}}" ether type ip6 icmpv6 type 134 drop
 	{{- end}}
 	{{if .filterUnwantedFrames -}}
 	iifname "{{.hostName}}" ether type != {arp, ip, ip6} drop

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -865,7 +865,7 @@ func (d Xtables) InstanceClearBridgeFilter(projectName string, instanceName stri
 		fieldsLen := len(fields)
 
 		for _, rule := range rules {
-			// Rule doesn't match if the field lenths aren't the same, move on.
+			// Rule doesn't match if the field lengths aren't the same, move on.
 			if len(rule) != fieldsLen {
 				continue
 			}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -806,10 +806,10 @@ func (d Xtables) instanceDeviceIPTablesComment(projectName string, instanceName 
 // If the parent bridge is managed by LXD then parentManaged argument should be true so that the rules added can
 // use the iptablesChainACLFilterPrefix chain. If not they are added to the main filter chains directly (which only
 // works for unmanaged bridges because those don't support ACLs).
-func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP, parentManaged bool) error {
+func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4Nets []*net.IPNet, IPv6Nets []*net.IPNet, parentManaged bool) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
-	rules := d.generateFilterEbtablesRules(hostName, hwAddr, IPv4, IPv6)
+	rules := d.generateFilterEbtablesRules(hostName, hwAddr, IPv4Nets, IPv6Nets)
 
 	ebtablesMu.Lock()
 	for _, rule := range rules {
@@ -821,7 +821,7 @@ func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName stri
 	}
 	ebtablesMu.Unlock()
 
-	rules, err := d.generateFilterIptablesRules(parentName, hostName, hwAddr, IPv6, parentManaged)
+	rules, err := d.generateFilterIptablesRules(parentName, hostName, hwAddr, IPv6Nets, parentManaged)
 	if err != nil {
 		return err
 	}
@@ -842,11 +842,11 @@ func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName stri
 }
 
 // InstanceClearBridgeFilter removes any filter rules that were added to apply bridged device IP filtering.
-func (d Xtables) InstanceClearBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error {
+func (d Xtables) InstanceClearBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4Nets []*net.IPNet, IPv6Nets []*net.IPNet) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
 	// Get a list of rules that we would have applied on instance start.
-	rules := d.generateFilterEbtablesRules(hostName, hwAddr, IPv4, IPv6)
+	rules := d.generateFilterEbtablesRules(hostName, hwAddr, IPv4Nets, IPv6Nets)
 
 	ebtablesMu.Lock()
 
@@ -998,7 +998,7 @@ func (d Xtables) InstanceClearProxyNAT(projectName string, instanceName string, 
 }
 
 // generateFilterEbtablesRules returns a customised set of ebtables filter rules based on the device.
-func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) [][]string {
+func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv4Nets []*net.IPNet, IPv6Nets []*net.IPNet) [][]string {
 	// MAC source filtering rules. Block any packet coming from instance with an incorrect Ethernet source MAC.
 	// This is required for IP filtering too.
 	rules := [][]string{
@@ -1006,62 +1006,81 @@ func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv
 		{"ebtables", "-t", "filter", "-A", "FORWARD", "-s", "!", hwAddr, "-i", hostName, "-j", "DROP"},
 	}
 
-	if IPv4 != nil {
-		if IPv4.String() == FilterIPv4All {
-			rules = append(rules,
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
-			)
-		} else {
+	// Don't write any firewall rules when IPv4Nets == nil (i.e. allow all traffic)
+	if IPv4Nets != nil {
+		if len(IPv4Nets) > 0 {
+			// Only apply these rules if there are allowed subnets, since all traffic would otherwise be blocked anyway.
 			rules = append(rules,
 				// Prevent ARP MAC spoofing (prevents the instance poisoning the ARP cache of its neighbours with a MAC address that isn't its own).
 				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "--arp-mac-src", "!", hwAddr, "-j", "DROP"},
 				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "--arp-mac-src", "!", hwAddr, "-j", "DROP"},
-				// Prevent ARP IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "--arp-ip-src", "!", IPv4.String(), "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "--arp-ip-src", "!", IPv4.String(), "-j", "DROP"},
 				// Allow DHCPv4 to the host only. This must come before the IP source filtering rules below.
 				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-s", hwAddr, "-i", hostName, "--ip-src", "0.0.0.0", "--ip-dst", "255.255.255.255", "--ip-proto", "udp", "--ip-dport", "67", "-j", "ACCEPT"},
-				// IP source filtering rules. Blocks any packet coming from instance with an incorrect IP source address.
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "--ip-src", "!", IPv4.String(), "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "--ip-src", "!", IPv4.String(), "-j", "DROP"},
 			)
+
+			// Apply exceptions to these networks. These exceptions must be applied before all IPv4 and ARP traffic is blocked below.
+			for _, IPv4Net := range IPv4Nets {
+				rules = append(rules,
+					// Allow ARP IP redirection (allows the instance to redirect traffic for IPs in the range).
+					[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "--arp-ip-src", fmt.Sprintf("%s/%s", IPv4Net.IP.String(), subnetMask(IPv4Net)), "-j", "ACCEPT"},
+					[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "--arp-ip-src", fmt.Sprintf("%s/%s", IPv4Net.IP.String(), subnetMask(IPv4Net)), "-j", "ACCEPT"},
+					// IP source filtering rules. Allows any packet coming from instance with a correct IP source address.
+					[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "--ip-src", fmt.Sprintf("%s/%s", IPv4Net.IP.String(), subnetMask(IPv4Net)), "-j", "ACCEPT"},
+					[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "--ip-src", fmt.Sprintf("%s/%s", IPv4Net.IP.String(), subnetMask(IPv4Net)), "-j", "ACCEPT"},
+				)
+			}
 		}
+
+		// Block any remaining traffic.
+		rules = append(rules,
+			[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "-j", "DROP"},
+			[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "-j", "DROP"},
+			[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
+			[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
+		)
+	} else {
+		rules = append(rules,
+			[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "-j", "ACCEPT"},
+			[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "-j", "ACCEPT"},
+			[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "-j", "ACCEPT"},
+			[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "-j", "ACCEPT"},
+		)
 	}
 
-	if IPv6 != nil {
-		if IPv6.String() == FilterIPv6All {
-			rules = append(rules,
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
-			)
-		} else {
+	if IPv6Nets != nil {
+		if len(IPv6Nets) > 0 {
 			rules = append(rules,
 				// Allow DHCPv6 and Router Solicitation to the host only. This must come before the IP source filtering rules below.
 				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-s", hwAddr, "-i", hostName, "--ip6-src", "fe80::/ffc0::", "--ip6-dst", "ff02::1:2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "--ip6-proto", "udp", "--ip6-dport", "547", "-j", "ACCEPT"},
 				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-s", hwAddr, "-i", hostName, "--ip6-src", "fe80::/ffc0::", "--ip6-dst", "ff02::2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-solicitation", "-j", "ACCEPT"},
-				// IP source filtering rules. Blocks any packet coming from instance with an incorrect IP source address.
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "--ip6-src", "!", fmt.Sprintf("%s/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", IPv6.String()), "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "--ip6-src", "!", fmt.Sprintf("%s/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", IPv6.String()), "-j", "DROP"},
 				// Block any IPv6 router advertisement packets from instance.
 				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-advertisement", "-j", "DROP"},
 				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-advertisement", "-j", "DROP"},
 			)
+			for _, IPv6Net := range IPv6Nets {
+				rules = append(rules,
+					// IP source filtering rules. Allows any packet coming from instance with a correct IP source address.
+					[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "--ip6-src", fmt.Sprintf("%s/%s", IPv6Net.IP.String(), subnetMask(IPv6Net)), "-j", "ACCEPT"},
+					[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "--ip6-src", fmt.Sprintf("%s/%s", IPv6Net.IP.String(), subnetMask(IPv6Net)), "-j", "ACCEPT"},
+				)
+			}
 		}
+
+		// Block any remaining traffic
+		rules = append(rules,
+			[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
+			[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
+		)
+	} else {
+		rules = append(rules,
+			[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "-j", "ACCEPT"},
+			[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "-j", "ACCEPT"},
+		)
 	}
 
-	if IPv4 != nil || IPv6 != nil {
+	if len(IPv4Nets)+len(IPv6Nets) > 0 {
 		// Filter unwanted ethernet frames when using IP filtering.
-		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "-j", "ACCEPT"})
-		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "-j", "ACCEPT"})
-		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "-j", "ACCEPT"})
 		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "INPUT", "-i", hostName, "-j", "DROP"})
-
-		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "-j", "ACCEPT"})
-		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "-j", "ACCEPT"})
-		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "-j", "ACCEPT"})
 		rules = append(rules, []string{"ebtables", "-t", "filter", "-A", "FORWARD", "-i", hostName, "-j", "DROP"})
 	}
 
@@ -1072,7 +1091,9 @@ func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv
 // If parentManaged is true then the rules are added to the iptablesChainACLFilterPrefix chain whereas if its false
 // then the rules are added to both the INPUT and FORWARD chains (so that no additional NIC chain is required, as
 // there's no managed network setup step available to create it and add jump rules).
-func (d Xtables) generateFilterIptablesRules(parentName string, hostName string, hwAddr string, IPv6 net.IP, parentManaged bool) (rules [][]string, err error) {
+//
+// IMPORTANT NOTE: These rules are generated in reverse order and should only be used in combination with iptablesPrepend.
+func (d Xtables) generateFilterIptablesRules(parentName string, hostName string, hwAddr string, IPv6Nets []*net.IPNet, parentManaged bool) (rules [][]string, err error) {
 	mac, err := net.ParseMAC(hwAddr)
 	if err != nil {
 		return
@@ -1088,8 +1109,7 @@ func (d Xtables) generateFilterIptablesRules(parentName string, hostName string,
 	// not assigned to the instance by sending a specially crafted gratuitous NDP packet with
 	// correct source address and MAC at the IP & ethernet layers, but a fraudulent IP or MAC
 	// inside the ICMPv6 NDP packet.
-	if IPv6 != nil {
-		ipv6Hex := hex.EncodeToString(IPv6)
+	if IPv6Nets != nil {
 
 		var chains []string
 
@@ -1106,12 +1126,28 @@ func (d Xtables) generateFilterIptablesRules(parentName string, hostName string,
 		}
 
 		for _, chain := range chains {
+			// Prevent Neighbor Advertisement IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
 			rules = append(rules,
-				// Prevent Neighbor Advertisement IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
-				[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", ipv6Hex), "--algo", "bm", "--from", "48", "--to", "64", "-j", "DROP"},
-				// Prevent Neighbor Advertisement MAC spoofing (prevents the instance poisoning the NDP cache of its neighbours with a MAC address that isn't its own).
-				[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", macHex), "--algo", "bm", "--from", "66", "--to", "72", "-j", "DROP"},
+				[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-j", "DROP"},
 			)
+
+			for _, IPv6Net := range IPv6Nets {
+				hexPrefix, err := subnetPrefixHex(IPv6Net)
+				if err != nil {
+					return nil, err
+				}
+
+				rules = append(rules,
+					// Prevent Neighbor Advertisement IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
+					[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "--hex-string", fmt.Sprintf("|%s|", hexPrefix), "--algo", "bm", "--from", "48", "--to", strconv.Itoa(48 + len(hexPrefix)/2), "-j", "ACCEPT"},
+				)
+			}
+			if len(IPv6Nets) > 0 {
+				rules = append(rules,
+					// Prevent Neighbor Advertisement MAC spoofing (prevents the instance poisoning the NDP cache of its neighbours with a MAC address that isn't its own).
+					[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", macHex), "--algo", "bm", "--from", "66", "--to", "72", "-j", "DROP"},
+				)
+			}
 		}
 	}
 

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -16,8 +16,8 @@ type Firewall interface {
 	NetworkApplyACLRules(networkName string, rules []drivers.ACLRule) error
 	NetworkApplyForwards(networkName string, rules []drivers.AddressForward) error
 
-	InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP, parentManaged bool) error
-	InstanceClearBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error
+	InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4Nets []*net.IPNet, IPv6Nets []*net.IPNet, parentManaged bool) error
+	InstanceClearBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4Nets []*net.IPNet, IPv6Nets []*net.IPNet) error
 
 	InstanceSetupProxyNAT(projectName string, instanceName string, deviceName string, forward *drivers.AddressForward) error
 	InstanceClearProxyNAT(projectName string, instanceName string, deviceName string) error

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -416,7 +416,7 @@ test_container_devices_nic_bridged_filtering() {
   wait_for_dad "${ctPrefix}A" eth0
 
   # Check basic connectivity with IPv6 filtering and real IPs configured.
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::2
+  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::1
   lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::3
 
   # Add a fake IP
@@ -425,7 +425,7 @@ test_container_devices_nic_bridged_filtering() {
   wait_for_dad "${ctPrefix}A" eth0
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::2; then
+  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::1; then
       echo "IPv6 filter not working to host"
       false
   fi


### PR DESCRIPTION
Changes the firewall interface for the bridge filter setup and and teardown to accept a slice of networks. These are passed in by the bridged nic device from it's settings and handled by each firewall driver accordingly.

Closes #9878 