### PR TITLE
lxd/network/ovn: Don't use HostPathFollow on OVN configs

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -247,9 +247,9 @@ func (o *OVN) xbctl(southbound bool, args ...string) (string, error) {
 
 	if strings.Contains(dbAddr, "ssl:") {
 		sslArgs := []string{
-			"-c", shared.HostPathFollow("/etc/ovn/cert_host"),
-			"-p", shared.HostPathFollow("/etc/ovn/key_host"),
-			"-C", shared.HostPathFollow("/etc/ovn/ovn-central.crt"),
+			"-c", "/etc/ovn/cert_host",
+			"-p", "/etc/ovn/key_host",
+			"-C", "/etc/ovn/ovn-central.crt",
 		}
 
 		args = append(sslArgs, args...)


### PR DESCRIPTION
The snap has a generated /etc/ovn which always points to the right
location, so we shouldn't be trying to directly reach the host path.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>