### PR TITLE
lxd/device/nic: Lock concurrent access to networkSRIOVRestoreVF

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -552,10 +552,13 @@ func (d *nicOVN) postStop() error {
 	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
 		if d.config["acceleration"] == "sriov" {
 			// Restoring host-side interface.
+			network.SRIOVVirtualFunctionMutex.Lock()
 			err := networkSRIOVRestoreVF(d.deviceCommon, false, v)
 			if err != nil {
+				network.SRIOVVirtualFunctionMutex.Unlock()
 				return err
 			}
+			network.SRIOVVirtualFunctionMutex.Unlock()
 
 			link := &ip.Link{Name: d.config["host_name"]}
 			err = link.SetDown()

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -214,10 +214,13 @@ func (d *nicSRIOV) postStop() error {
 
 	v := d.volatileGet()
 
+	network.SRIOVVirtualFunctionMutex.Lock()
 	err := networkSRIOVRestoreVF(d.deviceCommon, true, v)
 	if err != nil {
+		network.SRIOVVirtualFunctionMutex.Unlock()
 		return err
 	}
+	network.SRIOVVirtualFunctionMutex.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
This might help prevent syscall hangs when calling `DeviceUnbind` when multiple instances are shutting down at the same time.

@stgraber has seen this blocked go routine when shutting down a VM using SRIOV:

```
goroutine 14561 [syscall, 218 minutes]:
syscall.Syscall(0x1, 0x28, 0xc000a375e8, 0xc)
        /snap/go/9028/src/syscall/asm_linux_amd64.s:20 +0x5
syscall.write(0xc001287080, {0xc000a375e8, 0x426801, 0xc000a37498})
        /snap/go/9028/src/syscall/zsyscall_linux_amd64.go:915 +0x4d
syscall.Write(...)
        /snap/go/9028/src/syscall/syscall_unix.go:214
internal/poll.ignoringEINTRIO(...)
        /snap/go/9028/src/internal/poll/fd_unix.go:582
internal/poll.(*FD).Write(0xc001287080, {0xc000a375e8, 0xc, 0x20})
        /snap/go/9028/src/internal/poll/fd_unix.go:275 +0x36e
os.(*File).write(...)
        /snap/go/9028/src/os/file_posix.go:49
os.(*File).Write(0xc00056e228, {0xc000a375e8, 0x241, 0x418287})
        /snap/go/9028/src/os/file.go:176 +0x65
os.WriteFile({0xc0004d0480, 0xc000a0e20e}, {0xc000a375e8, 0xc, 0x20}, 0x9)
        /snap/go/9028/src/os/file.go:718 +0x57
io/ioutil.WriteFile(...)
        /snap/go/9028/src/io/ioutil/ioutil.go:46
github.com/lxc/lxd/lxd/device/pci.DeviceUnbind({{0xc0011983e7, 0x9}, {0xc000a0e20e, 0xc}, {0xc001198307, 0x8}})
        /build/lxd/parts/lxd/src/lxd/device/pci/pci.go:64 +0xed
github.com/lxc/lxd/lxd/device.networkSRIOVRestoreVF({{0x7f87c0187298, 0xc0009c2140}, {0x1cd3ee8, 0xc00036c640}, {0xc0007c4568, 0x4}, 0xc0010f6330, 0xc00099f2c0, 0xc0009c2100, 0xc0009c2120}, ...)
        /build/lxd/parts/lxd/src/lxd/device/device_utils_network.go:767 +0x27e
github.com/lxc/lxd/lxd/device.(*nicSRIOV).postStop(0xc0008ce0a0)
        /build/lxd/parts/lxd/src/lxd/device/nic_sriov.go:217 +0x3a5
github.com/lxc/lxd/lxd/instance/drivers.(*common).runHooks(0x17a3240, {0xc00056e218, 0x1, 0x4})
        /build/lxd/parts/lxd/src/lxd/instance/drivers/driver_common.go:521 +0x46
github.com/lxc/lxd/lxd/instance/drivers.(*qemu).deviceStop(0xc00036c640, {0xc0007c4568, 0x4}, 0x2e, 0x0)
        /build/lxd/parts/lxd/src/lxd/instance/drivers/driver_qemu.go:1877 +0x589
github.com/lxc/lxd/lxd/instance/drivers.(*qemu).cleanupDevices(0xc00036c640)
        /build/lxd/parts/lxd/src/lxd/instance/drivers/driver_qemu.go:4552 +0x2b6
github.com/lxc/lxd/lxd/instance/drivers.(*qemu).onStop(0xc00036c640, {0x194db4f, 0x1952fd7})
        /build/lxd/parts/lxd/src/lxd/instance/drivers/driver_qemu.go:645 +0x665
github.com/lxc/lxd/lxd/instance/drivers.(*qemu).getMonitorEventHandler.func1({0xc001198290, 0x0}, 0xc001738000)
        /build/lxd/parts/lxd/src/lxd/instance/drivers/driver_qemu.go:449 +0x6a5
created by github.com/lxc/lxd/lxd/instance/drivers/qmp.(*Monitor).start.func2
        /build/lxd/parts/lxd/src/lxd/instance/drivers/qmp/monitor.go:89 +0x225
```

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>