### PR TITLE
lxd-agent: cleaner shutdown sequence

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2085,6 +2085,8 @@ Documentation=https://linuxcontainers.org/lxd
 ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
 Before=cloud-init.target cloud-init.service cloud-init-local.service
 DefaultDependencies=no
+After=run-lxd_agent.mount
+Requires=run-lxd_agent.mount
 
 [Service]
 Type=notify


### PR DESCRIPTION
This prevents the following during shutdown (`journalctl -b-1 --grep lxd`):

```
Mar 21 21:03:17 foo systemd[1]: Unmounting /run/lxd_agent...
Mar 21 21:03:17 foo umount[487]: umount: /run/lxd_agent: target is busy.
Mar 21 21:03:17 foo systemd[1]: run-lxd_agent.mount: Mount process exited, code=exited, status=32/n/a
Mar 21 21:03:17 foo systemd[1]: Failed unmounting /run/lxd_agent.
```