### PR TITLE
doc: restrict docutils version to fix parsing of notes

### DIFF
--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -3,7 +3,7 @@ Babel
 certifi
 charset-normalizer
 colorama
-docutils
+docutils<0.18
 idna
 imagesize
 Jinja2


### PR DESCRIPTION
Seems docutils 0.18.1 messes up note formatting, which is probably
the reason why both Sphinx and myst-parser require docutils<0.18.

Pages with issues:
https://linuxcontainers.org/lxd/docs/master/network-acls/ 
https://linuxcontainers.org/lxd/docs/master/network-forwards/

I had checked mainly https://linuxcontainers.org/lxd/docs/master/doc-cheat-sheet/#notes , and there it works strangely enough ...

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>