### PR TITLE
Cluster: Fix hang during cluster upgrade due to missing event websocket handshake timeout

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -366,9 +367,10 @@ func (r *ProtocolLXD) rawWebsocket(url string) (*websocket.Conn, error) {
 	// Setup a new websocket dialer based on it
 	dialer := websocket.Dialer{
 		//lint:ignore SA1019 DialContext doesn't exist in Go 1.13
-		NetDial:         httpTransport.Dial,
-		TLSClientConfig: httpTransport.TLSClientConfig,
-		Proxy:           httpTransport.Proxy,
+		NetDial:          httpTransport.Dial,
+		TLSClientConfig:  httpTransport.TLSClientConfig,
+		Proxy:            httpTransport.Proxy,
+		HandshakeTimeout: time.Second * 5,
 	}
 
 	// Set the user agent

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -452,6 +452,11 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	unavailableMembers := make([]string, 0)
 
 	err = query.Retry(func() error {
+		// Durating cluster member fluctuations/upgrades the cluster can become unavailable so check here.
+		if g.Cluster == nil {
+			return fmt.Errorf("Cluster unavailable")
+		}
+
 		return g.Cluster.Transaction(func(tx *db.ClusterTx) error {
 			for _, node := range hbState.Members {
 				if !node.updated {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/dustinkirkland/golang-petname"
 	"github.com/gorilla/websocket"
@@ -352,8 +353,10 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 	migrationArgs := MigrationSinkArgs{
 		Url: req.Source.Operation,
 		Dialer: websocket.Dialer{
-			TLSClientConfig: config,
-			NetDial:         shared.RFC3493Dialer},
+			TLSClientConfig:  config,
+			NetDial:          shared.RFC3493Dialer,
+			HandshakeTimeout: time.Second * 5,
+		},
 		Instance:     inst,
 		Secrets:      req.Source.Websockets,
 		Push:         push,

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -230,8 +231,9 @@ func (s *migrationSourceWs) ConnectTarget(certificate string, operation string, 
 	}
 
 	dialer := websocket.Dialer{
-		TLSClientConfig: config,
-		NetDial:         shared.RFC3493Dialer,
+		TLSClientConfig:  config,
+		NetDial:          shared.RFC3493Dialer,
+		HandshakeTimeout: time.Second * 5,
 	}
 
 	for name, secret := range websockets {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	log "gopkg.in/inconshreveable/log15.v2"
 
@@ -830,8 +831,9 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 	migrationArgs := MigrationSinkArgs{
 		Url: req.Source.Operation,
 		Dialer: websocket.Dialer{
-			TLSClientConfig: config,
-			NetDial:         shared.RFC3493Dialer,
+			TLSClientConfig:  config,
+			NetDial:          shared.RFC3493Dialer,
+			HandshakeTimeout: time.Second * 5,
 		},
 		Secrets:    req.Source.Websockets,
 		Push:       push,

--- a/test/deps/devlxd-client.go
+++ b/test/deps/devlxd-client.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"gopkg.in/yaml.v2"
@@ -41,7 +42,8 @@ var devLxdTransport = &http.Transport{
 
 func devlxdMonitor(c http.Client) {
 	dialer := websocket.Dialer{
-		NetDial: devLxdTransport.Dial,
+		NetDial:          devLxdTransport.Dial,
+		HandshakeTimeout: time.Second * 5,
 	}
 
 	conn, _, err := dialer.Dial("ws://unix.socket/1.0/events", nil)


### PR DESCRIPTION
This PR fixes an issue intermittently caused LXD cluster upgrades to hang before triggering the snap package refresh and reload.

This was happened when the first member was refreshed. It would stand down as leader and a new member would become leader, triggering a heartbeat. As part of the heartbeat round, the event connections are checked for freshness, and because the first member had just been refreshed and reloaded, the old event connection to that first member was closed.

However not enough time had passed for the first member to be considered "offline", so rather than skipping it instead each member attempted to connect to the first member and setup an event websocket stream. 

Unfortunately in certain scenarios it was possible for the TCP/TLS connection to be established, but have the websocket handshake hang (probably because the first member was not yet fully started up waiting for the other members to update and the database was not available to allow `eventsSocket()` to complete).

In this situation the heartbeat refresh task would hang forever (Go in general does not like setting any default timeouts, and the Gorilla Websocket client is the same for its handshake timeout).

In a cherry-pick after LXD 4.23 was tagged that made it into the LXD 4.23 snap channel (https://github.com/lxc/lxd/pull/9935 via https://github.com/lxc/lxd/pull/9935/commits/5a3f18a55f6e2bb49b25d521288559120177ebc4) the event connections refresh function was made synchronous during the heartbeat refresh task.

The the lack of timeouts on opening an event websocket connection resulted in preventing the heartbeat refresh task from completing, which subsequently prevented a future heartbeat from starting and noticing that there was a newer member in the cluster and triggering the snap refresh that would bring the other members up to the same version and the cluster back into operation.

With this fix where the event connection refresh task would previously hang on:

```
lvl=dbug msg="Connecting to a remote LXD over HTTPS"
```

We now get:

```
lvl=dbug msg="Connecting to a remote LXD over HTTPS"
lvl=warn msg="Failed adding member event listener client" err="read tcp 10.64.199.139:44262->10.64.199.248:8443: i/o timeout" local=10.64.199.139:8443 remote=10.64.199.248:8443
```

And the event refresh and heartbeat refresh task finish normally allowing the cluster to be upgraded.

I've also gone an added the same 5s handshake timeout to all other uses of websocket clients I can find in the LXD code base.

Additionally I also noticed a rare crash due to `g.Cluster` being unavailable, which is now fixed too.