### PR TITLE
LXD: Switch to transitional IsNotFoundError() helper function

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -535,7 +535,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// Get all defined storage pools and networks, so they can be compared to the ones in the cluster.
 		pools := []api.StoragePool{}
 		poolNames, err := d.cluster.GetStoragePoolNames()
-		if err != nil && err != db.ErrNoSuchObject {
+		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		}
 
@@ -561,7 +561,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		networks := []internalClusterPostNetwork{}
 		for _, p := range projects {
 			networkNames, err := d.cluster.GetNetworks(p.Name)
-			if err != nil && err != db.ErrNoSuchObject {
+			if err != nil && !response.IsNotFoundError(err) {
 				return err
 			}
 
@@ -1876,7 +1876,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 		// Delete all the pools on this node
 		pools, err := d.cluster.GetStoragePoolNames()
-		if err != nil && err != db.ErrNoSuchObject {
+		if err != nil && !response.IsNotFoundError(err) {
 			return response.SmartError(err)
 		}
 
@@ -2444,7 +2444,7 @@ type internalClusterPostHandoverRequest struct {
 
 func clusterCheckStoragePoolsMatch(cluster *db.Cluster, reqPools []api.StoragePool) error {
 	poolNames, err := cluster.GetCreatedStoragePoolNames()
-	if err != nil && err != db.ErrNoSuchObject {
+	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
 	for _, name := range poolNames {
@@ -2492,7 +2492,7 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []internalCluste
 
 	for _, networkProjectName := range networkProjectNames {
 		networkNames, err := cluster.GetCreatedNetworks(networkProjectName)
-		if err != nil && err != db.ErrNoSuchObject {
+		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		}
 
@@ -3290,7 +3290,7 @@ func clusterGroupGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		if errors.Is(err, db.ErrNoSuchObject) {
+		if response.IsNotFoundError(err) {
 			return response.NotFound(fmt.Errorf("Cluster group %q not found", name))
 		}
 
@@ -3374,7 +3374,7 @@ func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		if errors.Is(err, db.ErrNoSuchObject) {
+		if response.IsNotFoundError(err) {
 			return response.NotFound(fmt.Errorf("Cluster group %q not found", name))
 		}
 

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -147,7 +146,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 	for _, p := range userPools {
 		pool, err := storagePools.GetPoolByName(d.State(), p.Name)
 		if err != nil {
-			if errors.Is(err, db.ErrNoSuchObject) {
+			if response.IsNotFoundError(err) {
 				// If the pool DB record doesn't exist, and we are clustered, then don't proceed
 				// any further as we do not support pool DB record recovery when clustered.
 				if isClustered {

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -649,7 +649,7 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 		var id int64
 		err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
 			project, err := tx.GetProject(req.Name)
-			if err != nil && err != db.ErrNoSuchObject {
+			if err != nil && !response.IsNotFoundError(err) {
 				return fmt.Errorf("Failed checking if project %q exists: %w", req.Name, err)
 			}
 

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -939,7 +939,7 @@ func (g *Gateway) nodeAddress(raftAddress string) (string, error) {
 		var err error
 		address, err = tx.GetRaftNodeAddress(1)
 		if err != nil {
-			if err != db.ErrNoSuchObject {
+			if !response.IsNotFoundError(err) {
 				return fmt.Errorf("Failed to fetch raft server address: %w", err)
 			}
 			// Use the initial address as fallback. This is an edge

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/lxd/node"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/lxd/warnings"
 	"github.com/lxc/lxd/shared"
@@ -469,7 +470,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 				}
 
 				err := tx.SetNodeHeartbeat(node.Address, node.LastHeartbeat)
-				if err != nil && !errors.Is(err, db.ErrNoSuchObject) {
+				if err != nil && !response.IsNotFoundError(err) {
 					return fmt.Errorf("Failed updating heartbeat time for member %q: %w", node.Address, err)
 				}
 			}

--- a/lxd/cluster/resolve.go
+++ b/lxd/cluster/resolve.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/response"
 )
 
 // ResolveTarget is a convenience for handling the value ?targetNode query
@@ -23,7 +24,7 @@ func ResolveTarget(cluster *db.Cluster, target string) (string, error) {
 
 		node, err := tx.GetNodeByName(target)
 		if err != nil {
-			if err == db.ErrNoSuchObject {
+			if response.IsNotFoundError(err) {
 				return fmt.Errorf("No cluster member called '%s'", target)
 			}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1658,7 +1658,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 			// Unmount storage pools after instances stopped.
 			logger.Info("Stopping storage pools")
 			pools, err := s.Cluster.GetStoragePoolNames()
-			if err != nil && err != db.ErrNoSuchObject {
+			if err != nil && !response.IsNotFoundError(err) {
 				logger.Error("Failed to get storage pools", log.Ctx{"err": err})
 			}
 

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/request"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -165,7 +166,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 				return nil, fmt.Errorf("Failed adding transferred image %q to local cluster member: %w", imgInfo.Fingerprint, err)
 			}
 		}
-	} else if err == db.ErrNoSuchObject {
+	} else if response.IsNotFoundError(err) {
 		// Check if the image already exists in some other project.
 		_, imgInfo, err = d.cluster.GetImageFromAnyProject(fp)
 		if err == nil {

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/response"
 )
 
 // The GetNetworksLocalConfigs method returns only node-specific config values.
@@ -98,5 +99,5 @@ func TestNetworksCreatePending_NonExistingNode(t *testing.T) {
 	defer cleanup()
 
 	err := tx.CreatePendingNetwork("buzz", project.Default, "network1", db.NetworkTypeBridge, map[string]string{})
-	require.Equal(t, db.ErrNoSuchObject, err)
+	require.True(t, response.IsNotFoundError(err))
 }

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/stretchr/testify/assert"
@@ -163,7 +164,7 @@ func TestRemoveNode(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = tx.GetNodeByName("rusp")
-	assert.Equal(t, db.ErrNoSuchObject, err)
+	assert.True(t, response.IsNotFoundError(err))
 }
 
 // Mark a node has pending.
@@ -180,7 +181,7 @@ func TestSetNodePendingFlag(t *testing.T) {
 
 	// Pending nodes are skipped from regular listing
 	_, err = tx.GetNodeByName("buzz")
-	assert.Equal(t, db.ErrNoSuchObject, err)
+	assert.True(t, response.IsNotFoundError(err))
 	nodes, err := tx.GetNodes()
 	require.NoError(t, err)
 	assert.Len(t, nodes, 1)

--- a/lxd/db/raft_test.go
+++ b/lxd/db/raft_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/response"
 )
 
 // Fetch all raft nodes.
@@ -113,7 +114,7 @@ func TestRemoveRaftNode_NonExisting(t *testing.T) {
 	defer cleanup()
 
 	err := tx.RemoveRaftNode(1)
-	assert.Equal(t, db.ErrNoSuchObject, err)
+	assert.True(t, response.IsNotFoundError(err))
 }
 
 // Replace all existing raft nodes.

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lxc/lxd/lxd/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/response"
 )
 
 func init() {
@@ -154,7 +156,7 @@ func TestStoragePoolsCreatePending_NonExistingNode(t *testing.T) {
 	defer cleanup()
 
 	err := tx.CreatePendingStoragePool("buzz", "pool1", "dir", map[string]string{})
-	require.Equal(t, db.ErrNoSuchObject, err)
+	require.True(t, response.IsNotFoundError(err))
 }
 
 // If a pool with the given name already exists but has different driver, an
@@ -214,7 +216,7 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 	require.NoError(t, err)
 	for _, nodeID := range []int64{1, 2} {
 		_, volume, err := cluster.GetStoragePoolVolume("default", "v1-new", 1, poolID, nodeID)
-		assert.Equal(t, db.ErrNoSuchObject, err)
+		assert.True(t, response.IsNotFoundError(err))
 		assert.Nil(t, volume)
 	}
 }

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -55,7 +54,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 
 			_, err := d.cluster.GetProject(projectName)
 			if err != nil {
-				if errors.Is(err, db.ErrNoSuchObject) {
+				if response.IsNotFoundError(err) {
 					response.BadRequest(fmt.Errorf("Project %q not found", projectName)).Render(w)
 				}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -343,7 +343,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	info.CreatedAt = time.Now().UTC()
 
 	_, _, err = d.cluster.GetImage(info.Fingerprint, db.ImageFilter{Project: &projectName})
-	if err != db.ErrNoSuchObject {
+	if !response.IsNotFoundError(err) {
 		if err != nil {
 			return nil, err
 		}
@@ -997,7 +997,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 
 		for _, alias := range req.Aliases {
 			_, _, err := d.cluster.GetImageAlias(projectName, alias.Name, true)
-			if err != db.ErrNoSuchObject {
+			if !response.IsNotFoundError(err) {
 				if err != nil {
 					return fmt.Errorf("Fetch image alias %q: %w", alias.Name, err)
 				}
@@ -2590,7 +2590,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	profileIds := make([]int64, len(req.Profiles))
 	for i, profile := range req.Profiles {
 		profileID, _, err := d.cluster.GetProfile(projectName, profile)
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return response.BadRequest(fmt.Errorf("Profile '%s' doesn't exist", profile))
 		} else if err != nil {
 			return response.SmartError(err)
@@ -2758,7 +2758,7 @@ func imageAliasesPost(d *Daemon, r *http.Request) response.Response {
 
 	// This is just to see if the alias name already exists.
 	_, _, err := d.cluster.GetImageAlias(projectName, req.Name, true)
-	if err != db.ErrNoSuchObject {
+	if !response.IsNotFoundError(err) {
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -46,6 +46,7 @@ import (
 	"github.com/lxc/lxd/lxd/metrics"
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/seccomp"
 	"github.com/lxc/lxd/lxd/state"
@@ -3696,7 +3697,7 @@ func (d *lxc) Delete(force bool) error {
 	}
 
 	pool, err := storagePools.GetPoolByInstance(d.state, d)
-	if err != nil && !errors.Is(err, db.ErrNoSuchObject) {
+	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	} else if pool != nil {
 		if d.IsSnapshot() {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -51,6 +51,7 @@ import (
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/resources"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -4598,7 +4599,7 @@ func (d *qemu) Delete(force bool) error {
 
 	// Attempt to initialize storage interface for the instance.
 	pool, err := d.getStoragePool()
-	if err != nil && !errors.Is(err, db.ErrNoSuchObject) {
+	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	} else if pool != nil {
 		if d.IsSnapshot() {

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -163,8 +163,8 @@ func instanceSnapRestore(s *state.State, projectName string, name string, snap s
 
 	source, err := instance.LoadByProjectAndName(s, projectName, snap)
 	if err != nil {
-		switch err {
-		case db.ErrNoSuchObject:
+		switch {
+		case response.IsNotFoundError(err):
 			return fmt.Errorf("Snapshot %s does not exist", snap)
 		default:
 			return err

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -678,7 +677,7 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 
 	// Check storage pool exists.
 	_, _, _, err = d.State().Cluster.GetStoragePoolInAnyState(bInfo.Pool)
-	if errors.Is(err, db.ErrNoSuchObject) {
+	if response.IsNotFoundError(err) {
 		// The storage pool doesn't exist. If backup is in binary format (so we cannot alter
 		// the backup.yaml) or the pool has been specified directly from the user restoring
 		// the backup then we cannot proceed so return an error.
@@ -1095,7 +1094,7 @@ func instanceFindStoragePool(d *Daemon, projectName string, req *api.InstancesPo
 	// Handle copying/moving between two storage-api LXD instances.
 	if storagePool != "" {
 		_, err := d.cluster.GetStoragePoolID(storagePool)
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			storagePool = ""
 			// Unset the local root disk device storage pool if not
 			// found.
@@ -1125,7 +1124,7 @@ func instanceFindStoragePool(d *Daemon, projectName string, req *api.InstancesPo
 		logger.Debugf("No valid storage pool in the container's local root disk device and profiles found")
 		pools, err := d.cluster.GetStoragePoolNames()
 		if err != nil {
-			if err == db.ErrNoSuchObject {
+			if response.IsNotFoundError(err) {
 				return "", "", "", nil, response.BadRequest(fmt.Errorf("This LXD instance does not have any storage pools configured"))
 			}
 			return "", "", "", nil, response.SmartError(err)

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -84,7 +85,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 
 	// Find networks using the ACLs. Cheapest to do.
 	networkNames, err := s.Cluster.GetCreatedNetworks(aclProjectName)
-	if err != nil && err != db.ErrNoSuchObject {
+	if err != nil && !response.IsNotFoundError(err) {
 		return fmt.Errorf("Failed loading networks for project %q: %w", aclProjectName, err)
 	}
 

--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -11,8 +11,8 @@ import (
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/cluster/request"
-	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
@@ -80,7 +80,7 @@ func (d *zone) usedBy(firstOnly bool) ([]string, error) {
 
 	// Find networks using the zone.
 	networkNames, err := d.state.Cluster.GetCreatedNetworks(d.projectName)
-	if err != nil && err != db.ErrNoSuchObject {
+	if err != nil && !response.IsNotFoundError(err) {
 		return nil, fmt.Errorf("Failed loading networks for project %q: %w", d.projectName, err)
 	}
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -541,7 +541,7 @@ func networksPostCluster(d *Daemon, projectName string, netInfo *api.Network, re
 		return tx.NetworkErrored(projectName, req.Name)
 	})
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return fmt.Errorf("Network not pending on any node (use --target <node> first)")
 		}
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/rsync"
 	driver "github.com/lxc/lxd/lxd/storage"
@@ -1082,7 +1083,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		if err != nil {
 			return err
 		}
-	} else if err == db.ErrNoSuchObject { // Likely a pristine upgrade.
+	} else if response.IsNotFoundError(err) { // Likely a pristine upgrade.
 		tmp, err := dbStoragePoolCreateAndUpdateCache(d.State(), defaultPoolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
 			return err
@@ -1139,7 +1140,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", ct, "", db.StoragePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -1227,7 +1228,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 				if err != nil {
 					return err
 				}
-			} else if err == db.ErrNoSuchObject {
+			} else if response.IsNotFoundError(err) {
 				// Insert storage volumes for containers into the database.
 				_, err := d.cluster.CreateStorageVolumeSnapshot("default", cs, "", db.StoragePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig, time.Time{})
 				if err != nil {
@@ -1308,7 +1309,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", img, "", db.StoragePoolVolumeTypeImage, poolID, imagePoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -1382,7 +1383,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 		if err != nil {
 			return err
 		}
-	} else if err == db.ErrNoSuchObject { // Likely a pristine upgrade.
+	} else if response.IsNotFoundError(err) { // Likely a pristine upgrade.
 		tmp, err := dbStoragePoolCreateAndUpdateCache(d.State(), defaultPoolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
 			return err
@@ -1429,7 +1430,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", ct, "", db.StoragePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -1546,7 +1547,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStorageVolumeSnapshot("default", cs, "", db.StoragePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig, time.Time{})
 			if err != nil {
@@ -1576,7 +1577,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", img, "", db.StoragePoolVolumeTypeImage, poolID, imagePoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -1684,7 +1685,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		if err != nil {
 			return err
 		}
-	} else if err == db.ErrNoSuchObject { // Likely a pristine upgrade.
+	} else if response.IsNotFoundError(err) { // Likely a pristine upgrade.
 		tmp, err := dbStoragePoolCreateAndUpdateCache(d.State(), defaultPoolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
 			return err
@@ -1738,7 +1739,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", ct, "", db.StoragePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -1896,7 +1897,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				if err != nil {
 					return err
 				}
-			} else if err == db.ErrNoSuchObject {
+			} else if response.IsNotFoundError(err) {
 				// Insert storage volumes for containers into the database.
 				_, err := d.cluster.CreateStorageVolumeSnapshot("default", cs, "", db.StoragePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig, time.Time{})
 				if err != nil {
@@ -2076,7 +2077,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", img, "", db.StoragePoolVolumeTypeImage, poolID, imagePoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -2196,7 +2197,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		if err != nil {
 			return err
 		}
-	} else if err == db.ErrNoSuchObject { // Likely a pristine upgrade.
+	} else if response.IsNotFoundError(err) { // Likely a pristine upgrade.
 		poolConfig["zfs.pool_name"] = defaultPoolName
 		if shared.PathExists(oldLoopFilePath) {
 			// This is a loop file pool.
@@ -2268,7 +2269,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", ct, "", db.StoragePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -2354,7 +2355,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 				if err != nil {
 					return err
 				}
-			} else if err == db.ErrNoSuchObject {
+			} else if response.IsNotFoundError(err) {
 				// Insert storage volumes for containers into the database.
 				_, err := d.cluster.CreateStorageVolumeSnapshot("default", cs, "", db.StoragePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig, time.Time{})
 				if err != nil {
@@ -2410,7 +2411,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				return err
 			}
-		} else if err == db.ErrNoSuchObject {
+		} else if response.IsNotFoundError(err) {
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.CreateStoragePoolVolume("default", img, "", db.StoragePoolVolumeTypeImage, poolID, imagePoolVolumeConfig, db.StoragePoolVolumeContentTypeFS)
 			if err != nil {
@@ -2598,7 +2599,7 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 
 func patchStorageApiV1(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err == db.ErrNoSuchObject {
+	if err != nil && response.IsNotFoundError(err) {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -2742,7 +2743,7 @@ func patchStorageApiLvmKeys(name string, d *Daemon) error {
 
 func patchStorageApiKeys(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err == db.ErrNoSuchObject {
+	if err != nil && response.IsNotFoundError(err) {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -2800,7 +2801,7 @@ func patchStorageApiKeys(name string, d *Daemon) error {
 func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -2882,7 +2883,7 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 		// Get all storage volumes on the storage pool.
 		volumes, err := d.cluster.GetLocalStoragePoolVolumes("default", poolID, supportedVolumeTypes)
 		if err != nil {
-			if err == db.ErrNoSuchObject {
+			if response.IsNotFoundError(err) {
 				continue
 			}
 			return err
@@ -2948,7 +2949,7 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 func patchStorageApiLxdOnBtrfs(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -3005,7 +3006,7 @@ func patchStorageApiLxdOnBtrfs(name string, d *Daemon) error {
 func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -3038,7 +3039,7 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 		// Get all storage volumes on the storage pool.
 		volumes, err := d.cluster.GetLocalStoragePoolVolumes("default", poolID, supportedVolumeTypes)
 		if err != nil {
-			if err == db.ErrNoSuchObject {
+			if response.IsNotFoundError(err) {
 				continue
 			}
 			return err
@@ -3115,7 +3116,7 @@ func patchStorageApiInsertZfsDriver(name string, d *Daemon) error {
 func patchStorageZFSnoauto(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -3177,7 +3178,7 @@ func patchStorageZFSnoauto(name string, d *Daemon) error {
 
 func patchStorageZFSVolumeSize(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err == db.ErrNoSuchObject {
+	if err != nil && response.IsNotFoundError(err) {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -3202,7 +3203,7 @@ func patchStorageZFSVolumeSize(name string, d *Daemon) error {
 		// Get all storage volumes on the storage pool.
 		volumes, err := d.cluster.GetLocalStoragePoolVolumes("default", poolID, supportedVolumeTypes)
 		if err != nil {
-			if err == db.ErrNoSuchObject {
+			if response.IsNotFoundError(err) {
 				continue
 			}
 			return err
@@ -3264,7 +3265,7 @@ func patchNetworkDnsmasqHosts(name string, d *Daemon) error {
 
 func patchStorageApiDirBindMount(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err == db.ErrNoSuchObject {
+	if err != nil && response.IsNotFoundError(err) {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -3350,7 +3351,7 @@ func patchFixUploadedAt(name string, d *Daemon) error {
 
 func patchStorageApiCephSizeRemove(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err == db.ErrNoSuchObject {
+	if err != nil && response.IsNotFoundError(err) {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -3547,7 +3548,7 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 	}
 
 	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err == db.ErrNoSuchObject {
+	if err != nil && response.IsNotFoundError(err) {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -3615,7 +3616,7 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 		}
 
 		volumes, err := d.cluster.GetLocalStoragePoolVolumesWithType(project.Default, db.StoragePoolVolumeTypeCustom, poolID)
-		if err != nil && err != db.ErrNoSuchObject {
+		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		}
 
@@ -3710,7 +3711,7 @@ func patchMoveBackups(name string, d *Daemon) error {
 	// Get all storage pools
 	pools, err := d.cluster.GetStoragePoolNames()
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return nil
 		}
 
@@ -3720,7 +3721,7 @@ func patchMoveBackups(name string, d *Daemon) error {
 	// Get all containers
 	containers, err := d.cluster.LegacyContainersList()
 	if err != nil {
-		if err != db.ErrNoSuchObject {
+		if !response.IsNotFoundError(err) {
 			return err
 		}
 
@@ -3827,7 +3828,7 @@ func patchMoveBackups(name string, d *Daemon) error {
 
 func patchStorageApiRenameContainerSnapshotsDir(name string, d *Daemon) error {
 	pools, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err == db.ErrNoSuchObject {
+	if err != nil && response.IsNotFoundError(err) {
 		// No pool was configured so we're on a pristine LXD instance.
 		return nil
 	} else if err != nil {

--- a/lxd/response/smart.go
+++ b/lxd/response/smart.go
@@ -44,3 +44,18 @@ func SmartError(err error) Response {
 
 	return &errorResponse{http.StatusInternalServerError, err.Error()}
 }
+
+// IsNotFoundError returns true if the error is considered a Not Found error.
+func IsNotFoundError(err error) bool {
+	if _, found := api.StatusErrorMatch(err, http.StatusNotFound); found {
+		return true
+	}
+
+	for _, checkErr := range httpResponseErrors[http.StatusNotFound] {
+		if errors.Is(err, checkErr) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/lxd/storage/filesystem"
@@ -36,7 +37,7 @@ func lxdPatchStorageRenameCustomVolumeAddProject(b *lxdBackend) error {
 	// Get all custom volumes in default project on this node.
 	// At this time, all custom volumes are in the default project.
 	volumes, err := b.state.Cluster.GetLocalStoragePoolVolumes(project.Default, b.ID(), []int{db.StoragePoolVolumeTypeCustom})
-	if err != nil && err != db.ErrNoSuchObject {
+	if err != nil && !response.IsNotFoundError(err) {
 		return fmt.Errorf("Failed getting custom volumes for default project: %w", err)
 	}
 

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -16,6 +16,7 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/ioprogress"
@@ -669,7 +670,7 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 			}
 		}
 	} else {
-		if err != db.ErrNoSuchObject {
+		if !response.IsNotFoundError(err) {
 			return -1, err
 		}
 
@@ -702,7 +703,7 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 				}
 			}
 		} else {
-			if err != db.ErrNoSuchObject {
+			if !response.IsNotFoundError(err) {
 				return -1, err
 			}
 
@@ -743,7 +744,7 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error) {
 	clones, err := d.rbdListSnapshotClones(vol, snapshotName)
 	if err != nil {
-		if err != db.ErrNoSuchObject {
+		if !response.IsNotFoundError(err) {
 			return -1, err
 		}
 

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -15,9 +15,9 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/lxc/lxd/lxd/backup"
-	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
@@ -621,7 +621,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 
 		if hasReadonlySnapshot {
 			dependantSnapshots, err := d.rbdListSnapshotClones(vol, "readonly")
-			if err != nil && err != db.ErrNoSuchObject {
+			if err != nil && !response.IsNotFoundError(err) {
 				return err
 			}
 
@@ -1641,7 +1641,7 @@ func (d *ceph) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (
 func (d *ceph) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error) {
 	snapshots, err := d.rbdListVolumeSnapshots(vol)
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return nil, nil
 		}
 

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"errors"
 	"fmt"
 
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -10,6 +9,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared/api"
@@ -49,7 +49,7 @@ func volIDFuncMake(state *state.State, poolID int64) func(volType drivers.Volume
 
 		volID, _, err := state.Cluster.GetLocalStoragePoolVolume(projectName, volName, volTypeID, poolID)
 		if err != nil {
-			if err == db.ErrNoSuchObject {
+			if response.IsNotFoundError(err) {
 				return -1, fmt.Errorf("Failed to get volume ID for project %q, volume %q, type %q: Volume doesn't exist", projectName, volName, volType)
 			}
 
@@ -287,7 +287,7 @@ func Patch(s *state.State, patchName string) error {
 	// Load all the pools.
 	pools, err := s.Cluster.GetStoragePoolNames()
 	if err != nil {
-		if errors.Is(err, db.ErrNoSuchObject) {
+		if response.IsNotFoundError(err) {
 			return nil
 		}
 

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -141,7 +141,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
 	poolNames, err := d.cluster.GetStoragePoolNames()
-	if err != nil && err != db.ErrNoSuchObject {
+	if err != nil && !response.IsNotFoundError(err) {
 		return response.SmartError(err)
 	}
 
@@ -316,7 +316,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 
 	// Load existing pool if exists, if not don't fail.
 	_, pool, _, err := d.cluster.GetStoragePoolInAnyState(req.Name)
-	if err != nil && err != db.ErrNoSuchObject {
+	if err != nil && !response.IsNotFoundError(err) {
 		return response.InternalError(err)
 	}
 
@@ -446,7 +446,7 @@ func storagePoolsPostCluster(d *Daemon, pool *api.StoragePool, req api.StoragePo
 		return tx.StoragePoolErrored(req.Name)
 	})
 	if err != nil {
-		if err == db.ErrNoSuchObject {
+		if response.IsNotFoundError(err) {
 			return fmt.Errorf("Pool not pending on any node (use --target <node> first)")
 		}
 		return err

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -176,7 +176,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 	// Ensure that the snapshot doesn't already exist.
 	_, _, err = d.cluster.GetLocalStoragePoolVolume(projectName, fmt.Sprintf("%s/%s", volumeName, req.Name), volumeType, poolID)
-	if err != db.ErrNoSuchObject {
+	if !response.IsNotFoundError(err) {
 		if err != nil {
 			return response.SmartError(err)
 		}


### PR DESCRIPTION
Part of addressing https://github.com/lxc/lxd/issues/5548

Allows us to start replacing the old not found error types with the new `api.StatusError` type (that will include context about specifically the type of entity not found) without having to worry about changing the behaviour of the caller.