### PR TITLE
seccomp: pass a PID FD to process_still_alive

### DIFF
--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -413,7 +413,7 @@ static int handle_bpf_syscall(pid_t pid_target, int notify_fd, int mem_fd,
 			// recycled in the meantime so we're not accidentally
 			// looking at a different threadgroup with the same
 			// open files.
-			if (!process_still_alive(tgid))
+			if (!process_still_alive(pidfd))
 				return -EINVAL;
 		}
 
@@ -446,7 +446,7 @@ static int handle_bpf_syscall(pid_t pid_target, int notify_fd, int mem_fd,
 			// recycled in the meantime so we're not accidentally
 			// looking at a different threadgroup with the same
 			// open files.
-			if (!process_still_alive(tgid))
+			if (!process_still_alive(pidfd))
 				return -EINVAL;
 		}
 


### PR DESCRIPTION
As process_still_alive calls pidfd_send_signal, it expects a pidfd and not a PID.

Failure to do this causes an error when the thread attaching the BPF program isn't a thread-group leader.

As I understand the code, we want to check that the comparison done before was done on a stable ground.
So it seems that sending a signal to the PID FD opened before the check should be the way to go.