### PR TITLE
lxd/images: Remove old db entry after image refresh

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1948,6 +1948,12 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 		}
 	}
 
+	// Remove database entry of the old image.
+	err = d.cluster.DeleteImage(id)
+	if err != nil {
+		logger.Debugf("Error deleting image from database: %s", err)
+	}
+
 	setRefreshResult(true)
 	return newInfo, nil
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -240,6 +240,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_image_auto_update "image auto-update"
     run_test test_image_prefer_cached "image prefer cached"
     run_test test_image_import_dir "import image from directory"
+    run_test test_image_refresh "image refresh"
     run_test test_cloud_init "cloud-init"
     run_test test_exec "exec"
     run_test test_concurrent_exec "concurrent exec"


### PR DESCRIPTION
When refreshing an image, the old image was kept in the database whereas
the actual files were deleted.

This removes the database entry of the old image when refreshing.

This fixes #10120.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
