### PR TITLE
Use allow inconsistent for cluster migrations

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -621,10 +621,11 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 
 	// Source request
 	sourceReq := api.InstancePost{
-		Migration:     true,
-		Live:          req.Source.Live,
-		ContainerOnly: req.Source.ContainerOnly, // Deprecated, use InstanceOnly.
-		InstanceOnly:  req.Source.InstanceOnly,
+		Migration:         true,
+		Live:              req.Source.Live,
+		ContainerOnly:     req.Source.ContainerOnly, // Deprecated, use InstanceOnly.
+		InstanceOnly:      req.Source.InstanceOnly,
+		AllowInconsistent: req.Source.AllowInconsistent,
 	}
 
 	// Push mode migration

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -843,6 +843,10 @@ func (r *ProtocolLXD) MigrateInstance(name string, instance api.InstancePost) (O
 		return nil, fmt.Errorf("The server is missing the required \"instance_project_move\" API extension")
 	}
 
+	if instance.AllowInconsistent && !r.HasExtension("cluster_migration_inconsistent_copy") {
+		return nil, fmt.Errorf("The server is missing the required \"cluster_migration_inconsistent_copy\" API extension")
+	}
+
 	// Quick check.
 	if !instance.Migration {
 		return nil, fmt.Errorf("Can't ask for a rename through MigrateInstance")

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1636,3 +1636,7 @@ client authentication.
 
 ## images\_target\_project
 Adds ability to copy image to a project different from the source.
+
+## cluster\_migration\_inconsistent\_copy
+Adds `allow_inconsistent` field to `POST /1.0/instances/<name>`. Set to true to allow inconsistent copying between cluster
+members.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -754,6 +754,11 @@ definitions:
         example: X509 PEM certificate
         type: string
         x-go-name: Certificate
+      project:
+        description: Project name
+        example: project1
+        type: string
+        x-go-name: Project
       secret:
         description: Image receive secret
         example: RANDOM-STRING
@@ -1462,6 +1467,11 @@ definitions:
     x-go-package: github.com/lxc/lxd/shared/api
   InstancePost:
     properties:
+      allow_inconsistent:
+        description: AllowInconsistent allow inconsistent copies when migrating.
+        example: false
+        type: boolean
+        x-go-name: AllowInconsistent
       container_only:
         description: Whether snapshots should be discarded (migration only, deprecated,
           use instance_only)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -521,7 +521,7 @@ func instancePostProjectMigration(d *Daemon, inst instance.Instance, newName str
 }
 
 // Move a non-ceph container to another cluster node.
-func instancePostClusteringMigrate(d *Daemon, r *http.Request, inst instance.Instance, newName string, newNode string, stateful bool) (func(op *operations.Operation) error, error) {
+func instancePostClusteringMigrate(d *Daemon, r *http.Request, inst instance.Instance, newName string, newNode string, stateful bool, allowInconsistent bool) (func(op *operations.Operation) error, error) {
 	var sourceAddress string
 	var targetAddress string
 
@@ -606,8 +606,9 @@ func instancePostClusteringMigrate(d *Daemon, r *http.Request, inst instance.Ins
 		}
 
 		args := lxd.InstanceCopyArgs{
-			Name: destName,
-			Mode: "pull",
+			Name:              destName,
+			Mode:              "pull",
+			AllowInconsistent: allowInconsistent,
 		}
 
 		copyOp, err := dest.CopyInstance(source, *entry, &args)
@@ -932,7 +933,7 @@ func migrateInstance(d *Daemon, r *http.Request, inst instance.Instance, targetN
 		return err
 	}
 
-	f, err := instancePostClusteringMigrate(d, r, inst, req.Name, targetNode, req.Live)
+	f, err := instancePostClusteringMigrate(d, r, inst, req.Name, targetNode, req.Live, req.AllowInconsistent)
 	if err != nil {
 		return err
 	}

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -90,6 +90,12 @@ type InstancePost struct {
 	//
 	// API extension: instance_project_move
 	Project string `json:"project" yaml:"project"`
+
+	// AllowInconsistent allow inconsistent copies when migrating.
+	// Example: false
+	//
+	// API extension: instance_allow_inconsistent_copy
+	AllowInconsistent bool `json:"allow_inconsistent" yaml:"allow_inconsistent"`
 }
 
 // InstancePostTarget represents the migration target host and operation.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -323,6 +323,7 @@ var APIExtensions = []string{
 	"projects_restricted_intercept",
 	"metrics_authentication",
 	"images_target_project",
+	"cluster_migration_inconsistent_copy",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
When making a calling `InstancePost` to set up a migration, the value of `AllowInconsistent` was not being set. This change should stop instances from being frozen when copying from one remote to another (e.g. `lxc copy remote1:a remote2:b --allow-inconsistent`).

Closes #10091 