### PR TITLE
Image: Fix image refresh record management

### DIFF
--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -5,6 +5,7 @@ package db
 
 import (
 	"database/sql"
+	"net/http"
 	"testing"
 	"time"
 
@@ -202,7 +203,8 @@ func (s *dbTestSuite) Test_ImageGet_for_missing_fingerprint() {
 	var err error
 
 	_, _, err = s.db.GetImage("unknown", ImageFilter{Project: &project})
-	s.Equal(err, ErrNoSuchObject)
+	_, matched := api.StatusErrorMatch(err, http.StatusNotFound)
+	s.True(matched)
 }
 
 func (s *dbTestSuite) Test_ImageExists_true() {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -456,11 +457,11 @@ func (c *Cluster) GetImage(fingerprintPrefix string, filter ImageFilter) (int, *
 	var image api.Image
 	var object Image
 	if fingerprintPrefix == "" {
-		return -1, nil, ErrNoSuchObject
+		return -1, nil, errors.New("No fingerprint prefix specified for the image")
 	}
 
 	if filter.Project == nil {
-		return -1, nil, errors.New("no project specified for the image")
+		return -1, nil, errors.New("No project specified for the image")
 	}
 
 	err := c.Transaction(func(tx *ClusterTx) error {
@@ -481,7 +482,7 @@ func (c *Cluster) GetImage(fingerprintPrefix string, filter ImageFilter) (int, *
 
 		switch len(images) {
 		case 0:
-			return ErrNoSuchObject
+			return api.StatusErrorf(http.StatusNotFound, "Image not found")
 		case 1:
 			object = images[0]
 		default:

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -566,7 +566,7 @@ func (c *Cluster) GetImageFromAnyProject(fingerprint string) (int, *api.Image, e
 func (c *ClusterTx) getImagesByFingerprintPrefix(fingerprintPrefix string, filter ImageFilter) ([]Image, error) {
 	sql := `
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
-FROM images 
+FROM images
 JOIN projects ON images.project_id = projects.id
 WHERE images.fingerprint LIKE ?
 `

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1594,7 +1594,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 			_, pool, _, err := d.cluster.GetStoragePool(fields[0])
 			if err != nil {
-				return fmt.Errorf("Failed to get pool info: %w", err)
+				return fmt.Errorf("Failed to get storage pool info: %w", err)
 			}
 
 			// Add the volume to the list if the pool is backed by remote
@@ -1619,14 +1619,14 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	// for the requested image currently exists.
 	poolIDs, err := d.cluster.GetPoolsWithImage(newImage.Fingerprint)
 	if err != nil {
-		logger.Error("Error getting image pools", log.Ctx{"err": err, "fingerprint": oldFingerprint})
+		logger.Error("Error getting image storage pools", log.Ctx{"err": err, "fingerprint": oldFingerprint})
 		return err
 	}
 
 	// Translate the IDs to poolNames.
 	poolNames, err := d.cluster.GetPoolNamesFromIDs(poolIDs)
 	if err != nil {
-		logger.Error("Error getting image pools", log.Ctx{"err": err, "fingerprint": oldFingerprint})
+		logger.Error("Error getting image storage pools", log.Ctx{"err": err, "fingerprint": oldFingerprint})
 		return err
 	}
 
@@ -1654,7 +1654,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 		resp, _, err := client.GetServer()
 		if err != nil {
-			logger.Error("Failed to retrieve information about cluster member", log.Ctx{"err": err, "address": nodeAddress})
+			logger.Error("Failed to retrieve information about cluster member", log.Ctx{"err": err, "remote": nodeAddress})
 		} else {
 			vol := ""
 
@@ -1685,7 +1685,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 				pool, _, err := client.GetStoragePool(fields[0])
 				if err != nil {
-					logger.Error("Failed to get pool info", log.Ctx{"err": err, "pool": fields[0]})
+					logger.Error("Failed to get storage pool info", log.Ctx{"err": err, "pool": fields[0]})
 				} else {
 					if shared.StringInSlice(pool.Driver, db.StorageRemoteDriverNames()) {
 						imageVolumes = append(imageVolumes, vol)
@@ -1751,12 +1751,12 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 			_, _, err = client.RawQuery("POST", "/internal/image-optimize", req, "")
 			if err != nil {
-				logger.Error("Failed to create image in pool", log.Ctx{"err": err, "pool": poolName, "fingerprint": newImage.Fingerprint})
+				logger.Error("Failed creating new image in storage pool", log.Ctx{"err": err, "remote": nodeAddress, "pool": poolName, "fingerprint": newImage.Fingerprint})
 			}
 
 			err = client.DeleteStoragePoolVolume(poolName, "image", oldFingerprint)
 			if err != nil {
-				logger.Error("Failed to delete image from pool", log.Ctx{"err": err, "pool": poolName, "fingerprint": oldFingerprint})
+				logger.Error("Failed deleting old image from storage pool", log.Ctx{"err": err, "remote": nodeAddress, "pool": poolName, "fingerprint": oldFingerprint})
 			}
 		}
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1609,7 +1609,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	// No need to return with an error as this is only an optimization in the
 	// distribution process. Instead, only log the error.
 	if err != nil {
-		logger.Warn("Failed to load config", log.Ctx{"err": err})
+		logger.Error("Failed to load config", log.Ctx{"err": err})
 	}
 
 	// Skip own node
@@ -1654,7 +1654,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 		resp, _, err := client.GetServer()
 		if err != nil {
-			logger.Warn("Failed to retrieve information about cluster member", log.Ctx{"err": err, "address": nodeAddress})
+			logger.Error("Failed to retrieve information about cluster member", log.Ctx{"err": err, "address": nodeAddress})
 		} else {
 			vol := ""
 
@@ -1685,7 +1685,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 				pool, _, err := client.GetStoragePool(fields[0])
 				if err != nil {
-					logger.Warn("Failed to get pool info", log.Ctx{"err": err, "pool": fields[0]})
+					logger.Error("Failed to get pool info", log.Ctx{"err": err, "pool": fields[0]})
 				} else {
 					if shared.StringInSlice(pool.Driver, db.StorageRemoteDriverNames()) {
 						imageVolumes = append(imageVolumes, vol)
@@ -1751,12 +1751,12 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 			_, _, err = client.RawQuery("POST", "/internal/image-optimize", req, "")
 			if err != nil {
-				logger.Debug("Failed to create image in pool", log.Ctx{"err": err, "pool": poolName, "fingerprint": newImage.Fingerprint})
+				logger.Error("Failed to create image in pool", log.Ctx{"err": err, "pool": poolName, "fingerprint": newImage.Fingerprint})
 			}
 
 			err = client.DeleteStoragePoolVolume(poolName, "image", oldFingerprint)
 			if err != nil {
-				logger.Debug("Failed to delete image from pool", log.Ctx{"err": err, "pool": poolName, "fingerprint": oldFingerprint})
+				logger.Error("Failed to delete image from pool", log.Ctx{"err": err, "pool": poolName, "fingerprint": oldFingerprint})
 			}
 		}
 	}
@@ -1941,7 +1941,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
-			logger.Warn("Error deleting image file", log.Ctx{"fingerprint": fingerprint, "file": fname, "err": err})
+			logger.Error("Error deleting image file", log.Ctx{"fingerprint": fingerprint, "file": fname, "err": err})
 		}
 	}
 
@@ -1950,14 +1950,14 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
-			logger.Warn("Error deleting image rootfs file", log.Ctx{"fingerprint": fingerprint, "file": fname, "err": err})
+			logger.Error("Error deleting image rootfs file", log.Ctx{"fingerprint": fingerprint, "file": fname, "err": err})
 		}
 	}
 
 	// Remove database entry of the old image.
 	err = d.cluster.DeleteImage(id)
 	if err != nil {
-		logger.Warn("Error deleting image from database", log.Ctx{"fingerprint": fingerprint, "err": err})
+		logger.Error("Error deleting image from database", log.Ctx{"fingerprint": fingerprint, "err": err})
 	}
 
 	setRefreshResult(true)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1551,7 +1551,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 		if newImage != nil {
 			err := distributeImage(ctx, d, nodes, fingerprint, newImage)
 			if err != nil {
-				logger.Error("Failed to distribute image", log.Ctx{"err": err, "fingerprint": newImage.Fingerprint})
+				logger.Error("Failed to distribute new image", log.Ctx{"err": err, "fingerprint": newImage.Fingerprint})
 
 				if err == context.Canceled {
 					return nil
@@ -1559,10 +1559,10 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 			}
 
 			for _, ID := range deleteIDs {
-				// Remove the database entry for the image.
+				// Remove the database entry for the image after distributing to cluster members.
 				err = d.cluster.DeleteImage(ID)
 				if err != nil {
-					logger.Error("Error deleting image from database", log.Ctx{"err": err, "fingerprint": fingerprint, "ID": ID})
+					logger.Error("Error deleting old image from database", log.Ctx{"err": err, "fingerprint": fingerprint, "ID": ID})
 				}
 			}
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1429,12 +1429,12 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 			return
 		}
 
-		logger.Infof("Updating images")
+		logger.Info("Updating images")
 		_, err = op.Run()
 		if err != nil {
 			logger.Error("Failed to update images", log.Ctx{"err": err})
 		}
-		logger.Infof("Done updating images")
+		logger.Info("Done updating images")
 	}
 
 	return f, task.Hourly()

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1549,12 +1549,14 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 		}
 
 		if newImage != nil {
-			err := distributeImage(ctx, d, nodes, fingerprint, newImage)
-			if err != nil {
-				logger.Error("Failed to distribute new image", log.Ctx{"err": err, "fingerprint": newImage.Fingerprint})
+			if len(nodes) > 1 {
+				err := distributeImage(ctx, d, nodes, fingerprint, newImage)
+				if err != nil {
+					logger.Error("Failed to distribute new image", log.Ctx{"err": err, "fingerprint": newImage.Fingerprint})
 
-				if err == context.Canceled {
-					return nil
+					if err == context.Canceled {
+						return nil
+					}
 				}
 			}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2190,7 +2190,8 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project db.Proj
 		}
 
 		// Remove the database entry for the image.
-		if err = d.cluster.DeleteImage(imgID); err != nil {
+		err = d.cluster.DeleteImage(imgID)
+		if err != nil {
 			return fmt.Errorf("Error deleting image %q from database: %w", img, err)
 		}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1954,12 +1954,6 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 		}
 	}
 
-	// Remove database entry of the old image.
-	err = d.cluster.DeleteImage(id)
-	if err != nil {
-		logger.Error("Error deleting image from database", log.Ctx{"fingerprint": fingerprint, "err": err})
-	}
-
 	setRefreshResult(true)
 	return newInfo, nil
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1562,7 +1562,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 				// Remove the database entry for the image.
 				err = d.cluster.DeleteImage(ID)
 				if err != nil {
-					logger.Error("Error deleting image from database", log.Ctx{"err": err, "ID": ID})
+					logger.Error("Error deleting image from database", log.Ctx{"err": err, "fingerprint": fingerprint, "ID": ID})
 				}
 			}
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1941,7 +1941,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
-			logger.Debugf("Error deleting image file %s: %s", fname, err)
+			logger.Warn("Error deleting image file", log.Ctx{"fingerprint": fingerprint, "file": fname, "err": err})
 		}
 	}
 
@@ -1950,14 +1950,14 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
-			logger.Debugf("Error deleting image file %s: %s", fname, err)
+			logger.Warn("Error deleting image rootfs file", log.Ctx{"fingerprint": fingerprint, "file": fname, "err": err})
 		}
 	}
 
 	// Remove database entry of the old image.
 	err = d.cluster.DeleteImage(id)
 	if err != nil {
-		logger.Debugf("Error deleting image from database: %s", err)
+		logger.Warn("Error deleting image from database", log.Ctx{"fingerprint": fingerprint, "err": err})
 	}
 
 	setRefreshResult(true)

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -254,7 +254,7 @@ func (op *Operation) done() {
 
 		err := removeDBOperation(op)
 		if err != nil {
-			logger.Warnf("Failed to delete operation %s: %s", op.id, err)
+			logger.Warn("Failed to delete operation", log.Ctx{"operation": op.id, "description": op.description, "status": op.status, "project": op.projectName, "err": err})
 		}
 	}()
 }

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -915,7 +915,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Only delete images if locally stored or running on initial member.
+	// Only perform the deletion of remote volumes on the server handling the request.
 	if !clusterNotification || !pool.Driver().Info().Remote {
 		// Only image volumes should remain now.
 		volumeNames, err := d.cluster.GetStoragePoolVolumesNames(pool.ID())
@@ -929,9 +929,9 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 				return response.InternalError(fmt.Errorf("Failed getting image info for %q: %w", volume, err))
 			}
 
-			err = doDeleteImageFromPool(d.State(), imgInfo.Fingerprint, pool.Name())
+			err = pool.DeleteImage(imgInfo.Fingerprint, nil)
 			if err != nil {
-				return response.InternalError(fmt.Errorf("Error deleting image %q from pool: %w", volume, err))
+				return response.InternalError(fmt.Errorf("Error deleting image %q from storage pool %q: %w", imgInfo.Fingerprint, pool.Name(), err))
 			}
 		}
 	}


### PR DESCRIPTION
- Reverts #10121 so that clustering image refresh tests don't fail.
- Fixes #10120 by moving the image record deletion into the API route handler.
- Improves image refresh logging and errors.
- Ensures full image fingerprint is returned to client when deleting image.
- Distributes manually refreshed image in cluster.