### PR TITLE
Allow ipv{n}.address=none for bridged NICs on managed networks

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -113,7 +113,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if dhcpv4Subnet != nil && !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
+			if dhcpv4Subnet != nil && d.config["ipv4.address"] != "none" && !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], n.Name())
 			}
 
@@ -148,7 +148,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if dhcpv6Subnet != nil && !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
+			if dhcpv6Subnet != nil && d.config["ipv6.address"] != "none" && !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], n.Name())
 			}
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1046,7 +1046,7 @@ func (d *nicBridged) setFilters() (err error) {
 		}
 
 		err = dhcpalloc.AllocateTask(opts, func(t *dhcpalloc.Transaction) error {
-			if shared.IsTrue(d.config["security.ipv4_filtering"]) && IPv4 == nil {
+			if shared.IsTrue(d.config["security.ipv4_filtering"]) && IPv4 == nil && d.config["ipv4.address"] != "none" {
 				IPv4, err = t.AllocateIPv4()
 
 				// If DHCP not supported, skip error, and will result in total protocol filter.
@@ -1055,7 +1055,7 @@ func (d *nicBridged) setFilters() (err error) {
 				}
 			}
 
-			if shared.IsTrue(d.config["security.ipv6_filtering"]) && IPv6 == nil {
+			if shared.IsTrue(d.config["security.ipv6_filtering"]) && IPv6 == nil && d.config["ipv6.address"] != "none" {
 				IPv6, err = t.AllocateIPv6()
 
 				// If DHCP not supported, skip error, and will result in total protocol filter.

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -45,6 +45,38 @@ test_container_devices_nic_bridged_filtering() {
   # Modify profile nictype and parent in atomic operation to ensure validation passes.
   lxc profile show "${ctPrefix}" | sed  "s/nictype: p2p/nictype: bridged\\n    parent: ${brName}/" | lxc profile edit "${ctPrefix}"
 
+  # Check filtering works when ipv4 and ipv6 addresses are set to none on the nic device and the parent network is managed.
+  lxc init testimage "${ctPrefix}A" -p "${ctPrefix}"
+  lxc config device add "${ctPrefix}A" eth0 nic \
+    name=eth0 \
+    nictype=bridged \
+    parent="${brName}" \
+    security.ipv4_filtering=true \
+    security.ipv6_filtering=true \
+    ipv4.address=none \
+    ipv6.address=none
+  lxc start "${ctPrefix}A"
+  ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
+
+  # When IPv{n} addresses are "none", every packet should be dropped.
+  if [ "$firewallDriver" = "xtables" ]; then
+    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p ARP -i ${ctAHost} -j DROP"
+    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p ARP -i ${ctAHost} -j DROP"
+    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p IPv4 -i ${ctAHost} -j DROP"
+    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p IPv4 -i ${ctAHost} -j DROP"
+    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p IPv6 -i ${ctAHost} -j DROP"
+    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p IPv6 -i ${ctAHost} -j DROP"
+  else
+    for table in "in" "fwd"
+    do
+      nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep -e "iifname \"${ctAHost}\" ether type 0x0806 drop" # ARP
+      nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep -e "iifname \"${ctAHost}\" ether type 0x0800 drop" # IPv4
+      nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep -e "iifname \"${ctAHost}\" ether type 0x86dd drop" # IPv6
+    done
+  fi
+
+  lxc delete -f "${ctPrefix}A"
+
   # Launch first container.
   lxc init testimage "${ctPrefix}A" -p "${ctPrefix}"
   lxc config device add "${ctPrefix}A" eth0 nic nictype=nic name=eth0 nictype=bridged parent="${brName}"


### PR DESCRIPTION
`ipv{n}.address=none` is currently not a valid setting when the parent network of the NIC is managed (if DHCP is enabled). This PR allows for this setting in validation, and then checks against this setting later to ensure that IPs are not allocated dynamically.

A test has also been added to ensure that when `ipv{n}.address=none` and `security.ipv{n}_filtering=true`, then all protocols are blocked.

Closes #10024 