### PR TITLE
lxd/instance/qemu: Switch TPM mode to CRB

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -563,6 +563,6 @@ type = "emulator"
 chardev = "qemu_tpm-chardev_{{.devName}}"
 
 [device "dev-lxd_{{.devName}}"]
-driver = "tpm-tis"
+driver = "tpm-crb"
 tpmdev = "qemu_tpm-tpmdev_{{.devName}}"
 `))


### PR DESCRIPTION
CRB mode is apparently faster than TIS and since we don't need 1.2 mode
(we only run in 2.0), TIS doesn't provide anything of value.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>