### PR TITLE
Storage: Manage instance storage volume database records in storage package

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -756,7 +756,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 
 	instDBArgs := backupConf.ToInstanceDBArgs(projectName)
 
-	_, instOp, err := instance.CreateInternal(d.State(), *instDBArgs, true, nil, revert)
+	_, instOp, err := instance.CreateInternal(d.State(), *instDBArgs, true, revert)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -848,7 +848,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 			Name:         snapInstName,
 			Profiles:     snap.Profiles,
 			Stateful:     snap.Stateful,
-		}, true, nil, revert)
+		}, true, revert)
 		if err != nil {
 			return fmt.Errorf("Failed creating instance snapshot record %q: %w", snap.Name, err)
 		}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -389,7 +389,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 				}
 
 				// Import custom volume and any snapshots.
-				err = pool.ImportCustomVolume(customStorageProjectName, *poolVol, nil)
+				err = pool.ImportCustomVolume(customStorageProjectName, poolVol, nil)
 				if err != nil {
 					return response.SmartError(fmt.Errorf("Failed importing custom volume %q in project %q: %w", poolVol.Volume.Name, projectName, err))
 				}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -473,19 +473,13 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 
 	internalImportRootDevicePopulate(pool.Name(), poolVol.Container.Devices, poolVol.Container.ExpandedDevices, profiles)
 
-	// Extract volume config from backup file if present.
-	var volConfig map[string]string
-	if poolVol.Volume != nil {
-		volConfig = poolVol.Volume.Config
-	}
-
 	dbInst := poolVol.ToInstanceDBArgs(projectName)
 
 	if dbInst.Type < 0 {
 		return nil, fmt.Errorf("Invalid instance type")
 	}
 
-	inst, instOp, err := instance.CreateInternal(s, *dbInst, false, volConfig, revert)
+	inst, instOp, err := instance.CreateInternal(s, *dbInst, false, revert)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -535,7 +529,7 @@ func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Poo
 		Name:         poolVol.Container.Name + shared.SnapshotDelimiter + snap.Name,
 		Profiles:     snap.Profiles,
 		Stateful:     snap.Stateful,
-	}, false, nil, revert)
+	}, false, revert)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance snapshot record %q: %w", snap.Name, err)
 	}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -434,7 +434,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 				}
 
 				// Recreate instance mount path and symlinks (must come after snapshot recovery).
-				err = pool.ImportInstance(inst, nil)
+				err = pool.ImportInstance(inst, poolVol, nil)
 				if err != nil {
 					return response.SmartError(fmt.Errorf("Failed importing instance %q in project %q: %w", poolVol.Container.Name, projectName, err))
 				}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -6,6 +6,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -697,7 +698,7 @@ SELECT storage_pools.name FROM storage_pools
 	err := c.tx.QueryRow(query, inargs...).Scan(outargs...)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return "", ErrNoSuchObject
+			return "", api.StatusErrorf(http.StatusNotFound, "Instance storage pool not found")
 		}
 
 		return "", err

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -730,7 +731,7 @@ func (c *Cluster) getStoragePool(onlyCreated bool, where string, args ...interfa
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return -1, nil, nil, ErrNoSuchObject
+			return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 		}
 
 		return -1, nil, nil, err

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -35,7 +35,7 @@ func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, 
 	defer revert.Fail()
 
 	// Create the instance record.
-	inst, instOp, err := instance.CreateInternal(d.State(), args, true, nil, revert)
+	inst, instOp, err := instance.CreateInternal(d.State(), args, true, revert)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -150,7 +150,7 @@ func instanceCreateFromImage(d *Daemon, r *http.Request, args db.InstanceArgs, h
 	args.BaseImage = hash
 
 	// Create the instance.
-	inst, instOp, err := instance.CreateInternal(s, args, true, nil, revert)
+	inst, instOp, err := instance.CreateInternal(s, args, true, revert)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -216,7 +216,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	// If we are not in refresh mode, then create a new instance as we are in copy mode.
 	if !opts.refresh {
 		// Create the instance.
-		inst, instOp, err = instance.CreateInternal(s, opts.targetInstance, true, nil, revert)
+		inst, instOp, err = instance.CreateInternal(s, opts.targetInstance, true, revert)
 		if err != nil {
 			return nil, fmt.Errorf("Failed creating instance record: %w", err)
 		}
@@ -338,7 +338,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			}
 
 			// Create the snapshots.
-			snapInst, snapInstOp, err := instance.CreateInternal(s, snapInstArgs, true, nil, revert)
+			snapInst, snapInstOp, err := instance.CreateInternal(s, snapInstArgs, true, revert)
 			if err != nil {
 				return nil, fmt.Errorf("Failed creating instance snapshot record %q: %w", newSnapName, err)
 			}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -221,31 +221,6 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			return nil, fmt.Errorf("Failed creating instance record: %w", err)
 		}
 		defer instOp.Done(err)
-
-		// Override the storage volume to match the source (if exists on the same pool).
-		pool, err := storagePools.GetPoolByInstance(s, inst)
-		if err != nil {
-			return nil, fmt.Errorf("Failed loading instance storage pool: %w", err)
-		}
-
-		volType, err := storagePools.InstanceTypeToVolumeType(inst.Type())
-		if err != nil {
-			return nil, err
-		}
-
-		volDBType, err := storagePools.VolumeTypeToDBType(volType)
-		if err != nil {
-			return nil, err
-		}
-
-		src := opts.sourceInstance
-		_, srcVol, err := s.Cluster.GetLocalStoragePoolVolume(src.Project(), src.Name(), volDBType, pool.ID())
-		if err == nil {
-			err = s.Cluster.UpdateStoragePoolVolume(inst.Project(), inst.Name(), volDBType, pool.ID(), srcVol.Description, srcVol.Config)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to update instance volume config: %w", err)
-			}
-		}
 	}
 
 	// At this point we have already figured out the instance's root disk device so we can simply retrieve it

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -559,7 +559,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 	}
 
 	// Create the snapshot.
-	snap, snapInstOp, err := instance.CreateInternal(d.state, args, true, nil, revert)
+	snap, snapInstOp, err := instance.CreateInternal(d.state, args, true, revert)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance snapshot record %q: %w", name, err)
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -172,7 +172,7 @@ func qemuInstantiate(s *state.State, args db.InstanceArgs, expandedDevices devic
 // qemuCreate creates a new storage volume record and returns an initialised Instance.
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
 // revert's Fail() or Success() function as needed.
-func qemuCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]string, revert *revert.Reverter) (instance.Instance, error) {
+func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
 	// Create the instance struct.
 	d := &qemu{
 		common: common{
@@ -268,40 +268,6 @@ func qemuCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]st
 	if !storagePoolSupported {
 		return nil, fmt.Errorf("Storage pool does not support instance type")
 	}
-
-	// Create a new database entry for the instance's storage volume.
-	if d.IsSnapshot() {
-		// Copy volume config from parent.
-		parentName, _, _ := shared.InstanceGetParentAndSnapshotName(args.Name)
-		_, parentVol, err := s.Cluster.GetLocalStoragePoolVolume(args.Project, parentName, db.StoragePoolVolumeTypeVM, d.storagePool.ID())
-		if err != nil {
-			return nil, fmt.Errorf("Failed loading source volume for snapshot: %w", err)
-		}
-
-		_, err = s.Cluster.CreateStorageVolumeSnapshot(args.Project, args.Name, "", db.StoragePoolVolumeTypeVM, d.storagePool.ID(), parentVol.Config, time.Time{})
-		if err != nil {
-			return nil, fmt.Errorf("Failed creating storage record for snapshot: %w", err)
-		}
-	} else {
-		// Fill default config for new instances.
-		if volumeConfig == nil {
-			volumeConfig = make(map[string]string)
-		}
-
-		err = d.storagePool.FillInstanceConfig(d, volumeConfig)
-		if err != nil {
-			return nil, fmt.Errorf("Failed filling default config: %w", err)
-		}
-
-		_, err = s.Cluster.CreateStoragePoolVolume(args.Project, args.Name, "", db.StoragePoolVolumeTypeVM, d.storagePool.ID(), volumeConfig, db.StoragePoolVolumeContentTypeBlock)
-		if err != nil {
-			return nil, fmt.Errorf("Failed creating storage record: %w", err)
-		}
-	}
-
-	revert.Add(func() {
-		s.Cluster.RemoveStoragePoolVolume(args.Project, args.Name, db.StoragePoolVolumeTypeVM, d.storagePool.ID())
-	})
 
 	if !d.IsSnapshot() {
 		// Add devices to instance.

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -101,11 +101,11 @@ func validDevices(state *state.State, projectName string, instanceType instancet
 	return nil
 }
 
-func create(s *state.State, args db.InstanceArgs, volumeConfig map[string]string, revert *revert.Reverter) (instance.Instance, error) {
+func create(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
 	if args.Type == instancetype.Container {
-		return lxcCreate(s, args, volumeConfig, revert)
+		return lxcCreate(s, args, revert)
 	} else if args.Type == instancetype.VM {
-		return qemuCreate(s, args, volumeConfig, revert)
+		return qemuCreate(s, args, revert)
 	}
 
 	return nil, fmt.Errorf("Instance type invalid")

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -869,12 +869,11 @@ func ValidName(instanceName string, isSnapshot bool) error {
 }
 
 // CreateInternal creates an instance record and storage volume record in the database and sets up devices.
-// Accepts an (optionally nil) volumeConfig map that can be used to specify extra custom settings for the volume
-// record. Also accepts a reverter that revert steps this function does will be added to. It is up to the caller to
+// Accepts a reverter that revert steps this function does will be added to. It is up to the caller to
 // call the revert's Fail() or Success() function as needed.
 // Returns the created instance, along with a "create" operation lock that needs to be marked as Done once the
 // instance is fully completed.
-func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volumeConfig map[string]string, revert *revert.Reverter) (Instance, *operationlock.InstanceOperation, error) {
+func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, revert *revert.Reverter) (Instance, *operationlock.InstanceOperation, error) {
 	// Check instance type requested is supported by this machine.
 	if _, supported := s.InstanceTypes[args.Type]; !supported {
 		return nil, nil, fmt.Errorf("Instance type %q is not supported on this server", args.Type)

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -46,7 +46,7 @@ var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Ins
 // Create is linked from instance/drivers.create to allow difference instance types to be created.
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
 // revert's Fail() or Success() function as needed.
-var Create func(s *state.State, args db.InstanceArgs, volumeConfig map[string]string, revert *revert.Reverter) (Instance, error)
+var Create func(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (Instance, error)
 
 // CompareSnapshots returns a list of snapshots to sync to the target and a list of
 // snapshots to remove from the target. A snapshot will be marked as "to sync" if it either doesn't
@@ -1084,7 +1084,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 	revert.Add(func() { s.Cluster.DeleteInstance(dbInst.Project, dbInst.Name) })
 
 	args = db.InstanceToArgs(&dbInst)
-	inst, err := Create(s, args, volumeConfig, revert)
+	inst, err := Create(s, args, revert)
 	if err != nil {
 		logger.Error("Failed initialising instance", log.Ctx{"project": args.Project, "instance": args.Name, "type": args.Type, "err": err})
 		return nil, nil, fmt.Errorf("Failed initialising instance: %w", err)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -898,7 +898,7 @@ func instancePostCreateInstanceMountPoint(d *Daemon, inst instance.Instance) err
 		return fmt.Errorf("Failed loading pool of instance on target node: %w", err)
 	}
 
-	err = pool.ImportInstance(inst, nil)
+	err = pool.ImportInstance(inst, nil, nil)
 	if err != nil {
 		return fmt.Errorf("Failed creating mount point of instance on target node: %w", err)
 	}

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -146,6 +146,15 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	op.Done(nil)
 	defer c.Delete(true)
 
+	poolName, err := c.StoragePool()
+	suite.Req.Nil(err)
+
+	pool, err := storagePools.GetPoolByName(state, poolName)
+	suite.Req.Nil(err)
+
+	_, err = state.Cluster.CreateStoragePoolVolume(c.Project(), c.Name(), "", db.StoragePoolVolumeContentTypeFS, pool.ID(), nil, db.StoragePoolVolumeContentTypeFS)
+	suite.Req.Nil(err)
+
 	// Load the container and trigger initLXC()
 	c2, err := instance.LoadByProjectAndName(state, "default", "testFoo")
 	c2.IsRunning()

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -30,7 +30,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c.Delete(true)
@@ -74,7 +74,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c.Delete(true)
@@ -106,7 +106,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 	_, err := suite.d.State().Cluster.CreateNetwork(project.Default, "unknownbr0", "", db.NetworkTypeBridge, nil)
 	suite.Req.Nil(err)
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -141,7 +141,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.Nil(err)
 
 	// Create the container
-	c, op, err := instance.CreateInternal(state, args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(state, args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c.Delete(true)
@@ -170,7 +170,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c.Delete(true)
@@ -187,7 +187,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c.Delete(true)
@@ -203,7 +203,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
@@ -226,7 +226,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.NoError(err)
 	op.Done(nil)
 	err = c.Update(db.InstanceArgs{
@@ -275,7 +275,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
@@ -289,7 +289,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c.Delete(true)
@@ -305,7 +305,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, nil, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c1.Delete(true)
@@ -316,7 +316,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, nil, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c2.Delete(true)
@@ -348,7 +348,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
 		},
-	}, true, nil, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c1.Delete(true)
@@ -359,7 +359,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, nil, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c2.Delete(true)
@@ -392,7 +392,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 			"security.idmap.isolated": "false",
 			"raw.idmap":               "both 1000 1000",
 		},
-	}, true, nil, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer c1.Delete(true)
@@ -431,7 +431,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 			Config: map[string]string{
 				"security.idmap.isolated": "true",
 			},
-		}, true, nil, revert.New())
+		}, true, revert.New())
 
 		/* we should fail if there are no ids left */
 		if i != 6 {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -319,7 +319,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.
-		inst, instOp, err = instance.CreateInternal(d.State(), args, true, nil, revert)
+		inst, instOp, err = instance.CreateInternal(d.State(), args, true, revert)
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed creating instance record: %w", err))
 		}

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -944,7 +944,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 				}
 
 				// Create the snapshot instance.
-				_, snapInstOp, err := instance.CreateInternal(state, snapArgs, true, nil, revert)
+				_, snapInstOp, err := instance.CreateInternal(state, snapArgs, true, revert)
 				if err != nil {
 					return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 				}

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -18,7 +18,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 		Name:      "hal9000",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
+	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	suite.Equal(true, snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -599,38 +599,6 @@ func (b *lxdBackend) instanceEffectiveRootVolume(inst instance.Instance, volConf
 	return &vol, err
 }
 
-// FillInstanceConfig populates the supplied instance volume config map with any defaults based on the storage
-// pool and instance type being used.
-func (b *lxdBackend) FillInstanceConfig(inst instance.Instance, config map[string]string) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name()})
-	logger.Debug("FillInstanceConfig started")
-	defer logger.Debug("FillInstanceConfig finished")
-
-	volType, err := InstanceTypeToVolumeType(inst.Type())
-	if err != nil {
-		return err
-	}
-
-	contentType := InstanceContentType(inst)
-
-	// Get the volume name on storage.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
-
-	// Fill default config in volume (creates internal copy of supplied config and modifies that).
-	vol := b.GetVolume(volType, contentType, volStorageName, config)
-	err = b.driver.FillVolumeConfig(vol)
-	if err != nil {
-		return err
-	}
-
-	// Copy filled volume config back into supplied config map.
-	for k, v := range vol.Config() {
-		config[k] = v
-	}
-
-	return nil
-}
-
 // CreateInstance creates an empty instance.
 func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Operation) error {
 	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name()})

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3884,7 +3884,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backup.Conf
 	// Create the storage volume DB records.
 	err := VolumeDBCreate(b, projectName, poolVol.Volume.Name, poolVol.Volume.Description, drivers.VolumeTypeCustom, false, volumeConfig, time.Time{}, drivers.ContentType(poolVol.Volume.ContentType))
 	if err != nil {
-		return fmt.Errorf("Failed creating custom volume %q record in project %q: %w", poolVol.Volume.Name, projectName, err)
+		return err
 	}
 
 	revert.Add(func() { VolumeDBDelete(b, projectName, poolVol.Volume.Name, drivers.VolumeTypeCustom) })

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2022,12 +2022,12 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 	if len(changedConfig) != 0 {
 		// Check that the volume's size property isn't being changed.
 		if changedConfig["size"] != "" {
-			return fmt.Errorf("Instance volume 'size' property cannot be changed")
+			return fmt.Errorf(`Instance volume "size" property cannot be changed`)
 		}
 
 		// Check that the volume's block.filesystem property isn't being changed.
 		if changedConfig["block.filesystem"] != "" {
-			return fmt.Errorf("Instance volume 'block.filesystem' property cannot be changed")
+			return fmt.Errorf(`Instance volume "block.filesystem" property cannot be changed`)
 		}
 
 		// Load storage volume from database.

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -141,7 +141,7 @@ func (b *mockBackend) ListUnknownVolumes(op *operations.Operation) (map[string][
 	return nil, nil
 }
 
-func (b *mockBackend) ImportInstance(inst instance.Instance, op *operations.Operation) error {
+func (b *mockBackend) ImportInstance(inst instance.Instance, poolVol *backup.Config, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -261,7 +261,7 @@ func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, op
 	return true, nil
 }
 
-func (b *mockBackend) ImportCustomVolume(projectName string, poolVol backup.Config, op *operations.Operation) error {
+func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backup.Config, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -97,10 +97,6 @@ func (b *mockBackend) GetVolume(volType drivers.VolumeType, contentType drivers.
 	return drivers.Volume{}
 }
 
-func (b *mockBackend) FillInstanceConfig(inst instance.Instance, config map[string]string) error {
-	return nil
-}
-
 func (b *mockBackend) CreateInstance(inst instance.Instance, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -45,7 +45,6 @@ type Pool interface {
 	GetVolume(volumeType drivers.VolumeType, contentType drivers.ContentType, name string, config map[string]string) drivers.Volume
 
 	// Instances.
-	FillInstanceConfig(inst instance.Instance, config map[string]string) error
 	CreateInstance(inst instance.Instance, op *operations.Operation) error
 	CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error)
 	CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -55,7 +55,7 @@ type Pool interface {
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error
 	CheckInstanceBackupFileSnapshots(backupConf *backup.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error)
-	ImportInstance(inst instance.Instance, op *operations.Operation) error
+	ImportInstance(inst instance.Instance, poolVol *backup.Config, op *operations.Operation) error
 
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -91,7 +91,7 @@ type Pool interface {
 	GetCustomVolumeUsage(projectName string, volName string) (int64, error)
 	MountCustomVolume(projectName string, volName string, op *operations.Operation) error
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
-	ImportCustomVolume(projectName string, poolVol backup.Config, op *operations.Operation) error
+	ImportCustomVolume(projectName string, poolVol *backup.Config, op *operations.Operation) error
 	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
 
 	// Custom volume snapshots.


### PR DESCRIPTION
This PR completes the move of the storage volume DB record management from being spread over different subsystems in LXD to being exlusively managed in the `lxd/storage` package.

- [x] CreateInstance
- [x] CreateInstanceFromBackup
- [x] CreateInstanceFromCopy
- [x] RefreshInstance
- [x] CreateInstanceFromImage
- [x] CreateInstanceFromMigration
- [x] ImportInstance
- [x] UpdateInstance (nothing to do)
- [x] RestoreInstanceSnapshot (nothing to do)
- [x] DeleteInstanceSnapshot (nothing to do)
- [x] DeleteInstance (nothing to do)

As part of this process I have found several bugs in the existing storage layer, which I have not attempted to fix in this PR in an attempt to minimise the risk of a regression whilst the DB record management is moved.

* https://github.com/lxc/lxd/issues/10118
* https://github.com/lxc/lxd/issues/10117
* https://github.com/lxc/lxd/issues/10103
* https://github.com/lxc/lxd/issues/10102