### PR TITLE
Refresh instance allow inconsistent

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -359,7 +359,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	}
 
 	if opts.refresh {
-		err = pool.RefreshInstance(inst, opts.sourceInstance, snapshots, false, op)
+		err = pool.RefreshInstance(inst, opts.sourceInstance, snapshots, opts.allowInconsistent, op)
 		if err != nil {
 			return nil, errors.Wrap(err, "Refresh instance")
 		}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -359,7 +359,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	}
 
 	if opts.refresh {
-		err = pool.RefreshInstance(inst, opts.sourceInstance, snapshots, op)
+		err = pool.RefreshInstance(inst, opts.sourceInstance, snapshots, false, op)
 		if err != nil {
 			return nil, errors.Wrap(err, "Refresh instance")
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1322,10 +1322,11 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		bEndErrCh := make(chan error, 1)
 		go func() {
 			err := srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
-				Name:          src.Name(),
-				Snapshots:     snapshotNames,
-				MigrationType: migrationTypes[0],
-				TrackProgress: true, // Do use a progress tracker on sender.
+				Name:              src.Name(),
+				Snapshots:         snapshotNames,
+				MigrationType:     migrationTypes[0],
+				TrackProgress:     true, // Do use a progress tracker on sender.
+				AllowInconsistent: allowInconsistent,
 			}, op)
 
 			if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1233,7 +1233,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 // RefreshInstance synchronises one instance's volume (and optionally snapshots) over another.
 // Snapshots that are not present in the source but are in the destination are removed from the
 // destination if snapshots are included in the synchronisation.
-func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, op *operations.Operation) error {
+func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
 	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name(), "src": src.Name(), "srcSnapshots": len(srcSnapshots)})
 	logger.Debug("RefreshInstance started")
 	defer logger.Debug("RefreshInstance finished")

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -153,7 +153,7 @@ func (b *mockBackend) RefreshCustomVolume(projectName string, srcProjectName str
 	return nil
 }
 
-func (b *mockBackend) RefreshInstance(i instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -58,7 +58,7 @@ type Pool interface {
 	ImportInstance(inst instance.Instance, op *operations.Operation) error
 
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
-	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, op *operations.Operation) error
+	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error
 	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
 
 	GetInstanceUsage(inst instance.Instance) (int64, error)


### PR DESCRIPTION
For `lxc copy`, the `--refresh` flag caused the `--allow-inconsistent` flag to be ignored. This change passes the value of `allowInconsistent` into `pool.RefreshInstance` to be used accordingly.

See https://github.com/lxc/lxd/pull/9833#issuecomment-1047260094