### PR TITLE
VM: Fix VM support detection regression

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5906,13 +5906,12 @@ func (d *qemu) checkFeature(qemu string, args ...string) (bool, error) {
 
 	err = checkFeature.Start()
 	if err != nil {
-		// Not supported.
-		return false, nil
+		return false, err // QEMU not operational. VM support missing.
 	}
 
 	err = checkFeature.Wait()
 	if err != nil {
-		return false, err
+		return false, nil // VM support available, but io_ring feature not.
 	}
 
 	pidFile.Seek(0, 0)


### PR DESCRIPTION
Otherwise we get an error like this on QEMU 4.2 and LXD does not support VMs.

```
WARN[02-28|14:15:57] Instance type not operational type=virtual-machine driver=qemu err="QEMU failed to run a feature check: exit status 1"
```

Fixes regression caused by https://github.com/lxc/lxd/pull/9973

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>