### PR TITLE
doc: fix Open Graph version

### DIFF
--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -31,4 +31,4 @@ sphinx-tabs
 sphinx-reredirects
 linkify-it-py
 furo
-git+git://github.com/ru-fu/sphinxext-opengraph@fix-url-for-dirhtml#egg=sphinxext-opengraph
+sphinxext-opengraph>=0.6.1


### PR DESCRIPTION
The fix to the Open Graph Sphinx extension has been merged.
Updating the requirements to use the official version.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>