### PR TITLE
Network: Don't refresh BGP prefixes during forward update

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2735,12 +2735,6 @@ func (n *bridge) ForwardUpdate(listenAddress string, req api.NetworkForwardPut, 
 		return err
 	}
 
-	// Refresh exported BGP prefixes on local member.
-	err = n.forwardBGPSetupPrefixes()
-	if err != nil {
-		return fmt.Errorf("Failed applying BGP prefixes for address forwards: %w", err)
-	}
-
 	revert.Success()
 	return nil
 }


### PR DESCRIPTION
As forward listen address cannot be changed during update.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>