### PR TITLE
'lxc storage volume info' returns empty 'EXPIRES AT' values

### DIFF
--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -388,6 +388,11 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 			tmp.Description = vol.Description
 			tmp.Name = vol.Name
 
+			expiryDate := volume.ExpiryDate
+			if expiryDate.Unix() > 0 {
+				tmp.ExpiresAt = &expiryDate
+			}
+
 			resultMap = append(resultMap, tmp)
 		}
 	}


### PR DESCRIPTION
`lxc storage volume info default f1`  command returns:
```
Name: f1
Type: custom
Content type: filesystem
Usage: 24.00KiB

Snapshots:
+-------+-------------+------------+
| NAME  | DESCRIPTION | EXPIRES AT |
+-------+-------------+------------+
| snap5 |             |            |
+-------+-------------+------------+
| snap6 |             |            |
+-------+-------------+------------+
| snap7 |             |            |
+-------+-------------+------------+
| snap8 |             |            |
+-------+-------------+------------+
| snap9 |             |            |
+-------+-------------+------------+
```

even though there is `snapshots.expiry` value set for storage volume.
Below is output after fix:
```
Name: f1
Type: custom
Content type: filesystem
Usage: 24.00KiB

Snapshots:
+-------+-------------+----------------------+
| NAME  | DESCRIPTION |      EXPIRES AT      |
+-------+-------------+----------------------+
| snap5 |             |                      |
+-------+-------------+----------------------+
| snap6 |             |                      |
+-------+-------------+----------------------+
| snap7 |             |                      |
+-------+-------------+----------------------+
| snap8 |             | 2022/03/11 19:59 CET |
+-------+-------------+----------------------+
| snap9 |             | 2022/03/11 19:59 CET |
+-------+-------------+----------------------+
```
