### PR TITLE
Instance: Add mount support via SFTP

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -2,9 +2,11 @@ package lxd
 
 import (
 	"io"
+	"net"
 	"net/http"
 
 	"github.com/gorilla/websocket"
+	"github.com/pkg/sftp"
 
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cancel"
@@ -174,6 +176,9 @@ type InstanceServer interface {
 	GetInstanceFile(instanceName string, path string) (content io.ReadCloser, resp *InstanceFileResponse, err error)
 	CreateInstanceFile(instanceName string, path string, args InstanceFileArgs) (err error)
 	DeleteInstanceFile(instanceName string, path string) (err error)
+
+	GetInstanceFileSFTPConn(instanceName string) (net.Conn, error)
+	GetInstanceFileSFTP(instanceName string) (*sftp.Client, error)
 
 	GetInstanceSnapshotNames(instanceName string) (names []string, err error)
 	GetInstanceSnapshots(instanceName string) (snapshots []api.InstanceSnapshot, err error)

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -8615,6 +8615,27 @@ paths:
       summary: Create or replace a template file
       tags:
       - instances
+  /1.0/instances/{name}/sftp:
+    get:
+      description: Upgrades the request to an SFTP connection of the instance's filesystem.
+      operationId: instance_sftp
+      produces:
+      - application/json
+      - application/octet-stream
+      responses:
+        "101":
+          description: Switching protocols to SFTP
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the instance SFTP connection
+      tags:
+      - instances
   /1.0/instances/{name}/snapshots:
     get:
       description: Returns a list of instance snapshots (URLs).

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -57,6 +57,7 @@ var api10 = []APIEndpoint{
 	instanceMetadataCmd,
 	instanceMetadataTemplatesCmd,
 	instancesCmd,
+	instanceSFTPCmd,
 	instanceSnapshotCmd,
 	instanceSnapshotsCmd,
 	instanceStateCmd,

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/mux"
+	log "gopkg.in/inconshreveable/log15.v2"
+
+	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/logging"
+	"github.com/lxc/lxd/shared/tcp"
+)
+
+// swagger:operation GET /1.0/instances/{name}/sftp instances instance_sftp
+//
+// Get the instance SFTP connection
+//
+// Upgrades the request to an SFTP connection of the instance's filesystem.
+//
+// ---
+// produces:
+//   - application/json
+//   - application/octet-stream
+// responses:
+//   "101":
+//     description: Switching protocols to SFTP
+//   "400":
+//     $ref: "#/responses/BadRequest"
+//   "404":
+//     $ref: "#/responses/NotFound"
+//   "403":
+//     $ref: "#/responses/Forbidden"
+//   "500":
+//     $ref: "#/responses/InternalServerError"
+func instanceSFTPHandler(d *Daemon, r *http.Request) response.Response {
+	projectName := projectParam(r)
+	instName := mux.Vars(r)["name"]
+
+	if r.Header.Get("Upgrade") != "sftp" {
+		return response.SmartError(api.StatusErrorf(http.StatusBadRequest, "Missing or invalid upgrade header"))
+	}
+
+	// Redirect to correct server if needed.
+	instanceType, err := urlInstanceTypeDetect(r)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	resp := &sftpServeResponse{
+		req:         r,
+		d:           d,
+		projectName: projectName,
+		instName:    instName,
+	}
+
+	// Forward the request if the instance is remote.
+	client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, projectName, instName, d.endpoints.NetworkCert(), d.serverCert(), r, instanceType)
+	if err != nil {
+		return response.SmartError(err)
+	}
+	if client != nil {
+		resp.instConn, err = client.GetInstanceFileSFTPConn(instName)
+		if err != nil {
+			return response.SmartError(err)
+		}
+	} else {
+		inst, err := instance.LoadByProjectAndName(d.State(), projectName, instName)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		resp.instConn, err = inst.FileSFTPConn()
+		if err != nil {
+			return response.SmartError(api.StatusErrorf(http.StatusInternalServerError, "Failed getting instance SFTP connection: %v", err))
+		}
+	}
+
+	return resp
+}
+
+type sftpServeResponse struct {
+	req         *http.Request
+	d           *Daemon
+	projectName string
+	instName    string
+	instConn    net.Conn
+}
+
+func (r *sftpServeResponse) String() string {
+	return "sftp handler"
+}
+
+func (r *sftpServeResponse) Render(w http.ResponseWriter) error {
+	defer r.instConn.Close()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		return api.StatusErrorf(http.StatusInternalServerError, "Webserver doesn't support hijacking")
+	}
+
+	remoteConn, _, err := hijacker.Hijack()
+	if err != nil {
+		return api.StatusErrorf(http.StatusInternalServerError, "Failed to hijack connection: %v", err)
+	}
+	defer remoteConn.Close()
+
+	remoteTCP, err := tcp.ExtractConn(remoteConn)
+	if err == nil {
+		// Apply TCP timeouts if remote connection is TCP (rather than Unix).
+		err = tcp.SetTimeouts(remoteTCP)
+		if err != nil {
+			return api.StatusErrorf(http.StatusInternalServerError, "Failed setting TCP timeouts on remote connection: %v", err)
+		}
+	}
+
+	data := []byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: sftp\r\n\r\n")
+	n, err := remoteConn.Write(data)
+	if err != nil || n != len(data) {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(r.req.Context())
+	logger := logging.AddContext(logger.Log, log.Ctx{
+		"project":  r.projectName,
+		"instance": r.instName,
+		"local":    remoteConn.LocalAddr(),
+		"remote":   remoteConn.RemoteAddr(),
+		"err":      err,
+	})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := io.Copy(remoteConn, r.instConn)
+		if err != nil {
+			if ctx.Err() == nil {
+				logger.Warn("Failed copying SFTP instance connection to remote connection", log.Ctx{"err": err})
+			}
+		}
+		cancel()           // Cancel context first so when remoteConn is closed it doesn't cause a warning.
+		remoteConn.Close() // Trigger the cancellation of the io.Copy reading from remoteConn.
+	}()
+
+	_, err = io.Copy(r.instConn, remoteConn)
+	if err != nil {
+		if ctx.Err() == nil {
+			logger.Warn("Failed copying SFTP remote connection to instance connection", log.Ctx{"err": err})
+		}
+	}
+	cancel()           // Cancel context first so when instConn is closed it doesn't cause a warning.
+	r.instConn.Close() // Trigger the cancellation of the io.Copy reading from instConn.
+
+	wg.Wait() // Wait for copy go routine to finish.
+
+	return nil
+}

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -64,6 +64,17 @@ var instanceStateCmd = APIEndpoint{
 	Put: APIEndpointAction{Handler: instanceStatePut, AccessHandler: allowProjectPermission("containers", "operate-containers")},
 }
 
+var instanceSFTPCmd = APIEndpoint{
+	Name: "instanceFile",
+	Path: "instances/{name}/sftp",
+	Aliases: []APIEndpointAlias{
+		{Name: "containerFile", Path: "containers/{name}/files"},
+		{Name: "vmFile", Path: "virtual-machines/{name}/files"},
+	},
+
+	Get: APIEndpointAction{Handler: instanceSFTPHandler, AccessHandler: allowProjectPermission("containers", "operate-containers")},
+}
+
 var instanceFileCmd = APIEndpoint{
 	Name: "instanceFile",
 	Path: "instances/{name}/files",

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -506,7 +506,7 @@ msgstr "%s (%d mehr)"
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
@@ -516,7 +516,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1358,7 +1358,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
@@ -1475,7 +1475,7 @@ msgstr "BESCHREIBUNG"
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1592,18 +1592,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1638,7 +1638,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2049,10 +2049,20 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
+
+#: lxc/file.go:986
+#, fuzzy, c-format
+msgid "Failed starting sshfs: %w"
+msgstr "Akzeptiere Zertifikat"
 
 #: lxc/remote.go:229
 msgid "Failed to add remote"
@@ -2098,7 +2108,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2317,6 +2327,16 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2572,7 +2592,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -2589,12 +2609,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3074,7 +3094,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3186,8 +3206,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3341,7 +3361,7 @@ msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3373,7 +3393,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3408,10 +3428,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
+
+#: lxc/file.go:906 lxc/file.go:907
+#, fuzzy
+msgid "Mount files from instances"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/move.go:36 lxc/move.go:37
 #, fuzzy
@@ -3458,7 +3483,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3816,6 +3841,10 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3959,22 +3988,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4000,7 +4029,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4051,6 +4080,11 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr "Entferntes Administrator Passwort"
+
+#: lxc/file.go:1011
+#, fuzzy
+msgid "Remote disconnected"
 msgstr "Entferntes Administrator Passwort"
 
 #: lxc/remote.go:250
@@ -4287,7 +4321,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -4296,7 +4330,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4490,12 +4524,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4522,15 +4556,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -4643,7 +4677,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4674,7 +4708,7 @@ msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4876,6 +4910,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -5116,7 +5154,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -5130,7 +5168,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5151,7 +5189,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -5238,7 +5276,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -5290,7 +5328,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5798,7 +5836,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -5807,7 +5845,16 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+"Löscht einen Container oder Container Sicherungspunkt.\n"
+"\n"
+"Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
+"Daten (Konfiguration, Sicherungspunkte, ...).\n"
+
+#: lxc/file.go:114
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -5815,7 +5862,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6076,7 +6123,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 #, fuzzy
 msgid "[<remote>:]<pool>"
@@ -6101,7 +6148,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -6109,7 +6156,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -6546,14 +6593,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6729,8 +6782,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6755,6 +6808,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456
@@ -6790,7 +6852,7 @@ msgstr ""
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Kein Zertifikat für diese Verbindung"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Profil %s wurde auf %s angewandt\n"
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -886,7 +886,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1178,7 +1178,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1211,7 +1211,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1299,18 +1299,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1345,7 +1345,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1511,7 +1511,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1724,9 +1724,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1772,7 +1782,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1981,6 +1991,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2228,7 +2248,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2264,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2692,7 +2712,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2790,8 +2810,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2937,7 +2957,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2966,7 +2986,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3000,8 +3020,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3045,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3398,6 +3422,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3535,20 +3563,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3574,7 +3602,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3624,6 +3652,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3841,7 +3873,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3850,7 +3882,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4038,11 +4070,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4068,15 +4100,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4182,7 +4214,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4210,7 +4242,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4402,6 +4434,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4631,7 +4667,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4645,7 +4681,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4666,7 +4702,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4748,7 +4784,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4798,7 +4834,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5076,15 +5112,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5217,7 +5257,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5230,11 +5270,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5496,14 +5536,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5675,8 +5721,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5701,6 +5747,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -504,7 +504,7 @@ msgstr "%s (%d más)"
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
@@ -514,7 +514,7 @@ msgstr "%s no es un directorio"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -616,7 +616,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1002,7 +1002,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1108,7 +1108,7 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1310,7 +1310,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1408,7 +1408,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
@@ -1417,7 +1417,7 @@ msgstr "DESCRIPCIÓN"
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,18 +1530,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1576,7 +1576,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1743,7 +1743,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1960,10 +1960,20 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
+
+#: lxc/file.go:986
+#, fuzzy, c-format
+msgid "Failed starting sshfs: %w"
+msgstr "Acepta certificado"
 
 #: lxc/remote.go:229
 msgid "Failed to add remote"
@@ -2009,7 +2019,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2219,6 +2229,16 @@ msgstr "Aliases:"
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2471,7 +2491,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2488,12 +2508,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2944,7 +2964,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3042,8 +3062,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3195,7 +3215,7 @@ msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3225,7 +3245,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -3261,9 +3281,14 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+#, fuzzy
+msgid "Mount files from instances"
+msgstr "Aliases:"
 
 #: lxc/move.go:36 lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
@@ -3306,7 +3331,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3657,6 +3682,10 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3797,20 +3826,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3836,7 +3865,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3886,6 +3915,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4109,7 +4142,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -4118,7 +4151,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4306,11 +4339,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4336,15 +4369,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4450,7 +4483,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4478,7 +4511,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4671,6 +4704,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4905,7 +4942,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4919,7 +4956,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4940,7 +4977,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5022,7 +5059,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -5073,7 +5110,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5400,17 +5437,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/file.go:114
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -5573,7 +5615,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 #, fuzzy
 msgid "[<remote>:]<pool>"
@@ -5589,12 +5631,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5897,14 +5939,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6076,8 +6124,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6102,6 +6150,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -504,7 +504,7 @@ msgstr "%s (%d de plus)"
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
@@ -514,7 +514,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompre encore deux fois pour forcer)"
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -625,7 +625,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1148,7 +1148,7 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1363,7 +1363,7 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1487,7 +1487,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1496,7 +1496,7 @@ msgstr "DESCRIPTION"
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr "PILOTE"
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -1618,18 +1618,18 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1664,7 +1664,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1821,7 +1821,7 @@ msgstr "ÉPHÉMÈRE"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2082,10 +2082,20 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, fuzzy, c-format
+msgid "Failed finding sshfs: %w"
+msgstr "Échec lors de la génération de 'lxc.1': %v"
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
+
+#: lxc/file.go:986
+#, fuzzy, c-format
+msgid "Failed starting sshfs: %w"
+msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
 #: lxc/remote.go:229
 #, fuzzy
@@ -2132,7 +2142,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2353,6 +2363,16 @@ msgstr "L'arrêt du conteneur a échoué !"
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2616,7 +2636,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -2633,12 +2653,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3154,7 +3174,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -3266,8 +3286,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3424,7 +3444,7 @@ msgid "Missing peer name"
 msgstr "Résumé manquant."
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3456,7 +3476,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -3493,10 +3513,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
+
+#: lxc/file.go:906 lxc/file.go:907
+#, fuzzy
+msgid "Mount files from instances"
+msgstr "Création du conteneur"
 
 #: lxc/move.go:36 lxc/move.go:37
 #, fuzzy
@@ -3543,7 +3568,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr "NOM"
@@ -3914,6 +3939,10 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -4057,22 +4086,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4099,7 +4128,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -4152,6 +4181,11 @@ msgstr "le serveur distant %s est statique et ne peut être modifié"
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr "Mot de passe de l'administrateur distant"
+
+#: lxc/file.go:1011
+#, fuzzy
+msgid "Remote disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
 #: lxc/remote.go:250
@@ -4404,7 +4438,7 @@ msgstr "TAILLE"
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -4413,7 +4447,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -4611,12 +4645,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4643,15 +4677,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -4769,7 +4803,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4801,7 +4835,7 @@ msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -5008,6 +5042,10 @@ msgstr "TYPE"
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
+msgstr ""
 
 #: lxc/move.go:160
 msgid "The --instance-only flag can't be used with --target"
@@ -5252,7 +5290,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -5266,7 +5304,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5287,7 +5325,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5376,7 +5414,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 #, fuzzy
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
@@ -5430,7 +5468,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5982,7 +6020,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -5994,7 +6032,19 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+"Supprimer des conteneurs ou des instantanés.\n"
+"\n"
+"lxc delete [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
+"<snapshot>]...]\n"
+"\n"
+"Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
+"(configuration, instantanés, …)."
+
+#: lxc/file.go:114
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6002,7 +6052,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6284,7 +6334,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 #, fuzzy
 msgid "[<remote>:]<pool>"
@@ -6309,7 +6359,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -6317,7 +6367,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -6788,14 +6838,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6989,8 +7045,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -7017,6 +7073,15 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 #: lxc/storage.go:457
 msgid "space used"
 msgstr "espace utilisé"
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
+msgstr ""
 
 #: lxc/storage.go:456
 msgid "total space"
@@ -7051,11 +7116,11 @@ msgstr "oui"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Nom du réseau"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to create alias %s"
 #~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Profil %s ajouté à %s"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -498,7 +498,7 @@ msgstr "%s (altri %d)"
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
@@ -508,7 +508,7 @@ msgstr "%s non è una directory"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompi altre due volte per forzare)"
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -607,7 +607,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1296,7 +1296,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1396,7 +1396,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -1405,7 +1405,7 @@ msgstr "DESCRIZIONE"
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -1518,18 +1518,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1564,7 +1564,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1717,7 +1717,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1731,7 +1731,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -1947,10 +1947,20 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
+
+#: lxc/file.go:986
+#, fuzzy, c-format
+msgid "Failed starting sshfs: %w"
+msgstr "Accetta certificato"
 
 #: lxc/remote.go:229
 msgid "Failed to add remote"
@@ -1995,7 +2005,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2205,6 +2215,16 @@ msgstr "Creazione del container in corso"
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2457,7 +2477,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2474,12 +2494,12 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2931,7 +2951,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -3032,8 +3052,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3184,7 +3204,7 @@ msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3214,7 +3234,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3249,9 +3269,14 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+#, fuzzy
+msgid "Mount files from instances"
+msgstr "Creazione del container in corso"
 
 #: lxc/move.go:36 lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
@@ -3294,7 +3319,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3647,6 +3672,10 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3785,21 +3814,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3825,7 +3854,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3875,6 +3904,10 @@ msgstr "il remote %s è statico e non può essere modificato"
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4099,7 +4132,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -4108,7 +4141,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4294,11 +4327,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4324,15 +4357,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4438,7 +4471,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4466,7 +4499,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4663,6 +4696,10 @@ msgstr ""
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
+msgstr ""
 
 #: lxc/move.go:160
 msgid "The --instance-only flag can't be used with --target"
@@ -4894,7 +4931,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4908,7 +4945,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4929,7 +4966,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5009,7 +5046,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -5060,7 +5097,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5389,17 +5426,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr "Creazione del container in corso"
+
+#: lxc/file.go:114
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -5562,7 +5604,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 #, fuzzy
 msgid "[<remote>:]<pool>"
@@ -5578,12 +5620,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -5886,14 +5928,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6065,8 +6113,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6092,6 +6140,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -492,7 +492,7 @@ msgstr "%s (%d個使用可能)"
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
@@ -503,7 +503,7 @@ msgid "%v (interrupt two more times to force)"
 msgstr ""
 "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -600,7 +600,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -970,7 +970,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1001,7 +1001,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1106,7 +1106,7 @@ msgstr "デバイス %s が %s から削除されました"
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1311,7 +1311,7 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1411,7 +1411,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1420,7 +1420,7 @@ msgstr "DESCRIPTION"
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1445,7 +1445,7 @@ msgstr "クラスタメンバの名前を変更します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -1532,18 +1532,18 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1578,7 +1578,7 @@ msgstr "警告を削除します"
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1733,7 +1733,7 @@ msgstr "EPHEMERAL"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1749,7 +1749,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -1986,9 +1986,19 @@ msgstr "FIRST SEEN"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, fuzzy, c-format
+msgid "Failed finding sshfs: %w"
+msgstr "ピアのステータスの取得に失敗しました: %w"
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr "ピアのステータスの取得に失敗しました: %w"
+
+#: lxc/file.go:986
+#, fuzzy, c-format
+msgid "Failed starting sshfs: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
 #: lxc/remote.go:229
@@ -2035,7 +2045,7 @@ msgstr "'lxc.%s.1' の生成が失敗しました: %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました"
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2256,6 +2266,16 @@ msgstr "ホストインターフェース"
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
+msgstr ""
 
 #: lxc/operation.go:161
 msgid "ID"
@@ -2516,7 +2536,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -2533,12 +2553,12 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3125,7 +3145,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -3235,8 +3255,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -3384,7 +3404,7 @@ msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3413,7 +3433,7 @@ msgstr "コピー元のプロファイル名を指定する必要があります
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -3450,11 +3470,16 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
+
+#: lxc/file.go:906 lxc/file.go:907
+#, fuzzy
+msgid "Mount files from instances"
+msgstr "インスタンスからファイルを取得します"
 
 #: lxc/move.go:36 lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
@@ -3497,7 +3522,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr "NAME"
@@ -3853,6 +3878,10 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3992,20 +4021,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -4031,7 +4060,7 @@ msgstr "ROLES"
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -4081,6 +4110,11 @@ msgstr "リモート %s は static ですので変更できません"
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr "リモートの管理者パスワード"
+
+#: lxc/file.go:1011
+#, fuzzy
+msgid "Remote disconnected"
 msgstr "リモートの管理者パスワード"
 
 #: lxc/remote.go:250
@@ -4309,7 +4343,7 @@ msgstr "SIZE"
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -4318,7 +4352,7 @@ msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr "STATE"
 
@@ -4542,11 +4576,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr "ストレージプールの設定項目を設定します"
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4580,15 +4614,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -4692,7 +4726,7 @@ msgstr "プロファイルの設定を表示します"
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
@@ -4720,7 +4754,7 @@ msgstr "インスタンスログの最後の 100 行を表示しますか?"
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr "ストレージプールで利用可能なリソースを表示します"
 
@@ -4913,6 +4947,10 @@ msgstr "TYPE"
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
 msgstr "取得日時"
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
+msgstr ""
 
 #: lxc/move.go:160
 msgid "The --instance-only flag can't be used with --target"
@@ -5169,7 +5207,7 @@ msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr "USED BY"
@@ -5183,7 +5221,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -5204,7 +5242,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -5280,7 +5318,7 @@ msgstr "プロファイルの設定を削除します"
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
@@ -5333,7 +5371,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5620,15 +5658,20 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr "[<remote>:]<instance>/<path>"
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5769,7 +5812,7 @@ msgstr "[<remote>:]<network> [key=value...]"
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
@@ -5782,11 +5825,11 @@ msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "[<remote>:]<pool> <driver> [key=value...]"
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr "[<remote>:]<pool> <key>"
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
@@ -6091,7 +6134,17 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+#, fuzzy
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+"lxc file pull foo/etc/hosts .\n"
+"   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
+"ます。"
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -6101,7 +6154,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6362,8 +6415,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 "lxc storage volume show default data\n"
 "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
@@ -6396,6 +6449,15 @@ msgstr "`lxc profile` コマンドを使ってください"
 #: lxc/storage.go:457
 msgid "space used"
 msgstr "使用量"
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
+msgstr ""
 
 #: lxc/storage.go:456
 msgid "total space"
@@ -6430,7 +6492,7 @@ msgstr "yes"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "ネットワークゾーンを管理します"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "メンバ %s の join トークン:"
 
@@ -7980,8 +8042,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect "
-#~ "\"custom\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect \"custom"
+#~ "\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-03-02 09:57+0100\n"
+        "POT-Creation-Date: 2022-03-02 15:31+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,7 +272,7 @@ msgstr  ""
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
@@ -282,7 +282,7 @@ msgstr  ""
 msgid   "%v (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -378,7 +378,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -719,7 +719,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -748,7 +748,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -844,7 +844,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1401 lxc/storage_volume.go:1433 lxc/storage_volume.go:1549 lxc/storage_volume.go:1640 lxc/storage_volume.go:1733 lxc/storage_volume.go:1770 lxc/storage_volume.go:1864 lxc/storage_volume.go:1936 lxc/storage_volume.go:2075
+#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1401 lxc/storage_volume.go:1433 lxc/storage_volume.go:1549 lxc/storage_volume.go:1640 lxc/storage_volume.go:1733 lxc/storage_volume.go:1770 lxc/storage_volume.go:1864 lxc/storage_volume.go:1936 lxc/storage_volume.go:2075
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1024,7 +1024,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1114,7 +1114,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1034 lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914 lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584 lxc/storage_volume.go:1307
+#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1034 lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914 lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581 lxc/storage_volume.go:1307
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1122,7 +1122,7 @@ msgstr  ""
 msgid   "DISK USAGE"
 msgstr  ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid   "DRIVER"
 msgstr  ""
 
@@ -1146,7 +1146,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1210,7 +1210,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198 lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375 lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706 lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059 lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416 lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1213 lxc/storage_volume.go:1397 lxc/storage_volume.go:1430 lxc/storage_volume.go:1543 lxc/storage_volume.go:1631 lxc/storage_volume.go:1730 lxc/storage_volume.go:1764 lxc/storage_volume.go:1862 lxc/storage_volume.go:1929 lxc/storage_volume.go:2070 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198 lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375 lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706 lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059 lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416 lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166 lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38 lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1213 lxc/storage_volume.go:1397 lxc/storage_volume.go:1430 lxc/storage_volume.go:1543 lxc/storage_volume.go:1631 lxc/storage_volume.go:1730 lxc/storage_volume.go:1764 lxc/storage_volume.go:1862 lxc/storage_volume.go:1929 lxc/storage_volume.go:2070 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1341,7 +1341,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1353,7 +1353,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1554,9 +1554,19 @@ msgstr  ""
 msgid   "Failed converting token operation to certificate add token: %w"
 msgstr  ""
 
+#: lxc/file.go:966
+#, c-format
+msgid   "Failed finding sshfs: %w"
+msgstr  ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid   "Failed getting peer's status: %w"
+msgstr  ""
+
+#: lxc/file.go:986
+#, c-format
+msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
 #: lxc/remote.go:229
@@ -1602,7 +1612,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -1793,6 +1803,16 @@ msgstr  ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid   "Hugepages:\n"
+msgstr  ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid   "I/O copy from remote to sshfs failed: %v"
+msgstr  ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid   "I/O copy from sshfs to remote failed: %v"
 msgstr  ""
 
 #: lxc/operation.go:161
@@ -2036,7 +2056,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2050,12 +2070,12 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2483,7 +2503,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -2689,7 +2709,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423 lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189 lxc/storage_volume.go:264 lxc/storage_volume.go:546 lxc/storage_volume.go:623 lxc/storage_volume.go:699 lxc/storage_volume.go:781 lxc/storage_volume.go:880 lxc/storage_volume.go:1063 lxc/storage_volume.go:1151 lxc/storage_volume.go:1254 lxc/storage_volume.go:1455 lxc/storage_volume.go:1570 lxc/storage_volume.go:1662 lxc/storage_volume.go:1790 lxc/storage_volume.go:1886
+#: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423 lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189 lxc/storage_volume.go:264 lxc/storage_volume.go:546 lxc/storage_volume.go:623 lxc/storage_volume.go:699 lxc/storage_volume.go:781 lxc/storage_volume.go:880 lxc/storage_volume.go:1063 lxc/storage_volume.go:1151 lxc/storage_volume.go:1254 lxc/storage_volume.go:1455 lxc/storage_volume.go:1570 lxc/storage_volume.go:1662 lxc/storage_volume.go:1790 lxc/storage_volume.go:1886
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -2709,7 +2729,7 @@ msgstr  ""
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -2741,8 +2761,12 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid   "More than one file to download, but target is not a directory"
+msgstr  ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid   "Mount files from instances"
 msgstr  ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -2782,7 +2806,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427 lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567 lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577 lxc/storage_volume.go:1306
+#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427 lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567 lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574 lxc/storage_volume.go:1306
 msgid   "NAME"
 msgstr  ""
 
@@ -3128,6 +3152,10 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
+#: lxc/file.go:990
+msgid   "Press ctlc+c to finish"
+msgstr  ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675 lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
@@ -3259,20 +3287,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -3298,7 +3326,7 @@ msgstr  ""
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -3347,6 +3375,10 @@ msgstr  ""
 
 #: lxc/remote.go:99
 msgid   "Remote admin password"
+msgstr  ""
+
+#: lxc/file.go:1011
+msgid   "Remote disconnected"
 msgstr  ""
 
 #: lxc/remote.go:250
@@ -3559,7 +3591,7 @@ msgstr  ""
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid   "SOURCE"
 msgstr  ""
 
@@ -3567,7 +3599,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918 lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918 lxc/network_peer.go:143 lxc/storage.go:583
 msgid   "STATE"
 msgstr  ""
 
@@ -3730,11 +3762,11 @@ msgid   "Set project configuration keys\n"
         "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid   "Set storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid   "Set storage pool configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -3756,15 +3788,15 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -3864,7 +3896,7 @@ msgstr  ""
 msgid   "Show project options"
 msgstr  ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
@@ -3892,7 +3924,7 @@ msgstr  ""
 msgid   "Show the resources available to the server"
 msgstr  ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid   "Show the resources available to the storage pool"
 msgstr  ""
 
@@ -4082,6 +4114,10 @@ msgstr  ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid   "Taken at"
+msgstr  ""
+
+#: lxc/file.go:932
+msgid   "Target path must be a directory"
 msgstr  ""
 
 #: lxc/move.go:160
@@ -4299,7 +4335,7 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140 lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585 lxc/storage_volume.go:1309
+#: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140 lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582 lxc/storage_volume.go:1309
 msgid   "USED BY"
 msgstr  ""
 
@@ -4312,7 +4348,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -4332,7 +4368,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -4407,7 +4443,7 @@ msgstr  ""
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
@@ -4454,7 +4490,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -4719,15 +4755,19 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid   "[<remote>:]<instance>/<path> <target path>"
+msgstr  ""
+
+#: lxc/file.go:114
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
@@ -4851,7 +4891,7 @@ msgstr  ""
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675 lxc/storage_volume.go:1207
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670 lxc/storage_volume.go:1207
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
@@ -4863,11 +4903,11 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <driver> [key=value...]"
 msgstr  ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid   "[<remote>:]<pool> <key>"
 msgstr  ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
@@ -5114,12 +5154,17 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid   "lxc file mount foo/root fooroot\n"
+        "   To mount /root from the instance and onto the local fooroot directory."
+msgstr  ""
+
+#: lxc/file.go:231
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -5288,6 +5333,15 @@ msgstr  ""
 
 #: lxc/storage.go:457
 msgid   "space used"
+msgstr  ""
+
+#: lxc/file.go:989
+#, c-format
+msgid   "sshfs has mounted %q on %q"
+msgstr  ""
+
+#: lxc/file.go:1028
+msgid   "sshfs has stopped"
 msgstr  ""
 
 #: lxc/storage.go:456

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -486,7 +486,7 @@ msgstr "%s (en nog %d)"
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -496,7 +496,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -593,7 +593,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1367,7 +1367,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1400,7 +1400,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1486,18 +1486,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1532,7 +1532,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1680,7 +1680,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1694,7 +1694,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1904,9 +1904,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1952,7 +1962,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2156,6 +2166,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2403,7 +2423,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2419,12 +2439,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2866,7 +2886,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2961,8 +2981,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3104,7 +3124,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3133,7 +3153,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3167,8 +3187,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3212,7 +3236,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3562,6 +3586,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3699,20 +3727,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3738,7 +3766,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3788,6 +3816,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4003,7 +4035,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -4012,7 +4044,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4195,11 +4227,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4225,15 +4257,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4333,7 +4365,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4361,7 +4393,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4553,6 +4585,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4782,7 +4818,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4796,7 +4832,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4817,7 +4853,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4892,7 +4928,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4942,7 +4978,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5220,15 +5256,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5361,7 +5401,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5374,11 +5414,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5640,14 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5819,8 +5865,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5845,6 +5891,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,7 +516,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -526,7 +526,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -623,7 +623,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1302,7 +1302,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1516,18 +1516,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1562,7 +1562,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1710,7 +1710,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1724,7 +1724,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1934,9 +1934,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1982,7 +1992,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2186,6 +2196,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2433,7 +2453,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2449,12 +2469,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2896,7 +2916,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2991,8 +3011,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3134,7 +3154,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3163,7 +3183,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3197,8 +3217,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3242,7 +3266,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3592,6 +3616,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3729,20 +3757,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3768,7 +3796,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3818,6 +3846,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4033,7 +4065,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -4042,7 +4074,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4225,11 +4257,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4255,15 +4287,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4363,7 +4395,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4391,7 +4423,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4583,6 +4615,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4812,7 +4848,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4826,7 +4862,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4847,7 +4883,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4922,7 +4958,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4972,7 +5008,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5250,15 +5286,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5391,7 +5431,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5404,11 +5444,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5670,14 +5710,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5849,8 +5895,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5875,6 +5921,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -504,7 +504,7 @@ msgstr "%s (%d mais)"
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
@@ -514,7 +514,7 @@ msgstr "%s não é um diretório"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompa mais duas vezes para forçar)"
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -621,7 +621,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -985,7 +985,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1121,7 +1121,7 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1435,7 +1435,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1444,7 +1444,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -1564,18 +1564,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1610,7 +1610,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1764,7 +1764,7 @@ msgstr "EFÊMERO"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2001,10 +2001,20 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
+
+#: lxc/file.go:986
+#, fuzzy, c-format
+msgid "Failed starting sshfs: %w"
+msgstr "Aceitar certificado"
 
 #: lxc/remote.go:229
 msgid "Failed to add remote"
@@ -2049,7 +2059,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2263,6 +2273,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2513,7 +2533,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2530,12 +2550,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2983,7 +3003,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -3089,8 +3109,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3242,7 +3262,7 @@ msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3271,7 +3291,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3306,9 +3326,14 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+#, fuzzy
+msgid "Mount files from instances"
+msgstr "Adicionar perfis aos containers"
 
 #: lxc/move.go:36 lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
@@ -3351,7 +3376,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3702,6 +3727,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3843,21 +3872,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3883,7 +3912,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3933,6 +3962,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4164,7 +4197,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -4173,7 +4206,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4366,11 +4399,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4396,15 +4429,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4517,7 +4550,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4546,7 +4579,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4740,6 +4773,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4975,7 +5012,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4989,7 +5026,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5010,7 +5047,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5098,7 +5135,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -5149,7 +5186,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5450,15 +5487,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr "Editar templates de arquivo do container"
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5603,7 +5645,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5617,11 +5659,11 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5897,14 +5939,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6076,8 +6124,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6102,6 +6150,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456
@@ -6133,7 +6190,7 @@ msgstr "sim"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Criar novas redes"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Versão do cliente: %s\n"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
 #: lxc/storage.go:229
@@ -513,7 +513,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -629,7 +629,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1327,7 +1327,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1558,18 +1558,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1604,7 +1604,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1772,7 +1772,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1996,10 +1996,20 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
+
+#: lxc/file.go:986
+#, fuzzy, c-format
+msgid "Failed starting sshfs: %w"
+msgstr "Принять сертификат"
 
 #: lxc/remote.go:229
 msgid "Failed to add remote"
@@ -2044,7 +2054,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2254,6 +2264,16 @@ msgstr "Псевдонимы:"
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2508,7 +2528,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2525,12 +2545,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2985,7 +3005,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3091,8 +3111,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3245,7 +3265,7 @@ msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3276,7 +3296,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3311,9 +3331,14 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+#, fuzzy
+msgid "Mount files from instances"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/move.go:36 lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
@@ -3357,7 +3382,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3712,6 +3737,10 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3849,20 +3878,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3888,7 +3917,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3940,6 +3969,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4167,7 +4200,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -4176,7 +4209,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4364,11 +4397,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4394,15 +4427,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4511,7 +4544,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4540,7 +4573,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4738,6 +4771,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4968,7 +5005,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4982,7 +5019,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5003,7 +5040,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5085,7 +5122,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -5136,7 +5173,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5614,7 +5651,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -5622,7 +5659,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/file.go:114
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -5630,7 +5675,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -5883,7 +5928,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 #, fuzzy
 msgid "[<remote>:]<pool>"
@@ -5908,7 +5953,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -5916,7 +5961,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -6342,14 +6387,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6521,8 +6572,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6547,6 +6598,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -396,7 +396,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
@@ -406,7 +406,7 @@ msgstr "%s 不是一个目录"
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1396,18 +1396,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1442,7 +1442,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1590,7 +1590,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1604,7 +1604,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1814,9 +1814,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1862,7 +1872,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2066,6 +2076,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2313,7 +2333,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2329,12 +2349,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2776,7 +2796,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2871,8 +2891,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3014,7 +3034,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -3043,7 +3063,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -3077,8 +3097,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3122,7 +3146,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3472,6 +3496,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3609,20 +3637,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3648,7 +3676,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3698,6 +3726,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3913,7 +3945,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3922,7 +3954,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4105,11 +4137,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4135,15 +4167,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4243,7 +4275,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4271,7 +4303,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4463,6 +4495,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4692,7 +4728,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4706,7 +4742,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4727,7 +4763,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4802,7 +4838,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4852,7 +4888,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5130,15 +5166,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5271,7 +5311,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5284,11 +5324,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5550,14 +5590,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5729,8 +5775,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5755,6 +5801,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 09:28+0100\n"
+"POT-Creation-Date: 2022-03-02 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:855
+#: lxc/file.go:861
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:749
+#: lxc/file.go:755
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:416
+#: lxc/file.go:422
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:312
+#: lxc/file.go:318
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:492
+#: lxc/file.go:498
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 #: lxc/network_forward.go:389 lxc/network_forward.go:490
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340
-#: lxc/storage.go:401 lxc/storage.go:609 lxc/storage.go:681 lxc/storage.go:764
+#: lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:523
 #: lxc/storage_volume.go:602 lxc/storage_volume.go:844
 #: lxc/storage_volume.go:1041 lxc/storage_volume.go:1129
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:229 lxc/file.go:425
+#: lxc/file.go:235 lxc/file.go:431
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:914
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:584
+#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1307
 msgid "DESCRIPTION"
 msgstr ""
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:578
+#: lxc/storage.go:575
 msgid "DRIVER"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:110 lxc/file.go:111
+#: lxc/file.go:116 lxc/file.go:117
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,18 +1291,18 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160
-#: lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144
-#: lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639
-#: lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372
-#: lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25
-#: lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40
-#: lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22
-#: lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128
-#: lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410
-#: lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761
-#: lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
+#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
+#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
+#: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
+#: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
+#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
+#: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
+#: lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
+#: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
+#: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
+#: lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005
 #: lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187
 #: lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166
 #: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93
 #: lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397
-#: lxc/storage.go:523 lxc/storage.go:603 lxc/storage.go:677 lxc/storage.go:761
+#: lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756
 #: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:520
 #: lxc/storage_volume.go:599 lxc/storage_volume.go:675
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:68
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:159 lxc/file.go:160
+#: lxc/file.go:165 lxc/file.go:166
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1709,9 +1709,19 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
+#: lxc/file.go:966
+#, c-format
+msgid "Failed finding sshfs: %w"
+msgstr ""
+
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/file.go:986
+#, c-format
+msgid "Failed starting sshfs: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,7 +1767,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:744
+#: lxc/file.go:750
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1961,6 +1971,16 @@ msgstr ""
 
 #: lxc/info.go:363 lxc/info.go:374
 msgid "Hugepages:\n"
+msgstr ""
+
+#: lxc/file.go:1009
+#, c-format
+msgid "I/O copy from remote to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1019
+#, c-format
+msgid "I/O copy from sshfs to remote failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2208,7 +2228,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:135
+#: lxc/file.go:141
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2224,12 +2244,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:292 lxc/file.go:945
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:446
+#: lxc/file.go:452
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2671,7 +2691,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:76 lxc/file.go:77
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2766,8 +2786,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2909,7 +2929,7 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:191 lxc/storage.go:261 lxc/storage.go:362 lxc/storage.go:423
-#: lxc/storage.go:632 lxc/storage.go:709 lxc/storage_volume.go:189
+#: lxc/storage.go:627 lxc/storage.go:704 lxc/storage_volume.go:189
 #: lxc/storage_volume.go:264 lxc/storage_volume.go:546
 #: lxc/storage_volume.go:623 lxc/storage_volume.go:699
 #: lxc/storage_volume.go:781 lxc/storage_volume.go:880
@@ -2938,7 +2958,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:545
 msgid "Missing target directory"
 msgstr ""
 
@@ -2972,8 +2992,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:262
+#: lxc/file.go:268
 msgid "More than one file to download, but target is not a directory"
+msgstr ""
+
+#: lxc/file.go:906 lxc/file.go:907
+msgid "Mount files from instances"
 msgstr ""
 
 #: lxc/move.go:36 lxc/move.go:37
@@ -3017,7 +3041,7 @@ msgstr ""
 #: lxc/config_trust.go:393 lxc/config_trust.go:488 lxc/list.go:567
 #: lxc/network.go:909 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
-#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:577
+#: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1306
 msgid "NAME"
 msgstr ""
@@ -3367,6 +3391,10 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
+#: lxc/file.go:990
+msgid "Press ctlc+c to finish"
+msgstr ""
+
 #: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:302 lxc/image.go:449 lxc/network.go:675
@@ -3504,20 +3532,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:222 lxc/file.go:223
+#: lxc/file.go:228 lxc/file.go:229
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:375 lxc/file.go:698
+#: lxc/file.go:381 lxc/file.go:704
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:418
+#: lxc/file.go:423 lxc/file.go:424
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:634 lxc/file.go:790
+#: lxc/file.go:640 lxc/file.go:796
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3543,7 +3571,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:424
+#: lxc/file.go:236 lxc/file.go:430
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3593,6 +3621,10 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
+msgstr ""
+
+#: lxc/file.go:1011
+msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3808,7 +3840,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:578
 msgid "SOURCE"
 msgstr ""
 
@@ -3817,7 +3849,7 @@ msgid "SR-IOV information:"
 msgstr ""
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
-#: lxc/network_peer.go:143 lxc/storage.go:587
+#: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
 
@@ -4000,11 +4032,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:602
+#: lxc/storage.go:597
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:603
+#: lxc/storage.go:598
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4030,15 +4062,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:427
+#: lxc/file.go:433
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:434
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:432
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4138,7 +4170,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:676 lxc/storage.go:677
+#: lxc/storage.go:671 lxc/storage.go:672
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -4166,7 +4198,7 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:680
+#: lxc/storage.go:675
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -4358,6 +4390,10 @@ msgstr ""
 
 #: lxc/info.go:622 lxc/info.go:673
 msgid "Taken at"
+msgstr ""
+
+#: lxc/file.go:932
+msgid "Target path must be a directory"
 msgstr ""
 
 #: lxc/move.go:160
@@ -4587,7 +4623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:585
+#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1309
 msgid "USED BY"
 msgstr ""
@@ -4601,7 +4637,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:191
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4622,7 +4658,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:731
+#: lxc/file.go:737
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4697,7 +4733,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:760 lxc/storage.go:761
+#: lxc/storage.go:755 lxc/storage.go:756
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -4747,7 +4783,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:63 lxc/utils/cancel.go:63
+#: lxc/file.go:65 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5025,15 +5061,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:158
+#: lxc/file.go:164
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:108
+#: lxc/file.go:905
+msgid "[<remote>:]<instance>/<path> <target path>"
+msgstr ""
+
+#: lxc/file.go:114
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:221
+#: lxc/file.go:227
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5166,7 +5206,7 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:675
+#: lxc/storage.go:164 lxc/storage.go:215 lxc/storage.go:395 lxc/storage.go:670
 #: lxc/storage_volume.go:1207
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5179,11 +5219,11 @@ msgstr ""
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:335 lxc/storage.go:759
+#: lxc/storage.go:335 lxc/storage.go:754
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:601
+#: lxc/storage.go:596
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -5445,14 +5485,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:225
+#: lxc/file.go:909
+msgid ""
+"lxc file mount foo/root fooroot\n"
+"   To mount /root from the instance and onto the local fooroot directory."
+msgstr ""
+
+#: lxc/file.go:231
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:420
+#: lxc/file.go:426
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5624,8 +5670,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5650,6 +5696,15 @@ msgstr ""
 
 #: lxc/storage.go:457
 msgid "space used"
+msgstr ""
+
+#: lxc/file.go:989
+#, c-format
+msgid "sshfs has mounted %q on %q"
+msgstr ""
+
+#: lxc/file.go:1028
+msgid "sshfs has stopped"
 msgstr ""
 
 #: lxc/storage.go:456

--- a/test/godeps.list
+++ b/test/godeps.list
@@ -7,7 +7,9 @@ github.com/lxc/lxd/shared/cancel
 github.com/lxc/lxd/shared/ioprogress
 github.com/lxc/lxd/shared/logger
 github.com/lxc/lxd/shared/simplestreams
+github.com/lxc/lxd/shared/tcp
 github.com/lxc/lxd/shared/units
+github.com/pkg/sftp
 gopkg.in/inconshreveable/log15.v2
 gopkg.in/juju/environschema.v1/form
 gopkg.in/macaroon-bakery.v2/bakery


### PR DESCRIPTION
- [x] Introduce `GET /1.0/instances/NAME/sftp`.
- [x] Hitting the endpoint will cause an upgrade to sftp similar to what we did between LXD and the agent.
- [x] Add two new functions in the client package, one to get a raw net.Conn to the sftp endpoint and another which gets us a sftp.Client. This mostly mirrors the behavior within the instance interface on the server side.
- [x] On the `lxc` side, introduce a `lxc file mount` command which takes an instance name and path using the same syntax as lxc file pull, so something like `lxc file mount my-instance/srv srv` and will connect to the sftp endpoint, get the raw net.Conn and pass it as stdin and stdout to a `sshfs -o slave` process. This will handle the mount for us.

Example usage:

```
lxc file mount c1/ /mnt
```