### PR TITLE
lxc/file: Use random auth creds if no-auth and auth-user flags not specified

### DIFF
--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -506,7 +506,7 @@ msgstr "%s (%d mehr)"
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
@@ -516,7 +516,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1049,7 +1049,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1375,7 +1375,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1520,7 +1520,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1613,8 +1613,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1768,6 +1768,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1845,7 +1849,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2075,22 +2079,22 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2100,7 +2104,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2110,17 +2114,17 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2159,7 +2163,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2174,7 +2178,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2399,22 +2403,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2580,12 +2584,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2599,7 +2603,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2652,7 +2656,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -2696,7 +2700,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -2713,12 +2717,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3212,7 +3216,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3516,7 +3520,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3555,12 +3559,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3973,7 +3977,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4120,22 +4124,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4161,7 +4165,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4456,12 +4460,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -4522,6 +4526,10 @@ msgstr ""
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 #, fuzzy
@@ -4697,19 +4705,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5057,12 +5065,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5323,7 +5331,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5333,7 +5341,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -5349,7 +5357,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -5502,7 +5510,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6026,7 +6034,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -6035,7 +6043,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6043,7 +6051,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6053,7 +6061,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -6783,20 +6791,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7000,16 +7008,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1232,7 +1232,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1320,8 +1320,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1466,6 +1466,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1527,7 +1531,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1541,7 +1545,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1750,22 +1754,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -1775,7 +1779,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1785,17 +1789,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1833,7 +1837,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1848,7 +1852,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2063,22 +2067,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2238,11 +2242,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2256,7 +2260,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2308,7 +2312,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2350,7 +2354,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2366,12 +2370,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2826,7 +2830,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3105,7 +3109,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3143,11 +3147,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3550,7 +3554,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3691,20 +3695,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3730,7 +3734,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4005,12 +4009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4069,6 +4073,10 @@ msgstr ""
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 msgid "Set device configuration keys"
@@ -4238,19 +4246,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4578,11 +4586,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4832,7 +4840,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4842,7 +4850,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4858,7 +4866,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5003,7 +5011,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5297,20 +5305,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5721,20 +5729,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5934,16 +5942,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -501,7 +501,7 @@ msgstr "%s (%d más)"
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
@@ -511,7 +511,7 @@ msgstr "%s no es un directorio"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -613,7 +613,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1007,7 +1007,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1548,8 +1548,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1695,6 +1695,10 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1756,7 +1760,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1770,7 +1774,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1983,22 +1987,22 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2008,7 +2012,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2018,17 +2022,17 @@ msgstr "Acepta certificado"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2067,7 +2071,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2082,7 +2086,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2298,22 +2302,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -2477,11 +2481,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2496,7 +2500,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2548,7 +2552,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -2591,7 +2595,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2608,12 +2612,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3076,7 +3080,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3362,7 +3366,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -3402,11 +3406,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -3808,7 +3812,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3952,20 +3956,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4272,12 +4276,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4336,6 +4340,10 @@ msgstr ""
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 msgid "Set device configuration keys"
@@ -4505,19 +4513,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4846,11 +4854,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5105,7 +5113,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5115,7 +5123,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5131,7 +5139,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5277,7 +5285,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5620,23 +5628,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6122,20 +6130,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6335,16 +6343,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -504,7 +504,7 @@ msgstr "%s (%d de plus)"
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
@@ -514,7 +514,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompre encore deux fois pour forcer)"
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -625,7 +625,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1380,7 +1380,7 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1543,7 +1543,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -1639,8 +1639,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1788,6 +1788,10 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr "Désactiver l'allocation pseudo-terminal"
@@ -1851,7 +1855,7 @@ msgstr "ÉPHÉMÈRE"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1866,7 +1870,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2108,22 +2112,22 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2133,7 +2137,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2143,17 +2147,17 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2193,7 +2197,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to get the new instance name"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2208,7 +2212,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2435,22 +2439,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2624,12 +2628,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2644,7 +2648,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2696,7 +2700,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -2740,7 +2744,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -2757,12 +2761,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3292,7 +3296,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -3599,7 +3603,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -3641,12 +3645,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4072,7 +4076,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4219,22 +4223,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4261,7 +4265,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -4574,12 +4578,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -4642,6 +4646,10 @@ msgstr ""
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 #, fuzzy
@@ -4819,19 +4827,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5189,11 +5197,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5459,7 +5467,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5469,7 +5477,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5485,7 +5493,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5642,7 +5650,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6210,7 +6218,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -6222,7 +6230,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6230,7 +6238,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6243,7 +6251,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7028,20 +7036,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7264,16 +7272,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1316,8 +1316,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1461,6 +1461,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1519,7 +1523,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1533,7 +1537,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1739,22 +1743,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1764,7 +1768,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1774,17 +1778,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1822,7 +1826,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1837,7 +1841,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2047,22 +2051,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2222,11 +2226,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2240,7 +2244,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2292,7 +2296,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2334,7 +2338,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2350,12 +2354,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2809,7 +2813,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3080,7 +3084,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3118,11 +3122,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3522,7 +3526,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3663,20 +3667,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3702,7 +3706,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3975,12 +3979,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4037,6 +4041,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4203,19 +4211,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4537,11 +4545,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4791,7 +4799,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4801,7 +4809,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4817,7 +4825,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4955,7 +4963,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5249,20 +5257,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5673,20 +5681,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5886,16 +5894,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -498,7 +498,7 @@ msgstr "%s (altri %d)"
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
@@ -508,7 +508,7 @@ msgstr "%s non è una directory"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompi altre due volte per forzare)"
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -607,7 +607,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -1539,8 +1539,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1686,6 +1686,10 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1747,7 +1751,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1761,7 +1765,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -1973,22 +1977,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -1998,7 +2002,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2008,17 +2012,17 @@ msgstr "Accetta certificato"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2056,7 +2060,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2071,7 +2075,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2287,22 +2291,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -2465,11 +2469,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2483,7 +2487,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2535,7 +2539,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -2579,7 +2583,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2596,12 +2600,12 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3067,7 +3071,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -3355,7 +3359,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3394,11 +3398,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -3802,7 +3806,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3944,21 +3948,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3984,7 +3988,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4266,12 +4270,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4330,6 +4334,10 @@ msgstr ""
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 msgid "Set device configuration keys"
@@ -4497,19 +4505,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4841,11 +4849,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5098,7 +5106,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5108,7 +5116,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5124,7 +5132,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5269,7 +5277,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5614,23 +5622,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -6116,20 +6124,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6330,16 +6338,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Fujiwara Software <fujisoft@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -490,7 +490,7 @@ msgstr "%s (%d個使用可能)"
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
@@ -501,7 +501,7 @@ msgid "%v (interrupt two more times to force)"
 msgstr ""
 "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -598,7 +598,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -974,7 +974,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1004,7 +1004,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1323,7 +1323,7 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1459,7 +1459,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -1545,8 +1545,8 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1696,6 +1696,10 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr "擬似端末の割り当てを無効にします"
@@ -1754,7 +1758,7 @@ msgstr "EPHEMERAL"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1770,7 +1774,7 @@ msgstr "クラスタグループを編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2002,22 +2006,22 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "クラスタメンバへの接続に失敗しました"
@@ -2027,7 +2031,7 @@ msgstr "クラスタメンバへの接続に失敗しました"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr "証明書追加トークンのトークン変換操作に失敗しました: %w"
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
@@ -2037,17 +2041,17 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
@@ -2085,7 +2089,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to get the new instance name"
 msgstr "新しいインスタンス名が取得できません"
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
@@ -2100,7 +2104,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2325,22 +2329,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "インスタンスの停止に失敗しました: %s"
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスの停止に失敗しました: %s"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "インスタンスの停止に失敗しました: %s"
@@ -2510,12 +2514,12 @@ msgstr "入力するデータ"
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2529,7 +2533,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2582,7 +2586,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンス名: %s"
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -2647,12 +2651,12 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3251,7 +3255,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -3540,7 +3544,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -3582,13 +3586,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルを取得します"
@@ -3994,7 +3998,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4137,20 +4141,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -4176,7 +4180,7 @@ msgstr "ROLES"
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -4456,12 +4460,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "リモートの管理者パスワード"
@@ -4519,6 +4523,10 @@ msgstr "サーバのバージョン: %s\n"
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 msgid "Set device configuration keys"
@@ -4732,19 +4740,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5066,12 +5074,12 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5347,7 +5355,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -5357,7 +5365,7 @@ msgstr "テンポラリファイルを作成できません: %v"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "未知のファイルタイプ '%s'"
@@ -5373,7 +5381,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -5515,7 +5523,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5814,21 +5822,21 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>/<path>"
@@ -6276,7 +6284,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 #, fuzzy
 msgid ""
 "lxc file mount foo/root fooroot\n"
@@ -6286,7 +6294,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -6296,7 +6304,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6591,16 +6599,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-03-14 16:23-0400\n"
+        "POT-Creation-Date: 2022-03-15 11:37+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,7 +272,7 @@ msgstr  ""
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
@@ -282,7 +282,7 @@ msgstr  ""
 msgid   "%v (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -378,7 +378,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -727,7 +727,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -756,7 +756,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1041,7 +1041,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1167,7 +1167,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1231,7 +1231,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198 lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375 lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706 lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059 lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416 lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38 lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:979 lxc/network.go:1048 lxc/network.go:1098 lxc/network.go:1168 lxc/network.go:1230 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1257 lxc/storage_volume.go:1339 lxc/storage_volume.go:1523 lxc/storage_volume.go:1556 lxc/storage_volume.go:1669 lxc/storage_volume.go:1757 lxc/storage_volume.go:1856 lxc/storage_volume.go:1890 lxc/storage_volume.go:1988 lxc/storage_volume.go:2055 lxc/storage_volume.go:2196 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198 lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375 lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706 lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059 lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416 lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38 lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480 lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293 lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:979 lxc/network.go:1048 lxc/network.go:1098 lxc/network.go:1168 lxc/network.go:1230 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1257 lxc/storage_volume.go:1339 lxc/storage_volume.go:1523 lxc/storage_volume.go:1556 lxc/storage_volume.go:1669 lxc/storage_volume.go:1757 lxc/storage_volume.go:1856 lxc/storage_volume.go:1890 lxc/storage_volume.go:1988 lxc/storage_volume.go:2055 lxc/storage_volume.go:2196 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1313,6 +1313,10 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
+#: lxc/file.go:922
+msgid   "Disable authentication when using SSH SFTP listener"
+msgstr  ""
+
 #: lxc/exec.go:58
 msgid   "Disable pseudo-terminal allocation"
 msgstr  ""
@@ -1371,7 +1375,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1383,7 +1387,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1579,22 +1583,22 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -1604,7 +1608,7 @@ msgstr  ""
 msgid   "Failed converting token operation to certificate add token: %w"
 msgstr  ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -1614,17 +1618,17 @@ msgstr  ""
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -1662,7 +1666,7 @@ msgstr  ""
 msgid   "Failed to get the new instance name"
 msgstr  ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -1677,7 +1681,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -1874,22 +1878,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2046,11 +2050,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2064,7 +2068,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2116,7 +2120,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2157,7 +2161,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2171,12 +2175,12 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2616,7 +2620,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -2846,7 +2850,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -2882,11 +2886,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3277,7 +3281,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -3412,20 +3416,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -3451,7 +3455,7 @@ msgstr  ""
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -3720,12 +3724,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -3781,6 +3785,10 @@ msgstr  ""
 
 #: lxc/cluster.go:293
 msgid   "Set a cluster member's configuration keys"
+msgstr  ""
+
+#: lxc/file.go:923
+msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
 #: lxc/config_device.go:532
@@ -3923,19 +3931,19 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -4255,11 +4263,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -4495,7 +4503,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -4505,7 +4513,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -4520,7 +4528,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -4655,7 +4663,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -4936,19 +4944,19 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -5335,17 +5343,17 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -5516,16 +5524,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -486,7 +486,7 @@ msgstr "%s (en nog %d)"
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -496,7 +496,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -593,7 +593,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1507,8 +1507,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1652,6 +1652,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1710,7 +1714,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1724,7 +1728,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1930,22 +1934,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1955,7 +1959,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1965,17 +1969,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2013,7 +2017,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2238,22 +2242,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2413,11 +2417,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2431,7 +2435,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2483,7 +2487,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2525,7 +2529,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2541,12 +2545,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3004,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3271,7 +3275,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3309,11 +3313,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3713,7 +3717,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3854,20 +3858,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4166,12 +4170,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4228,6 +4232,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4394,19 +4402,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4728,11 +4736,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4982,7 +4990,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4992,7 +5000,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5008,7 +5016,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5146,7 +5154,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5440,20 +5448,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5864,20 +5872,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6077,16 +6085,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,7 +516,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -526,7 +526,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -623,7 +623,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1537,8 +1537,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1682,6 +1682,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1740,7 +1744,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1754,7 +1758,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1960,22 +1964,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1985,7 +1989,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1995,17 +1999,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2058,7 +2062,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2268,22 +2272,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2443,11 +2447,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2461,7 +2465,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2513,7 +2517,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2555,7 +2559,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2571,12 +2575,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3030,7 +3034,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3301,7 +3305,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3339,11 +3343,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3743,7 +3747,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3884,20 +3888,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3923,7 +3927,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4196,12 +4200,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4258,6 +4262,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4424,19 +4432,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4758,11 +4766,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5012,7 +5020,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5022,7 +5030,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5038,7 +5046,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5176,7 +5184,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5470,20 +5478,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5894,20 +5902,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6107,16 +6115,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -504,7 +504,7 @@ msgstr "%s (%d mais)"
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
@@ -514,7 +514,7 @@ msgstr "%s não é um diretório"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompa mais duas vezes para forçar)"
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -621,7 +621,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -993,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1491,7 +1491,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -1585,8 +1585,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1734,6 +1734,10 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr "Desabilitar alocação de pseudo-terminal"
@@ -1794,7 +1798,7 @@ msgstr "EFÊMERO"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1809,7 +1813,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2027,22 +2031,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2052,7 +2056,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2062,17 +2066,17 @@ msgstr "Aceitar certificado"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2110,7 +2114,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2125,7 +2129,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2345,22 +2349,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -2522,11 +2526,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2540,7 +2544,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2592,7 +2596,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -2635,7 +2639,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2652,12 +2656,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3119,7 +3123,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -3412,7 +3416,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3451,11 +3455,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -3857,7 +3861,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4002,21 +4006,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4042,7 +4046,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4331,12 +4335,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4395,6 +4399,10 @@ msgstr ""
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 #, fuzzy
@@ -4569,19 +4577,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4919,12 +4927,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5180,7 +5188,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5190,7 +5198,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5206,7 +5214,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5359,7 +5367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5676,20 +5684,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -6128,20 +6136,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6341,16 +6349,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -513,7 +513,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -629,7 +629,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1487,7 +1487,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1579,8 +1579,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1726,6 +1726,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1788,7 +1792,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1802,7 +1806,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2022,22 +2026,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2047,7 +2051,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2057,17 +2061,17 @@ msgstr "Принять сертификат"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2105,7 +2109,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2120,7 +2124,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2336,22 +2340,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2516,11 +2520,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2535,7 +2539,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2587,7 +2591,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -2630,7 +2634,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2647,12 +2651,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3121,7 +3125,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3417,7 +3421,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3456,11 +3460,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3867,7 +3871,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4008,20 +4012,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4047,7 +4051,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4334,12 +4338,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4398,6 +4402,10 @@ msgstr ""
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
+msgstr ""
 
 #: lxc/config_device.go:532
 msgid "Set device configuration keys"
@@ -4567,19 +4575,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4917,11 +4925,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5172,7 +5180,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5182,7 +5190,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5198,7 +5206,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5345,7 +5353,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5839,7 +5847,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -5847,7 +5855,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -5855,7 +5863,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -5864,7 +5872,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -6575,20 +6583,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6788,16 +6796,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1316,8 +1316,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1461,6 +1461,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1519,7 +1523,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1533,7 +1537,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1739,22 +1743,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1764,7 +1768,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1774,17 +1778,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1822,7 +1826,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1837,7 +1841,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2047,22 +2051,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2222,11 +2226,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2240,7 +2244,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2292,7 +2296,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2334,7 +2338,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2350,12 +2354,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2809,7 +2813,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3080,7 +3084,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3118,11 +3122,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3522,7 +3526,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3663,20 +3667,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3702,7 +3706,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3975,12 +3979,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4037,6 +4041,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4203,19 +4211,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4537,11 +4545,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4791,7 +4799,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4801,7 +4809,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4817,7 +4825,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4955,7 +4963,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5249,20 +5257,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5673,20 +5681,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5886,16 +5894,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1316,8 +1316,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1461,6 +1461,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1519,7 +1523,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1533,7 +1537,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1739,22 +1743,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1764,7 +1768,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1774,17 +1778,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1822,7 +1826,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1837,7 +1841,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2047,22 +2051,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2222,11 +2226,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2240,7 +2244,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2292,7 +2296,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2334,7 +2338,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2350,12 +2354,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2809,7 +2813,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3080,7 +3084,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3118,11 +3122,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3522,7 +3526,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3663,20 +3667,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3702,7 +3706,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3975,12 +3979,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4037,6 +4041,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4203,19 +4211,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4537,11 +4545,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4791,7 +4799,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4801,7 +4809,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4817,7 +4825,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4955,7 +4963,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5249,20 +5257,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5673,20 +5681,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5886,16 +5894,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1316,8 +1316,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1461,6 +1461,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1519,7 +1523,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1533,7 +1537,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1739,22 +1743,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1764,7 +1768,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1774,17 +1778,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1822,7 +1826,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1837,7 +1841,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2047,22 +2051,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2222,11 +2226,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2240,7 +2244,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2292,7 +2296,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2334,7 +2338,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2350,12 +2354,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2809,7 +2813,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3080,7 +3084,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3118,11 +3122,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3522,7 +3526,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3663,20 +3667,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3702,7 +3706,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3975,12 +3979,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4037,6 +4041,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4203,19 +4211,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4537,11 +4545,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4791,7 +4799,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4801,7 +4809,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4817,7 +4825,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4955,7 +4963,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5249,20 +5257,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5673,20 +5681,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5886,16 +5894,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -396,7 +396,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
@@ -406,7 +406,7 @@ msgstr "%s 不是一个目录"
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -860,7 +860,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1199,7 +1199,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1417,8 +1417,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1562,6 +1562,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1620,7 +1624,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1634,7 +1638,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1840,22 +1844,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1865,7 +1869,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1875,17 +1879,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1923,7 +1927,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1938,7 +1942,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2148,22 +2152,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2323,11 +2327,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2341,7 +2345,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2393,7 +2397,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2435,7 +2439,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2451,12 +2455,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2910,7 +2914,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3181,7 +3185,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3219,11 +3223,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3623,7 +3627,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3764,20 +3768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3803,7 +3807,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4076,12 +4080,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4138,6 +4142,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4304,19 +4312,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4638,11 +4646,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4892,7 +4900,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4902,7 +4910,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4918,7 +4926,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5056,7 +5064,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5350,20 +5358,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5774,20 +5782,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5987,16 +5995,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-14 16:23-0400\n"
+"POT-Creation-Date: 2022-03-15 11:37+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:863
+#: lxc/file.go:864
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:757
+#: lxc/file.go:758
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:424
+#: lxc/file.go:425
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:320
+#: lxc/file.go:321
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:500
+#: lxc/file.go:501
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:433
+#: lxc/file.go:238 lxc/file.go:434
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:119 lxc/file.go:120
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1315,8 +1315,8 @@ msgstr ""
 #: lxc/config_trust.go:223 lxc/config_trust.go:335 lxc/config_trust.go:416
 #: lxc/config_trust.go:507 lxc/config_trust.go:550 lxc/config_trust.go:621
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:231 lxc/file.go:426 lxc/file.go:911 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
+#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
 #: lxc/image.go:144 lxc/image.go:304 lxc/image.go:355 lxc/image.go:480
 #: lxc/image.go:639 lxc/image.go:860 lxc/image.go:995 lxc/image.go:1293
 #: lxc/image.go:1372 lxc/image.go:1431 lxc/image.go:1483 lxc/image.go:1539
@@ -1460,6 +1460,10 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
+#: lxc/file.go:922
+msgid "Disable authentication when using SSH SFTP listener"
+msgstr ""
+
 #: lxc/exec.go:58
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:71
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1532,7 +1536,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:168 lxc/file.go:169
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1738,22 +1742,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1120
+#: lxc/file.go:1160
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1183
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1170
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:999
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1763,7 +1767,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1117
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1088
+#: lxc/file.go:1122
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1019
+#: lxc/file.go:1024
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1108
+#: lxc/file.go:1148
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1100
+#: lxc/file.go:1134
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1836,7 +1840,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:752
+#: lxc/file.go:753
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2046,22 +2050,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1232
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1181
+#: lxc/file.go:1221
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1047
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1052
+#: lxc/file.go:1057
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2221,11 +2225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1049
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1183
+#: lxc/file.go:1223
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:971
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:961
+#: lxc/file.go:966
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2333,7 +2337,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:144
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2349,12 +2353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:294
+#: lxc/file.go:295
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:455
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:79 lxc/file.go:80
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:548
 msgid "Missing target directory"
 msgstr ""
 
@@ -3117,11 +3121,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:270
+#: lxc/file.go:271
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:910 lxc/file.go:911
+#: lxc/file.go:913 lxc/file.go:914
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3521,7 +3525,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1023
+#: lxc/file.go:1028
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3662,20 +3666,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:230 lxc/file.go:231
+#: lxc/file.go:231 lxc/file.go:232
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:383 lxc/file.go:706
+#: lxc/file.go:384 lxc/file.go:707
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:425 lxc/file.go:426
+#: lxc/file.go:426 lxc/file.go:427
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:642 lxc/file.go:798
+#: lxc/file.go:643 lxc/file.go:799
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3701,7 +3705,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:432
+#: lxc/file.go:239 lxc/file.go:433
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3974,12 +3978,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1153
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1154
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4036,6 +4040,10 @@ msgstr ""
 
 #: lxc/cluster.go:293
 msgid "Set a cluster member's configuration keys"
+msgstr ""
+
+#: lxc/file.go:923
+msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
 #: lxc/config_device.go:532
@@ -4202,19 +4210,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:436
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:437
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:434
+#: lxc/file.go:435
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:918
+#: lxc/file.go:921
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4536,11 +4544,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:954
+#: lxc/file.go:959
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:948
+#: lxc/file.go:953
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4790,7 +4798,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -4800,7 +4808,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1136
+#: lxc/file.go:1176
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4816,7 +4824,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:739
+#: lxc/file.go:740
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:63
+#: lxc/file.go:68 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -5248,20 +5256,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:167
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:117
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:229
+#: lxc/file.go:230
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:909
+#: lxc/file.go:912
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5672,20 +5680,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:913
+#: lxc/file.go:916
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:233
+#: lxc/file.go:234
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:428
+#: lxc/file.go:429
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5885,16 +5893,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1066
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1022
+#: lxc/file.go:1027
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:981
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -119,7 +119,7 @@ test_filemanip() {
 
   # Test SFTP functionality.
   cmd=$(unset -f lxc; command -v lxc)
-  $cmd file mount filemanip --listen=127.0.0.1:2022 &
+  $cmd file mount filemanip --listen=127.0.0.1:2022 --no-auth &
   mountPID=$!
   sleep 1
 


### PR DESCRIPTION
Generates random username and password for SSH SFTP mount login by default.

If `--no-auth` is specified then no authentication is required.
If `--auth-user` is specified then the specified user name is required, and a random password is still generated.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>