### PR TITLE
VM: Only enable io_uring support on kernels >= 5.13.0

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -129,6 +129,9 @@ type Daemon struct {
 
 	// Keep track of skews.
 	timeSkew bool
+
+	// Kernel version.
+	kernelVersion version.DottedVersion
 }
 
 type externalAuth struct {
@@ -452,6 +455,7 @@ func (d *Daemon) State() *state.State {
 		UpdateCertificateCache: func() { updateCertificateCache(d) },
 		InstanceTypes:          supportedInstanceTypes,
 		DevMonitor:             d.devmonitor,
+		KernelVersion:          d.kernelVersion,
 	}
 }
 
@@ -833,6 +837,15 @@ func (d *Daemon) init() error {
 
 	// Look for kernel features
 	logger.Infof("Kernel features:")
+
+	uname, _ := shared.Uname()
+	if uname != nil {
+		kernelVersion, err := version.Parse(strings.Split(uname.Release, "-")[0])
+		if err == nil {
+			d.kernelVersion = *kernelVersion
+		}
+	}
+
 	d.os.CloseRange = canUseCloseRange()
 	if d.os.CloseRange {
 		logger.Info(" - closing multiple file descriptors efficiently: yes")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1250,20 +1250,9 @@ func (d *qemu) Start(stateful bool) error {
 	cpuExtensions := []string{}
 
 	if d.architecture == osarch.ARCH_64BIT_INTEL_X86 {
-		// Get the kernel version.
-		uname, err := shared.Uname()
-		if err != nil {
-			return err
-		}
-
 		// If using Linux 5.10 or later, use HyperV optimizations.
-		currentVer, err := version.Parse(strings.Split(uname.Release, "-")[0])
-		if err != nil {
-			return err
-		}
-
 		minVer, _ := version.NewDottedVersion("5.10.0")
-		if currentVer.Compare(minVer) >= 0 && shared.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
+		if d.state.KernelVersion.Compare(minVer) >= 0 && shared.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
 			// x86_64 can use hv_time to improve Windows guest performance.
 			cpuExtensions = append(cpuExtensions, "hv_passthrough")
 		}

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/maas"
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/version"
 )
 
 // State is a gateway to the two main stateful components of LXD, the database
@@ -64,4 +65,7 @@ type State struct {
 
 	// Filesystem monitor
 	DevMonitor fsmonitor.FSMonitor
+
+	// Kernel Version
+	KernelVersion version.DottedVersion
 }


### PR DESCRIPTION
We've been seeing multiple issues with VMs not starting on various storage drivers with io_uring on earlier kernels.

Tested on the 5.4 and 5.13 kernels, with the latter confirming that iouring support was enabled in QEMU:

- `dir` driver
- `btrfs` driver on loop image (io_uring still not used).
- `zfs` driver atop an LVM volume.
- `zfs` driver atop loop image.
- `lvm` driver atop physical disk.
- `lvm` driver atop loop image.

Fixes #10061