### PR TITLE
Warnings: Use WarningExists from DB generator

### DIFF
--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -458,6 +458,9 @@ func naturalKeySelect(entity string, mapping *Mapping) string {
 		var column string
 		if field.IsScalar() {
 			column = field.Config.Get("join")
+			if column == "" {
+				column = field.Config.Get("leftjoin")
+			}
 		} else {
 			column = mapping.FieldColumnName(field.Name, table)
 		}
@@ -467,6 +470,10 @@ func naturalKeySelect(entity string, mapping *Mapping) string {
 
 	for _, field := range mapping.ScalarFields() {
 		join := field.Config.Get("join")
+		if join == "" {
+			join = field.Config.Get("leftjoin")
+		}
+
 		right := strings.Split(join, ".")[0]
 		via := entityTable(entity)
 		if field.Config.Get("via") != "" {

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -120,7 +120,7 @@ SELECT instances.id, projects.name AS project, instances.name, nodes.name AS nod
 `)
 
 var instanceID = cluster.RegisterStmt(`
-SELECT instances.id FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+SELECT instances.id FROM instances JOIN projects ON instances.project_id = projects.id
   WHERE projects.name = ? AND instances.name = ?
 `)
 

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -30,11 +30,14 @@ import (
 //go:generate mapper stmt -p db -e warning objects-by-Node-and-TypeCode-and-Project-and-EntityTypeCode-and-EntityID
 //go:generate mapper stmt -p db -e warning delete-by-UUID
 //go:generate mapper stmt -p db -e warning delete-by-EntityTypeCode-and-EntityID
+//go:generate mapper stmt -p db -e warning id
 //
 //go:generate mapper method -p db -e warning GetMany
 //go:generate mapper method -p db -e warning GetOne-by-UUID
 //go:generate mapper method -p db -e warning DeleteOne-by-UUID
 //go:generate mapper method -p db -e warning DeleteMany-by-EntityTypeCode-and-EntityID
+//go:generate mapper method -p db -e warning ID struct=Warning
+//go:generate mapper method -p db -e warning Exists struct=Warning
 
 // Warning is a value object holding db-related details about a warning.
 type Warning struct {
@@ -274,19 +277,6 @@ func (c *ClusterTx) createWarning(object Warning) (int64, error) {
 	}
 
 	return id, nil
-}
-
-// WarningExists checks if a warning with the given key exists.
-func (c *ClusterTx) WarningExists(UUID string) (bool, error) {
-	_, err := c.GetWarning(UUID)
-	if err != nil {
-		if err == ErrNoSuchObject {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }
 
 // ToAPI returns a LXD API entry.

--- a/lxd/db/warnings.interface.mapper.go
+++ b/lxd/db/warnings.interface.mapper.go
@@ -20,4 +20,12 @@ type WarningGenerated interface {
 	// DeleteWarnings deletes the warning matching the given key parameters.
 	// generator: warning DeleteMany-by-EntityTypeCode-and-EntityID
 	DeleteWarnings(entityTypeCode int, entityID int) error
+
+	// GetWarningID return the ID of the warning with the given key.
+	// generator: warning ID
+	GetWarningID(uuid string) (int64, error)
+
+	// WarningExists checks if a warning with the given key exists.
+	// generator: warning Exists
+	WarningExists(uuid string) (bool, error)
 }


### PR DESCRIPTION
Updates the DB generator's `naturalKeySelect` function to only join on scalar fields that are part of the natural key, as there's no point in joining on additional tables when just getting the entity's ID.

As per suggestion from @masnax in https://github.com/lxc/lxd/pull/9970#issuecomment-1051233703