### PR TITLE
lxc/file: Adds support for setting up local SFTP server for mount command

### DIFF
--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -506,7 +506,7 @@ msgstr "%s (%d mehr)"
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
@@ -516,7 +516,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1592,8 +1592,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2044,24 +2044,59 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
-#, c-format
-msgid "Failed finding sshfs: %w"
-msgstr ""
+#: lxc/file.go:959
+#, fuzzy, c-format
+msgid "Failed finding sshfs: %v\n"
+msgstr "Akzeptiere Zertifikat"
+
+#: lxc/file.go:1055
+#, fuzzy, c-format
+msgid "Failed generating SSH host key: %w"
+msgstr "Akzeptiere Zertifikat"
 
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, fuzzy, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr "Akzeptiere Zertifikat"
+
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
+msgstr "Akzeptiere Zertifikat"
+
+#: lxc/file.go:1076
+#, fuzzy, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
 #: lxc/remote.go:229
@@ -2098,6 +2133,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: lxc/file.go:1068
+#, fuzzy, c-format
+msgid "Failed to listen for connection: %w"
+msgstr "Akzeptiere Zertifikat"
+
 #: lxc/copy.go:366
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -2108,7 +2148,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2329,15 +2369,25 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
-#, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
-msgstr ""
+#: lxc/file.go:1160
+#, fuzzy, c-format
+msgid "I/O copy from SSH to instance failed: %v"
+msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1019
-#, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
-msgstr ""
+#: lxc/file.go:1149
+#, fuzzy, c-format
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
+#: lxc/file.go:1020
+#, fuzzy, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
+#: lxc/file.go:1030
+#, fuzzy, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
+msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: lxc/operation.go:161
 msgid "ID"
@@ -2495,6 +2545,16 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+#, fuzzy
+msgid "Instance disconnected"
+msgstr "Entferntes Administrator Passwort"
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2592,7 +2652,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -2609,12 +2669,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3094,7 +3154,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3393,7 +3453,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3428,12 +3488,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3841,7 +3901,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3988,22 +4048,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4029,7 +4089,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4080,11 +4140,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr "Entferntes Administrator Passwort"
-
-#: lxc/file.go:1011
-#, fuzzy
-msgid "Remote disconnected"
 msgstr "Entferntes Administrator Passwort"
 
 #: lxc/remote.go:250
@@ -4329,6 +4384,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, fuzzy, c-format
+msgid "SSH client disconnected %q"
+msgstr "Entferntes Administrator Passwort"
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4556,15 +4621,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -4912,7 +4977,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5168,7 +5233,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5176,6 +5241,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, fuzzy, c-format
 msgid "Unknown certificate type %q"
+msgstr "Unbekannter Befehl %s für Abbild"
+
+#: lxc/file.go:1104
+#, fuzzy, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -5189,7 +5259,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -5328,7 +5398,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5836,7 +5906,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -5845,7 +5915,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
@@ -5854,7 +5924,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -5862,7 +5932,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6593,20 +6663,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6810,12 +6880,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1211,7 +1211,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1299,8 +1299,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1511,7 +1511,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1719,14 +1719,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "  Χρήση δικτύου:"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1734,9 +1759,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1772,6 +1807,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1782,7 +1822,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1993,14 +2033,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2154,6 +2204,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2248,7 +2307,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2264,12 +2323,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2712,7 +2771,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2986,7 +3045,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3020,11 +3079,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3422,7 +3481,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3563,20 +3622,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3602,7 +3661,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3652,10 +3711,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3881,6 +3936,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4100,15 +4165,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4436,7 +4501,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4681,7 +4746,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4689,6 +4754,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4702,7 +4772,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4834,7 +4904,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5112,19 +5182,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5536,20 +5606,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5749,12 +5819,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -504,7 +504,7 @@ msgstr "%s (%d más)"
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
@@ -514,7 +514,7 @@ msgstr "%s no es un directorio"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -616,7 +616,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1002,7 +1002,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1310,7 +1310,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,8 +1530,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1743,7 +1743,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1955,24 +1955,59 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "Nombre del Miembro del Cluster"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
-#, c-format
-msgid "Failed finding sshfs: %w"
-msgstr ""
+#: lxc/file.go:959
+#, fuzzy, c-format
+msgid "Failed finding sshfs: %v\n"
+msgstr "Acepta certificado"
+
+#: lxc/file.go:1055
+#, fuzzy, c-format
+msgid "Failed generating SSH host key: %w"
+msgstr "Acepta certificado"
 
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, fuzzy, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr "Acepta certificado"
+
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
+msgstr "Acepta certificado"
+
+#: lxc/file.go:1076
+#, fuzzy, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
 #: lxc/remote.go:229
@@ -2009,6 +2044,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
+#: lxc/file.go:1068
+#, fuzzy, c-format
+msgid "Failed to listen for connection: %w"
+msgstr "Acepta certificado"
+
 #: lxc/copy.go:366
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -2019,7 +2059,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2231,15 +2271,25 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
-#, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
-msgstr ""
+#: lxc/file.go:1160
+#, fuzzy, c-format
+msgid "I/O copy from SSH to instance failed: %v"
+msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1019
-#, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
-msgstr ""
+#: lxc/file.go:1149
+#, fuzzy, c-format
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr "Copiando la imagen: %s"
+
+#: lxc/file.go:1020
+#, fuzzy, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr "Dispositivo %s añadido a %s"
+
+#: lxc/file.go:1030
+#, fuzzy, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
+msgstr "Copiando la imagen: %s"
 
 #: lxc/operation.go:161
 msgid "ID"
@@ -2395,6 +2445,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 #, fuzzy
 msgid "Instance name is mandatory"
@@ -2491,7 +2550,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2508,12 +2567,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2964,7 +3023,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3245,7 +3304,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -3281,11 +3340,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -3682,7 +3741,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3826,20 +3885,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3865,7 +3924,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3915,10 +3974,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4150,6 +4205,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4369,15 +4434,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4706,7 +4771,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4956,7 +5021,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4964,6 +5029,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4977,7 +5047,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5110,7 +5180,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5437,22 +5507,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -5939,20 +6009,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6152,12 +6222,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -504,7 +504,7 @@ msgstr "%s (%d de plus)"
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
@@ -514,7 +514,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompre encore deux fois pour forcer)"
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -625,7 +625,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1363,7 +1363,7 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -1618,8 +1618,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1821,7 +1821,7 @@ msgstr "ÉPHÉMÈRE"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2077,25 +2077,60 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "Profil à appliquer au nouveau conteneur"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, fuzzy, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
+
+#: lxc/file.go:1055
+#, fuzzy, c-format
+msgid "Failed generating SSH host key: %w"
+msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, fuzzy, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
+
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
+
+#: lxc/file.go:1076
+#, fuzzy, c-format
+msgid "Failed to accept incoming connection: %w"
+msgstr "Échec lors de la génération de 'lxc.1': %v"
 
 #: lxc/remote.go:229
 #, fuzzy
@@ -2132,6 +2167,11 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to get the new instance name"
 msgstr "Profil à appliquer au nouveau conteneur"
 
+#: lxc/file.go:1068
+#, fuzzy, c-format
+msgid "Failed to listen for connection: %w"
+msgstr "Échec lors de la génération de 'lxc.1': %v"
+
 #: lxc/copy.go:366
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -2142,7 +2182,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2365,15 +2405,25 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
-#, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
-msgstr ""
+#: lxc/file.go:1160
+#, fuzzy, c-format
+msgid "I/O copy from SSH to instance failed: %v"
+msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1019
-#, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
-msgstr ""
+#: lxc/file.go:1149
+#, fuzzy, c-format
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr "L'arrêt du conteneur a échoué !"
+
+#: lxc/file.go:1020
+#, fuzzy, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr "L'arrêt du conteneur a échoué !"
+
+#: lxc/file.go:1030
+#, fuzzy, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
+msgstr "L'arrêt du conteneur a échoué !"
 
 #: lxc/operation.go:161
 #, fuzzy
@@ -2539,6 +2589,16 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
+#: lxc/file.go:1022
+#, fuzzy
+msgid "Instance disconnected"
+msgstr "Mot de passe de l'administrateur distant"
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 #, fuzzy
 msgid "Instance name is mandatory"
@@ -2636,7 +2696,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -2653,12 +2713,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3174,7 +3234,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -3476,7 +3536,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -3513,12 +3573,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -3939,7 +3999,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -4086,22 +4146,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4128,7 +4188,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -4181,11 +4241,6 @@ msgstr "le serveur distant %s est statique et ne peut être modifié"
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr "Mot de passe de l'administrateur distant"
-
-#: lxc/file.go:1011
-#, fuzzy
-msgid "Remote disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
 #: lxc/remote.go:250
@@ -4446,6 +4501,16 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, fuzzy, c-format
+msgid "SSH client disconnected %q"
+msgstr "Mot de passe de l'administrateur distant"
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4677,15 +4742,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -5043,7 +5108,7 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5304,7 +5369,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5312,6 +5377,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -5325,7 +5395,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5468,7 +5538,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6020,7 +6090,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -6032,7 +6102,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
@@ -6044,7 +6114,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6052,7 +6122,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6838,20 +6908,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7074,12 +7144,12 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -498,7 +498,7 @@ msgstr "%s (altri %d)"
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
@@ -508,7 +508,7 @@ msgstr "%s non è una directory"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompi altre due volte per forzare)"
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -607,7 +607,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1296,7 +1296,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -1518,8 +1518,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1717,7 +1717,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1731,7 +1731,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -1942,24 +1942,59 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "Il nome del container è: %s"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
-#, c-format
-msgid "Failed finding sshfs: %w"
-msgstr ""
+#: lxc/file.go:959
+#, fuzzy, c-format
+msgid "Failed finding sshfs: %v\n"
+msgstr "Accetta certificato"
+
+#: lxc/file.go:1055
+#, fuzzy, c-format
+msgid "Failed generating SSH host key: %w"
+msgstr "Accetta certificato"
 
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, fuzzy, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr "Accetta certificato"
+
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
+msgstr "Accetta certificato"
+
+#: lxc/file.go:1076
+#, fuzzy, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
 #: lxc/remote.go:229
@@ -1995,6 +2030,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, fuzzy, c-format
+msgid "Failed to listen for connection: %w"
+msgstr "Accetta certificato"
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -2005,7 +2045,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2217,15 +2257,25 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
-#, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
-msgstr ""
+#: lxc/file.go:1160
+#, fuzzy, c-format
+msgid "I/O copy from SSH to instance failed: %v"
+msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1019
-#, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
-msgstr ""
+#: lxc/file.go:1149
+#, fuzzy, c-format
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr "errore di processamento degli alias %s\n"
+
+#: lxc/file.go:1020
+#, fuzzy, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr "errore di processamento degli alias %s\n"
+
+#: lxc/file.go:1030
+#, fuzzy, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
+msgstr "errore di processamento degli alias %s\n"
 
 #: lxc/operation.go:161
 msgid "ID"
@@ -2381,6 +2431,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2477,7 +2536,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2494,12 +2553,12 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2951,7 +3010,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -3234,7 +3293,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3269,11 +3328,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -3672,7 +3731,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3814,21 +3873,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3854,7 +3913,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3904,10 +3963,6 @@ msgstr "il remote %s è statico e non può essere modificato"
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4140,6 +4195,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4357,15 +4422,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4697,7 +4762,7 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4945,7 +5010,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4953,6 +5018,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4966,7 +5036,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5097,7 +5167,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5426,22 +5496,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -5928,20 +5998,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6142,12 +6212,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -492,7 +492,7 @@ msgstr "%s (%d個使用可能)"
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
@@ -503,7 +503,7 @@ msgid "%v (interrupt two more times to force)"
 msgstr ""
 "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -600,7 +600,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -970,7 +970,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1001,7 +1001,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1311,7 +1311,7 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1445,7 +1445,7 @@ msgstr "クラスタメンバの名前を変更します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -1532,8 +1532,8 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1733,7 +1733,7 @@ msgstr "EPHEMERAL"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1749,7 +1749,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -1981,14 +1981,39 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "クラスタメンバへの接続に失敗しました"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, fuzzy, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr "ピアのステータスの取得に失敗しました: %w"
+
+#: lxc/file.go:1055
+#, fuzzy, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
 #: lxc/network_peer.go:305
@@ -1996,9 +2021,19 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, fuzzy, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr "ピアのステータスの取得に失敗しました: %w"
+
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
+msgstr "ピアのステータスの取得に失敗しました: %w"
+
+#: lxc/file.go:1076
+#, fuzzy, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
 #: lxc/remote.go:229
@@ -2035,6 +2070,11 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed to get the new instance name"
 msgstr "新しいインスタンス名が取得できません"
 
+#: lxc/file.go:1068
+#, fuzzy, c-format
+msgid "Failed to listen for connection: %w"
+msgstr "ピアのステータスの取得に失敗しました: %w"
+
 #: lxc/copy.go:366
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -2045,7 +2085,7 @@ msgstr "'lxc.%s.1' の生成が失敗しました: %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました"
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2267,15 +2307,25 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1009
-#, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
-msgstr ""
+#: lxc/file.go:1160
+#, fuzzy, c-format
+msgid "I/O copy from SSH to instance failed: %v"
+msgstr "インスタンスの停止に失敗しました: %s"
 
-#: lxc/file.go:1019
-#, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
-msgstr ""
+#: lxc/file.go:1149
+#, fuzzy, c-format
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr "インスタンスの停止に失敗しました: %s"
+
+#: lxc/file.go:1020
+#, fuzzy, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr "一部のインスタンスで %s が失敗しました"
+
+#: lxc/file.go:1030
+#, fuzzy, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
+msgstr "インスタンスの停止に失敗しました: %s"
 
 #: lxc/operation.go:161
 msgid "ID"
@@ -2437,6 +2487,16 @@ msgstr "入力するデータ"
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
+#: lxc/file.go:1022
+#, fuzzy
+msgid "Instance disconnected"
+msgstr "リモートの管理者パスワード"
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
@@ -2536,7 +2596,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -2553,12 +2613,12 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3145,7 +3205,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -3433,7 +3493,7 @@ msgstr "コピー元のプロファイル名を指定する必要があります
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -3470,13 +3530,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルを取得します"
@@ -3878,7 +3938,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -4021,20 +4081,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -4060,7 +4120,7 @@ msgstr "ROLES"
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -4110,11 +4170,6 @@ msgstr "リモート %s は static ですので変更できません"
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr "リモートの管理者パスワード"
-
-#: lxc/file.go:1011
-#, fuzzy
-msgid "Remote disconnected"
 msgstr "リモートの管理者パスワード"
 
 #: lxc/remote.go:250
@@ -4350,6 +4405,16 @@ msgstr "SOURCE"
 #: lxc/info.go:136 lxc/info.go:242
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
+
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, fuzzy, c-format
+msgid "SSH client disconnected %q"
+msgstr "リモートの管理者パスワード"
 
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
@@ -4614,15 +4679,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -4948,7 +5013,7 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5221,7 +5286,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -5229,6 +5294,11 @@ msgstr "テンポラリファイルを作成できません: %v"
 #: lxc/config_trust.go:115
 #, fuzzy, c-format
 msgid "Unknown certificate type %q"
+msgstr "未知のファイルタイプ '%s'"
+
+#: lxc/file.go:1104
+#, fuzzy, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr "未知のファイルタイプ '%s'"
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -5242,7 +5312,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -5371,7 +5441,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5658,20 +5728,20 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -6134,7 +6204,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 #, fuzzy
 msgid ""
 "lxc file mount foo/root fooroot\n"
@@ -6144,7 +6214,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -6154,7 +6224,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6450,12 +6520,12 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-03-02 15:31+0000\n"
+        "POT-Creation-Date: 2022-03-04 13:49+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,7 +272,7 @@ msgstr  ""
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
@@ -282,7 +282,7 @@ msgstr  ""
 msgid   "%v (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -378,7 +378,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -719,7 +719,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -748,7 +748,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1024,7 +1024,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1146,7 +1146,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1210,7 +1210,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198 lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375 lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706 lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059 lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416 lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166 lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38 lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1213 lxc/storage_volume.go:1397 lxc/storage_volume.go:1430 lxc/storage_volume.go:1543 lxc/storage_volume.go:1631 lxc/storage_volume.go:1730 lxc/storage_volume.go:1764 lxc/storage_volume.go:1862 lxc/storage_volume.go:1929 lxc/storage_volume.go:2070 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198 lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375 lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706 lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059 lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416 lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38 lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1213 lxc/storage_volume.go:1397 lxc/storage_volume.go:1430 lxc/storage_volume.go:1543 lxc/storage_volume.go:1631 lxc/storage_volume.go:1730 lxc/storage_volume.go:1764 lxc/storage_volume.go:1862 lxc/storage_volume.go:1929 lxc/storage_volume.go:2070 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1341,7 +1341,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1353,7 +1353,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1549,14 +1549,39 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid   "Failed SSH handshake with client %q: %v"
+msgstr  ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid   "Failed accepting channel client %q: %v"
+msgstr  ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid   "Failed connecting to instance SFTP for client %q: %v"
+msgstr  ""
+
+#: lxc/file.go:972
+#, c-format
+msgid   "Failed connecting to instance SFTP: %w"
+msgstr  ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid   "Failed converting token operation to certificate add token: %w"
 msgstr  ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid   "Failed finding sshfs: %w"
+msgid   "Failed finding sshfs: %v\n"
+msgstr  ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid   "Failed generating SSH host key: %w"
 msgstr  ""
 
 #: lxc/network_peer.go:305
@@ -1564,9 +1589,19 @@ msgstr  ""
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid   "Failed parsing SSH host key: %w"
+msgstr  ""
+
+#: lxc/file.go:997
 #, c-format
 msgid   "Failed starting sshfs: %w"
+msgstr  ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
 #: lxc/remote.go:229
@@ -1602,6 +1637,11 @@ msgstr  ""
 msgid   "Failed to get the new instance name"
 msgstr  ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid   "Failed to listen for connection: %w"
+msgstr  ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
@@ -1612,7 +1652,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -1805,14 +1845,24 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid   "I/O copy from remote to sshfs failed: %v"
+msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid   "I/O copy from sshfs to remote failed: %v"
+msgid   "I/O copy from instance to SSH failed: %v"
+msgstr  ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid   "I/O copy from instance to sshfs failed: %v"
+msgstr  ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
 #: lxc/operation.go:161
@@ -1963,6 +2013,15 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
+#: lxc/file.go:1022
+msgid   "Instance disconnected"
+msgstr  ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid   "Instance disconnected for client %q"
+msgstr  ""
+
 #: lxc/publish.go:79
 msgid   "Instance name is mandatory"
 msgstr  ""
@@ -2056,7 +2115,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2070,12 +2129,12 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2503,7 +2562,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -2729,7 +2788,7 @@ msgstr  ""
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -2761,11 +2820,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3152,7 +3211,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid   "Press ctlc+c to finish"
 msgstr  ""
 
@@ -3287,20 +3346,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -3326,7 +3385,7 @@ msgstr  ""
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -3375,10 +3434,6 @@ msgstr  ""
 
 #: lxc/remote.go:99
 msgid   "Remote admin password"
-msgstr  ""
-
-#: lxc/file.go:1011
-msgid   "Remote disconnected"
 msgstr  ""
 
 #: lxc/remote.go:250
@@ -3599,6 +3654,16 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid   "SSH client connected %q"
+msgstr  ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid   "SSH client disconnected %q"
+msgstr  ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918 lxc/network_peer.go:143 lxc/storage.go:583
 msgid   "STATE"
 msgstr  ""
@@ -3788,15 +3853,15 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -4116,7 +4181,7 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -4348,7 +4413,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -4356,6 +4421,11 @@ msgstr  ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid   "Unknown certificate type %q"
+msgstr  ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336 lxc/warning.go:241
@@ -4368,7 +4438,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -4490,7 +4560,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -4755,19 +4825,19 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid   "[<remote>:]<instance>/<path> <target path>"
 msgstr  ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
@@ -5154,17 +5224,17 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance and onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -5335,12 +5405,12 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid   "sshfs has mounted %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid   "sshfs has stopped"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -486,7 +486,7 @@ msgstr "%s (en nog %d)"
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -496,7 +496,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -593,7 +593,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1400,7 +1400,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1486,8 +1486,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1680,7 +1680,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1694,7 +1694,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1899,14 +1899,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1914,9 +1939,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1952,6 +1987,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1962,7 +2002,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2168,14 +2208,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2329,6 +2379,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2423,7 +2482,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2439,12 +2498,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2886,7 +2945,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3153,7 +3212,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3187,11 +3246,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3586,7 +3645,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3727,20 +3786,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3766,7 +3825,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3816,10 +3875,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4043,6 +4098,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4257,15 +4322,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4587,7 +4652,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4832,7 +4897,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4840,6 +4905,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4853,7 +4923,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4978,7 +5048,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5256,19 +5326,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5680,20 +5750,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5893,12 +5963,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,7 +516,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -526,7 +526,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -623,7 +623,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1302,7 +1302,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1516,8 +1516,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1710,7 +1710,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1724,7 +1724,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1929,14 +1929,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1944,9 +1969,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1982,6 +2017,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1992,7 +2032,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2198,14 +2238,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2359,6 +2409,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2453,7 +2512,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2469,12 +2528,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2916,7 +2975,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3183,7 +3242,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3217,11 +3276,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3616,7 +3675,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3757,20 +3816,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3796,7 +3855,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3846,10 +3905,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4073,6 +4128,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4287,15 +4352,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4617,7 +4682,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4862,7 +4927,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4870,6 +4935,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4883,7 +4953,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5008,7 +5078,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5286,19 +5356,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5710,20 +5780,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5923,12 +5993,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -504,7 +504,7 @@ msgstr "%s (%d mais)"
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
@@ -514,7 +514,7 @@ msgstr "%s não é um diretório"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompa mais duas vezes para forçar)"
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -621,7 +621,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -985,7 +985,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -1564,8 +1564,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1764,7 +1764,7 @@ msgstr "EFÊMERO"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -1996,24 +1996,59 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "Nome de membro do cluster"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
-#, c-format
-msgid "Failed finding sshfs: %w"
-msgstr ""
+#: lxc/file.go:959
+#, fuzzy, c-format
+msgid "Failed finding sshfs: %v\n"
+msgstr "Aceitar certificado"
+
+#: lxc/file.go:1055
+#, fuzzy, c-format
+msgid "Failed generating SSH host key: %w"
+msgstr "Aceitar certificado"
 
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, fuzzy, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr "Aceitar certificado"
+
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
+msgstr "Aceitar certificado"
+
+#: lxc/file.go:1076
+#, fuzzy, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
 #: lxc/remote.go:229
@@ -2049,6 +2084,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, fuzzy, c-format
+msgid "Failed to listen for connection: %w"
+msgstr "Aceitar certificado"
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -2059,7 +2099,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2275,15 +2315,25 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
-#, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
-msgstr ""
+#: lxc/file.go:1160
+#, fuzzy, c-format
+msgid "I/O copy from SSH to instance failed: %v"
+msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1019
-#, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
-msgstr ""
+#: lxc/file.go:1149
+#, fuzzy, c-format
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr "Copiar a imagem: %s"
+
+#: lxc/file.go:1020
+#, fuzzy, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr "Dispositivo %s adicionado a %s"
+
+#: lxc/file.go:1030
+#, fuzzy, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
+msgstr "Copiar a imagem: %s"
 
 #: lxc/operation.go:161
 msgid "ID"
@@ -2438,6 +2488,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2533,7 +2592,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2550,12 +2609,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3003,7 +3062,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -3291,7 +3350,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3326,11 +3385,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -3727,7 +3786,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3872,21 +3931,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3912,7 +3971,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3962,10 +4021,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4205,6 +4260,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4429,15 +4494,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4775,7 +4840,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5026,7 +5091,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5034,6 +5099,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -5047,7 +5117,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5186,7 +5256,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5487,20 +5557,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5939,20 +6009,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6152,12 +6222,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -513,7 +513,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -629,7 +629,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1327,7 +1327,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1558,8 +1558,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1772,7 +1772,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1991,24 +1991,59 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, fuzzy, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr "Копирование образа: %s"
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
-#, c-format
-msgid "Failed finding sshfs: %w"
-msgstr ""
+#: lxc/file.go:959
+#, fuzzy, c-format
+msgid "Failed finding sshfs: %v\n"
+msgstr "Принять сертификат"
+
+#: lxc/file.go:1055
+#, fuzzy, c-format
+msgid "Failed generating SSH host key: %w"
+msgstr "Принять сертификат"
 
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, fuzzy, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr "Принять сертификат"
+
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
+msgstr "Принять сертификат"
+
+#: lxc/file.go:1076
+#, fuzzy, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
 #: lxc/remote.go:229
@@ -2044,6 +2079,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, fuzzy, c-format
+msgid "Failed to listen for connection: %w"
+msgstr "Принять сертификат"
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -2054,7 +2094,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2266,15 +2306,25 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
-#, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
-msgstr ""
+#: lxc/file.go:1160
+#, fuzzy, c-format
+msgid "I/O copy from SSH to instance failed: %v"
+msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1019
-#, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
-msgstr ""
+#: lxc/file.go:1149
+#, fuzzy, c-format
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr "Невозможно добавить имя контейнера в список"
+
+#: lxc/file.go:1020
+#, fuzzy, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr "Невозможно добавить имя контейнера в список"
+
+#: lxc/file.go:1030
+#, fuzzy, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/operation.go:161
 msgid "ID"
@@ -2432,6 +2482,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 #, fuzzy
 msgid "Instance name is mandatory"
@@ -2528,7 +2587,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2545,12 +2604,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3005,7 +3064,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3296,7 +3355,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3331,11 +3390,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3737,7 +3796,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3878,20 +3937,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3917,7 +3976,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3969,10 +4028,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -4208,6 +4263,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4427,15 +4492,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4773,7 +4838,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5019,7 +5084,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5027,6 +5092,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -5040,7 +5110,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5173,7 +5243,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5651,7 +5721,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -5659,7 +5729,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
@@ -5667,7 +5737,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -5675,7 +5745,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6387,20 +6457,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6600,12 +6670,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -396,7 +396,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
@@ -406,7 +406,7 @@ msgstr "%s 不是一个目录"
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1396,8 +1396,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1590,7 +1590,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1604,7 +1604,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1809,14 +1809,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1824,9 +1849,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1862,6 +1897,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1872,7 +1912,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2078,14 +2118,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2239,6 +2289,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2333,7 +2392,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2408,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2796,7 +2855,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3063,7 +3122,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -3097,11 +3156,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3496,7 +3555,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3637,20 +3696,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3676,7 +3735,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3726,10 +3785,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3953,6 +4008,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4167,15 +4232,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4497,7 +4562,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4742,7 +4807,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4750,6 +4815,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4763,7 +4833,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4888,7 +4958,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5166,19 +5236,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5590,20 +5660,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5803,12 +5873,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-02 15:31+0000\n"
+"POT-Creation-Date: 2022-03-04 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,7 +291,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:861
+#: lxc/file.go:863
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:755
+#: lxc/file.go:757
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:422
+#: lxc/file.go:424
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:318
+#: lxc/file.go:320
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:500
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:235 lxc/file.go:431
+#: lxc/file.go:237 lxc/file.go:433
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:116 lxc/file.go:117
+#: lxc/file.go:118 lxc/file.go:119
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1291,8 +1291,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:77 lxc/file.go:117 lxc/file.go:166
-#: lxc/file.go:229 lxc/file.go:424 lxc/file.go:907 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
+#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:909 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:68
+#: lxc/file.go:70
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:165 lxc/file.go:166
+#: lxc/file.go:167 lxc/file.go:168
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1704,14 +1704,39 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
+#: lxc/file.go:1088
+#, c-format
+msgid "Failed SSH handshake with client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1111
+#, c-format
+msgid "Failed accepting channel client %q: %v"
+msgstr ""
+
+#: lxc/file.go:1138
+#, c-format
+msgid "Failed connecting to instance SFTP for client %q: %v"
+msgstr ""
+
+#: lxc/file.go:972
+#, c-format
+msgid "Failed connecting to instance SFTP: %w"
+msgstr ""
+
 #: lxc/config_trust.go:200
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:959
 #, c-format
-msgid "Failed finding sshfs: %w"
+msgid "Failed finding sshfs: %v\n"
+msgstr ""
+
+#: lxc/file.go:1055
+#, c-format
+msgid "Failed generating SSH host key: %w"
 msgstr ""
 
 #: lxc/network_peer.go:305
@@ -1719,9 +1744,19 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:986
+#: lxc/file.go:1060
+#, c-format
+msgid "Failed parsing SSH host key: %w"
+msgstr ""
+
+#: lxc/file.go:997
 #, c-format
 msgid "Failed starting sshfs: %w"
+msgstr ""
+
+#: lxc/file.go:1076
+#, c-format
+msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
 #: lxc/remote.go:229
@@ -1757,6 +1792,11 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
+#: lxc/file.go:1068
+#, c-format
+msgid "Failed to listen for connection: %w"
+msgstr ""
+
 #: lxc/copy.go:366
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
@@ -1767,7 +1807,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:750
+#: lxc/file.go:752
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1973,14 +2013,24 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1009
+#: lxc/file.go:1160
 #, c-format
-msgid "I/O copy from remote to sshfs failed: %v"
+msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1149
 #, c-format
-msgid "I/O copy from sshfs to remote failed: %v"
+msgid "I/O copy from instance to SSH failed: %v"
+msgstr ""
+
+#: lxc/file.go:1020
+#, c-format
+msgid "I/O copy from instance to sshfs failed: %v"
+msgstr ""
+
+#: lxc/file.go:1030
+#, c-format
+msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
 #: lxc/operation.go:161
@@ -2134,6 +2184,15 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: lxc/file.go:1022
+msgid "Instance disconnected"
+msgstr ""
+
+#: lxc/file.go:1151
+#, c-format
+msgid "Instance disconnected for client %q"
+msgstr ""
+
 #: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
@@ -2228,7 +2287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:141
+#: lxc/file.go:143
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2244,12 +2303,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:292 lxc/file.go:945
+#: lxc/file.go:294 lxc/file.go:947
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:452
+#: lxc/file.go:454
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2691,7 +2750,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:76 lxc/file.go:77
+#: lxc/file.go:78 lxc/file.go:79
 msgid "Manage files in instances"
 msgstr ""
 
@@ -2958,7 +3017,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:545
+#: lxc/file.go:547
 msgid "Missing target directory"
 msgstr ""
 
@@ -2992,11 +3051,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:268
+#: lxc/file.go:270
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:906 lxc/file.go:907
+#: lxc/file.go:908 lxc/file.go:909
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3391,7 +3450,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:990
+#: lxc/file.go:1001
 msgid "Press ctlc+c to finish"
 msgstr ""
 
@@ -3532,20 +3591,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:228 lxc/file.go:229
+#: lxc/file.go:230 lxc/file.go:231
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:381 lxc/file.go:704
+#: lxc/file.go:383 lxc/file.go:706
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:423 lxc/file.go:424
+#: lxc/file.go:425 lxc/file.go:426
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:640 lxc/file.go:796
+#: lxc/file.go:642 lxc/file.go:798
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3571,7 +3630,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:430
+#: lxc/file.go:238 lxc/file.go:432
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3621,10 +3680,6 @@ msgstr ""
 
 #: lxc/remote.go:99
 msgid "Remote admin password"
-msgstr ""
-
-#: lxc/file.go:1011
-msgid "Remote disconnected"
 msgstr ""
 
 #: lxc/remote.go:250
@@ -3848,6 +3903,16 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
+#: lxc/file.go:1081
+#, c-format
+msgid "SSH client connected %q"
+msgstr ""
+
+#: lxc/file.go:1082
+#, c-format
+msgid "SSH client disconnected %q"
+msgstr ""
+
 #: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
@@ -4062,15 +4127,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:433
+#: lxc/file.go:435
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:436
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:432
+#: lxc/file.go:434
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4392,7 +4457,7 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:932
+#: lxc/file.go:934
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4637,7 +4702,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:191
+#: lxc/file.go:193
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4645,6 +4710,11 @@ msgstr ""
 #: lxc/config_trust.go:115
 #, c-format
 msgid "Unknown certificate type %q"
+msgstr ""
+
+#: lxc/file.go:1104
+#, c-format
+msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1053 lxc/list.go:630 lxc/storage_volume.go:1336
@@ -4658,7 +4728,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:737
+#: lxc/file.go:739
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4783,7 +4853,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:65 lxc/utils/cancel.go:63
+#: lxc/file.go:67 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5061,19 +5131,19 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:164
+#: lxc/file.go:166
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:905
+#: lxc/file.go:907
 msgid "[<remote>:]<instance>/<path> <target path>"
 msgstr ""
 
-#: lxc/file.go:114
+#: lxc/file.go:116
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:227
+#: lxc/file.go:229
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
@@ -5485,20 +5555,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:911
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance and onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:231
+#: lxc/file.go:233
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:426
+#: lxc/file.go:428
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5698,12 +5768,12 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:1000
 #, c-format
 msgid "sshfs has mounted %q on %q"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 msgid "sshfs has stopped"
 msgstr ""
 


### PR DESCRIPTION
Following on from https://github.com/lxc/lxd/pull/9985

When using `lxc file mount [<remote>:]<instance>/<path> <target path>` if the `sshfs` cannot be found, the `lxc` command will instead launch an unauthenticated SSH service listening on a random port on 127.0.0.1 that provides an SFTP service connected to the instance's file system.

In this case the `<path>` and `<target path>` parameters are ignored and the whole filesystem is served.

- [x] Get local SSH/SFTP server working.
- [x] Generate host key.

Tested with Gnome Nautilus, OpenSSH SFTP command and FileZilla.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>