### PR TITLE
doc: add Open Graph metadata

### DIFF
--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -14,7 +14,8 @@ with open("../shared/version/flex.go") as fd:
 extensions = [
     "myst_parser",
     "sphinx_tabs.tabs",
-    "sphinx_reredirects"
+    "sphinx_reredirects",
+    "sphinxext.opengraph"
 ]
 
 myst_enable_extensions = [
@@ -110,6 +111,12 @@ source_suffix = ".md"
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['html', 'README.md']
+
+# Open Graph configuration
+
+ogp_site_url = "https://linuxcontainers.org/lxd/docs/master/"
+ogp_site_name = "LXD documentation"
+ogp_image = "https://linuxcontainers.org/static/img/containers.png"
 
 # Setup redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 redirects = {

--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -31,3 +31,4 @@ sphinx-tabs
 sphinx-reredirects
 linkify-it-py
 furo
+sphinxext-opengraph

--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -31,4 +31,4 @@ sphinx-tabs
 sphinx-reredirects
 linkify-it-py
 furo
-sphinxext-opengraph
+git+git://github.com/ru-fu/sphinxext-opengraph@fix-url-for-dirhtml#egg=sphinxext-opengraph


### PR DESCRIPTION
Open Graph tags add information to websites that are displayed when linking in supported tools - like Facebook, Mattermost or the forum:
![image](https://user-images.githubusercontent.com/11227796/155294297-6aa62667-255c-424e-9151-2328a5862c60.png)

This fix seems to work for the forum. :grinning: 

However, it looks like there is a bug in the Sphinx extension, because it generates a wrong page URL (...installing.html instead of ...installing/ ). The Facebook debugger complains about this - seems the forum is more tolerant. ;)
I'll check if I can fix this in the extension.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>