### PR TITLE
Export sorting helpers.

### DIFF
--- a/lxc/alias.go
+++ b/lxc/alias.go
@@ -123,7 +123,7 @@ func (c *cmdAliasList) Run(cmd *cobra.Command, args []string) error {
 	for k, v := range conf.Aliases {
 		data = append(data, []string{k, v})
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("ALIAS"),

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -169,7 +169,7 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 		line := []string{member.ServerName, member.URL, strings.Join(roles, rolesDelimiter), member.Architecture, member.FailureDomain, member.Description, strings.ToUpper(member.Status), member.Message}
 		data = append(data, line)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -851,7 +851,7 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 		line := []string{token.ServerName, token.Token}
 		data = append(data, line)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -421,7 +421,7 @@ func (c *cmdClusterGroupList) Run(cmd *cobra.Command, args []string) error {
 		line := []string{group.Name, group.Description, fmt.Sprintf("%d", len(group.Members))}
 		data = append(data, line)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -275,7 +275,7 @@ func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
 	for _, template := range templates {
 		data = append(data, []string{template})
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("FILENAME"),

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -386,7 +386,7 @@ func (c *cmdConfigTrustList) Run(cmd *cobra.Command, args []string) error {
 		expiry := tlsCert.NotAfter.Format(layout)
 		data = append(data, []string{cert.Type, cert.Name, tlsCert.Subject.CommonName, fp, issue, expiry})
 	}
-	sort.Sort(stringList(data))
+	sort.Sort(utils.StringList(data))
 
 	header := []string{
 		i18n.G("TYPE"),
@@ -482,7 +482,7 @@ func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error 
 		line := []string{token.ClientName, token.Token}
 		data = append(data, line)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1265,7 +1265,7 @@ func (c *cmdImageList) Run(cmd *cobra.Command, args []string) error {
 		}
 		data = append(data, row)
 	}
-	sort.Sort(stringList(data))
+	sort.Sort(utils.StringList(data))
 
 	rawData := make([]*api.Image, len(images))
 	for i := range images {

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -228,7 +228,7 @@ func (c *cmdImageAliasList) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, []string{alias.Name, alias.Target[0:12], strings.ToUpper(alias.Type), alias.Description})
 	}
-	sort.Sort(stringList(data))
+	sort.Sort(utils.StringList(data))
 
 	header := []string{
 		i18n.G("ALIAS"),

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -616,7 +616,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, remote config.Remote, name 
 			snapData = append(snapData, row)
 		}
 
-		sort.Sort(byName(snapData))
+		sort.Sort(utils.ByName(snapData))
 		snapHeader := []string{
 			i18n.G("Name"),
 			i18n.G("Taken at"),

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -428,7 +428,7 @@ func (c *cmdList) showInstances(cts []api.InstanceFull, filters []string, column
 		}
 		data = append(data, col)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	headers := []string{}
 	for _, column := range columns {

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -903,7 +903,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 		}
 		data = append(data, details)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -976,7 +976,7 @@ func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, entry)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("HOSTNAME"),

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -142,7 +142,7 @@ func (c *cmdNetworkACLList) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, details)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -138,7 +138,7 @@ func (c *cmdNetworkForwardList) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, details)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("LISTEN ADDRESS"),

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -134,7 +134,7 @@ func (c *cmdNetworkPeerList) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, details)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -132,7 +132,7 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, details)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -695,7 +695,7 @@ func (c *cmdNetworkZoneRecordList) Run(cmd *cobra.Command, args []string) error 
 
 		data = append(data, details)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -155,7 +155,7 @@ func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, entry)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("ID"),

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -617,7 +617,7 @@ func (c *cmdProfileList) Run(cmd *cobra.Command, args []string) error {
 		strUsedBy := fmt.Sprintf("%d", len(profile.UsedBy))
 		data = append(data, []string{profile.Name, profile.Description, strUsedBy})
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -462,7 +462,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		strUsedBy := fmt.Sprintf("%d", len(project.UsedBy))
 		data = append(data, []string{name, images, profiles, storageVolumes, networks, project.Description, strUsedBy})
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -800,7 +800,7 @@ func (c *cmdProjectInfo) Run(cmd *cobra.Command, args []string) error {
 
 		data = append(data, []string{strings.ToUpper(k), limit, usage})
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("RESOURCE"),

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -668,7 +668,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 		}
 		data = append(data, []string{strName, rc.Addr, rc.Protocol, rc.AuthType, strPublic, strStatic, strGlobal})
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -568,7 +568,7 @@ func (c *cmdStorageList) Run(cmd *cobra.Command, args []string) error {
 		details = append(details, strings.ToUpper(pool.Status))
 		data = append(data, details)
 	}
-	sort.Sort(byName(data))
+	sort.Sort(utils.ByName(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1251,7 +1251,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			snapData = append(snapData, row)
 		}
 
-		sort.Sort(byName(snapData))
+		sort.Sort(utils.ByName(snapData))
 		snapHeader := []string{
 			i18n.G("Name"),
 			i18n.G("Description"),
@@ -1410,7 +1410,7 @@ func (c *cmdStorageVolumeList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, row)
 	}
 	if len(columns) >= 2 {
-		sort.Sort(byNameAndType(data))
+		sort.Sort(utils.ByNameAndType(data))
 	}
 
 	rawData := make([]*api.StorageVolume, len(volumes))

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -7,104 +7,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fvbommel/sortorder"
-
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/i18n"
 	"github.com/lxc/lxd/shared/termios"
 )
-
-type stringList [][]string
-
-func (a stringList) Len() int {
-	return len(a)
-}
-
-func (a stringList) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-func (a stringList) Less(i, j int) bool {
-	x := 0
-	for x = range a[i] {
-		if a[i][x] != a[j][x] {
-			break
-		}
-	}
-
-	if a[i][x] == "" {
-		return false
-	}
-
-	if a[j][x] == "" {
-		return true
-	}
-
-	return sortorder.NaturalLess(a[i][x], a[j][x])
-}
-
-// Instance name sorting
-type byName [][]string
-
-func (a byName) Len() int {
-	return len(a)
-}
-
-func (a byName) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-func (a byName) Less(i, j int) bool {
-	for k := range a[i] {
-		if a[i][k] == a[j][k] {
-			continue
-		}
-
-		if a[i][k] == "" {
-			return false
-		}
-
-		if a[j][k] == "" {
-			return true
-		}
-
-		return sortorder.NaturalLess(a[i][k], a[j][k])
-	}
-
-	return false
-}
-
-// Storage volume sorting
-type byNameAndType [][]string
-
-func (a byNameAndType) Len() int {
-	return len(a)
-}
-
-func (a byNameAndType) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-func (a byNameAndType) Less(i, j int) bool {
-	// Sort snapshot and parent together.
-	iType := strings.Split(a[i][0], " ")[0]
-	jType := strings.Split(a[j][0], " ")[0]
-
-	if iType != jType {
-		return sortorder.NaturalLess(a[i][0], a[j][0])
-	}
-
-	if a[i][1] == "" {
-		return false
-	}
-
-	if a[j][1] == "" {
-		return true
-	}
-
-	return sortorder.NaturalLess(a[i][1], a[j][1])
-}
 
 // Batch operations
 type batchResult struct {

--- a/lxc/utils/sort.go
+++ b/lxc/utils/sort.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/fvbommel/sortorder"
+)
+
+// StringList represents the type for sorting nested string lists.
+type StringList [][]string
+
+func (a StringList) Len() int {
+	return len(a)
+}
+
+func (a StringList) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a StringList) Less(i, j int) bool {
+	x := 0
+	for x = range a[i] {
+		if a[i][x] != a[j][x] {
+			break
+		}
+	}
+
+	if a[i][x] == "" {
+		return false
+	}
+
+	if a[j][x] == "" {
+		return true
+	}
+
+	return sortorder.NaturalLess(a[i][x], a[j][x])
+}
+
+// ByName represents the type for sorting by one string (i.e. Instance names).
+type ByName [][]string
+
+func (a ByName) Len() int {
+	return len(a)
+}
+
+func (a ByName) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a ByName) Less(i, j int) bool {
+	for k := range a[i] {
+		if a[i][k] == a[j][k] {
+			continue
+		}
+
+		if a[i][k] == "" {
+			return false
+		}
+
+		if a[j][k] == "" {
+			return true
+		}
+
+		return sortorder.NaturalLess(a[i][k], a[j][k])
+	}
+
+	return false
+}
+
+// ByNameAndType represents the type for sorting Storage volumes.
+type ByNameAndType [][]string
+
+func (a ByNameAndType) Len() int {
+	return len(a)
+}
+
+func (a ByNameAndType) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a ByNameAndType) Less(i, j int) bool {
+	// Sort snapshot and parent together.
+	iType := strings.Split(a[i][0], " ")[0]
+	jType := strings.Split(a[j][0], " ")[0]
+
+	if iType != jType {
+		return sortorder.NaturalLess(a[i][0], a[j][0])
+	}
+
+	if a[i][1] == "" {
+		return false
+	}
+
+	if a[j][1] == "" {
+		return true
+	}
+
+	return sortorder.NaturalLess(a[i][1], a[j][1])
+}

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -20,21 +21,21 @@ func TestUtilsTestSuite(t *testing.T) {
 // stringList can be used to sort a list of strings.
 func (s *utilsTestSuite) Test_stringList() {
 	data := [][]string{{"foo", "bar"}, {"baz", "bza"}}
-	sort.Sort(stringList(data))
+	sort.Sort(utils.StringList(data))
 	s.Equal([][]string{{"baz", "bza"}, {"foo", "bar"}}, data)
 }
 
 // The first different string is used in sorting.
 func (s *utilsTestSuite) Test_stringList_sort_by_column() {
 	data := [][]string{{"foo", "baz"}, {"foo", "bar"}}
-	sort.Sort(stringList(data))
+	sort.Sort(utils.StringList(data))
 	s.Equal([][]string{{"foo", "bar"}, {"foo", "baz"}}, data)
 }
 
 // Empty strings are sorted last.
 func (s *utilsTestSuite) Test_stringList_empty_strings() {
 	data := [][]string{{"", "bar"}, {"foo", "baz"}}
-	sort.Sort(stringList(data))
+	sort.Sort(utils.StringList(data))
 	s.Equal([][]string{{"foo", "baz"}, {"", "bar"}}, data)
 }
 

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -152,7 +152,7 @@ func (c *cmdWarningList) Run(cmd *cobra.Command, args []string) error {
 		}
 		data = append(data, row)
 	}
-	sort.Sort(stringList(data))
+	sort.Sort(utils.StringList(data))
 
 	rawData := make([]*api.Warning, len(warnings))
 	for i := range warnings {


### PR DESCRIPTION
Exports `byName`, `stringList`, and `byNameAndType` so that we can use LXD's sorting implementation for cli tables in other projects.