### PR TITLE
Instance: Run all device pre-start checks before starting any device

### DIFF
--- a/lxd/device/device_interface.go
+++ b/lxd/device/device_interface.go
@@ -33,6 +33,9 @@ type Type interface {
 type Device interface {
 	Type
 
+	Config() deviceConfig.Device
+	Name() string
+
 	// Add performs any host-side setup when a device is added to an instance.
 	// It is called irrespective of whether the instance is running or not.
 	Add() error

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1409,6 +1409,9 @@ func (d *lxc) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (devi
 
 // deviceAdd loads a new device and calls its Add() function.
 func (d *lxc) deviceAdd(dev device.Device, instanceRunning bool) error {
+	logger := logging.AddContext(d.logger, log.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
+	logger.Debug("Adding device")
+
 	if instanceRunning && !dev.CanHotPlug() {
 		return fmt.Errorf("Device cannot be added when instance is running")
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1408,12 +1408,7 @@ func (d *lxc) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (devi
 }
 
 // deviceAdd loads a new device and calls its Add() function.
-func (d *lxc) deviceAdd(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) error {
-	dev, _, err := d.deviceLoad(deviceName, rawConfig)
-	if err != nil {
-		return err
-	}
-
+func (d *lxc) deviceAdd(dev device.Device, instanceRunning bool) error {
 	if instanceRunning && !dev.CanHotPlug() {
 		return fmt.Errorf("Device cannot be added when instance is running")
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1376,7 +1376,7 @@ func (d *lxc) RegisterDevices() {
 }
 
 // deviceLoad instantiates and validates a new device and returns it along with enriched config.
-func (d *lxc) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (device.Device, deviceConfig.Device, error) {
+func (d *lxc) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (device.Device, error) {
 	var configCopy deviceConfig.Device
 	var err error
 
@@ -1384,7 +1384,7 @@ func (d *lxc) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (devi
 	if shared.StringInSlice(rawConfig["type"], []string{"nic", "infiniband"}) {
 		configCopy, err = d.FillNetworkDevice(deviceName, rawConfig)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	} else {
 		// Othewise copy the config so it cannot be modified by device.
@@ -1393,8 +1393,8 @@ func (d *lxc) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (devi
 
 	dev, err := device.New(d, d.state, deviceName, configCopy, d.deviceVolatileGetFunc(deviceName), d.deviceVolatileSetFunc(deviceName))
 
-	// Return device and config copy even if error occurs as caller may still use device.
-	return dev, configCopy, err
+	// Return device even if error occurs as caller may still use device.
+	return dev, err
 }
 
 // deviceAdd loads a new device and calls its Add() function.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1417,22 +1417,13 @@ func (d *lxc) deviceAdd(dev device.Device, instanceRunning bool) error {
 }
 
 // deviceStart loads a new device and calls its Start() function.
-func (d *lxc) deviceStart(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) (*deviceConfig.RunConfig, error) {
-	logger := logging.AddContext(d.logger, log.Ctx{"device": deviceName, "type": rawConfig["type"]})
+func (d *lxc) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfig.RunConfig, error) {
+	configCopy := dev.Config()
+	logger := logging.AddContext(d.logger, log.Ctx{"device": dev.Name(), "type": configCopy["type"]})
 	logger.Debug("Starting device")
 
 	revert := revert.New()
 	defer revert.Fail()
-
-	dev, configCopy, err := d.deviceLoad(deviceName, rawConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	err = dev.PreStartCheck()
-	if err != nil {
-		return nil, fmt.Errorf("Failed pre-start check for device: %w", err)
-	}
 
 	if instanceRunning && !dev.CanHotPlug() {
 		return nil, fmt.Errorf("Device cannot be started when instance is running")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -329,8 +329,18 @@ func lxcCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]str
 		for k, m := range d.expandedDevices {
 			devName := k
 			devConfig := m
-			err = d.deviceAdd(devName, devConfig, false)
-			if err != nil && err != device.ErrUnsupportedDevType {
+
+			dev, err := d.deviceLoad(devName, devConfig)
+			if err != nil {
+				if errors.Is(err, device.ErrUnsupportedDevType) {
+					continue
+				}
+
+				return nil, fmt.Errorf("Failed to load device to add %q: %w", devName, err)
+			}
+
+			err = d.deviceAdd(dev, false)
+			if err != nil {
 				return nil, fmt.Errorf("Failed to add device %q: %w", devName, err)
 			}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2092,9 +2092,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 
 	// Start devices in order.
 	for i := range startDevices {
-		// Local vars for revert.
-		rawConfig := sortedDevices[i].Config // For deviceStop.
-		dev := startDevices[i]
+		dev := startDevices[i] // Local var for revert.
 
 		// Start the device.
 		runConf, err := d.deviceStart(dev, false)
@@ -2104,7 +2102,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 
 		// Stop device on failure to setup container.
 		revert.Add(func() {
-			err := d.deviceStop(dev.Name(), rawConfig, false, "")
+			err := d.deviceStop(dev, false, "")
 			if err != nil {
 				d.logger.Error("Failed to cleanup device", log.Ctx{"device": dev.Name(), "err": err})
 			}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2101,6 +2101,12 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 			return "", nil, fmt.Errorf("Failed to load device to start %q: %w", dev.Name(), err)
 		}
 
+		// Run pre-start of check all devices before starting any device to avoid expensive revert.
+		err = dev.PreStartCheck()
+		if err != nil {
+			return "", nil, fmt.Errorf("Failed pre-start check for device %q: %w", dev.Name(), err)
+		}
+
 		startDevices[i] = dev
 	}
 
@@ -4764,6 +4770,11 @@ func (d *lxc) updateDevices(removeDevices deviceConfig.Devices, addDevices devic
 		revert.Add(func() { d.deviceRemove(dev.Name(), dev.Config(), instanceRunning) })
 
 		if instanceRunning {
+			err = dev.PreStartCheck()
+			if err != nil {
+				return fmt.Errorf("Failed pre-start check for device %q: %w", dev.Name(), err)
+			}
+
 			_, err := d.deviceStart(dev, instanceRunning)
 			if err != nil && err != device.ErrUnsupportedDevType {
 				return fmt.Errorf("Failed to start device %q: %w", dev.Name(), err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -304,8 +304,18 @@ func qemuCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]st
 		for k, m := range d.expandedDevices {
 			devName := k
 			devConfig := m
-			err = d.deviceAdd(devName, devConfig, false)
-			if err != nil && err != device.ErrUnsupportedDevType {
+
+			dev, err := d.deviceLoad(devName, devConfig)
+			if err != nil {
+				if errors.Is(err, device.ErrUnsupportedDevType) {
+					continue
+				}
+
+				return nil, fmt.Errorf("Failed to load device to add %q: %w", devName, err)
+			}
+
+			err = d.deviceAdd(dev, false)
+			if err != nil {
 				return nil, fmt.Errorf("Failed to add device %q: %w", devName, err)
 			}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1690,7 +1690,7 @@ func (d *qemu) OnHook(hookName string, args map[string]string) error {
 }
 
 // deviceLoad instantiates and validates a new device and returns it along with enriched config.
-func (d *qemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (device.Device, deviceConfig.Device, error) {
+func (d *qemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (device.Device, error) {
 	var configCopy deviceConfig.Device
 	var err error
 
@@ -1698,7 +1698,7 @@ func (d *qemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (dev
 	if shared.StringInSlice(rawConfig["type"], []string{"nic", "infiniband"}) {
 		configCopy, err = d.FillNetworkDevice(deviceName, rawConfig)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	} else {
 		// Othewise copy the config so it cannot be modified by device.
@@ -1708,7 +1708,7 @@ func (d *qemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (dev
 	dev, err := device.New(d, d.state, deviceName, configCopy, d.deviceVolatileGetFunc(deviceName), d.deviceVolatileSetFunc(deviceName))
 
 	// Return device and config copy even if error occurs as caller may still use device.
-	return dev, configCopy, err
+	return dev, err
 }
 
 // deviceStart loads a new device and calls its Start() function.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4418,30 +4418,43 @@ func (d *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices devi
 
 	// Add devices in sorted order, this ensures that device mounts are added in path order.
 	for _, dd := range addDevices.Sorted() {
-		dev := dd // Local var for loop revert.
-		err := d.deviceAdd(dev.Name, dev.Config, instanceRunning)
-		if err == device.ErrUnsupportedDevType {
-			continue // No point in trying to start device below.
-		} else if err != nil {
+		dev, err := d.deviceLoad(dd.Name, dd.Config)
+		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // No point in trying to add or start device below.
+			}
+
 			if userRequested {
-				return fmt.Errorf("Failed to add device %q: %w", dev.Name, err)
+				return fmt.Errorf("Failed to load device to add %q: %w", dev.Name(), err)
 			}
 
 			// If update is non-user requested (i.e from a snapshot restore), there's nothing we can
 			// do to fix the config and we don't want to prevent the snapshot restore so log and allow.
-			d.logger.Error("Failed to add device, skipping as non-user requested", log.Ctx{"device": dev.Name, "err": err})
+			d.logger.Error("Failed to load device to add, skipping as non-user requested", log.Ctx{"device": dev.Name(), "err": err})
+
 			continue
 		}
 
-		revert.Add(func() { d.deviceRemove(dev.Name, dev.Config, instanceRunning) })
-
-		if instanceRunning {
-			_, err := d.deviceStart(dev.Name, dev.Config, instanceRunning)
-			if err != nil && err != device.ErrUnsupportedDevType {
-				return fmt.Errorf("Failed to start device %q: %w", dev.Name, err)
+		err = d.deviceAdd(dev, instanceRunning)
+		if err != nil {
+			if userRequested {
+				return fmt.Errorf("Failed to add device %q: %w", dev.Name(), err)
 			}
 
-			revert.Add(func() { d.deviceStop(dev.Name, dev.Config, instanceRunning) })
+			// If update is non-user requested (i.e from a snapshot restore), there's nothing we can
+			// do to fix the config and we don't want to prevent the snapshot restore so log and allow.
+			d.logger.Error("Failed to add device, skipping as non-user requested", log.Ctx{"device": dev.Name(), "err": err})
+		}
+
+		revert.Add(func() { d.deviceRemove(dev.Name(), dev.Config(), instanceRunning) })
+
+		if instanceRunning {
+			_, err := d.deviceStart(dev.Name(), dev.Config(), instanceRunning)
+			if err != nil && err != device.ErrUnsupportedDevType {
+				return fmt.Errorf("Failed to start device %q: %w", dev.Name(), err)
+			}
+
+			revert.Add(func() { d.deviceStop(dev.Name(), dev.Config(), instanceRunning) })
 		}
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1160,13 +1160,26 @@ func (d *qemu) Start(stateful bool) error {
 	devConfs := make([]*deviceConfig.RunConfig, 0, len(d.expandedDevices))
 	postStartHooks := []func() error{}
 
-	// Setup devices in sorted order, this ensures that device mounts are added in path order.
-	for _, entry := range d.expandedDevices.Sorted() {
+	sortedDevices := d.expandedDevices.Sorted()
+	startDevices := make([]device.Device, len(sortedDevices))
+
+	// Load devices in sorted order, this ensures that device mounts are added in path order.
+	// Loading all devices first means that validation of all devices occurs before starting any of them.
+	for i, entry := range sortedDevices {
 		dev, err := d.deviceLoad(entry.Name, entry.Config)
 		if err != nil {
 			op.Done(err)
 			return fmt.Errorf("Failed to load device to start %q: %w", dev.Name(), err)
 		}
+
+		startDevices[i] = dev
+	}
+
+	// Start devices in order.
+	for i := range startDevices {
+		// Local vars for revert.
+		rawConfig := sortedDevices[i].Config // For deviceStop.
+		dev := startDevices[i]
 
 		// Start the device.
 		runConf, err := d.deviceStart(dev, false)
@@ -1176,7 +1189,7 @@ func (d *qemu) Start(stateful bool) error {
 		}
 
 		revert.Add(func() {
-			err := d.deviceStop(dev.Name(), dev.Config(), false)
+			err := d.deviceStop(dev.Name(), rawConfig, false)
 			if err != nil {
 				d.logger.Error("Failed to cleanup device", log.Ctx{"device": dev.Name(), "err": err})
 			}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1184,9 +1184,7 @@ func (d *qemu) Start(stateful bool) error {
 
 	// Start devices in order.
 	for i := range startDevices {
-		// Local vars for revert.
-		rawConfig := sortedDevices[i].Config // For deviceStop.
-		dev := startDevices[i]
+		dev := startDevices[i] // Local var for revert.
 
 		// Start the device.
 		runConf, err := d.deviceStart(dev, false)
@@ -1196,7 +1194,7 @@ func (d *qemu) Start(stateful bool) error {
 		}
 
 		revert.Add(func() {
-			err := d.deviceStop(dev.Name(), rawConfig, false)
+			err := d.deviceStop(dev, false)
 			if err != nil {
 				d.logger.Error("Failed to cleanup device", log.Ctx{"device": dev.Name(), "err": err})
 			}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4707,6 +4707,7 @@ func (d *qemu) deviceAdd(deviceName string, rawConfig deviceConfig.Device, insta
 
 func (d *qemu) deviceRemove(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) error {
 	logger := logging.AddContext(d.logger, log.Ctx{"device": deviceName, "type": rawConfig["type"]})
+	logger.Debug("Removing device")
 
 	dev, err := d.deviceLoad(deviceName, rawConfig)
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4390,27 +4390,42 @@ func (d *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices devi
 	defer revert.Fail()
 
 	// Remove devices in reverse order to how they were added.
-	for _, dev := range removeDevices.Reversed() {
+	for _, dd := range removeDevices.Reversed() {
 		if instanceRunning {
-			err := d.deviceStop(dev.Name, dev.Config, instanceRunning)
-			if err == device.ErrUnsupportedDevType {
-				continue // No point in trying to remove device below.
-			} else if err != nil {
-				return fmt.Errorf("Failed to stop device %q: %w", dev.Name, err)
+			dev, err := d.deviceLoad(dd.Name, dd.Config)
+			if err != nil {
+				// If deviceLoad fails with unsupported device type then skip stopping.
+				if errors.Is(err, device.ErrUnsupportedDevType) {
+					continue
+				}
+
+				// If deviceLoad fails for any other reason then just log the error and proceed
+				// with stop, as in the scenario that a new version of LXD has additional
+				// validation restrictions than older versions we still need to allow previously
+				// valid devices to be stopped.
+				d.logger.Error("Device stop validation failed", log.Ctx{"devName": dd.Name, "err": err})
+			}
+
+			// If a device was returned from deviceLoad even if validation fails, then try and stop.
+			if dev != nil {
+				err = d.deviceStop(dev, instanceRunning)
+				if err != nil {
+					return fmt.Errorf("Failed to stop device %q: %w", dev.Name(), err)
+				}
 			}
 		}
 
-		err := d.deviceRemove(dev.Name, dev.Config, instanceRunning)
+		err := d.deviceRemove(dd.Name, dd.Config, instanceRunning)
 		if err != nil && err != device.ErrUnsupportedDevType {
-			return fmt.Errorf("Failed to remove device %q: %w", dev.Name, err)
+			return fmt.Errorf("Failed to remove device %q: %w", dd.Name, err)
 		}
 
 		// Check whether we are about to add the same device back with updated config and
 		// if not, or if the device type has changed, then remove all volatile keys for
 		// this device (as its an actual removal or a device type change).
-		err = d.deviceVolatileReset(dev.Name, dev.Config, addDevices[dev.Name])
+		err = d.deviceVolatileReset(dd.Name, dd.Config, addDevices[dd.Name])
 		if err != nil {
-			return fmt.Errorf("Failed to reset volatile data for device %q: %w", dev.Name, err)
+			return fmt.Errorf("Failed to reset volatile data for device %q: %w", dd.Name, err)
 		}
 	}
 
@@ -4457,7 +4472,7 @@ func (d *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices devi
 				return fmt.Errorf("Failed to start device %q: %w", dev.Name(), err)
 			}
 
-			revert.Add(func() { d.deviceStop(dev.Name(), dev.Config(), instanceRunning) })
+			revert.Add(func() { d.deviceStop(dev, instanceRunning) })
 		}
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4690,6 +4690,9 @@ func (d *qemu) Delete(force bool) error {
 }
 
 func (d *qemu) deviceAdd(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) error {
+	logger := logging.AddContext(d.logger, log.Ctx{"device": deviceName, "type": rawConfig["type"]})
+	logger.Debug("Adding device")
+
 	dev, err := d.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4689,14 +4689,9 @@ func (d *qemu) Delete(force bool) error {
 	return nil
 }
 
-func (d *qemu) deviceAdd(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) error {
-	logger := logging.AddContext(d.logger, log.Ctx{"device": deviceName, "type": rawConfig["type"]})
+func (d *qemu) deviceAdd(dev device.Device, instanceRunning bool) error {
+	logger := logging.AddContext(d.logger, log.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
 	logger.Debug("Adding device")
-
-	dev, err := d.deviceLoad(deviceName, rawConfig)
-	if err != nil {
-		return err
-	}
 
 	if instanceRunning && !dev.CanHotPlug() {
 		return fmt.Errorf("Device cannot be added when instance is running")


### PR DESCRIPTION
Includes https://github.com/lxc/lxd/pull/10082

This PR builds on the device pre-start check concept added in https://github.com/lxc/lxd/pull/10082 by running the pre-start checks for all devices before calling `Start()` for any of the instance's devices.

This way if any of the instance's devices fail their pre-start check then we don't have to go through the (potentially expensive) device stop revert steps.

As well as being generally more efficient when manually starting an instance that is unavailable. It is also useful because when a storage pool (or eventually network) becomes available all auto-start instance candidates will tried to be started, and if they still cannot start because one of its other dependencies is unavailable then this may mean that some of the devices had been started and will need to be reverted.
