### PR TITLE
Network: Degraded startup

### DIFF
--- a/lxc/network.go
+++ b/lxc/network.go
@@ -940,10 +940,9 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 			network.Config["ipv6.address"],
 			network.Description,
 			strUsedBy,
+			strings.ToUpper(network.Status),
 		}
-		if resource.server.IsClustered() {
-			details = append(details, strings.ToUpper(network.Status))
-		}
+
 		data = append(data, details)
 	}
 	sort.Sort(utils.ByName(data))
@@ -956,9 +955,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("IPV6"),
 		i18n.G("DESCRIPTION"),
 		i18n.G("USED BY"),
-	}
-	if resource.server.IsClustered() {
-		header = append(header, i18n.G("STATE"))
+		i18n.G("STATE"),
 	}
 
 	return utils.RenderTable(c.flagFormat, header, data, networks)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1365,6 +1365,12 @@ func (d *Daemon) init() error {
 		return err
 	}
 
+	// Apply all patches that need to be run after networks are initialised.
+	err = patchesApply(d, patchPostNetworks)
+	if err != nil {
+		return err
+	}
+
 	// Cleanup leftover images.
 	pruneLeftoverImages(d)
 

--- a/lxd/db/warnings_types.go
+++ b/lxd/db/warnings_types.go
@@ -47,15 +47,15 @@ const (
 	WarningLargerIPv6PrefixThanSupported
 	// WarningProxyBridgeNetfilterNotEnabled represents the proxy bridge netfilter not enable warning
 	WarningProxyBridgeNetfilterNotEnabled
-	// WarningNetworkStartupFailure represents the network startup failure warning
-	WarningNetworkStartupFailure
+	// WarningNetworkUnvailable represents a network that cannot be initialized on the local server.
+	WarningNetworkUnvailable
 	// WarningOfflineClusterMember represents the offline cluster members warning
 	WarningOfflineClusterMember
 	// WarningInstanceAutostartFailure represents the failure of instance autostart process after three retries
 	WarningInstanceAutostartFailure
 	//WarningInstanceTypeNotOperational represents the lack of support for an instance driver
 	WarningInstanceTypeNotOperational
-	//WarningStoragePoolUnvailable represents a storage poolthat cannot be initialized on the local server.
+	//WarningStoragePoolUnvailable represents a storage pool that cannot be initialized on the local server.
 	WarningStoragePoolUnvailable
 )
 
@@ -81,7 +81,7 @@ var WarningTypeNames = map[WarningType]string{
 	WarningAppArmorDisabledDueToRawDnsmasq:        "Skipping AppArmor for dnsmasq due to raw.dnsmasq being set",
 	WarningLargerIPv6PrefixThanSupported:          "IPv6 networks with a prefix larger than 64 aren't properly supported by dnsmasq",
 	WarningProxyBridgeNetfilterNotEnabled:         "Proxy bridge netfilter not enabled",
-	WarningNetworkStartupFailure:                  "Failed to start network",
+	WarningNetworkUnvailable:                      "Network unavailable",
 	WarningOfflineClusterMember:                   "Offline cluster member",
 	WarningInstanceAutostartFailure:               "Failed to autostart instance",
 	WarningInstanceTypeNotOperational:             "Instance type not operational",
@@ -131,8 +131,8 @@ func (t WarningType) Severity() WarningSeverity {
 		return WarningSeverityLow
 	case WarningProxyBridgeNetfilterNotEnabled:
 		return WarningSeverityLow
-	case WarningNetworkStartupFailure:
-		return WarningSeverityLow
+	case WarningNetworkUnvailable:
+		return WarningSeverityHigh
 	case WarningOfflineClusterMember:
 		return WarningSeverityLow
 	case WarningInstanceAutostartFailure:

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"net/http"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
@@ -16,6 +17,8 @@ import (
 
 type nicMACVLAN struct {
 	deviceCommon
+
+	network network.Network // Populated in validateConfig().
 }
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running. Returns true.
@@ -61,20 +64,21 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 
 		// If network property is specified, lookup network settings and apply them to the device's config.
 		// project.Default is used here as macvlan networks don't suppprt projects.
-		n, err := network.LoadByName(d.state, project.Default, d.config["network"])
+		var err error
+		d.network, err = network.LoadByName(d.state, project.Default, d.config["network"])
 		if err != nil {
 			return fmt.Errorf("Error loading network config for %q: %w", d.config["network"], err)
 		}
 
-		if n.Status() != api.NetworkStatusCreated {
+		if d.network.Status() != api.NetworkStatusCreated {
 			return fmt.Errorf("Specified network is not fully created")
 		}
 
-		if n.Type() != "macvlan" {
+		if d.network.Type() != "macvlan" {
 			return fmt.Errorf("Specified network must be of type macvlan")
 		}
 
-		netConfig := n.Config()
+		netConfig := d.network.Config()
 
 		// Get actual parent device from network's parent setting.
 		d.config["parent"] = netConfig["parent"]
@@ -94,6 +98,21 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields, instConf))
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// PreStartCheck checks the managed parent network is available (if relevant).
+func (d *nicMACVLAN) PreStartCheck() error {
+	// Non-managed network NICs are not relevant for checking managed network availability.
+	if d.network == nil {
+		return nil
+	}
+
+	// If managed network is not available, don't try and start instance.
+	if d.network.LocalStatus() == api.StoragePoolStatusUnvailable {
+		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 
 	return nil

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 
 	"github.com/mdlayher/netx/eui64"
@@ -216,6 +217,21 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// PreStartCheck checks the managed parent network is available (if relevant).
+func (d *nicOVN) PreStartCheck() error {
+	// Non-managed network NICs are not relevant for checking managed network availability.
+	if d.network == nil {
+		return nil
+	}
+
+	// If managed network is not available, don't try and start instance.
+	if d.network.LocalStatus() == api.StoragePoolStatusUnvailable {
+		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 
 	return nil

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -573,17 +573,7 @@ func (n *bridge) Start() error {
 
 	err := n.setup(nil)
 	if err != nil {
-		warnErr := n.state.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), db.WarningNetworkStartupFailure, err.Error())
-		if warnErr != nil {
-			n.logger.Warn("Failed to create warning", log.Ctx{"err": err})
-		}
-
 		return err
-	}
-
-	warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(n.state.Cluster, n.project, db.WarningNetworkStartupFailure, dbCluster.TypeNetwork, int(n.id))
-	if warnErr != nil {
-		n.logger.Warn("Failed to resolve warning", log.Ctx{"err": err})
 	}
 
 	revert.Success()

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -498,14 +498,6 @@ func (n *bridge) isRunning() bool {
 func (n *bridge) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	// Delete all warnings regarding this network.
-	err := n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		return tx.DeleteWarnings(dbCluster.TypeNetwork, int(n.ID()))
-	})
-	if err != nil {
-		return fmt.Errorf("Failed deleting persistent warnings: %w", err)
-	}
-
 	if n.isRunning() {
 		err := n.Stop()
 		if err != nil {
@@ -514,7 +506,7 @@ func (n *bridge) Delete(clientType request.ClientType) error {
 	}
 
 	// Delete apparmor profiles.
-	err = apparmor.NetworkDelete(n.state.OS, n)
+	err := apparmor.NetworkDelete(n.state.OS, n)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -1060,3 +1060,25 @@ func (n *common) peerUsedBy(peerName string, firstOnly bool) ([]string, error) {
 func (n *common) State() (*api.NetworkState, error) {
 	return resources.GetNetworkState(n.name)
 }
+
+func (n *common) setUnavailable() {
+	pn := ProjectNetwork{
+		ProjectName: n.Project(),
+		NetworkName: n.Name(),
+	}
+
+	unavailableNetworksMu.Lock()
+	unavailableNetworks[pn] = struct{}{}
+	unavailableNetworksMu.Unlock()
+}
+
+func (n *common) setAvailable() {
+	pn := ProjectNetwork{
+		ProjectName: n.Project(),
+		NetworkName: n.Name(),
+	}
+
+	unavailableNetworksMu.Lock()
+	delete(unavailableNetworks, pn)
+	unavailableNetworksMu.Unlock()
+}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -181,6 +181,11 @@ func (n *common) Status() string {
 
 // LocalStatus returns network status of the local cluster member.
 func (n *common) LocalStatus() string {
+	// Check if network is unavailable locally and replace status if so.
+	if !IsAvailable(n.Project(), n.Name()) {
+		return api.NetworkStatusUnavailable
+	}
+
 	node, exists := n.nodes[n.state.Cluster.GetNodeID()]
 	if !exists {
 		return api.NetworkStatusUnknown

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -410,6 +410,15 @@ func (n *common) delete(clientType request.ClientType) error {
 		os.RemoveAll(shared.VarPath("networks", n.name))
 	}
 
+	pn := ProjectNetwork{
+		ProjectName: n.Project(),
+		NetworkName: n.Name(),
+	}
+
+	unavailableNetworksMu.Lock()
+	delete(unavailableNetworks, pn)
+	unavailableNetworksMu.Unlock()
+
 	return nil
 }
 

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -212,6 +212,16 @@ func (n *common) Info() Info {
 	}
 }
 
+// Locations returns the list of cluster members this network is configured on.
+func (n *common) Locations() []string {
+	locations := make([]string, 0, len(n.nodes))
+	for _, netNode := range n.nodes {
+		locations = append(locations, netNode.Name)
+	}
+
+	return locations
+}
+
 // IsUsed returns whether the network is used by any instances or profiles.
 func (n *common) IsUsed() (bool, error) {
 	usedBy, err := UsedBy(n.state, n.project, n.id, n.name, true)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2565,6 +2565,11 @@ func (n *ovn) Start() error {
 func (n *ovn) start() error {
 	n.logger.Debug("Start")
 
+	// Check that uplink network is available.
+	if n.config["network"] != "" && !IsAvailable(project.Default, n.config["network"]) {
+		return fmt.Errorf("Uplink network %q is unavailable", n.config["network"])
+	}
+
 	var err error
 	var projectID int64
 	err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2532,20 +2532,34 @@ func (n *ovn) Rename(newName string) error {
 
 // Start starts adds the local OVS chassis ID to the OVN chass group and starts the local OVS uplink port.
 func (n *ovn) Start() error {
+	n.logger.Debug("Start")
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() { n.setUnavailable() })
+
 	err := n.start()
 	if err != nil {
-		err := n.state.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), db.WarningNetworkStartupFailure, err.Error())
-		if err != nil {
+		warnErr := n.state.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), db.WarningNetworkStartupFailure, err.Error())
+		if warnErr != nil {
 			n.logger.Warn("Failed to create warning", log.Ctx{"err": err})
 		}
-	} else {
-		err := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(n.state.Cluster, n.project, db.WarningNetworkStartupFailure, dbCluster.TypeNetwork, int(n.id))
-		if err != nil {
-			n.logger.Warn("Failed to resolve warning", log.Ctx{"err": err})
-		}
+
+		return err
 	}
 
-	return err
+	warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(n.state.Cluster, n.project, db.WarningNetworkStartupFailure, dbCluster.TypeNetwork, int(n.id))
+	if warnErr != nil {
+		n.logger.Warn("Failed to resolve warning", log.Ctx{"err": err})
+	}
+
+	revert.Success()
+
+	// Ensure network is marked as available now its started.
+	n.setAvailable()
+
+	return nil
 }
 
 func (n *ovn) start() error {

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -180,7 +180,12 @@ func (n *physical) setup(oldConfig map[string]string) error {
 	revert := revert.New()
 	defer revert.Fail()
 
+	if !InterfaceExists(n.config["parent"]) {
+		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
+	}
+
 	hostName := GetHostDevice(n.config["parent"], n.config["vlan"])
+
 	created, err := VLANInterfaceCreate(n.config["parent"], hostName, n.config["vlan"], shared.IsTrue(n.config["gvrp"]))
 	if err != nil {
 		return err

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -158,20 +158,34 @@ func (n *physical) Rename(newName string) error {
 
 // Start sets up some global configuration.
 func (n *physical) Start() error {
+	n.logger.Debug("Start")
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() { n.setUnavailable() })
+
 	err := n.setup(nil)
 	if err != nil {
-		err := n.state.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), db.WarningNetworkStartupFailure, err.Error())
-		if err != nil {
+		warnErr := n.state.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), db.WarningNetworkStartupFailure, err.Error())
+		if warnErr != nil {
 			n.logger.Warn("Failed to create warning", log.Ctx{"err": err})
 		}
-	} else {
-		err := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(n.state.Cluster, n.project, db.WarningNetworkStartupFailure, dbCluster.TypeNetwork, int(n.id))
-		if err != nil {
-			n.logger.Warn("Failed to resolve warning", log.Ctx{"err": err})
-		}
+
+		return err
 	}
 
-	return err
+	warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(n.state.Cluster, n.project, db.WarningNetworkStartupFailure, dbCluster.TypeNetwork, int(n.id))
+	if warnErr != nil {
+		n.logger.Warn("Failed to resolve warning", log.Ctx{"err": err})
+	}
+
+	revert.Success()
+
+	// Ensure network is marked as available now its started.
+	n.setAvailable()
+
+	return nil
 }
 
 func (n *physical) setup(oldConfig map[string]string) error {

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -177,8 +177,6 @@ func (n *physical) Start() error {
 }
 
 func (n *physical) setup(oldConfig map[string]string) error {
-	n.logger.Debug("Start")
-
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -8,11 +8,9 @@ import (
 
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
-	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
-	"github.com/lxc/lxd/lxd/warnings"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/validate"
@@ -167,17 +165,7 @@ func (n *physical) Start() error {
 
 	err := n.setup(nil)
 	if err != nil {
-		warnErr := n.state.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), db.WarningNetworkStartupFailure, err.Error())
-		if warnErr != nil {
-			n.logger.Warn("Failed to create warning", log.Ctx{"err": err})
-		}
-
 		return err
-	}
-
-	warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(n.state.Cluster, n.project, db.WarningNetworkStartupFailure, dbCluster.TypeNetwork, int(n.id))
-	if warnErr != nil {
-		n.logger.Warn("Failed to resolve warning", log.Ctx{"err": err})
 	}
 
 	revert.Success()

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	log "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/lxc/lxd/lxd/cluster/request"
@@ -66,6 +67,15 @@ func (n *sriov) Rename(newName string) error {
 // Start starts is a no-op.
 func (n *sriov) Start() error {
 	n.logger.Debug("Start")
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() { n.setUnavailable() })
+
+	if !InterfaceExists(n.config["parent"]) {
+		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
+	}
 
 	return nil
 }

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -36,6 +36,7 @@ type Network interface {
 	Status() string
 	LocalStatus() string
 	Config() map[string]string
+	Locations() []string
 	IsUsed() (bool, error)
 	IsManaged() bool
 	DHCPv4Subnet() *net.IPNet

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/lxc/lxd/lxd/state"
@@ -51,6 +52,25 @@ func LoadByName(s *state.State, projectName string, name string) (Network, error
 	n.init(s, id, projectName, netInfo, netNodes)
 
 	return n, nil
+}
+
+// PatchPreCheck checks if there are any unavailable networks.
+func PatchPreCheck() error {
+	unavailableNetworksMu.Lock()
+
+	if len(unavailableNetworks) > 0 {
+		unavailableNetworkNames := make([]string, 0, len(unavailableNetworks))
+		for unavailablePoolName := range unavailableNetworks {
+			unavailableNetworkNames = append(unavailableNetworkNames, fmt.Sprintf("%s/%s", unavailablePoolName.ProjectName, unavailablePoolName.NetworkName))
+		}
+
+		unavailableNetworksMu.Unlock()
+		return fmt.Errorf("Unvailable networks: %v", unavailableNetworkNames)
+	}
+
+	unavailableNetworksMu.Unlock()
+
+	return nil
 }
 
 // IsAvailable checks if a network is available.

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -45,6 +45,7 @@ const (
 	patchNoStageSet patchStage = iota
 	patchPreDaemonStorage
 	patchPostDaemonStorage
+	patchPostNetworks
 )
 
 // Leave the string type in here! This guarantees that go treats this is as a

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -169,8 +169,8 @@ func storageStartup(s *state.State, forceCheck bool) error {
 					tryInstancesStart := false
 					for poolName := range initPools {
 						if initPool(poolName) {
-							// Storage pool initialized successfully so remove it from
-							// the list so its not retried.
+							// Storage pool initialized successfully or deleted so
+							// remove it from the list so its not retried.
 							delete(initPools, poolName)
 							tryInstancesStart = true
 						}

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -57,6 +57,9 @@ const NetworkStatusErrored = "Errored"
 // NetworkStatusUnknown network is in unknown status.
 const NetworkStatusUnknown = "Unknown"
 
+// NetworkStatusUnavailable network failed to initialize.
+const NetworkStatusUnavailable = "Unavailable"
+
 // Network represents a LXD network
 //
 // swagger:model


### PR DESCRIPTION
Includes https://github.com/lxc/lxd/pull/10072

- Attempts to initialize all networks at LXD startup.
- If any fail then launches a go routine to retry them in the background every 1 minute.

Items:
- [x] Degraded startup and recovery.
- [x] Don't start networks that are dependent on an unavailable network.
- [x] Mark network as UNAVAILABLE in the API.
- [x] Add network state to `lxc network ls` output in non-clustered environment.
- [x] Persistent warnings created/resolved.
- [x] Prevent use of network if locally unavailable.
- [x] Fail launching instances that depend on unavailable networks.
- [x] Start instances that were due to auto start if networks recover.
- [x] Clear warnings on network delete.
- [x] Expand the metadata on our patches to indicate whether they require all networks to startup.