### PR TITLE
TLS: do not prefer server ciphersuites selection and require TLS 1.3 minimum for LXD agent

### DIFF
--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -72,11 +72,10 @@ func serverTLSConfig() (*tls.Config, error) {
 		return nil, err
 	}
 
+	// LXD agent only talks with LXD so there is no need
+	// to support old TLS versions
 	tlsConfig := util.ServerTLSConfig(certInfo)
-	tlsConfig.CipherSuites = []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	}
+	tlsConfig.MinVersion = tls.VersionTLS13
 
 	return tlsConfig, nil
 }

--- a/shared/network.go
+++ b/shared/network.go
@@ -66,6 +66,14 @@ func IsConnectionError(err error) bool {
 // certificates used by LXD.
 func InitTLSConfig() *tls.Config {
 	return &tls.Config{
+		// LXD's ciphersuites selection is slightly stronger than what Mozilla
+		// recommends as of March 2022 for the "Intermediate compatibility" level:
+
+		// https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+		// > The cipher suites are all strong and so we allow the client to choose,
+		// > as they will know best if they have support for hardware-accelerated AES
+
+		// With Go 1.17+, Config.PreferServerCipherSuites is now ignored.
 		MinVersion: tls.VersionTLS12,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -75,7 +83,6 @@ func InitTLSConfig() *tls.Config {
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 		},
-		PreferServerCipherSuites: true,
 	}
 }
 


### PR DESCRIPTION
LXD's ciphersuites selection is slightly stronger than what Mozilla
recommends as of March 2022 for the "Intermediate compatibility" level:

https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
> The cipher suites are all strong and so we allow the client to choose,
> as they will know best if they have support for hardware-accelerated AES

With Go 1.17+, `Config.PreferServerCipherSuites` is now ignored.

For the LXD agent, supporting older TLS version makes no sense as the other side of the connection is LXD.