### PR TITLE
Network: Fix DHCP static allocation bug

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -875,7 +875,8 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	// If IP filtering is enabled, and no static IP in config, check if there is already a
 	// dynamically assigned static IP in dnsmasq config and write that back out in new config.
 	if (shared.IsTrue(d.config["security.ipv4_filtering"]) && ipv4Address == "") || (shared.IsTrue(d.config["security.ipv6_filtering"]) && ipv6Address == "") {
-		_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d.config["parent"], d.inst.Project(), d.inst.Name(), d.Name(), "")
+		deviceStaticFileName := dnsmasq.StaticAllocationFileName(d.inst.Project(), d.inst.Name(), d.Name())
+		_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d.config["parent"], deviceStaticFileName)
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -979,7 +980,8 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) {
 
 	// Read current static DHCP IP allocation configured from dnsmasq host config (if exists).
 	// This covers the case when IPs are not defined in config, but have been assigned in managed DHCP.
-	_, IPv4Alloc, IPv6Alloc, err := dnsmasq.DHCPStaticAllocation(m["parent"], d.inst.Project(), d.inst.Name(), d.Name(), "")
+	deviceStaticFileName := dnsmasq.StaticAllocationFileName(d.inst.Project(), d.inst.Name(), d.Name())
+	_, IPv4Alloc, IPv6Alloc, err := dnsmasq.DHCPStaticAllocation(m["parent"], deviceStaticFileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -225,13 +225,12 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 				copy(IPKey[:], IP.To16())
 
 				// Don't replace IPs from static config as more reliable.
-				if IPv6s[IPKey].Name != "" {
+				if IPv6s[IPKey].StaticFileName != "" {
 					continue
 				}
 
 				IPv6s[IPKey] = DHCPAllocation{
-					Static: false,
-					IP:     IP.To16(),
+					IP: IP.To16(),
 				}
 			} else {
 				// MAC only available in IPv4 leases.
@@ -244,14 +243,13 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 				copy(IPKey[:], IP.To4())
 
 				// Don't replace IPs from static config as more reliable.
-				if IPv4s[IPKey].Name != "" {
+				if IPv4s[IPKey].StaticFileName != "" {
 					continue
 				}
 
 				IPv4s[IPKey] = DHCPAllocation{
-					MAC:    MAC,
-					Static: false,
-					IP:     IP.To4(),
+					MAC: MAC,
+					IP:  IP.To4(),
 				}
 			}
 		}

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -17,6 +17,8 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
+const staticAllocationDeviceSeparator = "."
+
 // DHCPAllocation represents an IP allocation from dnsmasq.
 type DHCPAllocation struct {
 	IP     net.IP

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -185,7 +185,7 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 	}
 
 	for _, entry := range files {
-		_, IPv4, IPv6, err := DHCPStaticAllocation(network, "", "", "", entry.Name())
+		_, IPv4, IPv6, err := DHCPStaticAllocation(network, entry.Name())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -21,10 +21,9 @@ const staticAllocationDeviceSeparator = "."
 
 // DHCPAllocation represents an IP allocation from dnsmasq.
 type DHCPAllocation struct {
-	IP     net.IP
-	Name   string
-	MAC    net.HardwareAddr
-	Static bool
+	IP             net.IP
+	StaticFileName string
+	MAC            net.HardwareAddr
 }
 
 // ConfigMutex used to coordinate access to the dnsmasq config files.

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -52,8 +52,8 @@ func UpdateStaticEntry(network string, projectName string, instanceName string, 
 		return nil
 	}
 
-	entryFile := dnsMasqEntryFileName(projectName, instanceName, deviceName)
-	err := ioutil.WriteFile(shared.VarPath("networks", network, "dnsmasq.hosts", entryFile), []byte(line+"\n"), 0644)
+	deviceStaticFileName := StaticAllocationFileName(projectName, instanceName, deviceName)
+	err := ioutil.WriteFile(shared.VarPath("networks", network, "dnsmasq.hosts", deviceStaticFileName), []byte(line+"\n"), 0644)
 	if err != nil {
 		return err
 	}
@@ -63,8 +63,8 @@ func UpdateStaticEntry(network string, projectName string, instanceName string, 
 
 // RemoveStaticEntry removes a single dhcp-host line for a network/instance combination.
 func RemoveStaticEntry(network string, projectName string, instanceName string, deviceName string) error {
-	entryFile := dnsMasqEntryFileName(projectName, instanceName, deviceName)
-	err := os.Remove(shared.VarPath("networks", network, "dnsmasq.hosts", entryFile))
+	deviceStaticFileName := StaticAllocationFileName(projectName, instanceName, deviceName)
+	err := os.Remove(shared.VarPath("networks", network, "dnsmasq.hosts", deviceStaticFileName))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -126,7 +126,7 @@ func DHCPStaticAllocation(network, projectName, instanceName, deviceName, entryF
 	var mac net.HardwareAddr
 
 	if entryFileName == "" {
-		entryFileName = dnsMasqEntryFileName(projectName, instanceName, deviceName)
+		entryFileName = StaticAllocationFileName(projectName, instanceName, deviceName)
 	}
 
 	file, err := os.Open(shared.VarPath("networks", network, "dnsmasq.hosts", entryFileName))

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -270,8 +270,9 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 	return IPv4s, IPv6s, nil
 }
 
-func dnsMasqEntryFileName(projectName string, instanceName string, deviceName string) string {
+// StaticAllocationFileName returns the file name to use for a dnsmasq instance device static allocation.
+func StaticAllocationFileName(projectName string, instanceName string, deviceName string) string {
 	escapedDeviceName := filesystem.PathNameEncode(deviceName)
 
-	return strings.Join([]string{project.Instance(projectName, instanceName), escapedDeviceName}, ".")
+	return strings.Join([]string{project.Instance(projectName, instanceName), escapedDeviceName}, staticAllocationDeviceSeparator)
 }

--- a/lxd/dnsmasq/dnsmasq_test.go
+++ b/lxd/dnsmasq/dnsmasq_test.go
@@ -1,0 +1,15 @@
+package dnsmasq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_staticAllocationFileName(t *testing.T) {
+	projectName := "test.project"
+	instanceName := "test-instance"
+	deviceName := "test/.-_--.device"
+	fileName := StaticAllocationFileName(projectName, instanceName, deviceName)
+	assert.Equal(t, "test.project_test-instance.test-.--_----.device", fileName)
+}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -384,7 +384,8 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			}
 
 			if (shared.IsTrue(d["security.ipv4_filtering"]) && d["ipv4.address"] == "") || (shared.IsTrue(d["security.ipv6_filtering"]) && d["ipv6.address"] == "") {
-				_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d["parent"], inst.Project(), inst.Name(), deviceName, "")
+				deviceStaticFileName := dnsmasq.StaticAllocationFileName(inst.Project(), inst.Name(), deviceName)
+				_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d["parent"], deviceStaticFileName)
 				if err != nil && !os.IsNotExist(err) {
 					return err
 				}


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/lxc/lxd/pull/9790 that I noticed whilst working on https://github.com/lxc/lxd/pull/9960.

The change to `DHCPStaticAllocation()` to accept either a `projectName`, `instanceName` and `deviceName` *or* an `entryFileName` caused a bug because in the latter scenario the returned `DHCPAllocation` was populated with an empty instance `Name` field - which is used later when finding an existing static allocation for an instance NIC device.

This PR modifies the static allocation subsystem to use the NIC device's static allocation file itself as an identifier, in that way it is the lowest common denominator that is available in both usage scenarios, and also not supports matching the device name of a static allocation not just the instance name.

