### PR TITLE
lxd: Adds IdmappedMounts field to OS struct

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -324,6 +324,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		"seccomp_listener":          fmt.Sprintf("%v", d.os.SeccompListener),
 		"seccomp_listener_continue": fmt.Sprintf("%v", d.os.SeccompListenerContinue),
 		"shiftfs":                   fmt.Sprintf("%v", d.os.Shiftfs),
+		"idmapped_mounts":           fmt.Sprintf("%v", d.os.IdmappedMounts),
 	}
 
 	instanceTypes, _ := instanceDrivers.SupportedInstanceTypes()

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -943,7 +943,11 @@ func (d *Daemon) init() error {
 		}
 	}
 
-	if kernelSupportsIdmappedMounts() {
+	// Detect idmapped mounts support.
+	if shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
+		logger.Info(" - idmapped mounts kernel support: disabled")
+	} else if kernelSupportsIdmappedMounts() {
+		d.os.IdmappedMounts = true
 		logger.Info(" - idmapped mounts kernel support: yes")
 	} else {
 		logger.Info(" - idmapped mounts kernel support: no")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1312,7 +1312,7 @@ func (d *lxc) IdmappedStorage(path string) idmap.IdmapStorageType {
 		mode = idmap.IdmapStorageShiftfs
 	}
 
-	if !d.state.OS.LXCFeatures["idmapped_mounts_v2"] || shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
+	if !d.state.OS.LXCFeatures["idmapped_mounts_v2"] || !d.state.OS.IdmappedMounts {
 		return mode
 	}
 

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -74,6 +74,7 @@ type OS struct {
 	// Kernel features
 	CloseRange              bool
 	CoreScheduling          bool
+	IdmappedMounts          bool
 	NetnsGetifaddrs         bool
 	PidFdSetns              bool
 	SeccompListener         bool


### PR DESCRIPTION
And updates start up kernel feature detection to use it, and take into account LXD_SHIFTFS_DISABLE.

Follows comment from @brauner here https://github.com/lxc/lxd/pull/10012#issuecomment-1060886789

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>