### PR TITLE
lxd/util/sys: Pass liblxc version to RuntimeLiblxcVersionAtLeast

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -71,7 +71,7 @@ func lxcSetConfigItem(c *liblxc.Container, key string, value string) error {
 		return fmt.Errorf("Uninitialized go-lxc struct")
 	}
 
-	if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
+	if !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 2, 1, 0) {
 		switch key {
 		case "lxc.uts.name":
 			key = "lxc.utsname"
@@ -117,7 +117,7 @@ func lxcSetConfigItem(c *liblxc.Container, key string, value string) error {
 	}
 
 	if strings.HasPrefix(key, "lxc.prlimit.") {
-		if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
+		if !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 2, 1, 0) {
 			return fmt.Errorf(`Process limits require liblxc >= 2.1`)
 		}
 	}
@@ -700,7 +700,7 @@ func (d *lxc) initLXC(config bool) error {
 		return err
 	}
 
-	if util.RuntimeLiblxcVersionAtLeast(3, 0, 0) {
+	if instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 3, 0, 0) {
 		// Default size log buffer
 		err = lxcSetConfigItem(cc, "lxc.console.buffer.size", "auto")
 		if err != nil {
@@ -2112,7 +2112,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 
 		// Process rootfs setup.
 		if runConf.RootFS.Path != "" {
-			if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
+			if !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 2, 1, 0) {
 				// Set the rootfs backend type if supported (must happen before any other lxc.rootfs)
 				err := lxcSetConfigItem(d.c, "lxc.rootfs.backend", "dir")
 				if err == nil {
@@ -2129,7 +2129,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 				return "", nil, fmt.Errorf("Unable to resolve container rootfs: %w", err)
 			}
 
-			if util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
+			if instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 2, 1, 0) {
 				rootfsPath := fmt.Sprintf("dir:%s", absoluteRootfs)
 				err = lxcSetConfigItem(d.c, "lxc.rootfs.path", rootfsPath)
 			} else {
@@ -2195,7 +2195,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		// Pass any mounts into LXC.
 		if len(runConf.Mounts) > 0 {
 			for _, mount := range runConf.Mounts {
-				if shared.StringInSlice("propagation", mount.Opts) && !util.RuntimeLiblxcVersionAtLeast(3, 0, 0) {
+				if shared.StringInSlice("propagation", mount.Opts) && !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 3, 0, 0) {
 					return "", nil, errors.Wrapf(fmt.Errorf("liblxc 3.0 is required for mount propagation configuration"), "Failed to setup device mount '%s'", dev.Name)
 				}
 
@@ -2239,7 +2239,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 			nicID++
 
 			networkKeyPrefix := "lxc.net"
-			if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
+			if !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 2, 1, 0) {
 				networkKeyPrefix = "lxc.network"
 			}
 
@@ -5024,7 +5024,7 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 	/* This feature was only added in 2.0.1, let's not ask for it
 	 * before then or migrations will fail.
 	 */
-	if !util.RuntimeLiblxcVersionAtLeast(2, 0, 1) {
+	if !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 2, 0, 1) {
 		preservesInodes = false
 	}
 

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -22,7 +22,6 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/response"
-	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -551,7 +550,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	if !util.RuntimeLiblxcVersionAtLeast(3, 0, 0) {
+	if !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 3, 0, 0) {
 		return response.BadRequest(fmt.Errorf("Querying the console buffer requires liblxc >= 3.0"))
 	}
 
@@ -631,7 +630,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func instanceConsoleLogDelete(d *Daemon, r *http.Request) response.Response {
-	if !util.RuntimeLiblxcVersionAtLeast(3, 0, 0) {
+	if !instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 3, 0, 0) {
 		return response.BadRequest(fmt.Errorf("Clearing the console buffer requires liblxc >= 3.0"))
 	}
 

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -26,7 +26,6 @@ import (
 	"github.com/lxc/lxd/lxd/rsync"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
-	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
@@ -539,7 +538,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 			return abort(err)
 		}
 
-		if util.RuntimeLiblxcVersionAtLeast(2, 0, 4) {
+		if instance.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 2, 0, 4) {
 			// What happens below is slightly convoluted. Due to various complications
 			// with networking, there's no easy way for criu to exit and leave the
 			// container in a frozen state for us to somehow resume later.

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -157,7 +157,7 @@ func (s *OS) Init() ([]db.Warning, error) {
 		break
 	}
 
-	s.IdmapSet = util.GetIdmapSet()
+	s.IdmapSet = idmap.GetIdmapSet()
 	s.ExecPath = util.GetExecPath()
 	s.RunningInUserNS = shared.RunningInUserNS()
 

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -4,15 +4,11 @@
 package util
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
 	"golang.org/x/sys/unix"
-	log "gopkg.in/inconshreveable/log15.v2"
 
-	"github.com/lxc/lxd/shared/idmap"
-	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
 )
 
@@ -39,51 +35,6 @@ func GetArchitectures() ([]int, error) {
 		architectures = append(architectures, personality)
 	}
 	return architectures, nil
-}
-
-// GetIdmapSet reads the uid/gid allocation.
-func GetIdmapSet() *idmap.IdmapSet {
-	idmapSet, err := idmap.DefaultIdmapSet("", "")
-	if err != nil {
-		logger.Warn("Error reading default uid/gid map", log.Ctx{"err": err.Error()})
-		logger.Warnf("Only privileged containers will be able to run")
-		idmapSet = nil
-	} else {
-		kernelIdmapSet, err := idmap.CurrentIdmapSet()
-		if err == nil {
-			logger.Infof("Kernel uid/gid map:")
-			for _, lxcmap := range kernelIdmapSet.ToLxcString() {
-				logger.Infof(fmt.Sprintf(" - %s", lxcmap))
-			}
-		}
-
-		if len(idmapSet.Idmap) == 0 {
-			logger.Warnf("No available uid/gid map could be found")
-			logger.Warnf("Only privileged containers will be able to run")
-			idmapSet = nil
-		} else {
-			logger.Infof("Configured LXD uid/gid map:")
-			for _, lxcmap := range idmapSet.Idmap {
-				suffix := ""
-
-				if lxcmap.Usable() != nil {
-					suffix = " (unusable)"
-				}
-
-				for _, lxcEntry := range lxcmap.ToLxcString() {
-					logger.Infof(" - %s%s", lxcEntry, suffix)
-				}
-			}
-
-			err = idmapSet.Usable()
-			if err != nil {
-				logger.Warnf("One or more uid/gid map entry isn't usable (typically due to nesting)")
-				logger.Warnf("Only privileged containers will be able to run")
-				idmapSet = nil
-			}
-		}
-	}
-	return idmapSet
 }
 
 // GetExecPath returns the path to the current binary

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -6,12 +6,10 @@ package util
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"golang.org/x/sys/unix"
 	log "gopkg.in/inconshreveable/log15.v2"
-	liblxc "gopkg.in/lxc/go-lxc.v2"
 
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
@@ -86,76 +84,6 @@ func GetIdmapSet() *idmap.IdmapSet {
 		}
 	}
 	return idmapSet
-}
-
-// RuntimeLiblxcVersionAtLeast checks if the system's liblxc matches the
-// provided version requirement
-func RuntimeLiblxcVersionAtLeast(major int, minor int, micro int) bool {
-	version := liblxc.Version()
-	version = strings.Replace(version, " (devel)", "-devel", 1)
-	parts := strings.Split(version, ".")
-	partsLen := len(parts)
-	if partsLen == 0 {
-		return false
-	}
-
-	develParts := strings.Split(parts[partsLen-1], "-")
-	if len(develParts) == 2 && develParts[1] == "devel" {
-		return true
-	}
-
-	maj := -1
-	min := -1
-	mic := -1
-
-	for i, v := range parts {
-		if i > 2 {
-			break
-		}
-
-		num, err := strconv.Atoi(v)
-		if err != nil {
-			return false
-		}
-
-		switch i {
-		case 0:
-			maj = num
-		case 1:
-			min = num
-		case 2:
-			mic = num
-		}
-	}
-
-	/* Major version is greater. */
-	if maj > major {
-		return true
-	}
-
-	if maj < major {
-		return false
-	}
-
-	/* Minor number is greater.*/
-	if min > minor {
-		return true
-	}
-
-	if min < minor {
-		return false
-	}
-
-	/* Patch number is greater. */
-	if mic > micro {
-		return true
-	}
-
-	if mic < micro {
-		return false
-	}
-
-	return true
 }
 
 // GetExecPath returns the path to the current binary


### PR DESCRIPTION
So that we can export the lxd/util package without liblxc dependencies,
this commit adds the liblxc version as an argument to this helper
instead.

Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>