### PR TITLE
Revert "lxd-agent: cleaner shutdown sequence"

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2160,8 +2160,6 @@ Documentation=https://linuxcontainers.org/lxd
 ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
 Before=cloud-init.target cloud-init.service cloud-init-local.service
 DefaultDependencies=no
-After=run-lxd_agent.mount
-Requires=run-lxd_agent.mount
 
 [Service]
 Type=notify


### PR DESCRIPTION
This reverts commit 51eaa589f799d8814ed3fe0af6b8a6995c3daa2b.

This fixes a regression breaking lxd-agent on a variety of Linux distributions.

Closes https://github.com/lxc/lxc-ci/issues/480

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>