### PR TITLE
tests/includes: change wait_for_dad() to wait for real address(es)

### DIFF
--- a/test/includes/net.sh
+++ b/test/includes/net.sh
@@ -37,9 +37,9 @@ my_curl() {
 # Wait for duplicate address detection to complete.
 # Usage: Either "wait_for_dad <device>" or "wait_for_dad <container> <device>".
 wait_for_dad() {
-  cmd="ip -6 a show dev $1"
+  cmd="ip -6 a show -tentative dev $1"
   if [ "$#" -eq 2 ]; then
-    cmd="lxc exec $1 -- ip -6 a show dev $2"
+    cmd="lxc exec $1 -- ip -6 a show -tentative dev $2"
   fi
 
   # Ensure the command succeeds (else the while loop will break for the wrong reason).
@@ -52,7 +52,8 @@ wait_for_dad() {
   while true
   do
     ip -6 a show
-    if ! eval "$cmd" | grep "tentative" ; then
+    # Stop waiting as soon as non-tentative address(es) show up
+    if [ -n "$(eval "$cmd")" ]; then
       break
     fi
 


### PR DESCRIPTION
This can avoid early exit if the interface was down for example.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>