### PR TITLE
HTTP: Ensure Connection: Upgrade header is returned when LXD upgrades a connection 

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -1038,6 +1038,7 @@ func (c *cmdFileMount) sshfsMount(ctx context.Context, resource remoteResource, 
 
 		cancel()                              // Prevents error output when the io.Copy functions finish.
 		sshfsCmd.Process.Signal(os.Interrupt) // This will cause sshfs to unmount.
+		stdin.Close()
 	}()
 
 	go func() {

--- a/lxd-agent/sftp.go
+++ b/lxd-agent/sftp.go
@@ -39,19 +39,22 @@ func (r *sftpServe) Render(w http.ResponseWriter) error {
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "Webserver doesn't support hijacking", http.StatusInternalServerError)
+
 		return nil
 	}
 
 	conn, _, err := hijacker.Hijack()
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to hijack connection: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Errorf("Failed to hijack connection: %w", err).Error(), http.StatusInternalServerError)
+
 		return nil
 	}
 	defer conn.Close()
 
-	data := []byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: sftp\r\n\r\n")
-	n, err := conn.Write(data)
-	if err != nil || n != len(data) {
+	err = response.Upgrade(conn, "sftp")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
 		return nil
 	}
 

--- a/lxd/response/upgrade.go
+++ b/lxd/response/upgrade.go
@@ -1,0 +1,31 @@
+package response
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// Upgrade takes a hijacked HTTP connection and sends the HTTP 101 Switching Protocols headers for protocolName.
+func Upgrade(hijackedConn net.Conn, protocolName string) error {
+	// Write the status line and upgrade header by hand since w.WriteHeader() would fail after Hijack().
+	sb := strings.Builder{}
+	sb.WriteString("HTTP/1.1 101 Switching Protocols\r\n")
+	sb.WriteString(fmt.Sprintf("Upgrade: %s\r\n", protocolName))
+	sb.WriteString("Connection: Upgrade\r\n\r\n")
+
+	hijackedConn.SetWriteDeadline(time.Now().Add(time.Second * 5))
+	n, err := hijackedConn.Write([]byte(sb.String()))
+	hijackedConn.SetWriteDeadline(time.Time{}) // Cancel deadline.
+
+	if err != nil {
+		return fmt.Errorf("Failed writing upgrade headers: %w", err)
+	}
+
+	if n != sb.Len() {
+		return fmt.Errorf("Failed writing upgrade headers")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes #10073

Also makes the stopping of sshfs more reliable when the remote instance connection goes away.