### PR TITLE
lxd: Warn if exec control connection disconnects prematurely

### DIFF
--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -391,7 +391,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 				if mt == websocket.CloseMessage {
 					logger.Warn("Got exec control websocket close message, killing command")
 				} else {
-					logger.Debug("Failed getting exec control websocket reader, killing command", log.Ctx{"err": err})
+					logger.Warn("Failed getting exec control websocket reader, killing command", log.Ctx{"err": err})
 				}
 
 				err := unix.Kill(cmd.Process.Pid, unix.SIGKILL)

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -309,7 +309,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 				if mt == websocket.CloseMessage {
 					logger.Warn("Got exec control websocket close message, killing command")
 				} else {
-					logger.Debug("Failed getting exec control websocket reader, killing command", log.Ctx{"err": err})
+					logger.Warn("Failed getting exec control websocket reader, killing command", log.Ctx{"err": err})
 				}
 
 				cmdKillOnce.Do(cmdKill)


### PR DESCRIPTION
Related to #10034

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>