### PR TITLE
Device: Adds concept of a pre-start check to devices and pushes storage pool availability check into disk device

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1206,7 +1206,7 @@ func (d *Daemon) init() error {
 
 	// Mount the storage pools.
 	logger.Infof("Initializing storage pools")
-	err = setupStorageDriver(d.State(), false)
+	err = storageStartup(d.State(), false)
 	if err != nil {
 		return err
 	}

--- a/lxd/device/config/devices.go
+++ b/lxd/device/config/devices.go
@@ -11,7 +11,7 @@ type Device map[string]string
 
 // Clone returns a copy of the Device.
 func (device Device) Clone() Device {
-	copy := map[string]string{}
+	copy := make(map[string]string, len(device))
 
 	for k, v := range device {
 		copy[k] = v
@@ -159,7 +159,7 @@ func (list Devices) Update(newlist Devices, updateFields func(Device, Device) []
 
 // Clone returns a copy of the Devices set.
 func (list Devices) Clone() Devices {
-	copy := Devices{}
+	copy := make(Devices, len(list))
 
 	for deviceName, device := range list {
 		copy[deviceName] = device.Clone()
@@ -170,7 +170,7 @@ func (list Devices) Clone() Devices {
 
 // CloneNative returns a copy of the Devices set as a native map[string]map[string]string type.
 func (list Devices) CloneNative() map[string]map[string]string {
-	copy := map[string]map[string]string{}
+	copy := make(map[string]map[string]string, len(list))
 
 	for deviceName, device := range list {
 		copy[deviceName] = device.Clone()

--- a/lxd/device/device_common.go
+++ b/lxd/device/device_common.go
@@ -83,6 +83,11 @@ func (d *deviceCommon) UpdatableFields(oldDevice Type) []string {
 	return []string{}
 }
 
+// PreStartCheck indicates if the device is available for starting.
+func (d *deviceCommon) PreStartCheck() error {
+	return nil
+}
+
 // Update returns an ErrCannotUpdate error as most devices do not support updates.
 func (d *deviceCommon) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	return ErrCannotUpdate

--- a/lxd/device/device_interface.go
+++ b/lxd/device/device_interface.go
@@ -37,6 +37,9 @@ type Device interface {
 	// It is called irrespective of whether the instance is running or not.
 	Add() error
 
+	// PreStartCheck indicates if the device is available for starting.
+	PreStartCheck() error
+
 	// Start peforms any host-side configuration required to start the device for the instance.
 	// This can be when a device is plugged into a running instance or the instance is starting.
 	// Returns run-time configuration needed for configuring the instance with the new device.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -69,7 +69,7 @@ type diskSourceNotFoundError struct {
 }
 
 func (e diskSourceNotFoundError) Error() string {
-	return e.msg
+	return fmt.Sprintf("%s: %v", e.msg, e.err)
 }
 
 func (e diskSourceNotFoundError) Unwrap() error {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1720,7 +1720,7 @@ func (d *lxc) deviceDetachNIC(configCopy map[string]string, netIF []deviceConfig
 			if err != nil {
 				return fmt.Errorf("Failed to detach interface: %q to %q: %w", configCopy["name"], devName, err)
 			}
-			d.logger.Debug("Detached NIC device interface", log.Ctx{"name": configCopy["name"], "devName": devName})
+			d.logger.Debug("Detached NIC device interface", log.Ctx{"name": configCopy["name"], "device": devName})
 		}
 	}
 
@@ -2102,7 +2102,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		revert.Add(func() {
 			err := d.deviceStop(dev.Name, dev.Config, false, "")
 			if err != nil {
-				d.logger.Error("Failed to cleanup device", log.Ctx{"devName": dev.Name, "err": err})
+				d.logger.Error("Failed to cleanup device", log.Ctx{"device": dev.Name, "err": err})
 			}
 		})
 
@@ -3118,7 +3118,7 @@ func (d *lxc) cleanupDevices(instanceRunning bool, stopHookNetnsPath string) {
 		if err == device.ErrUnsupportedDevType {
 			continue
 		} else if err != nil {
-			d.logger.Error("Failed to stop device", log.Ctx{"devName": dev.Name, "err": err})
+			d.logger.Error("Failed to stop device", log.Ctx{"device": dev.Name, "err": err})
 		}
 	}
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1424,6 +1424,11 @@ func (d *lxc) deviceStart(deviceName string, rawConfig deviceConfig.Device, inst
 		return nil, err
 	}
 
+	err = dev.PreStartCheck()
+	if err != nil {
+		return nil, fmt.Errorf("Failed pre-start check for device: %w", err)
+	}
+
 	if instanceRunning && !dev.CanHotPlug() {
 		return nil, fmt.Errorf("Device cannot be started when instance is running")
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1164,7 +1164,7 @@ func (d *qemu) Start(stateful bool) error {
 		revert.Add(func() {
 			err := d.deviceStop(dev.Name, dev.Config, false)
 			if err != nil {
-				d.logger.Error("Failed to cleanup device", log.Ctx{"devName": dev.Name, "err": err})
+				d.logger.Error("Failed to cleanup device", log.Ctx{"device": dev.Name, "err": err})
 			}
 		})
 
@@ -4561,7 +4561,7 @@ func (d *qemu) cleanupDevices() {
 		if err == device.ErrUnsupportedDevType {
 			continue
 		} else if err != nil {
-			d.logger.Error("Failed to stop device", log.Ctx{"devName": dev.Name, "err": err})
+			d.logger.Error("Failed to stop device", log.Ctx{"device": dev.Name, "err": err})
 		}
 	}
 }

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1724,6 +1724,11 @@ func (d *qemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, ins
 		return nil, err
 	}
 
+	err = dev.PreStartCheck()
+	if err != nil {
+		return nil, fmt.Errorf("Failed pre-start check for device: %w", err)
+	}
+
 	if instanceRunning && !dev.CanHotPlug() {
 		return nil, fmt.Errorf("Device cannot be started when instance is running")
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -958,9 +958,22 @@ func (d *qemu) saveState(monitor *qmp.Monitor) error {
 
 // validateStartup checks any constraints that would prevent start up from succeeding under normal circumstances.
 func (d *qemu) validateStartup(stateful bool) error {
+	// Because the root disk is special and is mounted before the root disk device is setup we duplicate the
+	// pre-start check here before the isStartableStatusCode check below so that if there is a problem loading
+	// the instance status because the storage pool isn't available we don't mask the StatusServiceUnavailable
+	// error with an ERROR status code from the instance check instead.
+	_, rootDiskConf, err := shared.GetRootDiskDevice(d.expandedDevices.CloneNative())
+	if err != nil {
+		return err
+	}
+
+	if !storagePools.IsAvailable(rootDiskConf["pool"]) {
+		return api.StatusErrorf(http.StatusServiceUnavailable, "Storage pool %q unavailable on this server", rootDiskConf["pool"])
+	}
+
 	// Check that we are startable before creating an operation lock, so if the instance is in the
 	// process of stopping we don't prevent the stop hooks from running due to our start operation lock.
-	err := d.isStartableStatusCode(d.statusCode())
+	err = d.isStartableStatusCode(d.statusCode())
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5939,7 +5939,7 @@ func (d *qemu) getAgentMetrics() (*metrics.MetricSet, error) {
 
 	agent, err := lxd.ConnectLXDHTTP(nil, client)
 	if err != nil {
-		d.logger.Error("Failed to connect to lxd-agent", log.Ctx{"devName": d.Name(), "err": err})
+		d.logger.Error("Failed to connect to lxd-agent", log.Ctx{"project": d.Project(), "instance": d.Name(), "err": err})
 		return nil, fmt.Errorf("Failed to connect to lxd-agent")
 	}
 	defer agent.Disconnect()

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -18,9 +19,9 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
-	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/warnings"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
 )
@@ -225,7 +226,12 @@ func (slice instanceAutostartList) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
+var instancesStartMu sync.Mutex
+
 func instancesStart(s *state.State, instances []instance.Instance) {
+	instancesStartMu.Lock()
+	defer instancesStartMu.Unlock()
+
 	sort.Sort(instanceAutostartList(instances))
 
 	maxAttempts := 3

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -235,33 +235,6 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 	sort.Sort(instanceAutostartList(instances))
 
 	maxAttempts := 3
-	unavailableStoragePoolNames := storagePools.UnavailablePools()
-
-	// checkPoolsAvailable checks the storage pools for all of the instance's disk devices are available.
-	checkPoolsAvailable := func(inst instance.Instance) error {
-		for devName, devConfig := range inst.ExpandedDevices() {
-			if devConfig["type"] != "disk" {
-				continue // Only check disk devices.
-			}
-
-			if devConfig["pool"] == "" {
-				continue // Non-pool disks are not relevant for checking.
-			}
-
-			// Custom volume disks that are not required don't need to be checked as if the pool is
-			// not available we should still start the instance.
-			if devConfig["path"] != "/" && shared.IsFalse(devConfig["required"]) {
-				continue
-			}
-
-			// If disk is required and storage pool is not available, don't try and start instance.
-			if shared.StringInSlice(devConfig["pool"], unavailableStoragePoolNames) {
-				return fmt.Errorf("Storage pool %q for disk %q is unavailable", devConfig["pool"], devName)
-			}
-		}
-
-		return nil
-	}
 
 	// Restart the instances
 	for _, inst := range instances {
@@ -277,11 +250,6 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 			continue
 		}
 
-		err := checkPoolsAvailable(inst)
-		if err != nil {
-			continue // Skip instance start if any pools required are not available.
-		}
-
 		// If already running, we're done.
 		if inst.IsRunning() {
 			continue
@@ -293,41 +261,44 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 		var attempt = 0
 		for {
 			attempt++
-			err = inst.Start(false)
+			err := inst.Start(false)
 			if err != nil {
+				if _, matched := api.StatusErrorMatch(err, http.StatusServiceUnavailable); matched {
+					break // Don't log or retry instances that are not ready to start yet.
+				}
+
 				instLogger.Warn("Failed auto start instance attempt", log.Ctx{"attempt": attempt, "maxAttempts": maxAttempts, "err": err})
 
 				if attempt >= maxAttempts {
+					// If unable to start after 3 tries, record a warning.
+					warnErr := s.Cluster.UpsertWarningLocalNode(inst.Project(), cluster.TypeInstance, inst.ID(), db.WarningInstanceAutostartFailure, fmt.Sprintf("%v", err))
+					if warnErr != nil {
+						instLogger.Warn("Failed to create instance autostart failure warning", log.Ctx{"err": warnErr})
+					}
+
+					instLogger.Error("Failed to auto start instance", log.Ctx{"err": err})
+
 					break
 				}
 
 				time.Sleep(5 * time.Second)
-			} else {
-				// Resolve any previous warning.
-				warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(s.Cluster, inst.Project(), db.WarningInstanceAutostartFailure, cluster.TypeInstance, inst.ID())
-				if warnErr != nil {
-					instLogger.Warn("Failed to resolve instance autostart failure warning", log.Ctx{"err": warnErr})
-				}
 
-				break
+				continue
 			}
-		}
 
-		if err != nil {
-			// If unable to start after 3 tries, record a warning.
-			warnErr := s.Cluster.UpsertWarningLocalNode(inst.Project(), cluster.TypeInstance, inst.ID(), db.WarningInstanceAutostartFailure, fmt.Sprintf("%v", err))
+			// Resolve any previous warning.
+			warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(s.Cluster, inst.Project(), db.WarningInstanceAutostartFailure, cluster.TypeInstance, inst.ID())
 			if warnErr != nil {
-				instLogger.Warn("Failed to create instance autostart failure warning", log.Ctx{"err": warnErr})
+				instLogger.Warn("Failed to resolve instance autostart failure warning", log.Ctx{"err": warnErr})
 			}
 
-			instLogger.Error("Failed to auto start instance", log.Ctx{"err": err})
-			continue
-		}
+			// Wait the auto-start delay if set.
+			autoStartDelayInt, err := strconv.Atoi(autoStartDelay)
+			if err == nil {
+				time.Sleep(time.Duration(autoStartDelayInt) * time.Second)
+			}
 
-		// Wait the auto-start delay if set.
-		autoStartDelayInt, err := strconv.Atoi(autoStartDelay)
-		if err == nil {
-			time.Sleep(time.Duration(autoStartDelayInt) * time.Second)
+			break
 		}
 	}
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -370,7 +370,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	// Load existing pool if exists, if not don't fail.
+	// Load existing network if exists, if not don't fail.
 	_, netInfo, _, err := d.cluster.GetNetworkInAnyState(projectName, req.Name)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return response.InternalError(err)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1037,7 +1037,7 @@ func patchStorageApi(name string, d *Daemon) error {
 		return err
 	}
 
-	return setupStorageDriver(d.State(), true)
+	return storageStartup(d.State(), true)
 }
 
 func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -124,14 +124,14 @@ func storageStartup(s *state.State, forceCheck bool) error {
 				return true // Nothing to activate as pool has been deleted.
 			}
 
-			logger.Warn("Failed loading storage pool", log.Ctx{"pool": poolName, "err": err})
+			logger.Error("Failed loading storage pool", log.Ctx{"pool": poolName, "err": err})
 
 			return false
 		}
 
 		_, err = pool.Mount()
 		if err != nil {
-			logger.Warn("Failed mounting storage pool", log.Ctx{"pool": poolName, "err": err})
+			logger.Error("Failed mounting storage pool", log.Ctx{"pool": poolName, "err": err})
 			s.Cluster.UpsertWarningLocalNode("", cluster.TypeStoragePool, int(pool.ID()), db.WarningStoragePoolUnvailable, err.Error())
 
 			return false
@@ -185,7 +185,7 @@ func storageStartup(s *state.State, forceCheck bool) error {
 					if tryInstancesStart {
 						instances, err := instance.LoadNodeAll(s, instancetype.Any)
 						if err != nil {
-							logger.Warn("Failed loading instances to start", log.Ctx{"err": err})
+							logger.Error("Failed loading instances to start", log.Ctx{"err": err})
 						} else {
 							instancesStart(s, instances)
 						}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -78,7 +78,7 @@ func resetContainerDiskIdmap(container instance.Container, srcIdmap *idmap.Idmap
 	return nil
 }
 
-func setupStorageDriver(s *state.State, forceCheck bool) error {
+func storageStartup(s *state.State, forceCheck bool) error {
 	// Update the storage drivers supported and used cache in api_1.0.go.
 	storagePoolDriversCacheUpdate(s)
 

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -146,7 +146,7 @@ func storageStartup(s *state.State, forceCheck bool) error {
 	// Try initializing storage pools in random order.
 	for poolName := range initPools {
 		if initPool(poolName) {
-			// Storage pool initialized successfully then remove it from the list so its not retried.
+			// Storage pool initialized successfully so remove it from the list so its not retried.
 			delete(initPools, poolName)
 		}
 	}
@@ -169,8 +169,8 @@ func storageStartup(s *state.State, forceCheck bool) error {
 					tryInstancesStart := false
 					for poolName := range initPools {
 						if initPool(poolName) {
-							// Storage pool initialized successfully then remove it
-							// from the list so its not retried.
+							// Storage pool initialized successfully so remove it from
+							// the list so its not retried.
 							delete(initPools, poolName)
 							tryInstancesStart = true
 						}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -96,7 +96,7 @@ func (b *lxdBackend) isStatusReady() error {
 	}
 
 	if b.LocalStatus() == api.StoragePoolStatusUnvailable {
-		return ErrPoolUnavailable
+		return api.StatusErrorf(http.StatusServiceUnavailable, "Storage pool is unavailable on this server")
 	}
 
 	return nil

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,12 +75,9 @@ func (b *lxdBackend) Status() string {
 
 // LocalStatus returns storage pool status of the local cluster member.
 func (b *lxdBackend) LocalStatus() string {
-	unavailablePoolsMu.Lock()
-	defer unavailablePoolsMu.Unlock()
-
 	// Check if pool is unavailable locally and replace status if so.
 	// But don't modify b.db.Status as the status may be recovered later so we don't want to persist it here.
-	if _, found := unavailablePools[b.name]; found {
+	if !IsAvailable(b.name) {
 		return api.StoragePoolStatusUnvailable
 	}
 

--- a/lxd/storage/errors.go
+++ b/lxd/storage/errors.go
@@ -9,6 +9,3 @@ var ErrNilValue = fmt.Errorf("Nil value provided")
 
 // ErrBackupSnapshotsMismatch is the "Backup snapshots mismatch" error.
 var ErrBackupSnapshotsMismatch = fmt.Errorf("Backup snapshots mismatch")
-
-// ErrPoolUnavailable is the "Storage pool is unavailable on this server" error.
-var ErrPoolUnavailable = fmt.Errorf("Storage pool is unavailable on this server")


### PR DESCRIPTION
This lays the groundwork for degraded network startup by adding the concept of a pre-start check to devices.

The pre-start check will optionally perform some (cheap) checks that will indicate that the device cannot start, and use this as an indicator not to bother starting the device.

The error returned from the pre-start check will then be returned from the instance's `Start()` function and will be used to inform the auto-start instances function to avoid retrying the start of an instance. 

The instance disk device pool availability check was previously done in the auto-start instances function, but with the forthcoming degraded network start up feature we needed a way to push this check into the device itself so that a NIC can check whether its managed parent network is available whilst at the same time taking into account the effective network project that the instance was operating in. In addition it need to use existing logic inside the NIC device drivers that was able to ascertain whether or not the NIC `parent` setting indicated a managed network or an unmanaged interface, which I didn't want to duplicate in the auto-start instances function.

 