### PR TITLE
VM: Bug fixes and improvements to the lxd-agent NIC settings feature

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1622,6 +1622,6 @@ Adds the `ipv4.neighbor_probe` and `ipv6.neighbor_probe` NIC settings. Defaultin
 ## event\_hub
 This adds support for `event-hub` cluster member role and the `ServerEventMode` environment field.
 
-## agent\_rename\_interfaces
-If set to true, on start-up the lxd-agent will rename the network interfaces to match the names of the instances network
+## agent\_nic\_config
+If set to true, on VM start-up the lxd-agent will apply NIC config to change the names and MTU of the instance NIC
 devices.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -42,7 +42,7 @@ The currently supported keys are:
 
 Key                                         | Type      | Default           | Live update   | Condition                 | Description
 :--                                         | :---      | :------           | :----------   | :----------               | :----------
-agent.rename_interfaces                     | boolean   | false             | n/a           | virtual-machine           | Set the name and MTU of the default network interfaces to be the same as the instance devices (this is automatic for containers). 
+agent.nic_config                            | boolean   | false             | n/a           | virtual-machine           | Set the name and MTU of the default network interfaces to be the same as the instance devices (this is automatic for containers).
 boot.autostart                              | boolean   | -                 | n/a           | -                         | Always start the instance when LXD starts (if not set, restore last state)
 boot.autostart.delay                        | integer   | 0                 | n/a           | -                         | Number of seconds to wait after the instance started before starting the next one
 boot.autostart.priority                     | integer   | 0                 | n/a           | -                         | What order to start the instances in (starting with highest)

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -854,7 +854,7 @@ GPU device entries simply make the requested gpu device appear in the
 instance.
 
 ```{note}
-Container devices may match multiple GPUs at once. However, for virtual machines a device can only match a single GPU. 
+Container devices may match multiple GPUs at once. However, for virtual machines a device can only match a single GPU.
 ```
 
 ##### GPUs Available:

--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -58,6 +58,9 @@ type RunConfig struct {
 	Revert           *revert.Reverter // Revert setup of device on post-setup error.
 }
 
+// NICConfigDir shared constant used to indicate where NIC config is stored.
+const NICConfigDir = "nics"
+
 // NICConfig contains network interface configuration to be passed into a VM and applied by the agent.
 type NICConfig struct {
 	MACAddress string `json:"mac_address"`

--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/lxc/lxd/lxd/revert"
+import (
+	"github.com/lxc/lxd/lxd/revert"
+)
 
 // MountOwnerShiftNone do not use owner shifting.
 const MountOwnerShiftNone = ""

--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -63,6 +63,8 @@ const NICConfigDir = "nics"
 
 // NICConfig contains network interface configuration to be passed into a VM and applied by the agent.
 type NICConfig struct {
+	DeviceName string `json:"device_name"`
+	NICName    string `json:"nic_name"`
 	MACAddress string `json:"mac_address"`
 	MTU        uint32 `json:"mtu"`
 }

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -202,8 +202,8 @@ func networkRestorePhysicalNIC(hostName string, volatile map[string]string) erro
 // networkCreateVethPair creates and configures a veth pair. It will set the hwaddr and mtu settings
 // in the supplied config to the newly created peer interface. If mtu is not specified, but parent
 // is supplied in config, then the MTU of the new peer interface will inherit the parent MTU.
-// Accepts the name of the host side interface as a parameter and returns the peer interface name.
-func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, error) {
+// Accepts the name of the host side interface as a parameter and returns the peer interface name and MTU used.
+func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, uint32, error) {
 	peerName := network.RandomDevName("veth")
 
 	veth := &ip.Veth{
@@ -214,13 +214,13 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, erro
 	}
 	err := veth.Add()
 	if err != nil {
-		return "", fmt.Errorf("Failed to create the veth interfaces %s and %s: %v", hostName, peerName, err)
+		return "", 0, fmt.Errorf("Failed to create the veth interfaces %q and %q: %v", hostName, peerName, err)
 	}
 
 	err = veth.SetUp()
 	if err != nil {
 		network.InterfaceRemove(hostName)
-		return "", fmt.Errorf("Failed to bring up the veth interface %s: %v", hostName, err)
+		return "", 0, fmt.Errorf("Failed to bring up the veth interface %q: %w", hostName, err)
 	}
 
 	// Set the MAC address on peer.
@@ -229,52 +229,46 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, erro
 		err := link.SetAddress(m["hwaddr"])
 		if err != nil {
 			network.InterfaceRemove(peerName)
-			return "", fmt.Errorf("Failed to set the MAC address: %v", err)
+			return "", 0, fmt.Errorf("Failed to set the MAC address: %w", err)
 		}
 	}
 
 	// Set the MTU on peer. If not specified and has parent, will inherit MTU from parent.
+	var mtu uint32
 	if m["mtu"] != "" {
-		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
+		nicMTU, err := strconv.ParseUint(m["mtu"], 10, 32)
 		if err != nil {
-			return "", fmt.Errorf("Invalid MTU specified: %v", err)
+			return "", 0, fmt.Errorf("Invalid MTU specified: %w", err)
 		}
 
-		err = NetworkSetDevMTU(peerName, uint32(mtu))
-		if err != nil {
-			network.InterfaceRemove(peerName)
-			return "", fmt.Errorf("Failed to set the MTU: %v", err)
-		}
-
-		err = NetworkSetDevMTU(hostName, uint32(mtu))
-		if err != nil {
-			network.InterfaceRemove(peerName)
-			return "", fmt.Errorf("Failed to set the MTU: %v", err)
-		}
+		mtu = uint32(nicMTU)
 	} else if m["parent"] != "" {
-		parentMTU, err := network.GetDevMTU(m["parent"])
+		mtu, err = network.GetDevMTU(m["parent"])
 		if err != nil {
-			return "", fmt.Errorf("Failed to get the parent MTU: %v", err)
-		}
-
-		err = NetworkSetDevMTU(peerName, parentMTU)
-		if err != nil {
-			network.InterfaceRemove(peerName)
-			return "", fmt.Errorf("Failed to set the MTU: %v", err)
-		}
-
-		err = NetworkSetDevMTU(hostName, parentMTU)
-		if err != nil {
-			network.InterfaceRemove(peerName)
-			return "", fmt.Errorf("Failed to set the MTU: %v", err)
+			return "", 0, fmt.Errorf("Failed to get the parent MTU: %w", err)
 		}
 	}
 
-	return peerName, nil
+	if mtu > 0 {
+		err = NetworkSetDevMTU(peerName, mtu)
+		if err != nil {
+			network.InterfaceRemove(peerName)
+			return "", 0, fmt.Errorf("Failed to set the MTU %d: %w", mtu, err)
+		}
+
+		err = NetworkSetDevMTU(hostName, mtu)
+		if err != nil {
+			network.InterfaceRemove(peerName)
+			return "", 0, fmt.Errorf("Failed to set the MTU %d: %w", mtu, err)
+		}
+	}
+
+	return peerName, mtu, nil
 }
 
 // networkCreateTap creates and configures a TAP device.
-func networkCreateTap(hostName string, m deviceConfig.Device) error {
+// Returns the MTU used.
+func networkCreateTap(hostName string, m deviceConfig.Device) (uint32, error) {
 	tuntap := &ip.Tuntap{
 		Name:       hostName,
 		Mode:       "tap",
@@ -282,7 +276,7 @@ func networkCreateTap(hostName string, m deviceConfig.Device) error {
 	}
 	err := tuntap.Add()
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create the tap interfaces %s", hostName)
+		return 0, errors.Wrapf(err, "Failed to create the tap interfaces %q", hostName)
 	}
 
 	revert := revert.New()
@@ -291,35 +285,37 @@ func networkCreateTap(hostName string, m deviceConfig.Device) error {
 	link := &ip.Link{Name: hostName}
 	err = link.SetUp()
 	if err != nil {
-		return errors.Wrapf(err, "Failed to bring up the tap interface %s", hostName)
+		return 0, errors.Wrapf(err, "Failed to bring up the tap interface %q", hostName)
 	}
 	revert.Add(func() { network.InterfaceRemove(hostName) })
 
 	// Set the MTU on peer. If not specified and has parent, will inherit MTU from parent.
+	var mtu uint32
 	if m["mtu"] != "" {
-		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
+		nicMTU, err := strconv.ParseUint(m["mtu"], 10, 32)
 		if err != nil {
-			return errors.Wrap(err, "Invalid MTU specified")
+			return 0, errors.Wrap(err, "Invalid MTU specified")
 		}
 
-		err = NetworkSetDevMTU(hostName, uint32(mtu))
-		if err != nil {
-			return errors.Wrap(err, "Failed to set the MTU")
-		}
+		mtu = uint32(nicMTU)
 	} else if m["parent"] != "" {
 		parentMTU, err := network.GetDevMTU(m["parent"])
 		if err != nil {
-			return errors.Wrap(err, "Failed to get the parent MTU")
+			return 0, errors.Wrap(err, "Failed to get the parent MTU")
 		}
 
-		err = NetworkSetDevMTU(hostName, parentMTU)
+		mtu = parentMTU
+	}
+
+	if mtu > 0 {
+		err = NetworkSetDevMTU(hostName, mtu)
 		if err != nil {
-			return errors.Wrap(err, "Failed to set the MTU")
+			return 0, fmt.Errorf("Failed to set the MTU %d: %w", mtu, err)
 		}
 	}
 
 	revert.Success()
-	return nil
+	return mtu, nil
 }
 
 // networkVethFillFromVolatile fills veth host_name and hwaddr fields from volatile if not set in device config.

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -494,19 +494,20 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	saveData["host_name"] = d.config["host_name"]
 
 	var peerName string
+	var mtu uint32
 
 	// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
 	if d.inst.Type() == instancetype.Container {
 		if saveData["host_name"] == "" {
 			saveData["host_name"] = network.RandomDevName("veth")
 		}
-		peerName, err = networkCreateVethPair(saveData["host_name"], d.config)
+		peerName, mtu, err = networkCreateVethPair(saveData["host_name"], d.config)
 	} else if d.inst.Type() == instancetype.VM {
 		if saveData["host_name"] == "" {
 			saveData["host_name"] = network.RandomDevName("tap")
 		}
 		peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
-		err = networkCreateTap(saveData["host_name"], d.config)
+		mtu, err = networkCreateTap(saveData["host_name"], d.config)
 	}
 
 	if err != nil {
@@ -631,25 +632,11 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	if d.inst.Type() == instancetype.VM {
-		var mtu uint32
-		if d.config["mtu"] != "" {
-			mtu64, err := strconv.ParseUint(d.config["mtu"], 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			mtu = uint32(mtu64)
-		} else if d.config["parent"] != "" {
-			mtu, err = network.GetDevMTU(d.config["parent"])
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
 				{Key: "hwaddr", Value: d.config["hwaddr"]},
-				{Key: "mtu", Value: strconv.Itoa(int(mtu))},
+				{Key: "mtu", Value: fmt.Sprintf("%d", mtu)},
 			}...)
 	}
 

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -228,6 +228,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
 				{Key: "hwaddr", Value: d.config["hwaddr"]},
+				{Key: "mtu", Value: d.config["mtu"]},
 			}...)
 	}
 

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -80,19 +80,22 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 	saveData["host_name"] = d.config["host_name"]
 
 	var peerName string
+	var mtu uint32
 
 	// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
 	if d.inst.Type() == instancetype.Container {
 		if saveData["host_name"] == "" {
 			saveData["host_name"] = network.RandomDevName("veth")
 		}
-		peerName, err = networkCreateVethPair(saveData["host_name"], d.config)
+
+		peerName, mtu, err = networkCreateVethPair(saveData["host_name"], d.config)
 	} else if d.inst.Type() == instancetype.VM {
 		if saveData["host_name"] == "" {
 			saveData["host_name"] = network.RandomDevName("tap")
 		}
+
 		peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
-		err = networkCreateTap(saveData["host_name"], d.config)
+		mtu, err = networkCreateTap(saveData["host_name"], d.config)
 	}
 
 	if err != nil {
@@ -134,6 +137,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
 				{Key: "hwaddr", Value: d.config["hwaddr"]},
+				{Key: "mtu", Value: fmt.Sprintf("%d", mtu)},
 			}...)
 	}
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -34,7 +34,7 @@ type nicRouted struct {
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running.
 func (d *nicRouted) CanHotPlug() bool {
-	return false
+	return true
 }
 
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -500,6 +500,7 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 		}
 	} else if d.inst.Type() == instancetype.VM {
 		nic = append(nic, []deviceConfig.RunConfigItem{
+			{Key: "name", Value: d.config["name"]},
 			{Key: "devName", Value: d.name},
 			{Key: "link", Value: peerName},
 			{Key: "hwaddr", Value: d.config["hwaddr"]},

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3071,11 +3071,6 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 		}
 	}
 
-	// If the devices' configured name has no value, fallback to the device key/name.
-	if name == "" {
-		name = devName
-	}
-
 	if shared.IsTrue(d.expandedConfig["agent.rename_interfaces"]) {
 		err := d.writeNICDevConfig(mtu, name, devHwaddr)
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3071,7 +3071,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 		}
 	}
 
-	if shared.IsTrue(d.expandedConfig["agent.rename_interfaces"]) {
+	if shared.IsTrue(d.expandedConfig["agent.nic_config"]) {
 		err := d.writeNICDevConfig(mtu, devName, name, devHwaddr)
 		if err != nil {
 			return nil, fmt.Errorf("Failed writing NIC config for device %q: %w", devName, err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1913,8 +1913,9 @@ func (d *qemu) deviceDetachNIC(deviceName string) error {
 		return false, nil
 	}
 
-	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, deviceName)
-	netDevID := fmt.Sprintf("%s%s", qemuNetDevIDPrefix, deviceName)
+	escapedDeviceName := filesystem.PathNameEncode(deviceName)
+	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
+	netDevID := fmt.Sprintf("%s%s", qemuNetDevIDPrefix, escapedDeviceName)
 
 	// Request removal of device.
 	err = monitor.RemoveNIC(netDevID, deviceID)
@@ -3082,8 +3083,8 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 		}
 	}
 
-	var qemuNetDev map[string]interface{}
-	qemuDev["id"] = fmt.Sprintf("%s%s", qemuDeviceIDPrefix, devName)
+	escapedDeviceName := filesystem.PathNameEncode(devName)
+	qemuDev["id"] = fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
 
 	if len(bootIndexes) > 0 {
 		bootIndex, found := bootIndexes[devName]
@@ -3091,6 +3092,8 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 			qemuDev["bootindex"] = strconv.Itoa(bootIndex)
 		}
 	}
+
+	var qemuNetDev map[string]interface{}
 
 	// Detect MACVTAP interface types and figure out which tap device is being used.
 	// This is so we can open a file handle to the tap device and pass it to the qemu process.
@@ -3106,7 +3109,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 		}
 
 		qemuNetDev = map[string]interface{}{
-			"id":    fmt.Sprintf("%s%s", qemuNetDevIDPrefix, devName),
+			"id":    fmt.Sprintf("%s%s", qemuNetDevIDPrefix, escapedDeviceName),
 			"type":  "tap",
 			"vhost": true,
 			"fd":    fmt.Sprintf("/dev/tap%d", ifindex), // Indicates the file to open and the FD name.
@@ -3123,7 +3126,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 	} else if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/tun_flags", nicName)) {
 		// Detect TAP (via TUN driver) device.
 		qemuNetDev = map[string]interface{}{
-			"id":         fmt.Sprintf("%s%s", qemuNetDevIDPrefix, devName),
+			"id":         fmt.Sprintf("%s%s", qemuNetDevIDPrefix, escapedDeviceName),
 			"type":       "tap",
 			"vhost":      true,
 			"script":     "no",

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3205,7 +3205,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 
 			err := m.AddNIC(qemuNetDev, qemuDev)
 			if err != nil {
-				return errors.Wrapf(err, "Failed setting up device %v", devName)
+				return errors.Wrapf(err, "Failed setting up device %q", devName)
 			}
 
 			return nil

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2234,8 +2234,8 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 		}
 	}
 
-	// Clear and recreate nics directory to ensure that no leftover configuration is erroneously applied by the agent.
-	nicConfigPath := filepath.Join(configDrivePath, "nics")
+	// Clear NICConfigDir to ensure that no leftover configuration is erroneously applied by the agent.
+	nicConfigPath := filepath.Join(configDrivePath, deviceConfig.NICConfigDir)
 	os.RemoveAll(nicConfigPath)
 	err = os.MkdirAll(nicConfigPath, 0500)
 	if err != nil {

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -277,7 +277,7 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	"security.agent.metrics": validate.Optional(validate.IsBool),
 	"security.secureboot":    validate.Optional(validate.IsBool),
 
-	"agent.rename_interfaces": validate.Optional(validate.IsBool),
+	"agent.nic_config": validate.Optional(validate.IsBool),
 }
 
 // ConfigKeyChecker returns a function that will check whether or not

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -319,7 +319,7 @@ var APIExtensions = []string{
 	"certificate_token",
 	"instance_nic_routed_neighbor_probe",
 	"event_hub",
-	"agent_rename_interfaces",
+	"agent_nic_config",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -38,9 +38,9 @@ test_container_devices_nic_routed() {
   lxc config device add "${ctName}neigh" eth0 nic network="${ctName}"
   lxc start "${ctName}neigh"
   lxc exec "${ctName}neigh" -- ip -4 addr add 192.0.2.254/24 dev eth0
-  lxc exec "${ctName}neigh" -- ip -4 route add default via 192.0.2.1 dev eth0
+  lxc exec "${ctName}neigh" -- ip -4 route replace default via 192.0.2.1 dev eth0
   lxc exec "${ctName}neigh" -- ip -6 addr add 2001:db8::FFFF/64 dev eth0
-  lxc exec "${ctName}neigh" -- ip -6 route add default via 2001:db8::1 dev eth0
+  lxc exec "${ctName}neigh" -- ip -6 route replace default via 2001:db8::1 dev eth0
 
   # Wait for IPv6 DAD to complete.
   while true


### PR DESCRIPTION
Following on from https://github.com/lxc/lxd/pull/9893

I noticed that using a device name like "eth1/foo" without a NIC name set would prevent the VM from starting for two reasons:

1. If `agent.rename_interfaces=true` then the NIC config file couldn't be written due to missing escaping of file name (similar to issues raised in https://github.com/lxc/lxd/pull/9960).
2. The QEMU device config doesn't like `/` in the device IDs.

But escaping the NIC config file introduced another issue, in that the lxd-agent was getting the desired NIC name from the NIC config's file name. To avoid needing to unescape the file, this PR expands the NICConfig struct to include both the DeviceName and the NICName so that they are stored in the file's contents. This also changes the NIC config file to always be named using the Device Name rather than sometimes being named using the NIC name.

I've also applied various other improvements:

- Don't log warning if no MTU specified from device.
- Don't require the NIC name to be specified, this allows just the MTU to be applied.
- More contextual logging and errors.
- Use of constant to show shared usage of `nics` config dir name.
- Avoids needing to read the bridged NIC parent MTU device twice during NIC start up.
- Adds support for lxd-agent apply config to other NIC types supported by VMs (`routed`, `macvlan`, `ovn` and `p2p`).
- Don't bounce interface if not changing anything.
- Make `routed` NIC hotpluggable.
- Renames `agent.rename_interfaces` to `agent.nic_config` to indicate it does more than just rename the interface.