### PR TITLE
Storage: Try auto starting instances when storage pools become available

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1428,7 +1428,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Resolve warnings older than the daemon start time
-	warnings.ResolveWarningsByLocalNodeOlderThan(d.cluster, d.startTime)
+	err = warnings.ResolveWarningsByLocalNodeOlderThan(d.cluster, d.startTime)
 	if err != nil {
 		logger.Warn("Failed to resolve warnings", log.Ctx{"err": err})
 	}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -22,7 +22,6 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
-	"github.com/lxc/lxd/lxd/storage"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/lxd/storage/filesystem"
@@ -80,7 +79,7 @@ type disk struct {
 	deviceCommon
 
 	restrictedParentSourcePath string
-	pool                       storage.Pool
+	pool                       storagePools.Pool
 }
 
 // CanMigrate returns whether the device can be migrated to any other cluster member.
@@ -252,7 +251,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		// Only perform expensive instance pool volume checks when not validating a profile and after
 		// device expansion has occurred (to avoid doing it twice during instance load).
 		if d.inst != nil && !d.inst.IsSnapshot() && len(instConf.ExpandedDevices()) > 0 {
-			d.pool, err = storage.GetPoolByName(d.state, d.config["pool"])
+			d.pool, err = storagePools.GetPoolByName(d.state, d.config["pool"])
 			if err != nil {
 				return fmt.Errorf("Failed to get storage pool %q: %w", d.config["pool"], err)
 			}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -60,6 +60,11 @@ type common struct {
 	project         string
 	snapshot        bool
 	stateful        bool
+
+	// Cached handles.
+	// Do not use these variables directly, instead use their associated get functions so they
+	// will be initialised on demand.
+	storagePool storagePools.Pool
 }
 
 //

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -442,10 +442,9 @@ type lxc struct {
 	// Cached handles.
 	// Do not use these variables directly, instead use their associated get functions so they
 	// will be initialised on demand.
-	c           *liblxc.Container
-	cConfig     bool
-	idmapset    *idmap.IdmapSet
-	storagePool storagePools.Pool
+	c        *liblxc.Container
+	cConfig  bool
+	idmapset *idmap.IdmapSet
 }
 
 func idmapSize(state *state.State, isolatedStr string, size string) (int64, error) {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -340,7 +340,6 @@ type qemu struct {
 	// Do not use these variables directly, instead use their associated get functions so they
 	// will be initialised on demand.
 	architectureName string
-	storagePool      storagePools.Pool
 }
 
 // getAgentClient returns the current agent client handle. To avoid TLS setup each time this

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -98,7 +98,7 @@ func (b *lxdBackend) isStatusReady() error {
 	}
 
 	if b.LocalStatus() == api.StoragePoolStatusUnvailable {
-		return fmt.Errorf("Specified pool is not currently available on this server")
+		return ErrPoolUnavailable
 	}
 
 	return nil

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2181,6 +2181,11 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 	logger.Debug("MountInstance started")
 	defer logger.Debug("MountInstance finished")
 
+	err := b.isStatusReady()
+	if err != nil {
+		return nil, err
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -3723,6 +3728,11 @@ func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operatio
 	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName})
 	logger.Debug("MountCustomVolume started")
 	defer logger.Debug("MountCustomVolume finished")
+
+	err := b.isStatusReady()
+	if err != nil {
+		return err
+	}
 
 	_, volume, err := b.state.Cluster.GetLocalStoragePoolVolume(projectName, volName, db.StoragePoolVolumeTypeCustom, b.id)
 	if err != nil {

--- a/lxd/storage/errors.go
+++ b/lxd/storage/errors.go
@@ -9,3 +9,6 @@ var ErrNilValue = fmt.Errorf("Nil value provided")
 
 // ErrBackupSnapshotsMismatch is the "Backup snapshots mismatch" error.
 var ErrBackupSnapshotsMismatch = fmt.Errorf("Backup snapshots mismatch")
+
+// ErrPoolUnavailable is the "Storage pool is unavailable on this server" error.
+var ErrPoolUnavailable = fmt.Errorf("Storage pool is unavailable on this server")

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -255,21 +255,26 @@ func GetPoolByInstance(s *state.State, inst instance.Instance) (Pool, error) {
 	return nil, drivers.ErrNotSupported
 }
 
+// UnavailablePools returns the names of storage pools not available on the local server.
+func UnavailablePools() []string {
+	unavailablePoolsMu.Lock()
+	defer unavailablePoolsMu.Unlock()
+
+	unavailablePoolNames := make([]string, 0, len(unavailablePools))
+	for unavailablePoolName := range unavailablePools {
+		unavailablePoolNames = append(unavailablePoolNames, unavailablePoolName)
+	}
+
+	return unavailablePoolNames
+}
+
 // Patch applies specified patch to all storage pools.
 // All storage pools must be available locally before any storage pools are patched.
 func Patch(s *state.State, patchName string) error {
-	unavailablePoolsMu.Lock()
+	unavailablePoolNames := UnavailablePools()
 	if len(unavailablePools) > 0 {
-		unavailablePoolNames := make([]string, 0, len(unavailablePools))
-		for unavailablePoolName := range unavailablePools {
-			unavailablePoolNames = append(unavailablePoolNames, unavailablePoolName)
-		}
-
-		unavailablePoolsMu.Unlock()
-
-		return fmt.Errorf("Unvailable storage pools %v", unavailablePoolNames)
+		return fmt.Errorf("Unvailable storage pools: %v", unavailablePoolNames)
 	}
-	unavailablePoolsMu.Unlock()
 
 	// Load all the pools.
 	pools, err := s.Cluster.GetStoragePoolNames()

--- a/lxd/task/group.go
+++ b/lxd/task/group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 )
@@ -109,7 +108,7 @@ func (g *Group) Stop(timeout time.Duration) error {
 				running = append(running, strconv.Itoa(i))
 			}
 		}
-		return fmt.Errorf("tasks %s are still running", strings.Join(running, ", "))
+		return fmt.Errorf("Task(s) still running: IDs %v", running)
 	case <-graceful:
 		return nil
 

--- a/lxd/task/group_test.go
+++ b/lxd/task/group_test.go
@@ -37,7 +37,7 @@ func TestGroup_StopUngracefully(t *testing.T) {
 
 	assertRecv(t, ok)
 
-	assert.EqualError(t, group.Stop(time.Millisecond), "tasks 0 are still running")
+	assert.EqualError(t, group.Stop(time.Millisecond), "Task(s) still running: IDs [0]")
 }
 
 // Assert that the given channel receives an object within a second.


### PR DESCRIPTION
This PR improves upon https://github.com/lxc/lxd/pull/9951 by adding a pre-start check for auto starting instances to check that all storage pools required by the instance's `disk` devices are available. If they are not then the auto start is skipped initially on LXD start up.

If the pool then later becomes available then the instance auto start mechanism is tried again to see if any instances can now auto start where they should have before.

This PR also fixes a missing error check for warning resolution on LXD daemon start up and checks pool status before proceeding with volume mounting.