### PR TITLE
Device: Name validation improvements

### DIFF
--- a/lxd/device/device_load.go
+++ b/lxd/device/device_load.go
@@ -110,22 +110,26 @@ func load(inst instance.Instance, state *state.State, projectName string, name s
 // not compatible with the instance type then an ErrUnsupportedDevType error is returned.
 // Note: The supplied config may be modified during validation to enrich. If this is not desired, supply a copy.
 func New(inst instance.Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
-	err := validate.IsDeviceName(name)
-	if err != nil {
-		return nil, err
-	}
-
 	dev, err := load(inst, state, inst.Project(), name, conf, volatileGet, volatileSet)
 	if err != nil {
 		return nil, err
 	}
 
-	err = dev.validateConfig(inst)
-
 	// We still return the instantiated device here, as in some scenarios the caller
 	// may still want to use the device (such as when stopping or removing) even if
 	// the config validation has failed.
-	return dev, err
+
+	err = validate.IsDeviceName(name)
+	if err != nil {
+		return dev, err
+	}
+
+	err = dev.validateConfig(inst)
+	if err != nil {
+		return dev, err
+	}
+
+	return dev, nil
 }
 
 // Validate checks a device's config is valid. This only requires an instance.ConfigReader rather than an full

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -12,7 +12,7 @@ import (
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
-	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
@@ -191,7 +191,7 @@ func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath stri
 
 	destPath := unixDeviceDestPath(m)
 	relativeDestPath := strings.TrimPrefix(destPath, "/")
-	devName := storageDrivers.PathNameEncode(deviceJoinPath(prefix, relativeDestPath))
+	devName := filesystem.PathNameEncode(deviceJoinPath(prefix, relativeDestPath))
 	devPath := filepath.Join(devicesPath, devName)
 
 	// Create the new entry.
@@ -254,7 +254,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 
 	// Convert the requested dest path inside the instance to an encoded relative one.
 	ourDestPath := unixDeviceDestPath(m)
-	ourEncRelDestFile := storageDrivers.PathNameEncode(strings.TrimPrefix(ourDestPath, "/"))
+	ourEncRelDestFile := filesystem.PathNameEncode(strings.TrimPrefix(ourDestPath, "/"))
 
 	// Load all existing host devices.
 	dents, err := ioutil.ReadDir(devicesPath)
@@ -360,7 +360,7 @@ func unixDeviceSetupBlockNum(s *state.State, devicesPath string, typePrefix stri
 // UnixDeviceExists checks if the unix device already exists in devices path.
 func UnixDeviceExists(devicesPath string, prefix string, path string) bool {
 	relativeDestPath := strings.TrimPrefix(path, "/")
-	devName := fmt.Sprintf("%s.%s", storageDrivers.PathNameEncode(prefix), storageDrivers.PathNameEncode(relativeDestPath))
+	devName := fmt.Sprintf("%s.%s", filesystem.PathNameEncode(prefix), filesystem.PathNameEncode(relativeDestPath))
 	devPath := filepath.Join(devicesPath, devName)
 
 	return shared.PathExists(devPath)
@@ -385,9 +385,9 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 	var ourPrefix string
 	// If a prefix override has been supplied, use that for filtering the devices to remove.
 	if optPrefix != "" {
-		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
+		ourPrefix = filesystem.PathNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
 	} else {
-		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName))
+		ourPrefix = filesystem.PathNameEncode(deviceJoinPath(typePrefix, deviceName))
 	}
 
 	ourDevs := []string{}
@@ -449,7 +449,7 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 
 		// Append this device to the mount rules (these will be unmounted).
 		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-			TargetPath: storageDrivers.PathNameDecode(ourEncRelDestFile),
+			TargetPath: filesystem.PathNameDecode(ourEncRelDestFile),
 		})
 
 		absDevPath := filepath.Join(devicesPath, ourDev)
@@ -475,9 +475,9 @@ func unixDeviceDeleteFiles(s *state.State, devicesPath string, typePrefix string
 	var ourPrefix string
 	// If a prefix override has been supplied, use that for filtering the devices to remove.
 	if optPrefix != "" {
-		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
+		ourPrefix = filesystem.PathNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
 	} else {
-		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName))
+		ourPrefix = filesystem.PathNameEncode(deviceJoinPath(typePrefix, deviceName))
 	}
 
 	// Load all devices.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -314,7 +314,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 // getDevicePath returns the absolute path on the host for this instance and supplied device config.
 func (d *disk) getDevicePath(devName string, devConfig deviceConfig.Device) string {
 	relativeDestPath := strings.TrimPrefix(devConfig["path"], "/")
-	devPath := storageDrivers.PathNameEncode(deviceJoinPath("disk", devName, relativeDestPath))
+	devPath := filesystem.PathNameEncode(deviceJoinPath("disk", devName, relativeDestPath))
 	return filepath.Join(d.inst.DevicesPath(), devPath)
 }
 
@@ -1924,7 +1924,7 @@ func (d *disk) getParentBlocks(path string) ([]string, error) {
 // generateVMConfigDrive generates an ISO containing the cloud init config for a VM.
 // Returns the path to the ISO.
 func (d *disk) generateVMConfigDrive() (string, error) {
-	scratchDir := filepath.Join(d.inst.DevicesPath(), storageDrivers.PathNameEncode(d.name))
+	scratchDir := filepath.Join(d.inst.DevicesPath(), filesystem.PathNameEncode(d.name))
 
 	// Check we have the mkisofs tool available.
 	mkisofsPath, err := exec.LookPath("mkisofs")

--- a/lxd/device/unix_common.go
+++ b/lxd/device/unix_common.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lxc/lxd/lxd/fsmonitor/drivers"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
-	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/validate"
 )
@@ -104,7 +104,7 @@ func (d *unixCommon) Register() error {
 		// Derive the host side path for the instance device file.
 		ourPrefix := deviceJoinPath("unix", deviceName)
 		relativeDestPath := strings.TrimPrefix(unixDeviceDestPath(devConfig), "/")
-		devName := storageDrivers.PathNameEncode(deviceJoinPath(ourPrefix, relativeDestPath))
+		devName := filesystem.PathNameEncode(deviceJoinPath(ourPrefix, relativeDestPath))
 		devPath := filepath.Join(devicesPath, devName)
 
 		runConf := deviceConfig.RunConfig{}

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/subprocess"
 	"github.com/lxc/lxd/shared/version"
@@ -268,5 +269,7 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 }
 
 func dnsMasqEntryFileName(projectName string, instanceName string, deviceName string) string {
-	return strings.Join([]string{project.Instance(projectName, instanceName), deviceName}, ".")
+	escapedDeviceName := filesystem.PathNameEncode(deviceName)
+
+	return strings.Join([]string{project.Instance(projectName, instanceName), escapedDeviceName}, ".")
 }

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/instancewriter"
 	"github.com/lxc/lxd/shared/ioprogress"
@@ -251,7 +252,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcDat
 			if subVol.Path != string(filepath.Separator) {
 				// If subvolume is non-root, then we expect the file to be encoded as its original
 				// path with the leading / removed.
-				srcFilePath = filepath.Join("backup", fmt.Sprintf("%s_%s.bin", srcFilePrefix, PathNameEncode(strings.TrimPrefix(subVol.Path, string(filepath.Separator)))))
+				srcFilePath = filepath.Join("backup", fmt.Sprintf("%s_%s.bin", srcFilePrefix, filesystem.PathNameEncode(strings.TrimPrefix(subVol.Path, string(filepath.Separator)))))
 			}
 
 			// Define where we will move the subvolume after it is unpacked.
@@ -1218,7 +1219,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 			if subVolume.Path != string(filepath.Separator) {
 				// Encode the path of the subvolume (without the leading /) into the filename so
 				// that we find the file from the optimized header's Path field on restore.
-				subVolName = fmt.Sprintf("_%s", PathNameEncode(strings.TrimPrefix(subVolume.Path, string(filepath.Separator))))
+				subVolName = fmt.Sprintf("_%s", filesystem.PathNameEncode(strings.TrimPrefix(subVolume.Path, string(filepath.Separator))))
 			}
 
 			fileName := fmt.Sprintf("%s%s.bin", fileNamePrefix, subVolName)

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -854,20 +854,6 @@ func BlockDiskSizeBytes(blockDiskPath string) (int64, error) {
 	return fi.Size(), nil
 }
 
-// PathNameEncode encodes a path string to be used as part of a file name.
-// The encoding scheme replaces "-" with "--" and then "/" with "-".
-func PathNameEncode(text string) string {
-	return strings.Replace(strings.Replace(text, "-", "--", -1), "/", "-", -1)
-}
-
-// PathNameDecode decodes a string containing an encoded path back to its original form.
-// The decoding scheme converts "-" back to "/" and "--" back to "-".
-func PathNameDecode(text string) string {
-	// This converts "--" to the null character "\0" first, to allow remaining "-" chars to be
-	// converted back to "/" before making a final pass to convert "\0" back to original "-".
-	return strings.Replace(strings.Replace(strings.Replace(text, "--", "\000", -1), "-", "/", -1), "\000", "-", -1)
-}
-
 // OperationLockName returns the storage specific lock name to use with locking package.
 func OperationLockName(operationName string, poolName string, volType VolumeType, contentType ContentType, volName string) string {
 	return fmt.Sprintf("%s/%s/%s/%s/%s", operationName, poolName, volType, contentType, volName)

--- a/lxd/storage/filesystem/fs.go
+++ b/lxd/storage/filesystem/fs.go
@@ -147,3 +147,17 @@ func SyncFS(path string) error {
 	// Call SyncFS.
 	return unix.Syncfs(int(fsFile.Fd()))
 }
+
+// PathNameEncode encodes a path string to be used as part of a file name.
+// The encoding scheme replaces "-" with "--" and then "/" with "-".
+func PathNameEncode(text string) string {
+	return strings.Replace(strings.Replace(text, "-", "--", -1), "/", "-", -1)
+}
+
+// PathNameDecode decodes a string containing an encoded path back to its original form.
+// The decoding scheme converts "-" back to "/" and "--" back to "-".
+func PathNameDecode(text string) string {
+	// This converts "--" to the null character "\0" first, to allow remaining "-" chars to be
+	// converted back to "/" before making a final pass to convert "\0" back to original "-".
+	return strings.Replace(strings.Replace(strings.Replace(text, "--", "\000", -1), "-", "/", -1), "\000", "-", -1)
+}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -805,37 +805,6 @@ func ParseNetworkVLANRange(vlan string) (int, int, error) {
 
 // IsHostname checks the string is valid DNS hostname.
 func IsHostname(name string) error {
-	err := isName(name)
-	if err != nil {
-		return err
-	}
-
-	match, _ := regexp.MatchString("^[-a-zA-Z0-9]*$", name)
-	if !match {
-		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
-	}
-
-	return nil
-}
-
-// IsDeviceName performs the same checks as ValidHostname but also allows underscores.
-func IsDeviceName(name string) error {
-	err := isName(name)
-	if err != nil {
-		return err
-	}
-
-	match, _ := regexp.MatchString("^[-_a-zA-Z0-9]*$", name)
-	if !match {
-		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
-	}
-
-	return nil
-}
-
-// isName checks that the given string is 1-63 characters long, does not start or end with a hyphen and does not start
-// with a number.
-func isName(name string) error {
 	// Validate length
 	if len(name) < 1 || len(name) > 63 {
 		return fmt.Errorf("Name must be 1-63 characters long")
@@ -846,13 +815,46 @@ func isName(name string) error {
 		return fmt.Errorf(`Name must not start with "-" character`)
 	}
 
-	if _, err := strconv.Atoi(string(name[0])); err == nil {
-		return fmt.Errorf("Name must not start with a number")
-	}
-
 	// Validate last character
 	if strings.HasSuffix(name, "-") {
 		return fmt.Errorf(`Name must not end with "-" character`)
+	}
+
+	_, err := strconv.Atoi(string(name[0]))
+	if err == nil {
+		return fmt.Errorf("Name must not start with a number")
+	}
+
+	match, err := regexp.MatchString(`^[\-a-zA-Z0-9]+$`, name)
+	if err != nil {
+		return err
+	}
+
+	if !match {
+		return fmt.Errorf("Name can only contain alphanumeric and hyphen characters")
+	}
+
+	return nil
+}
+
+// IsDeviceName checks name is 1-63 characters long, doesn't start with a full stop and contains only alphanumeric,
+// forward slash, hyphen, colon, underscore and full stop characters.
+func IsDeviceName(name string) error {
+	if len(name) < 1 || len(name) > 63 {
+		return fmt.Errorf("Name must be 1-63 characters long")
+	}
+
+	if string(name[0]) == "." {
+		return fmt.Errorf(`Name must not start with "." character`)
+	}
+
+	match, err := regexp.MatchString(`^[\/\.\-:_a-zA-Z0-9]+$`, name)
+	if err != nil {
+		return err
+	}
+
+	if !match {
+		return fmt.Errorf("Name can only contain alphanumeric, forward slash, hyphen, colon, underscore and full stop characters")
 	}
 
 	return nil


### PR DESCRIPTION
- This PR restores the ability to use `.`, `:`, `/` in device names.
- It also allows device names to start with a number.
- But still prevents device names starting with `.` to prevent the creation of hidden files.
- It escapes `/` in device names used in filenames to `-` and escapes `-` to `--`.
- Allows for invalid devices to be stopped and removed.

Following on the heels from https://github.com/lxc/lxd/pull/9946
Prompted by this discussion https://discuss.linuxcontainers.org/t/lxc-4-23-invalid-devices-name-must-not-start-with-a-number/13440