### PR TITLE
Device: Fix regression for VM disk shares

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -450,6 +451,10 @@ func DiskVMVirtfsProxyStop(pidPath string) error {
 func DiskVMVirtiofsdStart(execPath string, inst instance.Instance, socketPath string, pidPath string, logPath string, sharePath string, idmaps []idmap.IdmapEntry) (func(), net.Listener, error) {
 	revert := revert.New()
 	defer revert.Fail()
+
+	if !filepath.IsAbs(sharePath) {
+		return nil, nil, fmt.Errorf("Share path not absolute: %q", sharePath)
+	}
 
 	// Remove old socket if needed.
 	os.Remove(socketPath)


### PR DESCRIPTION
Introduced by https://github.com/lxc/lxd/pull/9991 whist fixing https://github.com/lxc/lxd/pull/9976

By removing `srcPath` and using `mount.DevPath` directly, I inadvertently caused virtiofsd to not start properly because it was being passed the FD number of virtiofs-proxy-helper (which rewrites the mount.DevPath).

Changing the start order fixes this.
Also improves `DiskVMVirtiofsdStart` validation to check `sharePath` looks like a path to catch this sort of regression more quickly in the future.