### PR TITLE
Shared: Adds tcp package for setting timeouts on TCP connections

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
+	"github.com/lxc/lxd/shared/tcp"
 	"github.com/pkg/errors"
 )
 
@@ -994,11 +995,11 @@ func dqliteNetworkDial(ctx context.Context, name string, addr string, g *Gateway
 	logger := logging.AddContext(logger.Log, log.Ctx{"name": name, "local": conn.LocalAddr(), "remote": conn.RemoteAddr()})
 	logger.Info("Dqlite connected outbound")
 
-	remoteTCP, err := util.ExtractTCPConn(conn)
+	remoteTCP, err := tcp.ExtractConn(conn)
 	if err != nil {
 		logger.Error("Failed extracting TCP connection from remote connection", log.Ctx{"err": err})
 	} else {
-		err := util.SetTCPTimeouts(remoteTCP)
+		err := tcp.SetTimeouts(remoteTCP)
 		if err != nil {
 			logger.Error("Failed setting TCP timeouts on remote connection", log.Ctx{"err": err})
 		}
@@ -1086,11 +1087,11 @@ func dqliteProxy(name string, stopCh chan struct{}, remote net.Conn, local net.C
 	logger.Info("Dqlite proxy started")
 	defer logger.Info("Dqlite proxy stopped")
 
-	remoteTCP, err := util.ExtractTCPConn(remote)
+	remoteTCP, err := tcp.ExtractConn(remote)
 	if err != nil {
 		logger.Error("Failed extracting TCP connection from remote connection", log.Ctx{"err": err})
 	} else {
-		err := util.SetTCPTimeouts(remoteTCP)
+		err := tcp.SetTimeouts(remoteTCP)
 		if err != nil {
 			logger.Error("Failed setting TCP timeouts on remote connection", log.Ctx{"err": err})
 		}

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -23,10 +23,10 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
-	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/tcp"
 )
 
 type migrationFields struct {
@@ -178,11 +178,11 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 		return err
 	}
 
-	remoteTCP, err := util.ExtractTCPConn(c.UnderlyingConn())
+	remoteTCP, err := tcp.ExtractConn(c.UnderlyingConn())
 	if err != nil {
 		logger.Error("Failed extracting TCP connection from remote connection", log.Ctx{"err": err})
 	} else {
-		err := util.SetTCPTimeouts(remoteTCP)
+		err := tcp.SetTimeouts(remoteTCP)
 		if err != nil {
 			logger.Error("Failed setting TCP timeouts on remote connection", log.Ctx{"err": err})
 		}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -729,7 +729,7 @@ func (n *common) forwardValidate(listenAddress net.IP, forward *api.NetworkForwa
 			continue
 		}
 
-		return nil, fmt.Errorf("Invalid option option %q", k)
+		return nil, fmt.Errorf("Invalid option %q", k)
 	}
 
 	// Validate default target address.
@@ -977,7 +977,7 @@ func (n *common) peerValidate(peerName string, peer *api.NetworkPeerPut) error {
 			continue
 		}
 
-		return fmt.Errorf("Invalid option option %q", k)
+		return fmt.Errorf("Invalid option %q", k)
 	}
 
 	return nil

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -6,12 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"reflect"
-	"syscall"
-	"time"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
@@ -303,73 +297,6 @@ func SysctlSet(parts ...string) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	return nil
-}
-
-// ExtractTCPConn tries to extract the underlying net.TCPConn from a tls.Conn.
-func ExtractTCPConn(conn net.Conn) (*net.TCPConn, error) {
-	// Go doesn't currently expose the underlying TCP connection of a TLS connection, but we need it in order
-	// to set timeout properties on the connection. We use some reflect/unsafe magic to extract the private
-	// remote.conn field, which is indeed the underlying TCP connection.
-	tlsConn, ok := conn.(*tls.Conn)
-	if !ok {
-		return nil, fmt.Errorf("Connection is not a tls.Conn")
-	}
-
-	field := reflect.ValueOf(tlsConn).Elem().FieldByName("conn")
-	field = reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
-	c := field.Interface()
-
-	tcpConn, ok := c.(*net.TCPConn)
-	if !ok {
-		return nil, fmt.Errorf("Connection is not a net.TCPConn")
-	}
-
-	return tcpConn, nil
-}
-
-// SetTCPTimeouts sets TCP_USER_TIMEOUT and TCP keep alive timeouts on a connection.
-func SetTCPTimeouts(conn *net.TCPConn) error {
-	// Set TCP_USER_TIMEOUT option to limit the maximum amount of time in ms that transmitted data may remain
-	// unacknowledged before TCP will forcefully close the corresponding connection and return ETIMEDOUT to the
-	// application. This combined with the TCP keepalive options on the socket will ensure that should the
-	// remote side of the connection disappear abruptly that LXD will detect this and close the socket quickly.
-	// Decreasing the user timeouts allows applications to "fail fast" if so desired. Otherwise it may take
-	// up to 20 minutes with the current system defaults in a normal WAN environment if there are packets in
-	// the send queue that will prevent the keepalive timer from working as the retransmission timers kick in.
-	// See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dca43c75e7e545694a9dd6288553f55c53e2a3a3
-	err := SetTCPUserTimeout(conn, time.Second*30)
-	if err != nil {
-		return err
-	}
-
-	err = conn.SetKeepAlive(true)
-	if err != nil {
-		return err
-	}
-
-	err = conn.SetKeepAlivePeriod(3 * time.Second)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// SetTCPUserTimeout sets the TCP user timeout on a connection's socket
-func SetTCPUserTimeout(conn *net.TCPConn, timeout time.Duration) error {
-	rawConn, err := conn.SyscallConn()
-	if err != nil {
-		return fmt.Errorf("Error getting raw connection: %w", err)
-	}
-
-	err = rawConn.Control(func(fd uintptr) {
-		err = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(timeout/time.Millisecond))
-	})
-	if err != nil {
-		return fmt.Errorf("Error setting option on socket: %w", err)
 	}
 
 	return nil

--- a/shared/tcp/tcp_timeout_user.go
+++ b/shared/tcp/tcp_timeout_user.go
@@ -1,0 +1,29 @@
+//go:build linux || zos
+// +build linux zos
+
+package tcp
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// SetUserTimeout sets the TCP user timeout on a connection's socket.
+func SetUserTimeout(conn *net.TCPConn, timeout time.Duration) error {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("Error getting raw connection: %w", err)
+	}
+
+	err = rawConn.Control(func(fd uintptr) {
+		err = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(timeout/time.Millisecond))
+	})
+	if err != nil {
+		return fmt.Errorf("Error setting option on socket: %w", err)
+	}
+
+	return nil
+}

--- a/shared/tcp/tcp_timeout_user_noop.go
+++ b/shared/tcp/tcp_timeout_user_noop.go
@@ -1,0 +1,15 @@
+//go:build !linux && !zos
+// +build !linux,!zos
+
+package tcp
+
+import (
+	"net"
+	"time"
+)
+
+// SetUserTimeout sets the TCP user timeout on a connection's socket.
+// Only supported on Linux and ZOS.
+func SetUserTimeout(conn *net.TCPConn, timeout time.Duration) error {
+	return nil
+}

--- a/shared/tcp/tcp_timeouts.go
+++ b/shared/tcp/tcp_timeouts.go
@@ -1,0 +1,60 @@
+package tcp
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"reflect"
+	"time"
+	"unsafe"
+)
+
+// ExtractConn tries to extract the underlying net.TCPConn from a tls.Conn.
+func ExtractConn(conn net.Conn) (*net.TCPConn, error) {
+	// Go doesn't currently expose the underlying TCP connection of a TLS connection, but we need it in order
+	// to set timeout properties on the connection. We use some reflect/unsafe magic to extract the private
+	// remote.conn field, which is indeed the underlying TCP connection.
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return nil, fmt.Errorf("Connection is not a tls.Conn")
+	}
+
+	field := reflect.ValueOf(tlsConn).Elem().FieldByName("conn")
+	field = reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+	c := field.Interface()
+
+	tcpConn, ok := c.(*net.TCPConn)
+	if !ok {
+		return nil, fmt.Errorf("Connection is not a net.TCPConn")
+	}
+
+	return tcpConn, nil
+}
+
+// SetTimeouts sets TCP_USER_TIMEOUT and TCP keep alive timeouts on a connection.
+func SetTimeouts(conn *net.TCPConn) error {
+	// Set TCP_USER_TIMEOUT option to limit the maximum amount of time in ms that transmitted data may remain
+	// unacknowledged before TCP will forcefully close the corresponding connection and return ETIMEDOUT to the
+	// application. This combined with the TCP keepalive options on the socket will ensure that should the
+	// remote side of the connection disappear abruptly that LXD will detect this and close the socket quickly.
+	// Decreasing the user timeouts allows applications to "fail fast" if so desired. Otherwise it may take
+	// up to 20 minutes with the current system defaults in a normal WAN environment if there are packets in
+	// the send queue that will prevent the keepalive timer from working as the retransmission timers kick in.
+	// See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dca43c75e7e545694a9dd6288553f55c53e2a3a3
+	err := SetUserTimeout(conn, time.Second*30)
+	if err != nil {
+		return err
+	}
+
+	err = conn.SetKeepAlive(true)
+	if err != nil {
+		return err
+	}
+
+	err = conn.SetKeepAlivePeriod(3 * time.Second)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2242,7 +2242,7 @@ test_clustering_rebalance() {
 
   # Wait for the second node to be considered offline and be replaced by the
   # fourth node.
-  sleep 12
+  sleep 15
 
   # The second node is offline and has been demoted.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -q "status: Offline"


### PR DESCRIPTION
Will be used by LXD server and client.

Also removes use of deprecated `syscall` package.