### PR TITLE
shared/network: require TLS 1.2+ if LXD_INSECURE_TLS

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -71,6 +71,8 @@ func InitTLSConfig() *tls.Config {
 	// Restrict to TLS 1.3 unless LXD_INSECURE_TLS is set.
 	if IsFalseOrEmpty(os.Getenv("LXD_INSECURE_TLS")) {
 		config.MinVersion = tls.VersionTLS13
+	} else {
+		config.MinVersion = tls.VersionTLS12
 	}
 
 	return config


### PR DESCRIPTION
`crypto/tls` defaults to enabling TLS 1.0+ on server-side [*].
Before commit f91da807, LXD_INSECURE_TLS relied on the default
CipherSuites list but still had tls.VersionTLS12 as the MinVersion.

Bring back the MinVersion of TLS 1.2.

*: https://pkg.go.dev/crypto/tls#Config