### PR TITLE
LXD: Allow disabling shiftfs independently of idmapped mount support 

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -32,4 +32,5 @@ Name                            | Description
 `LXD_UNPRIVILEGED_ONLY`         | If set to `true`, enforces that only unprivileged containers can be created. Note that any privileged containers that have been created before setting LXD_UNPRIVILEGED_ONLY will continue to be privileged. To use this option effectively it should be set when the LXD daemon is first setup.
 `LXD_OVMF_PATH`                 | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd`
 `LXD_SHIFTFS_DISABLE`           | Disable shiftfs support (useful when testing traditional UID shifting)
+`LXD_IDMAPPED_MOUNTS_DISABLE`   | Disable idmapped mounts support (useful when testing traditional UID shifting)
 `LXD_DEVMONITOR_DIR`            | Path to be monitored by the device monitor. This is primarily for testing.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -957,7 +957,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Detect idmapped mounts support.
-	if shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
+	if shared.IsTrue(os.Getenv("LXD_IDMAPPED_MOUNTS_DISABLE")) {
 		logger.Info(" - idmapped mounts kernel support: disabled")
 	} else if kernelSupportsIdmappedMounts() {
 		d.os.IdmappedMounts = true


### PR DESCRIPTION
Adds `LXD_IDMAPPED_MOUNTS_DISABLE` env var to allow disabling shiftfs independently of idmapped mount support.

This is because the LXD snap package uses `LXD_SHIFTFS_DISABLE=true` to disable shiftfs support, but we do not want to also disable idmapped mount support.

This fixes an issue introduced with https://github.com/lxc/lxd/pull/6558

Reported from https://discuss.linuxcontainers.org/t/disk-device-inside-unprivileged-container-with-shiftfs/13622

