### PR TITLE
Storage: Update GetPoolByInstance to use instance's StoragePool() function

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -334,6 +334,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 				Profiles:     srcSnap.Profiles(),
 				Project:      opts.targetInstance.Project,
 				ExpiryDate:   srcSnap.ExpiryDate(),
+				CreationDate: srcSnap.CreationDate(),
 			}
 
 			// Create the snapshots.
@@ -342,12 +343,6 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 				return nil, fmt.Errorf("Failed creating instance snapshot record %q: %w", newSnapName, err)
 			}
 			defer snapInstOp.Done(err)
-
-			// Set snapshot creation date to that of the source snapshot.
-			err = s.Cluster.UpdateInstanceSnapshotCreationDate(snapInst.ID(), srcSnap.CreationDate())
-			if err != nil {
-				return nil, err
-			}
 
 			snapList = append(snapList, &snapInst)
 		}

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -943,18 +943,12 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 					}
 				}
 
-				// Check if snapshot exists already and if not then create
-				// a new snapshot DB record so that the storage layer can
-				// populate the volume on the storage device.
-				_, err := instance.LoadByProjectAndName(state, args.Instance.Project(), snapArgs.Name)
+				// Create the snapshot instance.
+				_, snapInstOp, err := instance.CreateInternal(state, snapArgs, true, nil, revert)
 				if err != nil {
-					// Create the snapshot as it doesn't seem to exist.
-					_, snapInstOp, err := instance.CreateInternal(state, snapArgs, true, nil, revert)
-					if err != nil {
-						return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
-					}
-					defer snapInstOp.Done(err)
+					return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 				}
+				defer snapInstOp.Done(err)
 			}
 		}
 

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -92,7 +92,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 	// Only send snapshots when requested.
 	if !s.volumeOnly {
 		var err error
-		snaps, err := storagePools.VolumeSnapshotsGet(state, projectName, poolName, volName, db.StoragePoolVolumeTypeCustom)
+		snaps, err := storagePools.VolumeDBSnapshotsGet(state, pool.ID(), projectName, volName, db.StoragePoolVolumeTypeCustom)
 		if err == nil {
 			for _, snap := range snaps {
 				_, snapVolume, err := state.Cluster.GetLocalStoragePoolVolume(projectName, snap.Name, db.StoragePoolVolumeTypeCustom, pool.ID())
@@ -334,7 +334,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 	if c.refresh {
 		// Get our existing snapshots.
 		targetSnapshots := []string{}
-		snaps, err := storagePools.VolumeSnapshotsGet(state, projectName, poolName, req.Name, db.StoragePoolVolumeTypeCustom)
+		snaps, err := storagePools.VolumeDBSnapshotsGet(state, pool.ID(), projectName, req.Name, db.StoragePoolVolumeTypeCustom)
 		if err == nil {
 			for _, snap := range snaps {
 				_, snapName, _ := shared.InstanceGetParentAndSnapshotName(snap.Name)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1185,10 +1185,11 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			return err
 		}
 
-		// Create database entry for new storage volume snapshots.
+		// Create database entries for new storage volume snapshots.
 		for _, snapshot := range syncSnapshots {
 			_, snapshotName, _ := shared.InstanceGetParentAndSnapshotName(snapshot.Name)
 
+			// Copy volume config from source snapshot.
 			err = VolumeDBCreate(b, projectName, fmt.Sprintf("%s/%s", volName, snapshotName), snapshot.Description, drivers.VolumeTypeCustom, true, snapshot.Config, snapshot.ExpiryDate, contentType)
 			if err != nil {
 				return err
@@ -3155,10 +3156,11 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 
 		revert.Add(func() { VolumeDBDelete(b, projectName, volName, vol.Type()) })
 
+		// Create database entries for new storage volume snapshots.
 		for _, snapName := range snapshotNames {
 			newSnapshotName := drivers.GetSnapshotVolumeName(volName, snapName)
 
-			// Create database entry for new storage volume snapshot.
+			// Copy volume config from parent.
 			err = VolumeDBCreate(b, projectName, newSnapshotName, desc, vol.Type(), true, vol.Config(), time.Time{}, vol.ContentType())
 			if err != nil {
 				return err
@@ -3364,10 +3366,11 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	}
 
 	if len(args.Snapshots) > 0 {
+		// Create database entries for new storage volume snapshots.
 		for _, snapName := range args.Snapshots {
 			newSnapshotName := drivers.GetSnapshotVolumeName(args.Name, snapName)
 
-			// Create database entry for new storage volume snapshot.
+			// Copy volume config from parent.
 			err = VolumeDBCreate(b, projectName, newSnapshotName, args.Description, vol.Type(), true, vol.Config(), time.Time{}, vol.ContentType())
 			if err != nil {
 				return err
@@ -3911,6 +3914,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	defer revert.Fail()
 
 	// Create database entry for new storage volume snapshot.
+	// Copy volume config from parent.
 	err = VolumeDBCreate(b, projectName, fullSnapshotName, parentVol.Description, drivers.VolumeTypeCustom, true, parentVol.Config, newExpiryDate, drivers.ContentType(parentVol.ContentType))
 	if err != nil {
 		return err

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2202,7 +2202,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 	revert.Add(func() { b.driver.UnmountVolume(vol, false, op) })
 
 	diskPath, err := b.getInstanceDisk(inst)
-	if err != nil && err != drivers.ErrNotSupported {
+	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, fmt.Errorf("Failed getting disk path: %w", err)
 	}
 
@@ -2589,7 +2589,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	}
 
 	diskPath, err := b.getInstanceDisk(inst)
-	if err != nil && err != drivers.ErrNotSupported {
+	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, fmt.Errorf("Failed getting disk path: %w", err)
 	}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -954,7 +954,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		// If we are copying snapshots, retrieve a list of snapshots from source volume.
 		snapshotNames := []string{}
 		if snapshots {
-			snapshots, err := VolumeSnapshotsGet(b.state, src.Project(), srcPool.Name(), src.Name(), volDBType)
+			snapshots, err := VolumeDBSnapshotsGet(b.state, srcPool.ID(), src.Project(), src.Name(), volDBType)
 			if err != nil {
 				return err
 			}
@@ -1137,12 +1137,12 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 	syncSnapshots := []db.StorageVolumeArgs{}
 	if snapshots {
 		// Detect added/deleted snapshots.
-		srcSnapshots, err := VolumeSnapshotsGet(srcPool.state, srcProjectName, srcPoolName, srcVolName, db.StoragePoolVolumeTypeCustom)
+		srcSnapshots, err := VolumeDBSnapshotsGet(srcPool.state, srcPool.ID(), srcProjectName, srcVolName, db.StoragePoolVolumeTypeCustom)
 		if err != nil {
 			return err
 		}
 
-		destSnapshots, err := VolumeSnapshotsGet(b.state, projectName, b.Name(), volName, db.StoragePoolVolumeTypeCustom)
+		destSnapshots, err := VolumeDBSnapshotsGet(b.state, b.ID(), projectName, volName, db.StoragePoolVolumeTypeCustom)
 		if err != nil {
 			return err
 		}
@@ -3113,7 +3113,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	// If we are copying snapshots, retrieve a list of snapshots from source volume.
 	snapshotNames := []string{}
 	if snapshots {
-		snapshots, err := VolumeSnapshotsGet(b.state, srcProjectName, srcPoolName, srcVolName, db.StoragePoolVolumeTypeCustom)
+		snapshots, err := VolumeDBSnapshotsGet(b.state, srcPool.ID(), srcProjectName, srcVolName, db.StoragePoolVolumeTypeCustom)
 		if err != nil {
 			return err
 		}
@@ -3413,7 +3413,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 	}
 
 	// Rename each snapshot to have the new parent volume prefix.
-	snapshots, err := VolumeSnapshotsGet(b.state, projectName, b.name, volName, db.StoragePoolVolumeTypeCustom)
+	snapshots, err := VolumeDBSnapshotsGet(b.state, b.ID(), projectName, volName, db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -3671,7 +3671,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	// Retrieve a list of snapshots.
-	snapshots, err := VolumeSnapshotsGet(b.state, projectName, b.name, volName, db.StoragePoolVolumeTypeCustom)
+	snapshots, err := VolumeDBSnapshotsGet(b.state, b.ID(), projectName, volName, db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -229,14 +229,14 @@ func GetPoolByName(state *state.State, name string) (Pool, error) {
 // If the pool's driver is not recognised then drivers.ErrUnknownDriver is returned. If the pool's
 // driver does not support the instance's type then drivers.ErrNotSupported is returned.
 func GetPoolByInstance(s *state.State, inst instance.Instance) (Pool, error) {
-	poolName, err := s.Cluster.GetInstancePool(inst.Project(), inst.Name())
+	poolName, err := inst.StoragePool()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed getting instance storage pool name: %w", err)
 	}
 
 	pool, err := GetPoolByName(s, poolName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
 	}
 
 	volType, err := InstanceTypeToVolumeType(inst.Type())

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -84,7 +84,7 @@ type Pool interface {
 
 	// Custom volumes.
 	CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, contentType drivers.ContentType, op *operations.Operation) error
-	CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error
+	CreateCustomVolumeFromCopy(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
 	UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error
 	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
@@ -93,7 +93,7 @@ type Pool interface {
 	MountCustomVolume(projectName string, volName string, op *operations.Operation) error
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 	ImportCustomVolume(projectName string, poolVol backup.Config, op *operations.Operation) error
-	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error
+	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
 
 	// Custom volume snapshots.
 	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newExpiryDate time.Time, op *operations.Operation) error

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -348,14 +348,9 @@ var StorageVolumeConfigKeys = map[string]func(value string) ([]string, error){
 	},
 }
 
-// VolumeSnapshotsGet returns a list of snapshots of the form <volume>/<snapshot-name>.
-func VolumeSnapshotsGet(s *state.State, projectName string, pool string, volume string, volType int) ([]db.StorageVolumeArgs, error) {
-	poolID, err := s.Cluster.GetStoragePoolID(pool)
-	if err != nil {
-		return nil, err
-	}
-
-	snapshots, err := s.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(projectName, volume, volType, poolID)
+// VolumeDBSnapshotsGet loads a list of snapshots volumes from the database.
+func VolumeDBSnapshotsGet(state *state.State, poolID int64, projectName string, volume string, volType int) ([]db.StorageVolumeArgs, error) {
+	snapshots, err := state.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(projectName, volume, volType, poolID)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -216,6 +216,7 @@ func VolumeDBGet(pool *lxdBackend, projectName string, volumeName string, volume
 }
 
 // VolumeDBCreate creates a volume in the database.
+// If volumeConfig is supplied, it is modified with any driver level default config options (if not set).
 func VolumeDBCreate(pool *lxdBackend, projectName string, volumeName string, volumeDescription string, volumeType drivers.VolumeType, snapshot bool, volumeConfig map[string]string, expiryDate time.Time, contentType drivers.ContentType) error {
 	// Convert the volume type to our internal integer representation.
 	volDBType, err := VolumeTypeToDBType(volumeType)

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -619,7 +619,7 @@ func doCustomVolumeRefresh(d *Daemon, r *http.Request, requestProjectName string
 			return fmt.Errorf("No source volume name supplied")
 		}
 
-		err = pool.RefreshCustomVolume(projectName, req.Source.Project, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, req.Source.VolumeOnly, op)
+		err = pool.RefreshCustomVolume(projectName, req.Source.Project, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 		if err != nil {
 			return err
 		}
@@ -662,7 +662,7 @@ func doVolumeCreateOrCopy(d *Daemon, r *http.Request, requestProjectName string,
 			return pool.CreateCustomVolume(projectName, req.Name, req.Description, req.Config, contentType, op)
 		}
 
-		return pool.CreateCustomVolumeFromCopy(projectName, req.Source.Project, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, req.Source.VolumeOnly, op)
+		return pool.CreateCustomVolumeFromCopy(projectName, req.Source.Project, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 	}
 
 	// If no source name supplied then this a volume create operation.
@@ -1164,7 +1164,7 @@ func storagePoolVolumeTypePostMove(d *Daemon, r *http.Request, poolName string, 
 
 		// Provide empty description and nil config to instruct CreateCustomVolumeFromCopy to copy it
 		// from source volume.
-		err = newPool.CreateCustomVolumeFromCopy(projectName, requestProjectName, newVol.Name, "", nil, pool.Name(), vol.Name, false, op)
+		err = newPool.CreateCustomVolumeFromCopy(projectName, requestProjectName, newVol.Name, "", nil, pool.Name(), vol.Name, true, op)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This ensures that it will use an pre-loaded storage pool var inside the instance,
to avoid extra DB queries.

This is also essential as we move to creating the storage volume DB records in the
storage package, as at instance create time the storage pool to use is derived from
the instance's root disk config and then that storage pool is pre-loaded inside the
instance. Meaning that we can then access it to create the instance's volume, whereas
without this the storage volume select query would fail as the DB record hasn't been
created yet.

Also improves error messages and several other storage related improvements or clarifications.