### PR TITLE
lxd/instance/drivers/qemu: Fix block devices

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3152,6 +3152,12 @@ func (d *qemu) addDriveConfig(fdFiles *[]*os.File, bootIndexes map[string]int, d
 		"read-only": false,
 	}
 
+	// If driver is "file", QEMU requires the file to be a regular file.
+	// However, if the file is a character or block device, driver needs to be set to "host_device".
+	if shared.IsBlockdevPath(srcDevPath) {
+		blockDev["driver"] = "host_device"
+	}
+
 	readonly := shared.StringInSlice("ro", driveConf.Opts)
 
 	if readonly {


### PR DESCRIPTION
Drives were always using the "file" driver which required the block
device file to be a regular file. The "file" driver however doesn't work
with character or or block devices.

This fixes the issue by checking whether the file is a character or
block device. In this case, the "host_device" driver is used.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
