### PR TITLE
Discourse links clean

### DIFF
--- a/.sphinx/_extensions/discourse-links.py
+++ b/.sphinx/_extensions/discourse-links.py
@@ -1,0 +1,50 @@
+import requests
+import json
+
+cache = {}
+
+def setup_func(app, pagename, templatename, context, doctree):
+
+    def discourse_links(IDlist):
+
+        if context["discourse_prefix"] and IDlist:
+
+            posts = IDlist.strip().replace(" ","").split(",")
+
+            linklist = "<ul>";
+
+            for post in posts:
+                title = ""
+                linkurl = context["discourse_prefix"]+post
+
+                if post in cache:
+                    title = cache[post]
+                else:
+                    try:
+                        r = requests.get(linkurl+".json")
+                        r.raise_for_status()
+                        title = json.loads(r.text)["title"]
+                        cache[post] = title
+                    except requests.HTTPError as err:
+                        print(err)
+
+                if title:
+                    linklist += '<li><a href="'+linkurl+'" target="_blank">'+title+'</a></li>'
+
+            linklist += "</ul>"
+
+            return linklist
+
+        else:
+            return ""
+
+    context['discourse_links'] = discourse_links
+
+def setup(app):
+    app.connect("html-page-context", setup_func)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -143,3 +143,43 @@ p.youtube_link span {
     font-size: small;
     max-width: 70px;
 }
+
+/** Discourse links **/
+
+.discourse-title {
+    color: var(--color-toc-title-text);
+    font-size: var(--toc-title-font-size);
+    padding-left: var(--toc-spacing-horizontal);
+    text-transform: uppercase;
+}
+
+.discourse {
+    font-size: var(--font-size--small--2);
+    padding-left: calc(var(--toc-spacing-horizontal) - var(--toc-item-spacing-horizontal));
+    padding-bottom: 1em;
+}
+
+.discourse ul {
+    list-style-type: none;
+    margin-bottom: 0;
+    margin-top: 0;
+    padding-left: var(--toc-item-spacing-horizontal);
+}
+
+.discourse li {
+    padding-top: var(--toc-item-spacing-vertical);
+}
+
+.discourse a {
+    overflow-wrap: anywhere;
+    text-decoration: none;
+}
+
+.discourse a::before {
+    content: url("data:image/svg+xml;charset=utf-8,%3Csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' stroke-width='1.5' stroke='%23607D8B' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M0 0h24v24H0z' stroke='none'/%3E%3Cpath d='M11 7H6a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2v-5M10 14 20 4M15 4h5v5'/%3E%3C/svg%3E");
+    margin-right: 0.25rem;
+}
+
+.discourse-title-container {
+    padding-top: 2em;
+}

--- a/.sphinx/_templates/page.html
+++ b/.sphinx/_templates/page.html
@@ -8,3 +8,37 @@
    {% include "header.html" %}
    {{ super() }}
 {%- endblock body %}
+
+{% if meta and meta.discourse %}
+   {% set furo_hide_toc_orig = furo_hide_toc %}
+   {% set furo_hide_toc=false %}
+{% endif %}
+
+{% block right_sidebar %}
+<div class="toc-sticky toc-scroll">
+   {% if not furo_hide_toc_orig %}
+    <div class="toc-title-container">
+      <span class="toc-title">
+       {{ _("Contents") }}
+      </span>
+    </div>
+    <div class="toc-tree-container">
+      <div class="toc-tree">
+        {{ toc }}
+      </div>
+    </div>
+   {% endif %}
+    {% if meta and meta.discourse and discourse_prefix %}
+    <div class="discourse-title-container">
+      <span class="discourse-title">
+       Related links
+      </span>
+    </div>
+    <div class="discourse-container">
+      <div class="discourse">
+        {{ discourse_links(meta.discourse) }}
+      </div>
+    </div>
+    {% endif %}
+  </div>
+{% endblock right_sidebar %}

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -19,7 +19,8 @@ extensions = [
     "sphinx_tabs.tabs",
     "sphinx_reredirects",
     "sphinxext.opengraph",
-    "youtube-link"
+    "youtube-link",
+    "discourse-links"
 ]
 
 myst_enable_extensions = [
@@ -106,8 +107,10 @@ html_context = {
     "github_url": "https://github.com/lxc/lxd",
     "github_version": "master",
     "github_folder": "/doc/",
-    "github_filetype": "md"
+    "github_filetype": "md",
+    "discourse_prefix": "https://discuss.linuxcontainers.org/t/"
 }
+
 
 source_suffix = ".md"
 

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -1,3 +1,7 @@
+---
+discourse: 13114
+---
+
 # Remote API authentication
 
 Remote communications with the LXD daemon happen using JSON over HTTPS.

--- a/doc/backup.md
+++ b/doc/backup.md
@@ -1,3 +1,7 @@
+---
+discourse: 11296
+---
+
 # Backing up a LXD server
 ## What to backup
 When planning to backup a LXD server, consider all the different objects

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -1,3 +1,7 @@
+---
+discourse: 12559
+---
+
 # cloud-init
 
 ```{youtube} https://www.youtube.com/watch?v=8OCG15TAldI

--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -1,3 +1,7 @@
+---
+discourse: 9076
+---
+
 # Clustering
 
 ```{youtube} https://www.youtube.com/watch?v=nrOR6yaO_MY

--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -1,5 +1,5 @@
 ---
-discourse: 9076
+discourse: 9076,11330,12716
 ---
 
 # Clustering

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -1,3 +1,7 @@
+---
+discourse: 8767
+---
+
 # Containers
 ## Introduction
 Containers are the default type for LXD and currently the most

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -1,3 +1,7 @@
+---
+discourse: 8178
+---
+
 # Installing LXD
 
 The easiest way to install LXD is to install one of the available packages, but you can also install LXD from the sources.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -1,3 +1,7 @@
+---
+discourse: 8355
+---
+
 # Instance configuration
 
 ## Instances

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -1,3 +1,7 @@
+---
+discourse: 12281
+---
+
 # Instance metrics
 
 ```{youtube} https://www.youtube.com/watch?v=EthK-8hm_fY

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12281
+discourse: 12281,11735
 ---
 
 # Instance metrics

--- a/doc/network-acls.md
+++ b/doc/network-acls.md
@@ -1,3 +1,7 @@
+---
+discourse: 13223
+---
+
 # How to configure network ACLs
 
 ```{note}

--- a/doc/network-forwards.md
+++ b/doc/network-forwards.md
@@ -1,3 +1,7 @@
+---
+discourse: 11801
+---
+
 # How to configure network forwards
 
 ```{note}

--- a/doc/network-peers.md
+++ b/doc/network-peers.md
@@ -1,3 +1,7 @@
+---
+discourse: 12165
+---
+
 # Network Peers configuration
 
 Network peers allow the creation of routing relationships between two OVN networks.

--- a/doc/network-zones.md
+++ b/doc/network-zones.md
@@ -1,3 +1,7 @@
+---
+discourse: 12033,13128
+---
+
 # Network Zones configuration
 Network zones are used to hold DNS records for LXD networks.
 

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11033,13021,7322
+discourse: 11033,13021,7322,11567
 ---
 
 # Network configuration

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -1,3 +1,7 @@
+---
+discourse: 11033,13021,7322
+---
+
 # Network configuration
 
 LXD supports the following network types:

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -1,3 +1,7 @@
+---
+discourse: 7735
+---
+
 # Storage configuration
 LXD supports creating and managing storage pools and storage volumes.
 General keys are top-level. Driver specific keys are namespaced by driver name.

--- a/doc/virtual-machines.md
+++ b/doc/virtual-machines.md
@@ -1,3 +1,7 @@
+---
+discourse: 7519,9281,9223
+---
+
 # Virtual Machines
 ## Introduction
 Virtual machines are a new instance type supported by LXD alongside containers.


### PR DESCRIPTION
Add an extension to add related Discourse links to the documentation.
They can be added as meta tags at the top of the file.

For now, I just added some random topics for testing. Need to add useful links before this is merged. ;)