### PR TITLE
lxd/apparmor: Allow rw remount of /run

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -75,6 +75,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount fstype=sysfs -> /sys/,
   mount options=(rw,nosuid,nodev,noexec,remount) -> /sys/,
 
+  # Handle /run remounts.
+  mount options=(rw,nosuid,nodev,remount) -> /run/,
+
   # Handle tmpfs
   mount fstype=tmpfs,
 


### PR DESCRIPTION
Apparently some distros are now doing a rw rather than ro remount of
/run on shutdown, this should be harmless (as it's effectively its
default state).

Closes #9977

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>