### PR TITLE
Storage: Pass --numeric-owner to backup tar unpack command

### DIFF
--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -662,6 +662,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 				"--xattrs-include=*",
 				"--restrict",
 				"--force-local",
+				"--numeric-owner",
 				"-C", mountPath,
 			}...)
 


### PR DESCRIPTION
This ensures that owner/group name info inside the tarball isn't used to resolve to a different
UID/GID as they are unpacked on the host, and instead ensures they remain the same UID/GID that
they were inside the instance when it was exported.

Reported from https://discuss.linuxcontainers.org/t/no-remapping-of-container-after-restore/13490

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>