### PR TITLE
LXD: Disable idmapped mounts if LXD_SHIFTFS_DISABLE=true

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1312,7 +1312,7 @@ func (d *lxc) IdmappedStorage(path string) idmap.IdmapStorageType {
 		mode = idmap.IdmapStorageShiftfs
 	}
 
-	if !d.state.OS.LXCFeatures["idmapped_mounts_v2"] {
+	if !d.state.OS.LXCFeatures["idmapped_mounts_v2"] || shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
 		return mode
 	}
 


### PR DESCRIPTION
This is a tentative fix for https://github.com/lxc/lxd/issues/10011