### PR TITLE
lxd/instance/qemu: Set spawn=allow

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1293,7 +1293,7 @@ func (d *qemu) Start(stateful bool) error {
 		"-serial", "chardev:console",
 		"-nodefaults",
 		"-no-user-config",
-		"-sandbox", "on,obsolete=deny,elevateprivileges=allow,spawn=deny,resourcecontrol=deny",
+		"-sandbox", "on,obsolete=deny,elevateprivileges=allow,spawn=allow,resourcecontrol=deny",
 		"-readconfig", confFile,
 		"-spice", d.spiceCmdlineConfig(),
 		"-pidfile", d.pidFilePath(),


### PR DESCRIPTION
spawn=allow is required when QEMU is asked to daemonize.

Previous QEMU versions would incorrectly block `fork` when spawn=deny
was passed while allowing clone to succeed.

This was then making it possible for us to use daemnize thanks to most
Linux distributions using the clone syscall to implement fork.

Current QEMU has fixed their seccomp profile to block both fork and
clone, preventing -daemonize when spawn=deny is passed.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>