### PR TITLE
Replace interface{} with any

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -380,9 +380,9 @@ type InstanceServer interface {
 	DeleteWarning(UUID string) (err error)
 
 	// Internal functions (for internal use)
-	RawQuery(method string, path string, data interface{}, queryETag string) (resp *api.Response, ETag string, err error)
+	RawQuery(method string, path string, data any, queryETag string) (resp *api.Response, ETag string, err error)
 	RawWebsocket(path string) (conn *websocket.Conn, err error)
-	RawOperation(method string, path string, data interface{}, queryETag string) (op Operation, ETag string, err error)
+	RawOperation(method string, path string, data any, queryETag string) (op Operation, ETag string, err error)
 }
 
 // The ConnectionInfo struct represents general information for a connection.

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -146,7 +146,7 @@ func (r *ProtocolLXD) RequireAuthenticated(authenticated bool) {
 // RawQuery allows directly querying the LXD API
 //
 // This should only be used by internal LXD tools.
-func (r *ProtocolLXD) RawQuery(method string, path string, data interface{}, ETag string) (*api.Response, string, error) {
+func (r *ProtocolLXD) RawQuery(method string, path string, data any, ETag string) (*api.Response, string, error) {
 	// Generate the URL
 	url := fmt.Sprintf("%s%s", r.httpBaseURL.String(), path)
 
@@ -162,7 +162,7 @@ func (r *ProtocolLXD) RawWebsocket(path string) (*websocket.Conn, error) {
 
 // RawOperation allows direct querying of a LXD API endpoint returning
 // background operations.
-func (r *ProtocolLXD) RawOperation(method string, path string, data interface{}, ETag string) (Operation, string, error) {
+func (r *ProtocolLXD) RawOperation(method string, path string, data any, ETag string) (Operation, string, error) {
 	return r.queryOperation(method, path, data, ETag)
 }
 
@@ -193,7 +193,7 @@ func lxdParseResponse(resp *http.Response) (*api.Response, string, error) {
 	return &response, etag, nil
 }
 
-func (r *ProtocolLXD) rawQuery(method string, url string, data interface{}, ETag string) (*api.Response, string, error) {
+func (r *ProtocolLXD) rawQuery(method string, url string, data any, ETag string) (*api.Response, string, error) {
 	var req *http.Request
 	var err error
 
@@ -291,7 +291,7 @@ func (r *ProtocolLXD) setQueryAttributes(uri string) (string, error) {
 	return fields.String(), nil
 }
 
-func (r *ProtocolLXD) query(method string, path string, data interface{}, ETag string) (*api.Response, string, error) {
+func (r *ProtocolLXD) query(method string, path string, data any, ETag string) (*api.Response, string, error) {
 	// Generate the URL
 	url := fmt.Sprintf("%s/1.0%s", r.httpBaseURL.String(), path)
 
@@ -305,7 +305,7 @@ func (r *ProtocolLXD) query(method string, path string, data interface{}, ETag s
 	return r.rawQuery(method, url, data, ETag)
 }
 
-func (r *ProtocolLXD) queryStruct(method string, path string, data interface{}, ETag string, target interface{}) (string, error) {
+func (r *ProtocolLXD) queryStruct(method string, path string, data any, ETag string, target any) (string, error) {
 	resp, etag, err := r.query(method, path, data, ETag)
 	if err != nil {
 		return "", err
@@ -323,7 +323,7 @@ func (r *ProtocolLXD) queryStruct(method string, path string, data interface{}, 
 	return etag, nil
 }
 
-func (r *ProtocolLXD) queryOperation(method string, path string, data interface{}, ETag string) (Operation, string, error) {
+func (r *ProtocolLXD) queryOperation(method string, path string, data any, ETag string) (Operation, string, error) {
 	// Attempt to setup an early event listener
 	listener, err := r.GetEvents()
 	if err != nil {

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -639,7 +639,7 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 
 		value, ok := opAPI.Metadata["fds"]
 		if ok {
-			values := value.(map[string]interface{})
+			values := value.(map[string]any)
 			for k, v := range values {
 				fds[k] = v.(string)
 			}
@@ -1524,7 +1524,7 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 
 	value, ok := opAPI.Metadata["fds"]
 	if ok {
-		values := value.(map[string]interface{})
+		values := value.(map[string]any)
 		for k, v := range values {
 			fds[k] = v.(string)
 		}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -918,7 +918,7 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 
 		value, ok := opAPI.Metadata["fds"]
 		if ok {
-			values := value.(map[string]interface{})
+			values := value.(map[string]any)
 			for k, v := range values {
 				fds[k] = v.(string)
 			}
@@ -2067,7 +2067,7 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 
 	value, ok := opAPI.Metadata["fds"]
 	if ok {
-		values := value.(map[string]interface{})
+		values := value.(map[string]any)
 		for k, v := range values {
 			fds[k] = v.(string)
 		}
@@ -2154,7 +2154,7 @@ func (r *ProtocolLXD) ConsoleInstanceDynamic(instanceName string, console api.In
 
 	value, ok := opAPI.Metadata["fds"]
 	if ok {
-		values := value.(map[string]interface{})
+		values := value.(map[string]any)
 		for k, v := range values {
 			fds[k] = v.(string)
 		}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -676,7 +676,7 @@ func (c *cmdConfigShow) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Instance or snapshot config
-		var brief interface{}
+		var brief any
 
 		if shared.IsSnapshot(resource.name) {
 			// Snapshot

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -152,7 +152,7 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Read back to a clean interface
-		var rawEvent interface{}
+		var rawEvent any
 		err = json.Unmarshal(jsonRender, &rawEvent)
 		if err != nil {
 			chError <- err

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -46,7 +46,7 @@ func (c *cmdQuery) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdQuery) pretty(input interface{}) string {
+func (c *cmdQuery) pretty(input any) string {
 	pretty := bytes.NewBufferString("")
 	enc := json.NewEncoder(pretty)
 	enc.SetEscapeHTML(false)
@@ -90,7 +90,7 @@ func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Guess the encoding of the input
-	var data interface{}
+	var data any
 	err = json.Unmarshal([]byte(c.flagData), &data)
 	if err != nil {
 		data = c.flagData
@@ -162,7 +162,7 @@ func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
 	if c.flagRespRaw {
 		fmt.Println(c.pretty(resp))
 	} else if resp.Metadata != nil && string(resp.Metadata) != "{}" {
-		var content interface{}
+		var content any
 		err := json.Unmarshal(resp.Metadata, &content)
 		if err != nil {
 			return err

--- a/lxc/utils/cancel.go
+++ b/lxc/utils/cancel.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CancelableWait waits for an operation and cancel it on SIGINT/SIGTERM
-func CancelableWait(rawOp interface{}, progress *ProgressRenderer) error {
+func CancelableWait(rawOp any, progress *ProgressRenderer) error {
 	var op lxd.Operation
 	var rop lxd.RemoteOperation
 

--- a/lxc/utils/table.go
+++ b/lxc/utils/table.go
@@ -21,7 +21,7 @@ const (
 )
 
 // RenderTable renders tabular data in various formats.
-func RenderTable(format string, header []string, data [][]string, raw interface{}) error {
+func RenderTable(format string, header []string, data [][]string, raw any) error {
 	switch format {
 	case TableFormatTable:
 		table := getBaseTable(header, data)

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -28,12 +28,12 @@ func devLxdServer(d *Daemon) *http.Server {
 }
 
 type devLxdResponse struct {
-	content interface{}
+	content any
 	code    int
 	ctype   string
 }
 
-func okResponse(ct interface{}, ctype string) *devLxdResponse {
+func okResponse(ct any, ctype string) *devLxdResponse {
 	return &devLxdResponse{ct, http.StatusOK, ctype}
 }
 

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -162,7 +162,7 @@ type execWs struct {
 	cwd                   string
 }
 
-func (s *execWs) Metadata() interface{} {
+func (s *execWs) Metadata() any {
 	fds := shared.Jmap{}
 	for fd, secret := range s.fds {
 		if fd == execWSControl {

--- a/lxd-benchmark/benchmark/util.go
+++ b/lxd-benchmark/benchmark/util.go
@@ -10,7 +10,7 @@ func getContainerName(count int, index int) string {
 	return fmt.Sprintf(nameFormat, index+1)
 }
 
-func logf(format string, args ...interface{}) {
+func logf(format string, args ...any) {
 	fmt.Printf(fmt.Sprintf("[%s] %s\n", time.Now().Format(time.StampMilli), format), args...)
 }
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -531,7 +531,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	s := d.State()
 
 	// First deal with config specific to the local daemon
-	nodeValues := map[string]interface{}{}
+	nodeValues := map[string]any{}
 
 	for key := range node.ConfigSchema {
 		value, ok := req.Config[key]
@@ -661,7 +661,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 			return err
 		}
 		serverPut := server.Writable()
-		serverPut.Config = make(map[string]interface{})
+		serverPut.Config = make(map[string]any)
 		// Only propagated cluster-wide changes
 		for key, value := range clusterChanged {
 			serverPut.Config[key] = value

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -371,7 +371,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 			return fmt.Errorf("Cannot use wildcard core.https_address %q for cluster.https_address. Please specify a new cluster.https_address or core.https_address", address)
 		}
 
-		_, err = config.Patch(map[string]interface{}{
+		_, err = config.Patch(map[string]any{
 			"cluster.https_address": address,
 		})
 		if err != nil {
@@ -441,7 +441,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
 
-			_, err = config.Patch(map[string]interface{}{
+			_, err = config.Patch(map[string]any{
 				"core.https_address":    req.ServerAddress,
 				"cluster.https_address": req.ServerAddress,
 			})
@@ -470,7 +470,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			if err != nil {
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
-			_, err = config.Patch(map[string]interface{}{
+			_, err = config.Patch(map[string]any{
 				"cluster.https_address": address,
 			})
 			return err
@@ -1196,7 +1196,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	// the joining member will not have to specify a joining address during the join process.
 	// Use anonymous interface type to align with how the API response will be returned for consistency when
 	// retrieving remote operations.
-	onlineNodeAddresses := make([]interface{}, 0)
+	onlineNodeAddresses := make([]any, 0)
 
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		// Get the offline threshold.
@@ -1278,7 +1278,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	meta := map[string]interface{}{
+	meta := map[string]any{
 		"serverName":  req.ServerName, // Add server name to allow validation of name during join process.
 		"secret":      joinSecret,
 		"fingerprint": fingerprint,
@@ -2689,7 +2689,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 			evacuateClusterSetState(d, nodeName, db.ClusterMemberStateCreated)
 		})
 
-		metadata := make(map[string]interface{})
+		metadata := make(map[string]any)
 
 		for _, inst := range instances {
 			// Check if migratable.
@@ -2874,7 +2874,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		var source lxd.InstanceServer
 		var sourceNode db.NodeInfo
 
-		metadata := make(map[string]interface{})
+		metadata := make(map[string]any)
 
 		// Restart the local instances.
 		for _, inst := range localInstances {
@@ -3200,7 +3200,7 @@ func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 
 	recursion := util.IsRecursionRequest(r)
 
-	var result interface{}
+	var result any
 
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		if recursion {
@@ -3571,7 +3571,7 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 	req := clusterGroup.Writable()
 
 	// Validate the ETag.
-	etag := []interface{}{clusterGroup.Description, clusterGroup.Members}
+	etag := []any{clusterGroup.Description, clusterGroup.Members}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -389,10 +389,10 @@ type internalSQLBatch struct {
 }
 
 type internalSQLResult struct {
-	Type         string          `json:"type" yaml:"type"`
-	Columns      []string        `json:"columns" yaml:"columns"`
-	Rows         [][]interface{} `json:"rows" yaml:"rows"`
-	RowsAffected int64           `json:"rows_affected" yaml:"rows_affected"`
+	Type         string   `json:"type" yaml:"type"`
+	Columns      []string `json:"columns" yaml:"columns"`
+	Rows         [][]any  `json:"rows" yaml:"rows"`
+	RowsAffected int64    `json:"rows_affected" yaml:"rows_affected"`
 }
 
 // Perform a database dump.
@@ -513,8 +513,8 @@ func internalSQLSelect(tx *sql.Tx, query string, result *internalSQLResult) erro
 	}
 
 	for rows.Next() {
-		row := make([]interface{}, len(result.Columns))
-		rowPointers := make([]interface{}, len(result.Columns))
+		row := make([]any, len(result.Columns))
+		rowPointers := make([]any, len(result.Columns))
 		for i := range row {
 			rowPointers[i] = &row[i]
 		}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -143,7 +143,7 @@ var projectStateCmd = APIEndpoint{
 func projectsGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
-	var result interface{}
+	var result any
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		filter := db.ProjectFilter{}
 		if recursion {
@@ -353,7 +353,7 @@ func projectGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	etag := []interface{}{
+	etag := []any{
 		project.Description,
 		project.Config,
 	}
@@ -405,7 +405,7 @@ func projectPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate ETag
-	etag := []interface{}{
+	etag := []any{
 		project.Description,
 		project.Config,
 	}
@@ -472,7 +472,7 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate ETag
-	etag := []interface{}{
+	etag := []any{
 		project.Description,
 		project.Config,
 	}

--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -113,7 +113,7 @@ func archiveProfile(outputPath string, allowedCommandPaths []string) (string, er
 
 	// Render the profile.
 	var sb *strings.Builder = &strings.Builder{}
-	err = archiveProfileTpl.Execute(sb, map[string]interface{}{
+	err = archiveProfileTpl.Execute(sb, map[string]any{
 		"name":                ArchiveProfileName(outputPath),
 		"outputPath":          outputPath,
 		"rootPath":            rootPath,

--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -156,7 +156,7 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 	// Render the profile.
 	var sb *strings.Builder = &strings.Builder{}
 	if inst.Type() == instancetype.Container {
-		err = lxcProfileTpl.Execute(sb, map[string]interface{}{
+		err = lxcProfileTpl.Execute(sb, map[string]any{
 			"feature_cgns":     sysOS.CGInfo.Namespacing,
 			"feature_cgroup2":  sysOS.CGInfo.Layout == cgroup.CgroupsUnified || sysOS.CGInfo.Layout == cgroup.CgroupsHybrid,
 			"feature_stacking": sysOS.AppArmorStacking && !sysOS.AppArmorStacked,
@@ -198,7 +198,7 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 			execPath = execPathFull
 		}
 
-		err = qemuProfileTpl.Execute(sb, map[string]interface{}{
+		err = qemuProfileTpl.Execute(sb, map[string]any{
 			"devicesPath": inst.DevicesPath(),
 			"exePath":     execPath,
 			"libraryPath": strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),

--- a/lxd/apparmor/instance_forkproxy.go
+++ b/lxd/apparmor/instance_forkproxy.go
@@ -151,7 +151,7 @@ func forkproxyProfile(sysOS *sys.OS, inst instance, dev device) (string, error) 
 
 	// Render the profile.
 	var sb *strings.Builder = &strings.Builder{}
-	err = forkproxyProfileTpl.Execute(sb, map[string]interface{}{
+	err = forkproxyProfileTpl.Execute(sb, map[string]any{
 		"name":        ForkproxyProfileName(inst, dev),
 		"varPath":     shared.VarPath(""),
 		"rootPath":    rootPath,

--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -75,7 +75,7 @@ func dnsmasqProfile(sysOS *sys.OS, n network) (string, error) {
 
 	// Render the profile.
 	var sb *strings.Builder = &strings.Builder{}
-	err := dnsmasqProfileTpl.Execute(sb, map[string]interface{}{
+	err := dnsmasqProfileTpl.Execute(sb, map[string]any{
 		"name":        DnsmasqProfileName(n),
 		"networkName": n.Name(),
 		"varPath":     shared.VarPath(""),

--- a/lxd/apparmor/network_forkdns.go
+++ b/lxd/apparmor/network_forkdns.go
@@ -71,7 +71,7 @@ func forkdnsProfile(sysOS *sys.OS, n network) (string, error) {
 
 	// Render the profile.
 	var sb *strings.Builder = &strings.Builder{}
-	err = forkdnsProfileTpl.Execute(sb, map[string]interface{}{
+	err = forkdnsProfileTpl.Execute(sb, map[string]any{
 		"name":        ForkdnsProfileName(n),
 		"networkName": n.Name(),
 		"varPath":     shared.VarPath(""),

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -141,7 +141,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 			Handler: func(value, speed int64) {
 				meta := op.Metadata()
 				if meta == nil {
-					meta = make(map[string]interface{})
+					meta = make(map[string]any)
 				}
 
 				progressText := fmt.Sprintf("%s (%s/s)", units.GetByteSizeString(value, 2), units.GetByteSizeString(speed, 2))

--- a/lxd/backup/backup_instance.go
+++ b/lxd/backup/backup_instance.go
@@ -99,7 +99,7 @@ func (b *InstanceBackup) Rename(newName string) error {
 
 	oldName := b.name
 	b.name = newName
-	b.state.Events.SendLifecycle(b.instance.Project(), lifecycle.InstanceBackupRenamed.Event(b.name, b.instance, map[string]interface{}{"old_name": oldName}))
+	b.state.Events.SendLifecycle(b.instance.Project(), lifecycle.InstanceBackupRenamed.Event(b.name, b.instance, map[string]any{"old_name": oldName}))
 	return nil
 }
 

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -596,7 +596,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 			req.Projects = []string{}
 		}
 
-		meta := map[string]interface{}{
+		meta := map[string]any{
 			"secret":      joinSecret,
 			"fingerprint": fingerprint,
 			"addresses":   addresses,

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -159,21 +159,21 @@ func (c *Config) ImagesDefaultArchitecture() string {
 
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
-func (c *Config) Dump() map[string]interface{} {
+func (c *Config) Dump() map[string]any {
 	return c.m.Dump()
 }
 
 // Replace the current configuration with the given values.
 //
 // Return what has actually changed.
-func (c *Config) Replace(values map[string]interface{}) (map[string]string, error) {
+func (c *Config) Replace(values map[string]any) (map[string]string, error) {
 	return c.update(values)
 }
 
 // Patch changes only the configuration keys in the given map.
 //
 // Return what has actually changed.
-func (c *Config) Patch(patch map[string]interface{}) (map[string]string, error) {
+func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 	values := c.Dump() // Use current values as defaults
 	for name, value := range patch {
 		values[name] = value
@@ -181,7 +181,7 @@ func (c *Config) Patch(patch map[string]interface{}) (map[string]string, error) 
 	return c.update(values)
 }
 
-func (c *Config) update(values map[string]interface{}) (map[string]string, error) {
+func (c *Config) update(values map[string]any) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {
 		return nil, err

--- a/lxd/cluster/config_test.go
+++ b/lxd/cluster/config_test.go
@@ -17,7 +17,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	config, err := cluster.ConfigLoad(tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 
 	assert.Equal(t, float64(20), config.OfflineThreshold().Seconds())
 }
@@ -36,7 +36,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	config, err := cluster.ConfigLoad(tx)
 
 	require.NoError(t, err)
-	values := map[string]interface{}{"core.proxy_http": "foo.bar"}
+	values := map[string]any{"core.proxy_http": "foo.bar"}
 	assert.Equal(t, values, config.Dump())
 }
 
@@ -48,7 +48,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	config, err := cluster.ConfigLoad(tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 }
 
 // Offline threshold must be greater than the heartbeat interval.
@@ -59,7 +59,7 @@ func TestConfigLoad_OfflineThresholdValidator(t *testing.T) {
 	config, err := cluster.ConfigLoad(tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]interface{}{"cluster.offline_threshold": "2"})
+	_, err = config.Patch(map[string]any{"cluster.offline_threshold": "2"})
 	require.EqualError(t, err, "cannot set 'cluster.offline_threshold' to '2': Value must be greater than '10'")
 
 }
@@ -72,7 +72,7 @@ func TestConfigLoad_MaxVotersValidator(t *testing.T) {
 	config, err := cluster.ConfigLoad(tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]interface{}{"cluster.max_voters": "4"})
+	_, err = config.Patch(map[string]any{"cluster.max_voters": "4"})
 	require.EqualError(t, err, "cannot set 'cluster.max_voters' to '4': Value must be an odd number equal to or higher than 3")
 
 }
@@ -86,11 +86,11 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	config, err := cluster.ConfigLoad(tx)
 	require.NoError(t, err)
 
-	changed, err := config.Replace(map[string]interface{}{"core.proxy_http": "foo.bar"})
+	changed, err := config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.proxy_http": "foo.bar"}, changed)
 
-	_, err = config.Replace(map[string]interface{}{})
+	_, err = config.Replace(map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", config.ProxyHTTP())
@@ -109,10 +109,10 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	config, err := cluster.ConfigLoad(tx)
 	require.NoError(t, err)
 
-	_, err = config.Replace(map[string]interface{}{"core.proxy_http": "foo.bar"})
+	_, err = config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 
-	_, err = config.Patch(map[string]interface{}{})
+	_, err = config.Patch(map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "foo.bar", config.ProxyHTTP())

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -1044,7 +1044,7 @@ func dqliteMemoryDial(bindAddress string) client.DialFunc {
 const databaseEndpoint = "/internal/database"
 
 // DqliteLog redirects dqlite's logs to our own logger
-func DqliteLog(l client.LogLevel, format string, a ...interface{}) {
+func DqliteLog(l client.LogLevel, format string, a ...any) {
 	format = fmt.Sprintf("Dqlite: %s", format)
 	switch l {
 	case client.LogDebug:

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -136,7 +136,7 @@ func (h *notifyFixtures) Nodes(cert *shared.CertInfo, n int) func() {
 		config, err := node.ConfigLoad(tx)
 		require.NoError(h.t, err)
 		address := servers[0].Listener.Addr().String()
-		values := map[string]interface{}{"cluster.https_address": address}
+		values := map[string]any{"cluster.https_address": address}
 		_, err = config.Patch(values)
 		require.NoError(h.t, err)
 		return nil
@@ -192,7 +192,7 @@ func newRestServer(cert *shared.CertInfo) *httptest.Server {
 
 	mux.HandleFunc("/1.0/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		config := map[string]interface{}{"cluster.https_address": server.Listener.Addr().String()}
+		config := map[string]any{"cluster.https_address": server.Listener.Addr().String()}
 		metadata := api.ServerPut{Config: config}
 		util.WriteJSON(w, api.ResponseRaw{Metadata: metadata}, nil)
 	})

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -108,7 +108,7 @@ func updateLocalAddress(database *db.Node, address string) error {
 			return err
 		}
 
-		newConfig := map[string]interface{}{"cluster.https_address": address}
+		newConfig := map[string]any{"cluster.https_address": address}
 		_, err = config.Patch(newConfig)
 		if err != nil {
 			return err

--- a/lxd/config/errors.go
+++ b/lxd/config/errors.go
@@ -7,9 +7,9 @@ import (
 
 // Error generated when trying to set a certain config key to certain value.
 type Error struct {
-	Name   string      // The name of the key this error is associated with.
-	Value  interface{} // The value that the key was tried to be set to.
-	Reason string      // Human-readable reason of the error.
+	Name   string // The name of the key this error is associated with.
+	Value  any    // The value that the key was tried to be set to.
+	Reason string // Human-readable reason of the error.
 }
 
 // Error implements the error interface.
@@ -45,6 +45,6 @@ func (l ErrorList) Less(i, j int) bool { return l[i].Name < l[j].Name }
 func (l ErrorList) sort() { sort.Sort(l) }
 
 // Add adds an Error with given key name, value and reason.
-func (l *ErrorList) add(name string, value interface{}, reason string) {
+func (l *ErrorList) add(name string, value any, reason string) {
 	*l = append(*l, &Error{name, value, reason})
 }

--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -37,7 +37,7 @@ func Load(schema Schema, values map[string]string) (Map, error) {
 //
 // Return a map of key/value pairs that were actually changed. If some keys
 // fail to apply, details are included in the returned ErrorList.
-func (m *Map) Change(changes map[string]interface{}) (map[string]string, error) {
+func (m *Map) Change(changes map[string]any) (map[string]string, error) {
 	values := make(map[string]string, len(m.schema))
 
 	errors := ErrorList{}
@@ -92,8 +92,8 @@ func (m *Map) Change(changes map[string]interface{}) (map[string]string, error) 
 // Keys that match their default value will not be included in the dump. Also,
 // if a Key has its Hidden attribute set to true, it will be rendered as
 // "true", for obfuscating the actual value.
-func (m *Map) Dump() map[string]interface{} {
-	values := map[string]interface{}{}
+func (m *Map) Dump() map[string]any {
+	values := map[string]any{}
 
 	for name, value := range m.values {
 		key, ok := m.schema[name]

--- a/lxd/config/map_test.go
+++ b/lxd/config/map_test.go
@@ -110,42 +110,42 @@ func TestChange(t *testing.T) {
 
 	cases := []struct {
 		title  string
-		values map[string]interface{} // New values
-		result map[string]string      // Expected values after change
+		values map[string]any    // New values
+		result map[string]string // Expected values after change
 	}{
 		{
 			`plain change of regular key`,
-			map[string]interface{}{"foo": "world"},
+			map[string]any{"foo": "world"},
 			map[string]string{"foo": "world"},
 		},
 		{
 			`key setter is honored`,
-			map[string]interface{}{"bar": "y"},
+			map[string]any{"bar": "y"},
 			map[string]string{"bar": "Y"},
 		},
 		{
 			`bool true values are normalized`,
-			map[string]interface{}{"egg": "yes"},
+			map[string]any{"egg": "yes"},
 			map[string]string{"egg": "true"},
 		},
 		{
 			`bool false values are normalized`,
-			map[string]interface{}{"yuk": "0"},
+			map[string]any{"yuk": "0"},
 			map[string]string{"yuk": "false"},
 		},
 		{
 			`the special value 'true' is a passthrough for hidden keys`,
-			map[string]interface{}{"xyz": true},
+			map[string]any{"xyz": true},
 			map[string]string{"xyz": "sekret"},
 		},
 		{
 			`the special value nil is converted to empty string`,
-			map[string]interface{}{"foo": nil},
+			map[string]any{"foo": nil},
 			map[string]string{"foo": ""},
 		},
 		{
 			`multiple values are all mutated`,
-			map[string]interface{}{"foo": "x", "bar": "hey", "egg": "0"},
+			map[string]any{"foo": "x", "bar": "hey", "egg": "0"},
 			map[string]string{"foo": "x", "bar": "HEY", "egg": ""},
 		},
 	}
@@ -175,32 +175,32 @@ func TestMap_ChangeReturnsChangedKeys(t *testing.T) {
 
 	cases := []struct {
 		title   string
-		changes map[string]interface{} // New values
-		changed map[string]string      // Keys that should have actually changed
+		changes map[string]any    // New values
+		changed map[string]string // Keys that should have actually changed
 	}{
 		{
 			`plain single change`,
-			map[string]interface{}{"foo": "no"},
+			map[string]any{"foo": "no"},
 			map[string]string{"foo": "false"},
 		},
 		{
 			`unchanged boolean value, even if it's spelled 'yes' and not 'true'`,
-			map[string]interface{}{"foo": "yes"},
+			map[string]any{"foo": "yes"},
 			map[string]string{},
 		},
 		{
 			`unset value`,
-			map[string]interface{}{"foo": ""},
+			map[string]any{"foo": ""},
 			map[string]string{"foo": "false"},
 		},
 		{
 			`unchanged value, since it matches the default`,
-			map[string]interface{}{"foo": "true", "bar": "egg"},
+			map[string]any{"foo": "true", "bar": "egg"},
 			map[string]string{},
 		},
 		{
 			`multiple changes`,
-			map[string]interface{}{"foo": "false", "bar": "baz"},
+			map[string]any{"foo": "false", "bar": "baz"},
 			map[string]string{"foo": "false", "bar": "baz"},
 		},
 	}
@@ -226,27 +226,27 @@ func TestMap_ChangeError(t *testing.T) {
 
 	var cases = []struct {
 		title   string
-		changes map[string]interface{}
+		changes map[string]any
 		message string
 	}{
 		{
 			`schema has no key with the given name`,
-			map[string]interface{}{"xxx": ""},
+			map[string]any{"xxx": ""},
 			"cannot set 'xxx' to '': unknown key",
 		},
 		{
 			`validation fails`,
-			map[string]interface{}{"foo": "yyy"},
+			map[string]any{"foo": "yyy"},
 			"cannot set 'foo' to 'yyy': invalid boolean",
 		},
 		{
 			`custom setter fails`,
-			map[string]interface{}{"egg": "xxx"},
+			map[string]any{"egg": "xxx"},
 			"cannot set 'egg' to 'xxx': boom",
 		},
 		{
 			`non string value`,
-			map[string]interface{}{"egg": 123},
+			map[string]any{"egg": 123},
 			"cannot set 'egg': invalid type int",
 		},
 	}
@@ -278,7 +278,7 @@ func TestMap_Dump(t *testing.T) {
 	m, err := config.Load(schema, values)
 	assert.NoError(t, err)
 
-	dump := map[string]interface{}{
+	dump := map[string]any{
 		"foo": "hello",
 		"egg": true,
 	}

--- a/lxd/config/safe_test.go
+++ b/lxd/config/safe_test.go
@@ -20,5 +20,5 @@ func TestSafeLoad_IgnoreInvalidKeys(t *testing.T) {
 	m, err := config.SafeLoad(schema, values)
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]interface{}{"bar": "x"}, m.Dump())
+	assert.Equal(t, map[string]any{"bar": "x"}, m.Dump())
 }

--- a/lxd/config/schema.go
+++ b/lxd/config/schema.go
@@ -27,8 +27,8 @@ func (s Schema) Keys() []string {
 
 // Defaults returns a map of all key names in the schema along with their default
 // values.
-func (s Schema) Defaults() map[string]interface{} {
-	values := make(map[string]interface{}, len(s))
+func (s Schema) Defaults() map[string]any {
+	values := make(map[string]any, len(s))
 	for name, key := range s {
 		values[name] = key.Default
 	}

--- a/lxd/config/schema_test.go
+++ b/lxd/config/schema_test.go
@@ -12,7 +12,7 @@ func TestSchema_Defaults(t *testing.T) {
 		"foo": {},
 		"bar": {Default: "x"},
 	}
-	values := map[string]interface{}{"foo": "", "bar": "x"}
+	values := map[string]any{"foo": "", "bar": "x"}
 	assert.Equal(t, values, schema.Defaults())
 }
 

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -8,8 +8,8 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func daemonConfigRender(state *state.State) (map[string]interface{}, error) {
-	config := map[string]interface{}{}
+func daemonConfigRender(state *state.State) (map[string]any, error) {
+	config := map[string]any{}
 
 	// Turn the config into a JSON-compatible map
 	err := state.Cluster.Transaction(func(tx *db.ClusterTx) error {

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -277,7 +277,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 
 		meta := op.Metadata()
 		if meta == nil {
-			meta = make(map[string]interface{})
+			meta = make(map[string]any)
 		}
 
 		if meta["download_progress"] != progress.Text {

--- a/lxd/db/backups.go
+++ b/lxd/db/backups.go
@@ -41,8 +41,8 @@ type StoragePoolVolumeBackup struct {
 func (c *Cluster) getInstanceBackupID(name string) (int, error) {
 	q := "SELECT id FROM instances_backups WHERE name=?"
 	id := -1
-	arg1 := []interface{}{name}
-	arg2 := []interface{}{&id}
+	arg1 := []any{name}
+	arg2 := []any{&id}
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err == sql.ErrNoRows {
 		return -1, ErrNoSuchObject
@@ -67,8 +67,8 @@ SELECT instances_backups.id, instances_backups.instance_id,
     JOIN projects ON projects.id=instances.project_id
     WHERE projects.name=? AND instances_backups.name=?
 `
-	arg1 := []interface{}{projectName, name}
-	arg2 := []interface{}{&args.ID, &args.InstanceID, &args.CreationDate,
+	arg1 := []any{projectName, name}
+	arg2 := []any{&args.ID, &args.InstanceID, &args.CreationDate,
 		&args.ExpiryDate, &instanceOnlyInt, &optimizedStorageInt}
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err != nil {
@@ -106,8 +106,8 @@ SELECT instances_backups.name, instances_backups.instance_id,
     JOIN projects ON projects.id=instances.project_id
     WHERE instances_backups.id=?
 `
-	arg1 := []interface{}{backupID}
-	arg2 := []interface{}{&args.Name, &args.InstanceID, &args.CreationDate,
+	arg1 := []any{backupID}
+	arg2 := []any{&args.Name, &args.InstanceID, &args.CreationDate,
 		&args.ExpiryDate, &instanceOnlyInt, &optimizedStorageInt}
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err != nil {
@@ -138,8 +138,8 @@ func (c *Cluster) GetInstanceBackups(projectName string, name string) ([]string,
 JOIN instances ON instances_backups.instance_id=instances.id
 JOIN projects ON projects.id=instances.project_id
 WHERE projects.name=? AND instances.name=?`
-	inargs := []interface{}{projectName, name}
-	outfmt := []interface{}{name}
+	inargs := []any{projectName, name}
+	outfmt := []any{name}
 	dbResults, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
@@ -243,7 +243,7 @@ func (c *Cluster) GetExpiredInstanceBackups() ([]InstanceBackup, error) {
 	var instanceID int
 
 	q := `SELECT instances_backups.name, instances_backups.expiry_date, instances_backups.instance_id FROM instances_backups`
-	outfmt := []interface{}{name, expiryDate, instanceID}
+	outfmt := []any{name, expiryDate, instanceID}
 	dbResults, err := queryScan(c, q, nil, outfmt)
 	if err != nil {
 		return nil, err
@@ -299,7 +299,7 @@ func (c *Cluster) GetStoragePoolVolumeBackups(projectName string, volumeName str
 	var backups []StoragePoolVolumeBackup
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var b StoragePoolVolumeBackup
 			var expiryTime sql.NullTime
 
@@ -331,8 +331,8 @@ JOIN storage_volumes ON storage_volumes_backups.storage_volume_id=storage_volume
 JOIN projects ON projects.id=storage_volumes.project_id
 WHERE projects.name=? AND storage_volumes.name=?
 ORDER BY storage_volumes_backups.id`
-	inargs := []interface{}{projectName, volumeName}
-	outfmt := []interface{}{volumeName}
+	inargs := []any{projectName, volumeName}
+	outfmt := []any{volumeName}
 	dbResults, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
@@ -391,8 +391,8 @@ func (c *Cluster) CreateStoragePoolVolumeBackup(args StoragePoolVolumeBackup) er
 func (c *Cluster) getStoragePoolVolumeBackupID(name string) (int, error) {
 	q := "SELECT id FROM storage_volumes_backups WHERE name=?"
 	id := -1
-	arg1 := []interface{}{name}
-	arg2 := []interface{}{&id}
+	arg1 := []any{name}
+	arg2 := []any{&id}
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err == sql.ErrNoRows {
 		return -1, ErrNoSuchObject
@@ -433,8 +433,8 @@ JOIN storage_volumes ON storage_volumes.id=backups.storage_volume_id
 JOIN projects ON projects.id=storage_volumes.project_id
 WHERE projects.name=? AND backups.name=?
 `
-	arg1 := []interface{}{projectName, backupName}
-	outfmt := []interface{}{&args.ID, &args.VolumeID, &args.Name, &args.CreationDate, &args.ExpiryDate, &args.VolumeOnly, &args.OptimizedStorage}
+	arg1 := []any{projectName, backupName}
+	outfmt := []any{&args.ID, &args.VolumeID, &args.Name, &args.CreationDate, &args.ExpiryDate, &args.VolumeOnly, &args.OptimizedStorage}
 	err := dbQueryRowScan(c, q, arg1, outfmt)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -464,8 +464,8 @@ JOIN storage_volumes ON storage_volumes.id=backups.storage_volume_id
 JOIN projects ON projects.id=storage_volumes.project_id
 WHERE backups.id=?
 `
-	arg1 := []interface{}{backupID}
-	outfmt := []interface{}{&args.ID, &args.VolumeID, &args.Name, &args.CreationDate, &args.ExpiryDate, &args.VolumeOnly, &args.OptimizedStorage}
+	arg1 := []any{backupID}
+	outfmt := []any{&args.ID, &args.VolumeID, &args.Name, &args.CreationDate, &args.ExpiryDate, &args.VolumeOnly, &args.OptimizedStorage}
 	err := dbQueryRowScan(c, q, arg1, outfmt)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/lxd/db/certificate_projects.mapper.go
+++ b/lxd/db/certificate_projects.mapper.go
@@ -39,12 +39,12 @@ func (c *ClusterTx) GetCertificateProjects() (map[int][]int, error) {
 	objects := make([]CertificateProject, 0)
 
 	stmt := c.stmt(certificateProjectObjects)
-	args := []interface{}{}
+	args := []any{}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, CertificateProject{})
-		return []interface{}{
+		return []any{
 			&objects[i].CertificateID,
 			&objects[i].ProjectID,
 		}
@@ -84,7 +84,7 @@ func (c *ClusterTx) DeleteCertificateProjects(object Certificate) error {
 // CreateCertificateProject adds a new certificate_project to the database.
 // generator: certificate_project Create
 func (c *ClusterTx) CreateCertificateProject(object CertificateProject) (int64, error) {
-	args := make([]interface{}, 2)
+	args := make([]any, 2)
 
 	// Populate the statement arguments.
 	args[0] = object.CertificateID

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -123,9 +123,9 @@ ORDER BY certificates.fingerprint
 		if err != nil {
 			return err
 		}
-		dest := func(i int) []interface{} {
+		dest := func(i int) []any {
 			objects = append(objects, Certificate{})
-			return []interface{}{
+			return []any{
 				&objects[i].ID,
 				&objects[i].Fingerprint,
 				&objects[i].Type,
@@ -194,14 +194,14 @@ func (n *NodeTx) GetCertificates() ([]Certificate, error) {
 		name        string
 		certificate string
 	}{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		dbCerts = append(dbCerts, struct {
 			fingerprint string
 			certType    CertificateType
 			name        string
 			certificate string
 		}{})
-		return []interface{}{&dbCerts[i].fingerprint, &dbCerts[i].certType, &dbCerts[i].name, &dbCerts[i].certificate}
+		return []any{&dbCerts[i].fingerprint, &dbCerts[i].certType, &dbCerts[i].name, &dbCerts[i].certificate}
 	}
 
 	stmt, err := n.tx.Prepare("SELECT fingerprint, type, name, certificate FROM certificates")

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -62,24 +62,24 @@ func (c *ClusterTx) GetCertificates(filter CertificateFilter) ([]Certificate, er
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Fingerprint != nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(certificateObjectsByFingerprint)
-		args = []interface{}{
+		args = []any{
 			filter.Fingerprint,
 		}
 	} else if filter.Fingerprint == nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(certificateObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Certificate{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Fingerprint,
 			&objects[i].Type,
@@ -203,7 +203,7 @@ func (c *ClusterTx) CreateCertificate(object Certificate) (int64, error) {
 		return -1, fmt.Errorf("This \"certificates\" entry already exists")
 	}
 
-	args := make([]interface{}, 5)
+	args := make([]any, 5)
 
 	// Populate the statement arguments.
 	args[0] = object.Fingerprint

--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -76,24 +76,24 @@ func (c *ClusterTx) GetClusterGroups(filter ClusterGroupFilter) ([]ClusterGroup,
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Name != nil && filter.ID == nil {
 		stmt = c.stmt(clusterGroupObjectsByName)
-		args = []interface{}{
+		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID == nil && filter.Name == nil {
 		stmt = c.stmt(clusterGroupObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, ClusterGroup{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Name,
 			&objects[i].Description,
@@ -194,7 +194,7 @@ func (c *ClusterTx) CreateClusterGroup(object ClusterGroup) (int64, error) {
 		return -1, fmt.Errorf("This cluster group already exists")
 	}
 
-	args := make([]interface{}, 2)
+	args := make([]any, 2)
 
 	// Populate the statement arguments.
 	args[0] = object.Name
@@ -331,18 +331,18 @@ WHERE cluster_groups.name = ?`
 // GetClusterGroupURIs returns all available ClusterGroup URIs.
 // generator: ClusterGroup URIs
 func (c *ClusterTx) GetClusterGroupURIs(filter ClusterGroupFilter) ([]string, error) {
-	var args []interface{}
+	var args []any
 	var sql string
 	if filter.Name != nil && filter.ID == nil {
 		sql = `SELECT cluster_groups.name FROM cluster_groups
 WHERE cluster_groups.name = ? ORDER BY cluster_groups.name
 `
-		args = []interface{}{
+		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID == nil && filter.Name == nil {
 		sql = `SELECT cluster_groups.name FROM cluster_groups ORDER BY cluster_groups.name`
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}

--- a/lxd/db/cluster/query.go
+++ b/lxd/db/cluster/query.go
@@ -38,9 +38,9 @@ func selectUnclusteredNodesCount(tx *sql.Tx) (int, error) {
 func selectNodesVersions(tx *sql.Tx) ([][2]int, error) {
 	versions := [][2]int{}
 
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		versions = append(versions, [2]int{})
-		return []interface{}{&versions[i][0], &versions[i][1]}
+		return []any{&versions[i][0], &versions[i][1]}
 	}
 
 	stmt, err := tx.Prepare("SELECT schema, api_extensions FROM nodes WHERE state=0")

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -185,7 +185,7 @@ CREATE TABLE certificates_projects_new (
 	UNIQUE (certificate_id, project_id)
 );
 
-INSERT INTO certificates_projects_new (certificate_id, project_id) SELECT certificate_id, project_id FROM certificates_projects; 
+INSERT INTO certificates_projects_new (certificate_id, project_id) SELECT certificate_id, project_id FROM certificates_projects;
 
 CREATE TABLE images_new (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -206,7 +206,7 @@ CREATE TABLE images_new (
     FOREIGN KEY (project_id) REFERENCES projects_new (id) ON DELETE CASCADE
 );
 
-INSERT INTO images_new (id, fingerprint, filename, size, public, architecture, creation_date, expiry_date, upload_date, cached, last_use_date, auto_update, project_id, type) 
+INSERT INTO images_new (id, fingerprint, filename, size, public, architecture, creation_date, expiry_date, upload_date, cached, last_use_date, auto_update, project_id, type)
 	SELECT id, fingerprint, filename, size, public, architecture, creation_date, expiry_date, upload_date, cached, last_use_date, auto_update, project_id, type FROM images;
 
 CREATE TABLE images_aliases_new (
@@ -220,7 +220,7 @@ CREATE TABLE images_aliases_new (
     FOREIGN KEY (project_id) REFERENCES projects_new (id) ON DELETE CASCADE
 );
 
-INSERT INTO images_aliases_new (id, name, image_id, description, project_id) 
+INSERT INTO images_aliases_new (id, name, image_id, description, project_id)
 	SELECT id, name, image_id, IFNULL(description, ''), project_id FROM images_aliases;
 
 CREATE TABLE nodes_new (
@@ -1666,8 +1666,8 @@ ORDER BY storage_volumes.name
 		ID   int
 		Name string
 	}, count)
-	dest := func(i int) []interface{} {
-		return []interface{}{
+	dest := func(i int) []any {
+		return []any{
 			&volumes[i].ID,
 			&volumes[i].Name,
 		}
@@ -1732,8 +1732,8 @@ CREATE TABLE storage_volumes_new (
 		ContentType   int
 	}, count)
 
-	dest = func(i int) []interface{} {
-		return []interface{}{
+	dest = func(i int) []any {
+		return []any{
 			&storageVolumes[i].ID,
 			&storageVolumes[i].Name,
 			&storageVolumes[i].StoragePoolID,
@@ -1781,8 +1781,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
 		Value           string
 	}, count)
 
-	dest = func(i int) []interface{} {
-		return []interface{}{
+	dest = func(i int) []any {
+		return []any{
 			&storageVolumeConfigs[i].ID,
 			&storageVolumeConfigs[i].StorageVolumeID,
 			&storageVolumeConfigs[i].Key,
@@ -1814,8 +1814,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
 		ExpiryDate      sql.NullTime
 	}, count)
 
-	dest = func(i int) []interface{} {
-		return []interface{}{
+	dest = func(i int) []any {
+		return []any{
 			&storageVolumeSnapshots[i].ID,
 			&storageVolumeSnapshots[i].StorageVolumeID,
 			&storageVolumeSnapshots[i].Name,
@@ -1847,8 +1847,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
 		Value                   string
 	}, count)
 
-	dest = func(i int) []interface{} {
-		return []interface{}{
+	dest = func(i int) []any {
+		return []any{
 			&storageVolumeSnapshotConfigs[i].ID,
 			&storageVolumeSnapshotConfigs[i].StorageVolumeSnapshotID,
 			&storageVolumeSnapshotConfigs[i].Key,
@@ -2158,8 +2158,8 @@ func updateFromV25(tx *sql.Tx) error {
 		ProjectID     int
 		Config        map[string]string
 	}, count)
-	dest := func(i int) []interface{} {
-		return []interface{}{
+	dest := func(i int) []any {
+		return []any{
 			&snapshots[i].ID,
 			&snapshots[i].Name,
 			&snapshots[i].StoragePoolID,
@@ -2675,8 +2675,8 @@ CREATE VIEW instances_snapshots_devices_ref (
 		ExpiryDate   sql.NullTime
 	}, count)
 
-	dest := func(i int) []interface{} {
-		return []interface{}{
+	dest := func(i int) []any {
+		return []any{
 			&instances[i].ID,
 			&instances[i].Name,
 			&instances[i].Type,
@@ -2724,8 +2724,8 @@ SELECT id, name, type, creation_date, stateful, coalesce(description, ''), expir
 		Value      string
 	}, count)
 
-	dest = func(i int) []interface{} {
-		return []interface{}{
+	dest = func(i int) []any {
+		return []any{
 			&configs[i].ID,
 			&configs[i].InstanceID,
 			&configs[i].Key,
@@ -2773,8 +2773,8 @@ SELECT instances_config.id, instance_id, key, value
 		Type       int
 	}, count)
 
-	dest = func(i int) []interface{} {
-		return []interface{}{
+	dest = func(i int) []any {
+		return []any{
 			&devices[i].ID,
 			&devices[i].InstanceID,
 			&devices[i].Name,
@@ -2855,7 +2855,7 @@ SELECT instances_devices.id, instance_id, instances_devices.name, instances_devi
 			tx,
 			"instances_snapshots",
 			columns,
-			[]interface{}{
+			[]any{
 				instanceID,
 				snapshotName,
 				instance.CreationDate,
@@ -2879,7 +2879,7 @@ SELECT instances_devices.id, instance_id, instances_devices.name, instances_devi
 				tx,
 				"instances_snapshots_config",
 				columns,
-				[]interface{}{
+				[]any{
 					id,
 					key,
 					value,
@@ -2901,7 +2901,7 @@ SELECT instances_devices.id, instance_id, instances_devices.name, instances_devi
 				tx,
 				"instances_snapshots_devices",
 				columns,
-				[]interface{}{
+				[]any{
 					id,
 					name,
 					device.Type,
@@ -2920,7 +2920,7 @@ SELECT instances_devices.id, instance_id, instances_devices.name, instances_devi
 					tx,
 					"instances_snapshots_devices_config",
 					columns,
-					[]interface{}{
+					[]any{
 						deviceID,
 						key,
 						value,
@@ -3730,8 +3730,8 @@ FROM storage_volumes
 		return err
 	}
 	defer stmt.Close()
-	err = query.SelectObjects(stmt, func(i int) []interface{} {
-		return []interface{}{
+	err = query.SelectObjects(stmt, func(i int) []any {
+		return []any{
 			&volumes[i].ID,
 			&volumes[i].Name,
 			&volumes[i].StoragePoolID,
@@ -3754,7 +3754,7 @@ FROM storage_volumes
 				// This node already has the volume row
 				continue
 			}
-			values := []interface{}{
+			values := []any{
 				volume.Name,
 				volume.StoragePoolID,
 				nodeID,

--- a/lxd/db/cluster/update_test.go
+++ b/lxd/db/cluster/update_test.go
@@ -758,7 +758,7 @@ func TestUpdateFromV34(t *testing.T) {
 
 	row := tx.QueryRow("SELECT id, node_id FROM storage_volumes")
 	var id int
-	var nodeID interface{}
+	var nodeID any
 	require.NoError(t, row.Scan(&id, &nodeID))
 	assert.Equal(t, id, 2)
 	assert.Equal(t, nodeID, nil)

--- a/lxd/db/config.mapper.go
+++ b/lxd/db/config.mapper.go
@@ -33,7 +33,7 @@ func (c *ClusterTx) GetConfig(parent string) (map[int]map[string]string, error) 
 	objects := make([]Config, 0)
 
 	configObjectsLocal := strings.Replace(configObjects, "%s_id", fmt.Sprintf("%s_id", parent), -1)
-	fillParent := make([]interface{}, strings.Count(configObjectsLocal, "%s"))
+	fillParent := make([]any, strings.Count(configObjectsLocal, "%s"))
 	for i := range fillParent {
 		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
 	}
@@ -43,12 +43,12 @@ func (c *ClusterTx) GetConfig(parent string) (map[int]map[string]string, error) 
 		return nil, err
 	}
 
-	args := []interface{}{}
+	args := []any{}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Config{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].ReferenceID,
 			&objects[i].Key,
@@ -82,7 +82,7 @@ func (c *ClusterTx) CreateConfig(parent string, object Config) error {
 	}
 
 	configCreateLocal := strings.Replace(configCreate, "%s_id", fmt.Sprintf("%s_id", parent), -1)
-	fillParent := make([]interface{}, strings.Count(configCreateLocal, "%s"))
+	fillParent := make([]any, strings.Count(configCreateLocal, "%s"))
 	for i := range fillParent {
 		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
 	}
@@ -130,7 +130,7 @@ func (c *ClusterTx) UpdateConfig(parent string, referenceID int, config map[stri
 // generator: config DeleteMany
 func (c *ClusterTx) DeleteConfig(parent string, referenceID int) error {
 	configDeleteLocal := strings.Replace(configDelete, "%s_id", fmt.Sprintf("%s_id", parent), -1)
-	fillParent := make([]interface{}, strings.Count(configDeleteLocal, "%s"))
+	fillParent := make([]any, strings.Count(configDeleteLocal, "%s"))
 	for i := range fillParent {
 		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
 	}

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -519,7 +519,7 @@ func DqliteLatestSegment() (string, error) {
 	return "none", nil
 }
 
-func dbQueryRowScan(c *Cluster, q string, args []interface{}, outargs []interface{}) error {
+func dbQueryRowScan(c *Cluster, q string, args []any, outargs []any) error {
 	return c.retry(func() error {
 		return query.Transaction(c.db, func(tx *sql.Tx) error {
 			return tx.QueryRow(q, args...).Scan(outargs...)
@@ -527,8 +527,8 @@ func dbQueryRowScan(c *Cluster, q string, args []interface{}, outargs []interfac
 	})
 }
 
-func doDbQueryScan(c *Cluster, q string, args []interface{}, outargs []interface{}) ([][]interface{}, error) {
-	result := [][]interface{}{}
+func doDbQueryScan(c *Cluster, q string, args []any, outargs []any) ([][]any, error) {
+	result := [][]any{}
 
 	err := c.retry(func() error {
 		return query.Transaction(c.db, func(tx *sql.Tx) error {
@@ -539,7 +539,7 @@ func doDbQueryScan(c *Cluster, q string, args []interface{}, outargs []interface
 			defer rows.Close()
 
 			for rows.Next() {
-				ptrargs := make([]interface{}, len(outargs))
+				ptrargs := make([]any, len(outargs))
 				for i := range outargs {
 					switch t := outargs[i].(type) {
 					case string:
@@ -562,7 +562,7 @@ func doDbQueryScan(c *Cluster, q string, args []interface{}, outargs []interface
 				if err != nil {
 					return err
 				}
-				newargs := make([]interface{}, len(outargs))
+				newargs := make([]any, len(outargs))
 				for i := range ptrargs {
 					switch t := outargs[i].(type) {
 					case string:
@@ -587,7 +587,7 @@ func doDbQueryScan(c *Cluster, q string, args []interface{}, outargs []interface
 		})
 	})
 	if err != nil {
-		return [][]interface{}{}, err
+		return [][]any{}, err
 	}
 
 	return result, nil
@@ -602,16 +602,16 @@ func doDbQueryScan(c *Cluster, q string, args []interface{}, outargs []interface
  *   arguments, i.e.
  *      var arg1 string
  *      var arg2 int
- *      outfmt := {}interface{}{arg1, arg2}
+ *      outfmt := {}any{arg1, arg2}
  *
  * The result will be an array (one per output row) of arrays (one per output argument)
  * of interfaces, containing pointers to the actual output arguments.
  */
-func queryScan(c *Cluster, q string, inargs []interface{}, outfmt []interface{}) ([][]interface{}, error) {
+func queryScan(c *Cluster, q string, inargs []any, outfmt []any) ([][]any, error) {
 	return doDbQueryScan(c, q, inargs, outfmt)
 }
 
-func exec(c *Cluster, q string, args ...interface{}) error {
+func exec(c *Cluster, q string, args ...any) error {
 	err := c.retry(func() error {
 		return query.Transaction(c.db, func(tx *sql.Tx) error {
 			_, err := tx.Exec(q, args...)

--- a/lxd/db/devices.mapper.go
+++ b/lxd/db/devices.mapper.go
@@ -33,7 +33,7 @@ func (c *ClusterTx) GetDevices(parent string) (map[int][]Device, error) {
 	objects := make([]Device, 0)
 
 	deviceObjectsLocal := strings.Replace(deviceObjects, "%s_id", fmt.Sprintf("%s_id", parent), -1)
-	fillParent := make([]interface{}, strings.Count(deviceObjectsLocal, "%s"))
+	fillParent := make([]any, strings.Count(deviceObjectsLocal, "%s"))
 	for i := range fillParent {
 		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
 	}
@@ -43,12 +43,12 @@ func (c *ClusterTx) GetDevices(parent string) (map[int][]Device, error) {
 		return nil, err
 	}
 
-	args := []interface{}{}
+	args := []any{}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Device{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].ReferenceID,
 			&objects[i].Name,
@@ -90,7 +90,7 @@ func (c *ClusterTx) GetDevices(parent string) (map[int][]Device, error) {
 // generator: device Create
 func (c *ClusterTx) CreateDevice(parent string, object Device) error {
 	deviceCreateLocal := strings.Replace(deviceCreate, "%s_id", fmt.Sprintf("%s_id", parent), -1)
-	fillParent := make([]interface{}, strings.Count(deviceCreateLocal, "%s"))
+	fillParent := make([]any, strings.Count(deviceCreateLocal, "%s"))
 	for i := range fillParent {
 		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
 	}
@@ -152,7 +152,7 @@ func (c *ClusterTx) UpdateDevice(parent string, referenceID int, devices map[str
 // generator: device DeleteMany
 func (c *ClusterTx) DeleteDevices(parent string, referenceID int) error {
 	deviceDeleteLocal := strings.Replace(deviceDelete, "%s_id", fmt.Sprintf("%s_id", parent), -1)
-	fillParent := make([]interface{}, strings.Count(deviceDeleteLocal, "%s"))
+	fillParent := make([]any, strings.Count(deviceDeleteLocal, "%s"))
 	for i := range fillParent {
 		fillParent[i] = strings.Replace(parent, "_", "s_", -1) + "s"
 	}

--- a/lxd/db/generate/db/lex.go
+++ b/lxd/db/generate/db/lex.go
@@ -96,9 +96,9 @@ func dbTxType(db string) string {
 // Return the code for a "dest" function, to be passed as parameter to
 // query.SelectObjects in order to scan a single row.
 func destFunc(slice string, typ string, fields []*Field) string {
-	f := fmt.Sprintf(`func(i int) []interface{} {
+	f := fmt.Sprintf(`func(i int) []any {
                       %s = append(%s, %s{})
-                      return []interface{}{
+                      return []any{
 `, slice, slice, typ)
 
 	for _, field := range fields {

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -117,7 +117,7 @@ func (m *Method) uris(buf *file.Buffer) error {
 	buf.N()
 	buf.L("// Pick the prepared statement and arguments to use based on active criteria.")
 	buf.L("var stmt *sql.Stmt")
-	buf.L("var args []interface{}")
+	buf.L("var args []any")
 	buf.N()
 
 	for i, filter := range filters {
@@ -128,7 +128,7 @@ func (m *Method) uris(buf *file.Buffer) error {
 		buf.L("%s %s {", branch, activeCriteria(filter, ignoredFilters[i]))
 
 		buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects", filter...))
-		buf.L("args = []interface{}{")
+		buf.L("args = []any{")
 
 		for _, name := range filter {
 			if name == "Parent" {
@@ -149,7 +149,7 @@ func (m *Method) uris(buf *file.Buffer) error {
 
 	buf.L("%s %s {", branch, activeCriteria([]string{}, FieldNames(mapping.Filters)))
 	buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects"))
-	buf.L("args = []interface{}{}")
+	buf.L("args = []any{}")
 	buf.L("} else {")
 	buf.L("return nil, fmt.Errorf(\"No statement exists for the given Filter\")")
 	buf.L("}")
@@ -202,23 +202,23 @@ func (m *Method) getMany(buf *file.Buffer) error {
 		stmtVar := stmtCodeVar(m.entity, "objects")
 		stmtLocal := stmtVar + "Local"
 		buf.L("%s := strings.Replace(%s, \"%%s_id\", fmt.Sprintf(\"%%s_id\", parent), -1)", stmtLocal, stmtVar)
-		buf.L("fillParent := make([]interface{}, strings.Count(%s, \"%%s\"))", stmtLocal)
+		buf.L("fillParent := make([]any, strings.Count(%s, \"%%s\"))", stmtLocal)
 		buf.L("for i := range fillParent {")
 		buf.L("fillParent[i] = strings.Replace(parent, \"_\", \"s_\", -1) + \"s\"")
 		buf.L("}")
 		buf.N()
 		buf.L("stmt, err := c.prepare(fmt.Sprintf(%s, fillParent...))", stmtLocal)
 		m.ifErrNotNil(buf, "nil", "err")
-		buf.L("args := []interface{}{}")
+		buf.L("args := []any{}")
 	} else if mapping.Type == AssociationTable {
 		buf.L("stmt := c.stmt(%s)", stmtCodeVar(m.entity, "objects"))
-		buf.L("args := []interface{}{}")
+		buf.L("args := []any{}")
 	} else {
 		filters, ignoredFilters := FiltersFromStmt(m.packages["db"], "objects", m.entity, mapping.Filters)
 		buf.N()
 		buf.L("// Pick the prepared statement and arguments to use based on active criteria.")
 		buf.L("var stmt *sql.Stmt")
-		buf.L("var args []interface{}")
+		buf.L("var args []any")
 		buf.N()
 
 		for i, filter := range filters {
@@ -229,7 +229,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 			buf.L("%s %s {", branch, activeCriteria(filter, ignoredFilters[i]))
 
 			buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects", filter...))
-			buf.L("args = []interface{}{")
+			buf.L("args = []any{")
 
 			for _, name := range filter {
 				if name == "Parent" {
@@ -250,7 +250,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 
 		buf.L("%s %s {", branch, activeCriteria([]string{}, FieldNames(mapping.Filters)))
 		buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects"))
-		buf.L("args = []interface{}{}")
+		buf.L("args = []any{}")
 		buf.L("} else {")
 		buf.L("return nil, fmt.Errorf(\"No statement exists for the given Filter\")")
 		buf.L("}")
@@ -517,7 +517,7 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 		stmtVar := stmtCodeVar(m.entity, "create")
 		stmtLocal := stmtVar + "Local"
 		buf.L("%s := strings.Replace(%s, \"%%s_id\", fmt.Sprintf(\"%%s_id\", parent), -1)", stmtLocal, stmtVar)
-		buf.L("fillParent := make([]interface{}, strings.Count(%s, \"%%s\"))", stmtLocal)
+		buf.L("fillParent := make([]any, strings.Count(%s, \"%%s\"))", stmtLocal)
 		buf.L("for i := range fillParent {")
 		buf.L("fillParent[i] = strings.Replace(parent, \"_\", \"s_\", -1) + \"s\"")
 		buf.L("}")
@@ -566,7 +566,7 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 		}
 
 		fields := mapping.ColumnFields("ID")
-		buf.L("args := make([]interface{}, %d)", len(fields))
+		buf.L("args := make([]any, %d)", len(fields))
 		buf.N()
 
 		buf.L("// Populate the statement arguments. ")
@@ -805,7 +805,7 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 		stmtVar := stmtCodeVar(m.entity, "delete")
 		stmtLocal := stmtVar + "Local"
 		buf.L("%s := strings.Replace(%s, \"%%s_id\", fmt.Sprintf(\"%%s_id\", parent), -1)", stmtLocal, stmtVar)
-		buf.L("fillParent := make([]interface{}, strings.Count(%s, \"%%s\"))", stmtLocal)
+		buf.L("fillParent := make([]any, strings.Count(%s, \"%%s\"))", stmtLocal)
 		buf.L("for i := range fillParent {")
 		buf.L("fillParent[i] = strings.Replace(parent, \"_\", \"s_\", -1) + \"s\"")
 		buf.L("}")

--- a/lxd/db/generate/file/buffer.go
+++ b/lxd/db/generate/file/buffer.go
@@ -19,7 +19,7 @@ func newBuffer() *Buffer {
 }
 
 // L accumulates a single line of source code.
-func (b *Buffer) L(format string, a ...interface{}) {
+func (b *Buffer) L(format string, a ...any) {
 	fmt.Fprintf(b.buf, format, a...)
 	b.N()
 }

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -89,7 +89,7 @@ func (c *ClusterTx) GetImageSource(imageID int) (int, api.ImageSource, error) {
 		Certificate string
 		Alias       string
 	}{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		sources = append(sources, struct {
 			ID          int
 			Server      string
@@ -97,7 +97,7 @@ func (c *ClusterTx) GetImageSource(imageID int) (int, api.ImageSource, error) {
 			Certificate string
 			Alias       string
 		}{})
-		return []interface{}{
+		return []any{
 			&sources[i].ID,
 			&sources[i].Server,
 			&sources[i].Protocol,
@@ -176,9 +176,9 @@ func (c *ClusterTx) imageFill(id int, image *api.Image, create, expire, used, up
 
 	// Get the aliases
 	aliases := []api.ImageAlias{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		aliases = append(aliases, api.ImageAlias{})
-		return []interface{}{
+		return []any{
 			&aliases[i].Name,
 			&aliases[i].Description,
 		}
@@ -321,7 +321,7 @@ func (c *Cluster) CreateImageSource(id int, server string, protocol string, cert
 			"protocol",
 			"certificate",
 			"alias",
-		}, []interface{}{
+		}, []any{
 			id,
 			server,
 			protocolInt,
@@ -365,7 +365,7 @@ func (c *Cluster) GetCachedImageSourceFingerprint(server string, protocol string
 			WHERE server=? AND protocol=? AND alias=? AND auto_update=1 AND images.architecture=?
 `
 
-	args := []interface{}{server, protocolInt, alias, architecture}
+	args := []any{server, protocolInt, alias, architecture}
 	if imageType != instancetype.Any {
 		q += "AND images.type=?\n"
 		args = append(args, imageType)
@@ -570,7 +570,7 @@ FROM images
 JOIN projects ON images.project_id = projects.id
 WHERE images.fingerprint LIKE ?
 `
-	args := []interface{}{fingerprintPrefix + "%"}
+	args := []any{fingerprintPrefix + "%"}
 	if filter.Project != nil {
 		sql += `AND project = ?
 	`
@@ -586,9 +586,9 @@ WHERE images.fingerprint LIKE ?
 
 	objects := []Image{}
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Image{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Project,
 			&objects[i].Fingerprint,
@@ -760,8 +760,8 @@ func (c *Cluster) GetImageAlias(project, name string, isTrustedClient bool) (int
 		var fingerprint, description string
 		var imageType int
 
-		arg1 := []interface{}{project, name}
-		arg2 := []interface{}{&id, &fingerprint, &imageType, &description}
+		arg1 := []any{project, name}
+		arg2 := []any{&id, &fingerprint, &imageType, &description}
 		err = tx.tx.QueryRow(q, arg1...).Scan(arg2...)
 		if err != nil {
 			if err == sql.ErrNoRows {
@@ -1118,7 +1118,7 @@ func (c *Cluster) GetPoolsWithImage(imageFingerprint string) ([]int64, error) {
 // GetPoolNamesFromIDs get the names of the storage pools with the given IDs.
 func (c *Cluster) GetPoolNamesFromIDs(poolIDs []int64) ([]string, error) {
 	params := make([]string, len(poolIDs))
-	args := make([]interface{}, len(poolIDs))
+	args := make([]any, len(poolIDs))
 	for i, id := range poolIDs {
 		params[i] = "?"
 		args[i] = id

--- a/lxd/db/images.mapper.go
+++ b/lxd/db/images.mapper.go
@@ -69,51 +69,51 @@ func (c *ClusterTx) GetImages(filter ImageFilter) ([]Image, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Project != nil && filter.Public != nil && filter.Fingerprint == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByProjectAndPublic)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Public,
 		}
 	} else if filter.Project != nil && filter.Cached != nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByProjectAndCached)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Cached,
 		}
 	} else if filter.Project != nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByProject)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 		}
 	} else if filter.Fingerprint != nil && filter.Project == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByFingerprint)
-		args = []interface{}{
+		args = []any{
 			filter.Fingerprint,
 		}
 	} else if filter.Cached != nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByCached)
-		args = []interface{}{
+		args = []any{
 			filter.Cached,
 		}
 	} else if filter.AutoUpdate != nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil {
 		stmt = c.stmt(imageObjectsByAutoUpdate)
-		args = []interface{}{
+		args = []any{
 			filter.AutoUpdate,
 		}
 	} else if filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Image{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Project,
 			&objects[i].Fingerprint,
@@ -172,51 +172,51 @@ func (c *ClusterTx) GetImageURIs(filter ImageFilter) ([]string, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Project != nil && filter.Public != nil && filter.Fingerprint == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByProjectAndPublic)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Public,
 		}
 	} else if filter.Project != nil && filter.Cached != nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByProjectAndCached)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Cached,
 		}
 	} else if filter.Project != nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByProject)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 		}
 	} else if filter.Fingerprint != nil && filter.Project == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByFingerprint)
-		args = []interface{}{
+		args = []any{
 			filter.Fingerprint,
 		}
 	} else if filter.Cached != nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjectsByCached)
-		args = []interface{}{
+		args = []any{
 			filter.Cached,
 		}
 	} else if filter.AutoUpdate != nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil {
 		stmt = c.stmt(imageObjectsByAutoUpdate)
-		args = []interface{}{
+		args = []any{
 			filter.AutoUpdate,
 		}
 	} else if filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
 		stmt = c.stmt(imageObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Image{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Project,
 			&objects[i].Fingerprint,

--- a/lxd/db/instance_profiles.mapper.go
+++ b/lxd/db/instance_profiles.mapper.go
@@ -39,12 +39,12 @@ func (c *ClusterTx) GetProfileInstances() (map[int][]int, error) {
 	objects := make([]InstanceProfile, 0)
 
 	stmt := c.stmt(instanceProfileObjects)
-	args := []interface{}{}
+	args := []any{}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, InstanceProfile{})
-		return []interface{}{
+		return []any{
 			&objects[i].InstanceID,
 			&objects[i].ProfileID,
 			&objects[i].ApplyOrder,
@@ -74,12 +74,12 @@ func (c *ClusterTx) GetInstanceProfiles() (map[int][]int, error) {
 	objects := make([]InstanceProfile, 0)
 
 	stmt := c.stmt(instanceProfileObjects)
-	args := []interface{}{}
+	args := []any{}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, InstanceProfile{})
-		return []interface{}{
+		return []any{
 			&objects[i].InstanceID,
 			&objects[i].ProfileID,
 			&objects[i].ApplyOrder,
@@ -103,7 +103,7 @@ func (c *ClusterTx) GetInstanceProfiles() (map[int][]int, error) {
 // CreateInstanceProfile adds a new instance_profile to the database.
 // generator: instance_profile Create
 func (c *ClusterTx) CreateInstanceProfile(object InstanceProfile) (int64, error) {
-	args := make([]interface{}, 3)
+	args := make([]any, 3)
 
 	// Populate the statement arguments.
 	args[0] = object.InstanceID

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -164,7 +164,7 @@ SELECT instances.name FROM instances
 func (c *ClusterTx) GetNodeAddressOfInstance(project string, name string, filter InstanceFilter) (string, error) {
 	var stmt string
 
-	args := make([]interface{}, 0, 4) // Expect up to 4 filters.
+	args := make([]any, 0, 4) // Expect up to 4 filters.
 	var filters strings.Builder
 
 	// Project filter.
@@ -257,7 +257,7 @@ func (c *ClusterTx) GetProjectAndInstanceNamesByNodeAddress(projects []string, f
 		return nil, err
 	}
 
-	args := make([]interface{}, 0, 2) // Expect up to 2 filters.
+	args := make([]any, 0, 2) // Expect up to 2 filters.
 	var filters strings.Builder
 
 	// Project filter.
@@ -398,7 +398,7 @@ func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst In
 // GetProjectInstanceToNodeMap returns a map associating the project (key element 0) and name (key element 1) of each
 // instance in the given projects to the name of the node hosting the instance.
 func (c *ClusterTx) GetProjectInstanceToNodeMap(projects []string, filter InstanceFilter) (map[[2]string]string, error) {
-	args := make([]interface{}, 0, 2) // Expect up to 2 filters.
+	args := make([]any, 0, 2) // Expect up to 2 filters.
 	var filters strings.Builder
 
 	// Project filter.
@@ -565,10 +565,10 @@ func (c *ClusterTx) configUpdate(id int, values map[string]string, insertSQL, de
 	if len(changes) > 0 {
 		query := insertSQL
 		exprs := []string{}
-		params := []interface{}{}
+		params := []any{}
 		for key, value := range changes {
 			exprs = append(exprs, "(?, ?, ?)")
-			params = append(params, []interface{}{id, key, value}...)
+			params = append(params, []any{id, key, value}...)
 		}
 
 		query += strings.Join(exprs, ",")
@@ -581,7 +581,7 @@ func (c *ClusterTx) configUpdate(id int, values map[string]string, insertSQL, de
 	// Delete keys
 	if len(deletes) > 0 {
 		query := fmt.Sprintf(deleteSQL, query.Params(len(deletes)))
-		params := []interface{}{}
+		params := []any{}
 		for _, key := range deletes {
 			params = append(params, key)
 		}
@@ -688,8 +688,8 @@ SELECT storage_pools.name FROM storage_pools
    AND storage_volumes_all.type IN(?,?)
    AND storage_volumes_all.project_id = instances.project_id
    AND (storage_volumes_all.node_id=? OR storage_volumes_all.node_id IS NULL AND storage_pools.driver IN %s)`, query.Params(len(remoteDrivers)))
-	inargs := []interface{}{projectName, instanceName, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeVM, c.nodeID}
-	outargs := []interface{}{&poolName}
+	inargs := []any{projectName, instanceName, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeVM, c.nodeID}
+	outargs := []any{&poolName}
 
 	for _, driver := range remoteDrivers {
 		inargs = append(inargs, driver)
@@ -822,10 +822,10 @@ FROM instances_snapshots
 JOIN instances ON instances.id = instances_snapshots.instance_id
 WHERE type=? ORDER BY instances.name, instances_snapshots.name
 `)
-	inargs := []interface{}{instancetype.Container}
+	inargs := []any{instancetype.Container}
 	var container string
 	var snapshot string
-	outfmt := []interface{}{container, snapshot}
+	outfmt := []any{container, snapshot}
 	result, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
@@ -859,8 +859,8 @@ SELECT instances_snapshots.name
 WHERE projects.name=? AND instances.name=?
 ORDER BY date(instances_snapshots.creation_date)
 `
-	inargs := []interface{}{project, name}
-	outfmt := []interface{}{name}
+	inargs := []any{project, name}
+	outfmt := []any{name}
 	dbResults, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {
 		return result, err
@@ -883,8 +883,8 @@ SELECT instances_snapshots.name
   JOIN projects ON projects.id = instances.project_id
 WHERE projects.name=? AND instances.name=?`
 	var numstr string
-	inargs := []interface{}{project, name}
-	outfmt := []interface{}{numstr}
+	inargs := []any{project, name}
+	outfmt := []any{numstr}
 	results, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {
 		return 0

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -153,11 +153,11 @@ func (c *ClusterTx) GetInstances(filter InstanceFilter) ([]Instance, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.Name != nil && filter.ID == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndTypeAndNodeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Node,
@@ -165,104 +165,104 @@ func (c *ClusterTx) GetInstances(filter InstanceFilter) ([]Instance, error) {
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndTypeAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndTypeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Name,
 		}
 	} else if filter.Type != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil {
 		stmt = c.stmt(instanceObjectsByTypeAndNameAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 			filter.Name,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndNameAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Name,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndType)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 		}
 	} else if filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(instanceObjectsByTypeAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 			filter.Node,
 		}
 	} else if filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByTypeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Name,
 		}
 	} else if filter.Node != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByNodeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Node,
 			filter.Name,
 		}
 	} else if filter.Type != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByType)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProject)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 		}
 	} else if filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByNode)
-		args = []interface{}{
+		args = []any{
 			filter.Node,
 		}
 	} else if filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByName)
-		args = []interface{}{
+		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByID)
-		args = []interface{}{
+		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Instance{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Project,
 			&objects[i].Name,
@@ -373,11 +373,11 @@ func (c *ClusterTx) GetInstanceURIs(filter InstanceFilter) ([]string, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.Name != nil && filter.ID == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndTypeAndNodeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Node,
@@ -385,104 +385,104 @@ func (c *ClusterTx) GetInstanceURIs(filter InstanceFilter) ([]string, error) {
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndTypeAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndTypeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Name,
 		}
 	} else if filter.Type != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil {
 		stmt = c.stmt(instanceObjectsByTypeAndNameAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 			filter.Name,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndNameAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Name,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndType)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Type,
 		}
 	} else if filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(instanceObjectsByTypeAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 			filter.Node,
 		}
 	} else if filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByTypeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndNode)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProjectAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Name,
 		}
 	} else if filter.Node != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByNodeAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Node,
 			filter.Name,
 		}
 	} else if filter.Type != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil {
 		stmt = c.stmt(instanceObjectsByType)
-		args = []interface{}{
+		args = []any{
 			filter.Type,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByProject)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 		}
 	} else if filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByNode)
-		args = []interface{}{
+		args = []any{
 			filter.Node,
 		}
 	} else if filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByName)
-		args = []interface{}{
+		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjectsByID)
-		args = []interface{}{
+		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
 		stmt = c.stmt(instanceObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Instance{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Project,
 			&objects[i].Name,
@@ -574,7 +574,7 @@ func (c *ClusterTx) CreateInstance(object Instance) (int64, error) {
 		return -1, fmt.Errorf("This \"instances\" entry already exists")
 	}
 
-	args := make([]interface{}, 11)
+	args := make([]any, 11)
 
 	// Populate the statement arguments.
 	args[0] = object.Project

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -47,11 +47,11 @@ DELETE FROM storage_volumes_config WHERE storage_volume_id NOT IN (SELECT id FRO
 	// Dump all tables.
 	dump := &Dump{
 		Schema: map[string][]string{},
-		Data:   map[string][][]interface{}{},
+		Data:   map[string][][]any{},
 	}
 	for _, table := range preClusteringTables {
 		logger.Debugf("Loading data from table %s", table)
-		data := [][]interface{}{}
+		data := [][]any{}
 		stmt := fmt.Sprintf("SELECT * FROM %s", table)
 
 		rows, err := tx.Query(stmt)
@@ -67,8 +67,8 @@ DELETE FROM storage_volumes_config WHERE storage_volume_id NOT IN (SELECT id FRO
 		dump.Schema[table] = columns
 
 		for rows.Next() {
-			values := make([]interface{}, len(columns))
-			row := make([]interface{}, len(columns))
+			values := make([]any, len(columns))
+			row := make([]any, len(columns))
 			for i := range values {
 				row[i] = &values[i]
 			}
@@ -255,7 +255,7 @@ INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.storag
 
 // Insert a row in one of the nodes association tables (storage_pools_nodes,
 // networks_nodes, images_nodes).
-func importNodeAssociation(entity string, columns []string, row []interface{}, tx *sql.Tx) error {
+func importNodeAssociation(entity string, columns []string, row []any, tx *sql.Tx) error {
 	stmt := fmt.Sprintf(
 		"INSERT INTO %ss_nodes(%s_id, node_id) VALUES(?, 1)", entity, entity)
 	var id int64
@@ -283,7 +283,7 @@ type Dump struct {
 
 	// Map a table name to all the rows it contains. Each row is a slice
 	// of interfaces.
-	Data map[string][][]interface{}
+	Data map[string][][]any
 }
 
 var preClusteringTables = []string{

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -29,17 +29,17 @@ func TestLoadPreClusteringData(t *testing.T) {
 	assert.Equal(t, []string{"id", "key", "value"}, dump.Schema["config"])
 	assert.Len(t, dump.Data["config"], 3)
 	assert.Equal(t, "1.2.3.4:666", dump.Data["config"][0][2])
-	rows := []interface{}{int64(1), "core.https_address", "1.2.3.4:666"}
+	rows := []any{int64(1), "core.https_address", "1.2.3.4:666"}
 	assert.Equal(t, rows, dump.Data["config"][0])
-	rows = []interface{}{int64(2), "core.trust_password", "sekret"}
+	rows = []any{int64(2), "core.trust_password", "sekret"}
 	assert.Equal(t, rows, dump.Data["config"][1])
-	rows = []interface{}{int64(3), "maas.machine", "mymaas"}
+	rows = []any{int64(3), "maas.machine", "mymaas"}
 	assert.Equal(t, rows, dump.Data["config"][2])
 
 	// networks
 	assert.Equal(t, []string{"id", "name", "description"}, dump.Schema["networks"])
 	assert.Len(t, dump.Data["networks"], 1)
-	rows = []interface{}{int64(1), "lxcbr0", "LXD bridge"}
+	rows = []any{int64(1), "lxcbr0", "LXD bridge"}
 	assert.Equal(t, rows, dump.Data["networks"][0])
 }
 

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -23,7 +23,7 @@ func (c *Cluster) GetNetworkACLs(project string) ([]string, error) {
 	var aclNames []string
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var aclName string
 
 			err := scan(&aclName)
@@ -53,7 +53,7 @@ func (c *Cluster) GetNetworkACLIDsByNames(project string) (map[string]int64, err
 	acls := make(map[string]int64)
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var aclID int64
 			var aclName string
 
@@ -163,7 +163,7 @@ func networkACLConfig(tx *ClusterTx, id int64, acl *api.NetworkACL) error {
 	`
 
 	acl.Config = make(map[string]string)
-	return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)

--- a/lxd/db/network_forwards.go
+++ b/lxd/db/network_forwards.go
@@ -20,7 +20,7 @@ import (
 func (c *Cluster) CreateNetworkForward(networkID int64, memberSpecific bool, info *api.NetworkForwardsPost) (int64, error) {
 	var err error
 	var forwardID int64
-	var nodeID interface{}
+	var nodeID any
 
 	if memberSpecific {
 		nodeID = c.nodeID
@@ -174,7 +174,7 @@ func (c *Cluster) DeleteNetworkForward(networkID int64, forwardID int64) error {
 // all members.
 func (c *Cluster) GetNetworkForward(networkID int64, memberSpecific bool, listenAddress string) (int64, *api.NetworkForward, error) {
 	var q *strings.Builder = &strings.Builder{}
-	args := []interface{}{networkID, listenAddress}
+	args := []any{networkID, listenAddress}
 
 	q.WriteString(`
 	SELECT
@@ -244,7 +244,7 @@ func networkForwardConfig(tx *ClusterTx, forwardID int64, forward *api.NetworkFo
 	`
 
 	forward.Config = make(map[string]string)
-	return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)
@@ -269,7 +269,7 @@ func networkForwardConfig(tx *ClusterTx, forwardID int64, forward *api.NetworkFo
 // all members.
 func (c *Cluster) GetNetworkForwardListenAddresses(networkID int64, memberSpecific bool) (map[int64]string, error) {
 	var q *strings.Builder = &strings.Builder{}
-	args := []interface{}{networkID}
+	args := []any{networkID}
 
 	q.WriteString(`
 	SELECT
@@ -287,7 +287,7 @@ func (c *Cluster) GetNetworkForwardListenAddresses(networkID int64, memberSpecif
 	forwards := make(map[int64]string)
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q.String(), func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q.String(), func(scan func(dest ...any) error) error {
 			var forwardID int64 = int64(-1)
 			var listenAddress string
 
@@ -328,7 +328,7 @@ func (c *ClusterTx) GetProjectNetworkForwardListenAddressesByUplink(uplinkNetwor
 	`
 	forwards := make(map[string]map[int64][]string)
 
-	err := c.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	err := c.QueryScan(q, func(scan func(dest ...any) error) error {
 		var projectName string
 		var networkID int64 = int64(-1)
 		var listenAddress string
@@ -373,7 +373,7 @@ func (c *ClusterTx) GetProjectNetworkForwardListenAddressesOnMember() (map[strin
 	`
 	forwards := make(map[string]map[int64][]string)
 
-	err := c.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	err := c.QueryScan(q, func(scan func(dest ...any) error) error {
 		var projectName string
 		var networkID int64 = int64(-1)
 		var listenAddress string
@@ -407,7 +407,7 @@ func (c *ClusterTx) GetProjectNetworkForwardListenAddressesOnMember() (map[strin
 // all members.
 func (c *Cluster) GetNetworkForwards(networkID int64, memberSpecific bool) (map[int64]*api.NetworkForward, error) {
 	var q *strings.Builder = &strings.Builder{}
-	args := []interface{}{networkID}
+	args := []any{networkID}
 
 	q.WriteString(`
 	SELECT
@@ -430,7 +430,7 @@ func (c *Cluster) GetNetworkForwards(networkID int64, memberSpecific bool) (map[
 	forwards := make(map[int64]*api.NetworkForward)
 
 	err = c.Transaction(func(tx *ClusterTx) error {
-		err = tx.QueryScan(q.String(), func(scan func(dest ...interface{}) error) error {
+		err = tx.QueryScan(q.String(), func(scan func(dest ...any) error) error {
 			var forwardID int64 = int64(-1)
 			var portsJSON string
 			var forward api.NetworkForward

--- a/lxd/db/network_peers.go
+++ b/lxd/db/network_peers.go
@@ -247,7 +247,7 @@ func networkPeerConfig(tx *ClusterTx, peerID int64, peer *api.NetworkPeer) error
 	`
 
 	peer.Config = make(map[string]string)
-	return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)
@@ -298,7 +298,7 @@ func (c *Cluster) GetNetworkPeers(networkID int64) (map[int64]*api.NetworkPeer, 
 	peers := make(map[int64]*api.NetworkPeer)
 
 	err = c.Transaction(func(tx *ClusterTx) error {
-		err = tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		err = tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var peerID int64 = int64(-1)
 			var peer api.NetworkPeer
 			var targetPeerNetworkName string
@@ -349,7 +349,7 @@ func (c *Cluster) GetNetworkPeerNames(networkID int64) (map[int64]string, error)
 	peers := make(map[int64]string)
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var peerID int64 = int64(-1)
 			var peerName string
 
@@ -462,7 +462,7 @@ func (c *Cluster) GetNetworkPeersTargetNetworkIDs(projectName string, networkTyp
 	`
 
 	err = c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var peerName string
 			var networkName string
 			var targetNetworkID int64 = int64(-1)

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -22,7 +22,7 @@ func (c *Cluster) GetNetworkZones(project string) ([]string, error) {
 	var zoneNames []string
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var zoneName string
 
 			err := scan(&zoneName)
@@ -52,7 +52,7 @@ func (c *Cluster) GetNetworkZoneKeys() (map[string]string, error) {
 
 	secrets := map[string]string{}
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var name string
 			var peer string
 			var secret string
@@ -95,7 +95,7 @@ func (c *Cluster) GetNetworksForZone(projectName string, zoneName string) ([]str
 	var networkNames []string
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var networkName string
 
 			err := scan(&networkName)
@@ -204,7 +204,7 @@ func networkZoneConfig(tx *ClusterTx, id int64, zone *api.NetworkZone) error {
 	`
 
 	zone.Config = make(map[string]string)
-	return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)
@@ -323,7 +323,7 @@ func (c *Cluster) GetNetworkZoneRecordNames(zone int64) ([]string, error) {
 
 	var recordNames []string
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var recordName string
 
 			err := scan(&recordName)
@@ -398,7 +398,7 @@ func networkZoneRecordConfig(tx *ClusterTx, id int64, record *api.NetworkZoneRec
 	`
 
 	record.Config = make(map[string]string)
-	return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -444,7 +444,7 @@ func (c *ClusterTx) SetDescription(id int64, description string) error {
 }
 
 // Nodes returns all LXD nodes part of the cluster.
-func (c *ClusterTx) nodes(pending bool, where string, args ...interface{}) ([]NodeInfo, error) {
+func (c *ClusterTx) nodes(pending bool, where string, args ...any) ([]NodeInfo, error) {
 	// Get node roles
 	sql := "SELECT node_id, role FROM nodes_roles"
 
@@ -521,9 +521,9 @@ JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id`
 
 	// Process node entries
 	nodes := []NodeInfo{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		nodes = append(nodes, NodeInfo{})
-		return []interface{}{
+		return []any{
 			&nodes[i].ID,
 			&nodes[i].Name,
 			&nodes[i].Address,
@@ -547,7 +547,7 @@ JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id`
 		sql += fmt.Sprintf("WHERE state!=? ")
 	}
 
-	args = append([]interface{}{ClusterMemberStatePending}, args...)
+	args = append([]any{ClusterMemberStatePending}, args...)
 
 	if where != "" {
 		sql += fmt.Sprintf("AND %s ", where)
@@ -612,7 +612,7 @@ func (c *ClusterTx) CreateNode(name string, address string) (int64, error) {
 // architecture explicitly.
 func (c *ClusterTx) CreateNodeWithArch(name string, address string, arch int) (int64, error) {
 	columns := []string{"name", "address", "schema", "api_extensions", "arch", "description"}
-	values := []interface{}{name, address, cluster.SchemaVersion, version.APIExtensionsCount(), arch, ""}
+	values := []any{name, address, cluster.SchemaVersion, version.APIExtensionsCount(), arch, ""}
 	return query.UpsertObject(c.tx, "nodes", columns, values)
 }
 
@@ -754,7 +754,7 @@ func (c *ClusterTx) UpdateNodeClusterGroups(id int64, groups []string) error {
 
 // UpdateNodeFailureDomain changes the failure domain of a node.
 func (c *ClusterTx) UpdateNodeFailureDomain(id int64, domain string) error {
-	var domainID interface{}
+	var domainID any
 
 	if domain == "" {
 		return fmt.Errorf("Failure domain name can't be empty")
@@ -843,12 +843,12 @@ func (c *ClusterTx) GetNodesFailureDomains() (map[string]uint64, error) {
 		FailureDomainID int64
 	}{}
 
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		rows = append(rows, struct {
 			Address         string
 			FailureDomainID int64
 		}{})
-		return []interface{}{&rows[len(rows)-1].Address, &rows[len(rows)-1].FailureDomainID}
+		return []any{&rows[len(rows)-1].Address, &rows[len(rows)-1].FailureDomainID}
 	}
 
 	err = query.SelectObjects(stmt, dest)
@@ -878,12 +878,12 @@ func (c *ClusterTx) GetFailureDomainsNames() (map[uint64]string, error) {
 		Name string
 	}{}
 
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		rows = append(rows, struct {
 			ID   int64
 			Name string
 		}{})
-		return []interface{}{&rows[len(rows)-1].ID, &rows[len(rows)-1].Name}
+		return []any{&rows[len(rows)-1].ID, &rows[len(rows)-1].Name}
 	}
 
 	err = query.SelectObjects(stmt, dest)
@@ -959,12 +959,12 @@ func (c *ClusterTx) NodeIsEmpty(id int64) (string, error) {
 		fingerprint string
 		nodeID      int64
 	}{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		images = append(images, struct {
 			fingerprint string
 			nodeID      int64
 		}{})
-		return []interface{}{&images[i].fingerprint, &images[i].nodeID}
+		return []any{&images[i].fingerprint, &images[i].nodeID}
 
 	}
 	stmt, err := c.tx.Prepare(`

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -135,12 +135,12 @@ func updateFromV39(tx *sql.Tx) error {
 		ID      uint64
 		Address string
 	}{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		nodes = append(nodes, struct {
 			ID      uint64
 			Address string
 		}{})
-		return []interface{}{&nodes[i].ID, &nodes[i].Address}
+		return []any{&nodes[i].ID, &nodes[i].Address}
 	}
 	stmt, err := tx.Prepare("SELECT id, address FROM raft_nodes")
 	if err != nil {

--- a/lxd/db/operations.mapper.go
+++ b/lxd/db/operations.mapper.go
@@ -63,34 +63,34 @@ func (c *ClusterTx) GetOperations(filter OperationFilter) ([]Operation, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.UUID != nil && filter.ID == nil && filter.NodeID == nil {
 		stmt = c.stmt(operationObjectsByUUID)
-		args = []interface{}{
+		args = []any{
 			filter.UUID,
 		}
 	} else if filter.NodeID != nil && filter.ID == nil && filter.UUID == nil {
 		stmt = c.stmt(operationObjectsByNodeID)
-		args = []interface{}{
+		args = []any{
 			filter.NodeID,
 		}
 	} else if filter.ID != nil && filter.NodeID == nil && filter.UUID == nil {
 		stmt = c.stmt(operationObjectsByID)
-		args = []interface{}{
+		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.NodeID == nil && filter.UUID == nil {
 		stmt = c.stmt(operationObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Operation{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].UUID,
 			&objects[i].NodeAddress,
@@ -112,7 +112,7 @@ func (c *ClusterTx) GetOperations(filter OperationFilter) ([]Operation, error) {
 // CreateOrReplaceOperation adds a new operation to the database.
 // generator: operation CreateOrReplace
 func (c *ClusterTx) CreateOrReplaceOperation(object Operation) (int64, error) {
-	args := make([]interface{}, 4)
+	args := make([]any, 4)
 
 	// Populate the statement arguments.
 	args[0] = object.UUID

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -150,9 +150,9 @@ SELECT profiles.name
  JOIN projects ON projects.id = profiles.project_id
 WHERE projects.name = ?
 `)
-	inargs := []interface{}{project}
+	inargs := []any{project}
 	var name string
-	outfmt := []interface{}{name}
+	outfmt := []any{name}
 	result, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {
 		return []string{}, err
@@ -265,9 +265,9 @@ func (c *Cluster) GetInstancesWithProfile(project, profile string) (map[string][
 		   WHERE profiles.name=? AND projects.name=?)`
 
 	results := map[string][]string{}
-	inargs := []interface{}{profile, project}
+	inargs := []any{profile, project}
 	var name string
-	outfmt := []interface{}{name, name}
+	outfmt := []any{name, name}
 
 	output, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -75,35 +75,35 @@ func (c *ClusterTx) GetProfileURIs(filter ProfileFilter) ([]string, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Project != nil && filter.Name != nil && filter.ID == nil {
 		stmt = c.stmt(profileObjectsByProjectAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjectsByProject)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjectsByID)
-		args = []interface{}{
+		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Profile{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].ProjectID,
 			&objects[i].Project,
@@ -139,35 +139,35 @@ func (c *ClusterTx) GetProfiles(filter ProfileFilter) ([]Profile, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Project != nil && filter.Name != nil && filter.ID == nil {
 		stmt = c.stmt(profileObjectsByProjectAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjectsByProject)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjectsByID)
-		args = []interface{}{
+		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Profile{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].ProjectID,
 			&objects[i].Project,
@@ -305,7 +305,7 @@ func (c *ClusterTx) CreateProfile(object Profile) (int64, error) {
 		return -1, fmt.Errorf("This \"profiles\" entry already exists")
 	}
 
-	args := make([]interface{}, 3)
+	args := make([]any, 3)
 
 	// Populate the statement arguments.
 	args[0] = object.Project

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -69,29 +69,29 @@ func (c *ClusterTx) GetProjectURIs(filter ProjectFilter) ([]string, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Name != nil && filter.ID == nil {
 		stmt = c.stmt(projectObjectsByName)
-		args = []interface{}{
+		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID != nil && filter.Name == nil {
 		stmt = c.stmt(projectObjectsByID)
-		args = []interface{}{
+		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Name == nil {
 		stmt = c.stmt(projectObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Project{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Description,
 			&objects[i].Name,
@@ -124,29 +124,29 @@ func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]Project, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Name != nil && filter.ID == nil {
 		stmt = c.stmt(projectObjectsByName)
-		args = []interface{}{
+		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID != nil && filter.Name == nil {
 		stmt = c.stmt(projectObjectsByID)
-		args = []interface{}{
+		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Name == nil {
 		stmt = c.stmt(projectObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Project{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Description,
 			&objects[i].Name,
@@ -233,7 +233,7 @@ func (c *ClusterTx) CreateProject(object Project) (int64, error) {
 		return -1, fmt.Errorf("This \"projects\" entry already exists")
 	}
 
-	args := make([]interface{}, 2)
+	args := make([]any, 2)
 
 	// Populate the statement arguments.
 	args[0] = object.Description

--- a/lxd/db/query/config.go
+++ b/lxd/db/query/config.go
@@ -11,7 +11,7 @@ import (
 // additional WHERE filters can be specified.
 //
 // Returns a map of key names to their associated values.
-func SelectConfig(tx *sql.Tx, table string, where string, args ...interface{}) (map[string]string, error) {
+func SelectConfig(tx *sql.Tx, table string, where string, args ...any) (map[string]string, error) {
 	query := fmt.Sprintf("SELECT key, value FROM %s", table)
 	if where != "" {
 		query += fmt.Sprintf(" WHERE %s", where)
@@ -79,7 +79,7 @@ func upsertConfig(tx *sql.Tx, table string, values map[string]string) error {
 
 	query := fmt.Sprintf("INSERT OR REPLACE INTO %s (key, value) VALUES", table)
 	exprs := []string{}
-	params := []interface{}{}
+	params := []any{}
 	for key, value := range values {
 		exprs = append(exprs, "(?, ?)")
 		params = append(params, key)
@@ -99,7 +99,7 @@ func deleteConfig(tx *sql.Tx, table string, keys []string) error {
 	}
 
 	query := fmt.Sprintf("DELETE FROM %s WHERE key IN %s", table, Params(n))
-	values := make([]interface{}, n)
+	values := make([]any, n)
 	for i, key := range keys {
 		values[i] = key
 	}

--- a/lxd/db/query/count.go
+++ b/lxd/db/query/count.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Count returns the number of rows in the given table.
-func Count(tx *sql.Tx, table string, where string, args ...interface{}) (int, error) {
+func Count(tx *sql.Tx, table string, where string, args ...any) (int, error) {
 	stmt := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
 	if where != "" {
 		stmt += fmt.Sprintf(" WHERE %s", where)

--- a/lxd/db/query/count_test.go
+++ b/lxd/db/query/count_test.go
@@ -14,22 +14,22 @@ import (
 func TestCount(t *testing.T) {
 	cases := []struct {
 		where string
-		args  []interface{}
+		args  []any
 		count int
 	}{
 		{
 			"id=?",
-			[]interface{}{999},
+			[]any{999},
 			0,
 		},
 		{
 			"id=?",
-			[]interface{}{1},
+			[]any{1},
 			1,
 		},
 		{
 			"",
-			[]interface{}{},
+			[]any{},
 			2,
 		},
 	}

--- a/lxd/db/query/dump.go
+++ b/lxd/db/query/dump.go
@@ -95,8 +95,8 @@ func dumpTable(ctx context.Context, tx *sql.Tx, table, schema string) (string, e
 
 	// Generate an INSERT statement for each row.
 	for i := 0; rows.Next(); i++ {
-		raw := make([]interface{}, len(columns)) // Raw column values
-		row := make([]interface{}, len(columns))
+		raw := make([]any, len(columns)) // Raw column values
+		row := make([]any, len(columns))
 		for i := range raw {
 			row[i] = &raw[i]
 		}

--- a/lxd/db/query/objects.go
+++ b/lxd/db/query/objects.go
@@ -8,7 +8,7 @@ import (
 
 // SelectObjects executes a statement which must yield rows with a specific
 // columns schema. It invokes the given Dest hook for each yielded row.
-func SelectObjects(stmt *sql.Stmt, dest Dest, args ...interface{}) error {
+func SelectObjects(stmt *sql.Stmt, dest Dest, args ...any) error {
 	rows, err := stmt.Query(args...)
 	if err != nil {
 		return err
@@ -32,15 +32,15 @@ func SelectObjects(stmt *sql.Stmt, dest Dest, args ...interface{}) error {
 // Dest is a function that is expected to return the objects to pass to the
 // 'dest' argument of sql.Rows.Scan(). It is invoked by SelectObjects once per
 // yielded row, and it will be passed the index of the row being scanned.
-type Dest func(i int) []interface{}
+type Dest func(i int) []any
 
 // UpsertObject inserts or replaces a new row with the given column values, to
 // the given table using columns order. For example:
 //
-// UpsertObject(tx, "cars", []string{"id", "brand"}, []interface{}{1, "ferrari"})
+// UpsertObject(tx, "cars", []string{"id", "brand"}, []any{1, "ferrari"})
 //
 // The number of elements in 'columns' must match the one in 'values'.
-func UpsertObject(tx *sql.Tx, table string, columns []string, values []interface{}) (int64, error) {
+func UpsertObject(tx *sql.Tx, table string, columns []string, values []any) (int64, error) {
 	n := len(columns)
 	if n == 0 {
 		return -1, fmt.Errorf("columns length is zero")

--- a/lxd/db/query/objects_test.go
+++ b/lxd/db/query/objects_test.go
@@ -17,7 +17,7 @@ func TestSelectObjects_Error(t *testing.T) {
 		error string
 	}{
 		{
-			func(int) []interface{} { return make([]interface{}, 1) },
+			func(int) []any { return make([]any, 1) },
 			"SELECT id, name FROM test",
 			"sql: expected 2 destination arguments in Scan, not 1",
 		},
@@ -44,9 +44,9 @@ func TestSelectObjects(t *testing.T) {
 	}, 1)
 	object := objects[0]
 
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		require.Equal(t, 0, i, "expected at most one row to be yielded")
-		return []interface{}{&object.ID, &object.Name}
+		return []any{&object.ID, &object.Name}
 	}
 
 	stmt, err := tx.Prepare("SELECT id, name FROM test WHERE name=?")
@@ -63,17 +63,17 @@ func TestSelectObjects(t *testing.T) {
 func TestUpsertObject_Error(t *testing.T) {
 	cases := []struct {
 		columns []string
-		values  []interface{}
+		values  []any
 		error   string
 	}{
 		{
 			[]string{},
-			[]interface{}{},
+			[]any{},
 			"columns length is zero",
 		},
 		{
 			[]string{"id"},
-			[]interface{}{2, "egg"},
+			[]any{2, "egg"},
 			"columns length does not match values length",
 		},
 	}
@@ -91,7 +91,7 @@ func TestUpsertObject_Error(t *testing.T) {
 func TestUpsertObject_Insert(t *testing.T) {
 	tx := newTxForObjects(t)
 
-	id, err := query.UpsertObject(tx, "test", []string{"name"}, []interface{}{"egg"})
+	id, err := query.UpsertObject(tx, "test", []string{"name"}, []any{"egg"})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), id)
 
@@ -101,9 +101,9 @@ func TestUpsertObject_Insert(t *testing.T) {
 	}, 1)
 	object := objects[0]
 
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		require.Equal(t, 0, i, "expected at most one row to be yielded")
-		return []interface{}{&object.ID, &object.Name}
+		return []any{&object.ID, &object.Name}
 	}
 
 	stmt, err := tx.Prepare("SELECT id, name FROM test WHERE name=?")
@@ -120,7 +120,7 @@ func TestUpsertObject_Insert(t *testing.T) {
 func TestUpsertObject_Update(t *testing.T) {
 	tx := newTxForObjects(t)
 
-	id, err := query.UpsertObject(tx, "test", []string{"id", "name"}, []interface{}{1, "egg"})
+	id, err := query.UpsertObject(tx, "test", []string{"id", "name"}, []any{1, "egg"})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), id)
 
@@ -130,9 +130,9 @@ func TestUpsertObject_Update(t *testing.T) {
 	}, 1)
 	object := objects[0]
 
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		require.Equal(t, 0, i, "expected at most one row to be yielded")
-		return []interface{}{&object.ID, &object.Name}
+		return []any{&object.ID, &object.Name}
 	}
 
 	stmt, err := tx.Prepare("SELECT id, name FROM test WHERE name=?")

--- a/lxd/db/query/slices.go
+++ b/lxd/db/query/slices.go
@@ -8,7 +8,7 @@ import (
 
 // SelectStrings executes a statement which must yield rows with a single string
 // column. It returns the list of column values.
-func SelectStrings(tx *sql.Tx, query string, args ...interface{}) ([]string, error) {
+func SelectStrings(tx *sql.Tx, query string, args ...any) ([]string, error) {
 	values := []string{}
 	scan := func(rows *sql.Rows) error {
 		var value string
@@ -30,7 +30,7 @@ func SelectStrings(tx *sql.Tx, query string, args ...interface{}) ([]string, err
 
 // SelectIntegers executes a statement which must yield rows with a single integer
 // column. It returns the list of column values.
-func SelectIntegers(tx *sql.Tx, query string, args ...interface{}) ([]int, error) {
+func SelectIntegers(tx *sql.Tx, query string, args ...any) ([]int, error) {
 	values := []int{}
 	scan := func(rows *sql.Rows) error {
 		var value int
@@ -62,7 +62,7 @@ func InsertStrings(tx *sql.Tx, stmt string, values []string) error {
 	}
 
 	params := make([]string, n)
-	args := make([]interface{}, n)
+	args := make([]any, n)
 	for i, value := range values {
 		params[i] = "(?)"
 		args[i] = value
@@ -76,7 +76,7 @@ func InsertStrings(tx *sql.Tx, stmt string, values []string) error {
 // Execute the given query and ensure that it yields rows with a single column
 // of the given database type. For every row yielded, execute the given
 // scanner.
-func scanSingleColumn(tx *sql.Tx, query string, args []interface{}, typeName string, scan scanFunc) error {
+func scanSingleColumn(tx *sql.Tx, query string, args []any, typeName string, scan scanFunc) error {
 	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return err

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -34,9 +34,9 @@ const (
 // instance is not running in clustered mode, an empty list is returned.
 func (n *NodeTx) GetRaftNodes() ([]RaftNode, error) {
 	nodes := []RaftNode{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		nodes = append(nodes, RaftNode{})
-		return []interface{}{&nodes[i].ID, &nodes[i].Address, &nodes[i].Role, &nodes[i].Name}
+		return []any{&nodes[i].ID, &nodes[i].Address, &nodes[i].Role, &nodes[i].Name}
 	}
 	stmt, err := n.tx.Prepare("SELECT id, address, role, name FROM raft_nodes ORDER BY id")
 	if err != nil {
@@ -84,7 +84,7 @@ func (n *NodeTx) GetRaftNodeAddress(id int64) (string, error) {
 // and it will replace whatever existing row has ID 1.
 func (n *NodeTx) CreateFirstRaftNode(address string, name string) error {
 	columns := []string{"id", "address", "name"}
-	values := []interface{}{int64(1), address, name}
+	values := []any{int64(1), address, name}
 	id, err := query.UpsertObject(n.tx, "raft_nodes", columns, values)
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func (n *NodeTx) CreateFirstRaftNode(address string, name string) error {
 // dqlite Raft cluster. It returns the ID of the newly inserted row.
 func (n *NodeTx) CreateRaftNode(address string, name string) (int64, error) {
 	columns := []string{"address", "name"}
-	values := []interface{}{address, name}
+	values := []any{address, name}
 	return query.UpsertObject(n.tx, "raft_nodes", columns, values)
 }
 
@@ -125,7 +125,7 @@ func (n *NodeTx) ReplaceRaftNodes(nodes []RaftNode) error {
 
 	columns := []string{"id", "address", "role", "name"}
 	for _, node := range nodes {
-		values := []interface{}{node.ID, node.Address, node.Role, node.Name}
+		values := []any{node.ID, node.Address, node.Role, node.Name}
 		_, err := query.UpsertObject(n.tx, "raft_nodes", columns, values)
 		if err != nil {
 			return err

--- a/lxd/db/snapshots.mapper.go
+++ b/lxd/db/snapshots.mapper.go
@@ -62,32 +62,32 @@ func (c *ClusterTx) GetInstanceSnapshots(filter InstanceSnapshotFilter) ([]Insta
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Project != nil && filter.Instance != nil && filter.Name != nil {
 		stmt = c.stmt(instanceSnapshotObjectsByProjectAndInstanceAndName)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Instance,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.Instance != nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotObjectsByProjectAndInstance)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 			filter.Instance,
 		}
 	} else if filter.Project == nil && filter.Instance == nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, InstanceSnapshot{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Project,
 			&objects[i].Instance,
@@ -219,7 +219,7 @@ func (c *ClusterTx) CreateInstanceSnapshot(object InstanceSnapshot) (int64, erro
 		return -1, fmt.Errorf("This \"instances_snapshots\" entry already exists")
 	}
 
-	args := make([]interface{}, 7)
+	args := make([]any, 7)
 
 	// Populate the statement arguments.
 	args[0] = object.Project

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -106,8 +106,8 @@ func (c *Cluster) UpdateStorageVolumeSnapshot(project, volumeName string, volume
 func (c *Cluster) GetStorageVolumeSnapshotsNames(volumeID int64) ([]string, error) {
 	var snapshotName string
 	query := "SELECT name FROM storage_volumes_snapshots WHERE storage_volume_id=?"
-	inargs := []interface{}{volumeID}
-	outargs := []interface{}{snapshotName}
+	inargs := []any{volumeID}
+	outargs := []any{snapshotName}
 
 	result, err := queryScan(c, query, inargs, outargs)
 	if err != nil {
@@ -138,8 +138,8 @@ JOIN projects ON projects.id=volumes.project_id
 JOIN storage_pools ON storage_pools.id=volumes.storage_pool_id
 WHERE volumes.id=?
 `
-	arg1 := []interface{}{snapshotID}
-	outfmt := []interface{}{&args.ID, &args.Name, &args.PoolName, &args.Type, &args.ProjectName}
+	arg1 := []any{snapshotID}
+	outfmt := []any{&args.ID, &args.Name, &args.PoolName, &args.Type, &args.ProjectName}
 	err := dbQueryRowScan(c, q, arg1, outfmt)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -163,8 +163,8 @@ func (c *Cluster) GetStorageVolumeSnapshotExpiry(volumeID int64) (time.Time, err
 	var expiry time.Time
 
 	query := "SELECT expiry_date FROM storage_volumes_snapshots WHERE id=?"
-	inargs := []interface{}{volumeID}
-	outargs := []interface{}{&expiry}
+	inargs := []any{volumeID}
+	outargs := []any{&expiry}
 
 	err := dbQueryRowScan(c, query, inargs, outargs)
 	if err != nil {
@@ -190,7 +190,7 @@ func (c *Cluster) GetExpiredStorageVolumeSnapshots() ([]StorageVolumeArgs, error
 	var snapshots []StorageVolumeArgs
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 			var snap StorageVolumeArgs
 			var snapName string
 			var volName string

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -20,8 +20,8 @@ import (
 func (c *Cluster) GetStoragePoolVolumesNames(poolID int64) ([]string, error) {
 	var volumeName string
 	query := "SELECT name FROM storage_volumes_all WHERE storage_pool_id=? AND node_id=?"
-	inargs := []interface{}{poolID, c.nodeID}
-	outargs := []interface{}{volumeName}
+	inargs := []any{poolID, c.nodeID}
+	outargs := []any{volumeName}
 
 	result, err := queryScan(c, query, inargs, outargs)
 	if err != nil {
@@ -54,8 +54,8 @@ JOIN projects ON projects.id = storage_volumes.project_id
 WHERE storage_volumes.type = ?
 `
 
-	inargs := []interface{}{volumeType}
-	outargs := []interface{}{id, name, description, poolName, projectName, nodeID}
+	inargs := []any{volumeType}
+	outargs := []any{id, name, description, poolName, projectName, nodeID}
 
 	result, err := queryScan(c, stmt, inargs, outargs)
 	if err != nil {
@@ -97,8 +97,8 @@ JOIN projects ON projects.id = storage_volumes.project_id
 WHERE storage_volumes.id = ?
 `
 
-	inargs := []interface{}{volumeID}
-	outargs := []interface{}{&response.ID, &response.Name, &response.Description, &response.PoolName, &response.Type, &response.ProjectName}
+	inargs := []any{volumeID}
+	outargs := []any{&response.ID, &response.Name, &response.Description, &response.PoolName, &response.Type, &response.ProjectName}
 
 	err := dbQueryRowScan(c, stmt, inargs, outargs)
 	if err != nil {
@@ -138,7 +138,7 @@ SELECT DISTINCT node_id
   JOIN storage_pools ON storage_pools.id = storage_volumes_all.storage_pool_id
  WHERE (projects.name=? OR storage_volumes_all.type=?) AND storage_volumes_all.storage_pool_id=? AND storage_pools.driver NOT IN %s`, query.Params(len(remoteDrivers)))
 
-		args := []interface{}{project, StoragePoolVolumeTypeCustom, poolID}
+		args := []any{project, StoragePoolVolumeTypeCustom, poolID}
 
 		for _, driver := range remoteDrivers {
 			args = append(args, driver)
@@ -234,8 +234,8 @@ SELECT storage_volumes_all.name
    AND storage_volumes_all.storage_pool_id=?
    AND storage_volumes_all.type=?
    AND (storage_volumes_all.node_id=? OR storage_volumes_all.node_id IS NULL AND storage_pools.driver IN %s)`, query.Params(len(remoteDrivers)))
-	inargs := []interface{}{project, poolID, volumeType, nodeID}
-	outargs := []interface{}{poolName}
+	inargs := []any{project, poolID, volumeType, nodeID}
+	outargs := []any{poolName}
 
 	for _, driver := range remoteDrivers {
 		inargs = append(inargs, driver)
@@ -276,7 +276,7 @@ SELECT storage_volumes_snapshots.id, storage_volumes_snapshots.name, storage_vol
     AND (storage_volumes.node_id=? OR storage_volumes.node_id IS NULL AND storage_pools.driver IN %s)
   ORDER BY storage_volumes_snapshots.id`, query.Params(len(remoteDrivers)))
 
-	args := []interface{}{poolID, volumeType, volumeName, projectName, c.nodeID}
+	args := []any{poolID, volumeType, volumeName, projectName, c.nodeID}
 	for _, driver := range remoteDrivers {
 		args = append(args, driver)
 	}
@@ -284,7 +284,7 @@ SELECT storage_volumes_snapshots.id, storage_volumes_snapshots.name, storage_vol
 	var snapshots []StorageVolumeArgs
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		err := tx.QueryScan(query, func(scan func(dest ...interface{}) error) error {
+		err := tx.QueryScan(query, func(scan func(dest ...any) error) error {
 			var s StorageVolumeArgs
 			var snapName string
 			var expiryDate sql.NullTime
@@ -326,7 +326,7 @@ func storageVolumeSnapshotConfig(tx *ClusterTx, volumeSnapshotID int64, volume *
 	q := "SELECT key, value FROM storage_volumes_snapshots_config WHERE storage_volume_snapshot_id = ?"
 
 	volume.Config = make(map[string]string)
-	return tx.QueryScan(q, func(scan func(dest ...interface{}) error) error {
+	return tx.QueryScan(q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)
@@ -619,7 +619,7 @@ SELECT storage_volumes_all.id
 	AND storage_volumes_all.type=?
 	AND (storage_volumes_all.node_id=? OR storage_volumes_all.node_id IS NULL AND storage_pools.driver IN %s)`, query.Params(len(remoteDrivers)))
 
-	args := []interface{}{project, poolID, volumeName, volumeType, nodeID}
+	args := []any{project, poolID, volumeName, volumeType, nodeID}
 
 	for _, driver := range remoteDrivers {
 		args = append(args, driver)
@@ -719,9 +719,9 @@ type StorageVolumeArgs struct {
 func (c *ClusterTx) GetStorageVolumeNodes(poolID int64, projectName string, volumeName string, volumeType int) ([]NodeInfo, error) {
 	nodes := []NodeInfo{}
 
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		nodes = append(nodes, NodeInfo{})
-		return []interface{}{&nodes[i].ID, &nodes[i].Address, &nodes[i].Name}
+		return []any{&nodes[i].ID, &nodes[i].Address, &nodes[i].Name}
 	}
 
 	sql := `
@@ -790,8 +790,8 @@ SELECT nodes.name FROM storage_volumes_all
   JOIN nodes ON nodes.id=storage_volumes_all.node_id
    WHERE storage_volumes_all.id=?
 `
-	inargs := []interface{}{volumeID}
-	outargs := []interface{}{&name}
+	inargs := []any{volumeID}
+	outargs := []any{&name}
 
 	err := dbQueryRowScan(c, query, inargs, outargs)
 	if err != nil {
@@ -814,8 +814,8 @@ func (c *Cluster) storageVolumeConfigGet(volumeID int64, isSnapshot bool) (map[s
 	} else {
 		query = "SELECT key, value FROM storage_volumes_config WHERE storage_volume_id=?"
 	}
-	inargs := []interface{}{volumeID}
-	outargs := []interface{}{key, value}
+	inargs := []any{volumeID}
+	outargs := []any{key, value}
 
 	results, err := queryScan(c, query, inargs, outargs)
 	if err != nil {
@@ -838,8 +838,8 @@ func (c *Cluster) storageVolumeConfigGet(volumeID int64, isSnapshot bool) (map[s
 func (c *Cluster) GetStorageVolumeDescription(volumeID int64) (string, error) {
 	var description string
 	query := "SELECT description FROM storage_volumes_all WHERE id=?"
-	inargs := []interface{}{volumeID}
-	outargs := []interface{}{&description}
+	inargs := []any{volumeID}
+	outargs := []any{&description}
 
 	err := dbQueryRowScan(c, query, inargs, outargs)
 	if err != nil {
@@ -856,8 +856,8 @@ func (c *Cluster) GetStorageVolumeDescription(volumeID int64) (string, error) {
 func (c *Cluster) getStorageVolumeContentType(volumeID int64) (int, error) {
 	var contentType int
 	query := "SELECT content_type FROM storage_volumes_all WHERE id=?"
-	inargs := []interface{}{volumeID}
-	outargs := []interface{}{&contentType}
+	inargs := []any{volumeID}
+	outargs := []any{&contentType}
 
 	err := dbQueryRowScan(c, query, inargs, outargs)
 	if err != nil {
@@ -888,8 +888,8 @@ SELECT storage_volumes_snapshots.name FROM storage_volumes_snapshots
    AND (storage_volumes.node_id=? OR storage_volumes.node_id IS NULL AND storage_pools.driver IN %s)
 `, query.Params(len(remoteDrivers)))
 	var numstr string
-	inargs := []interface{}{typ, name, pool, c.nodeID}
-	outfmt := []interface{}{numstr}
+	inargs := []any{typ, name, pool, c.nodeID}
+	outfmt := []any{numstr}
 
 	for _, driver := range remoteDrivers {
 		inargs = append(inargs, driver)
@@ -1003,7 +1003,7 @@ func (c *Cluster) RemoveStorageVolumeImages(fingerprints []string) error {
 	stmt := fmt.Sprintf(
 		"DELETE FROM storage_volumes WHERE type=? AND name NOT IN %s",
 		query.Params(len(fingerprints)))
-	args := []interface{}{StoragePoolVolumeTypeImage}
+	args := []any{StoragePoolVolumeTypeImage}
 	for _, fingerprint := range fingerprints {
 		args = append(args, fingerprint)
 	}
@@ -1075,9 +1075,9 @@ WHERE storage_volumes.type = ? AND projects.name = ?
 	defer stmt.Close()
 
 	volumes := []StorageVolumeArgs{}
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		volumes = append(volumes, StorageVolumeArgs{})
-		return []interface{}{
+		return []any{
 			&volumes[i].ID,
 			&volumes[i].Name,
 			&volumes[i].PoolName,

--- a/lxd/db/testing.go
+++ b/lxd/db/testing.go
@@ -156,7 +156,7 @@ func newDir(t *testing.T) (string, func()) {
 }
 
 func newLogFunc(t *testing.T) client.LogFunc {
-	return func(l client.LogLevel, format string, a ...interface{}) {
+	return func(l client.LogLevel, format string, a ...any) {
 		format = fmt.Sprintf("%s: %s", l.String(), format)
 		t.Logf(format, a...)
 	}

--- a/lxd/db/transaction.go
+++ b/lxd/db/transaction.go
@@ -66,7 +66,7 @@ func (c *ClusterTx) prepare(sql string) (*sql.Stmt, error) {
 
 // QueryScan runs a query with inArgs and provides the rowFunc with the scan function for each row.
 // It handles closing the rows and errors from the result set.
-func (c *ClusterTx) QueryScan(sql string, rowFunc func(scan func(dest ...interface{}) error) error, inArgs ...interface{}) error {
+func (c *ClusterTx) QueryScan(sql string, rowFunc func(scan func(dest ...any) error) error, inArgs ...any) error {
 	rows, err := c.tx.Query(sql, inArgs...)
 	if err != nil {
 		return err

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -218,7 +218,7 @@ func (c *ClusterTx) createWarning(object Warning) (int64, error) {
 		return -1, fmt.Errorf("This warning already exists")
 	}
 
-	args := make([]interface{}, 12)
+	args := make([]any, 12)
 
 	// Populate the statement arguments.
 	if object.Node != "" {

--- a/lxd/db/warnings.mapper.go
+++ b/lxd/db/warnings.mapper.go
@@ -81,11 +81,11 @@ func (c *ClusterTx) GetWarnings(filter WarningFilter) ([]Warning, error) {
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	var args []interface{}
+	var args []any
 
 	if filter.Node != nil && filter.TypeCode != nil && filter.Project != nil && filter.EntityTypeCode != nil && filter.EntityID != nil && filter.ID == nil && filter.UUID == nil && filter.Status == nil {
 		stmt = c.stmt(warningObjectsByNodeAndTypeCodeAndProjectAndEntityTypeCodeAndEntityID)
-		args = []interface{}{
+		args = []any{
 			filter.Node,
 			filter.TypeCode,
 			filter.Project,
@@ -94,43 +94,43 @@ func (c *ClusterTx) GetWarnings(filter WarningFilter) ([]Warning, error) {
 		}
 	} else if filter.Node != nil && filter.TypeCode != nil && filter.Project != nil && filter.ID == nil && filter.UUID == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
 		stmt = c.stmt(warningObjectsByNodeAndTypeCodeAndProject)
-		args = []interface{}{
+		args = []any{
 			filter.Node,
 			filter.TypeCode,
 			filter.Project,
 		}
 	} else if filter.Node != nil && filter.TypeCode != nil && filter.ID == nil && filter.UUID == nil && filter.Project == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
 		stmt = c.stmt(warningObjectsByNodeAndTypeCode)
-		args = []interface{}{
+		args = []any{
 			filter.Node,
 			filter.TypeCode,
 		}
 	} else if filter.UUID != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
 		stmt = c.stmt(warningObjectsByUUID)
-		args = []interface{}{
+		args = []any{
 			filter.UUID,
 		}
 	} else if filter.Status != nil && filter.ID == nil && filter.UUID == nil && filter.Project == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil {
 		stmt = c.stmt(warningObjectsByStatus)
-		args = []interface{}{
+		args = []any{
 			filter.Status,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.UUID == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
 		stmt = c.stmt(warningObjectsByProject)
-		args = []interface{}{
+		args = []any{
 			filter.Project,
 		}
 	} else if filter.ID == nil && filter.UUID == nil && filter.Project == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
 		stmt = c.stmt(warningObjects)
-		args = []interface{}{}
+		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
-	dest := func(i int) []interface{} {
+	dest := func(i int) []any {
 		objects = append(objects, Warning{})
-		return []interface{}{
+		return []any{
 			&objects[i].ID,
 			&objects[i].Node,
 			&objects[i].Project,

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -39,12 +39,12 @@ func devLxdServer(d *Daemon) *http.Server {
 }
 
 type devLxdResponse struct {
-	content interface{}
+	content any
 	code    int
 	ctype   string
 }
 
-func okResponse(ct interface{}, ctype string) *devLxdResponse {
+func okResponse(ct any, ctype string) *devLxdResponse {
 	return &devLxdResponse{ct, http.StatusOK, ctype}
 }
 

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -134,7 +134,7 @@ func (e *listenerCommon) Close() {
 }
 
 // WriteJSON message to the connection.
-func (e *listenerCommon) WriteJSON(v interface{}) error {
+func (e *listenerCommon) WriteJSON(v any) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 

--- a/lxd/events/devlxdEvents.go
+++ b/lxd/events/devlxdEvents.go
@@ -63,7 +63,7 @@ func (s *DevLXDServer) AddListener(instanceID int, connection *websocket.Conn, m
 }
 
 // Send broadcasts a custom event.
-func (s *DevLXDServer) Send(instanceID int, eventType string, eventMessage interface{}) error {
+func (s *DevLXDServer) Send(instanceID int, eventType string, eventMessage any) error {
 	encodedMessage, err := json.Marshal(eventMessage)
 	if err != nil {
 		return err

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -109,7 +109,7 @@ func (s *Server) SendLifecycle(projectName string, event api.EventLifecycle) {
 }
 
 // Send broadcasts a custom event.
-func (s *Server) Send(projectName string, eventType string, eventMessage interface{}) error {
+func (s *Server) Send(projectName string, eventType string, eventMessage any) error {
 	encodedMessage, err := json.Marshal(eventMessage)
 	if err != nil {
 		return err

--- a/lxd/events/logging.go
+++ b/lxd/events/logging.go
@@ -33,7 +33,7 @@ func (h Handler) Log(r *log.Record) error {
 	return nil
 }
 
-func logContextMap(ctx []interface{}) map[string]string {
+func logContextMap(ctx []any) map[string]string {
 	var key string
 	ctxMap := map[string]string{}
 

--- a/lxd/filter/match.go
+++ b/lxd/filter/match.go
@@ -1,7 +1,7 @@
 package filter
 
 // Match returns true if the given object matches the given filter.
-func Match(obj interface{}, clauses []Clause) bool {
+func Match(obj any, clauses []Clause) bool {
 	match := true
 
 	for _, clause := range clauses {

--- a/lxd/filter/match_test.go
+++ b/lxd/filter/match_test.go
@@ -33,7 +33,7 @@ func TestMatch_Instance(t *testing.T) {
 		},
 		Status: "Running",
 	}
-	cases := map[string]interface{}{
+	cases := map[string]any{
 		"architecture eq x86_64":                                         true,
 		"architecture eq i686":                                           false,
 		"name eq c1 and status eq Running":                               true,
@@ -62,7 +62,7 @@ func TestMatch_Image(t *testing.T) {
 		},
 		Architecture: "i686",
 	}
-	cases := map[string]interface{}{
+	cases := map[string]any{
 		"properties.os eq Ubuntu": true,
 		"architecture eq x86_64":  false,
 	}

--- a/lxd/filter/value.go
+++ b/lxd/filter/value.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ValueOf returns the value of the given field.
-func ValueOf(obj interface{}, field string) interface{} {
+func ValueOf(obj any, field string) any {
 	value := reflect.ValueOf(obj)
 	typ := value.Type()
 	parts := strings.Split(field, ".")
@@ -14,7 +14,7 @@ func ValueOf(obj interface{}, field string) interface{} {
 	key := parts[0]
 	rest := strings.Join(parts[1:], ".")
 
-	var parent interface{}
+	var parent any
 
 	if value.Kind() == reflect.Map {
 		switch reflect.TypeOf(obj).Elem().Kind() {

--- a/lxd/filter/value_test.go
+++ b/lxd/filter/value_test.go
@@ -34,7 +34,7 @@ func TestValueOf_Instance(t *testing.T) {
 		Status: "Running",
 	}
 
-	cases := map[string]interface{}{}
+	cases := map[string]any{}
 	cases["architecture"] = "x86_64"
 	cases["created_at"] = date
 	cases["config.image.os"] = "BusyBox"

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -192,7 +192,7 @@ func (d Nftables) hostVersion() (*version.DottedVersion, error) {
 
 // networkSetupForwardingPolicy allows forwarding dependent on boolean argument
 func (d Nftables) networkSetupForwardingPolicy(networkName string, ip4Allow *bool, ip6Allow *bool) error {
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"networkName":    networkName,
@@ -233,7 +233,7 @@ func (d Nftables) networkSetupForwardingPolicy(networkName string, ip4Allow *boo
 func (d Nftables) networkSetupOutboundNAT(networkName string, SNATV4 *SNATOpts, SNATV6 *SNATOpts) error {
 	rules := make(map[string]*SNATOpts, 0)
 
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"networkName":    networkName,
@@ -271,7 +271,7 @@ func (d Nftables) networkSetupICMPDHCPDNSAccess(networkName string, ipVersions [
 		}
 	}
 
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"networkName":    networkName,
@@ -288,7 +288,7 @@ func (d Nftables) networkSetupICMPDHCPDNSAccess(networkName string, ipVersions [
 }
 
 func (d Nftables) networkSetupACLChainAndJumpRules(networkName string) error {
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"networkName":    networkName,
@@ -393,7 +393,7 @@ func (d Nftables) InstanceSetupBridgeFilter(projectName string, instanceName str
 		return err
 	}
 
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"family":         "bridge",
@@ -491,13 +491,13 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 	targetAddressStr := forward.TargetAddress.String()
 
 	// Generate slices of rules to add.
-	var dnatRules []map[string]interface{}
-	var snatRules []map[string]interface{}
+	var dnatRules []map[string]any
+	var snatRules []map[string]any
 
 	targetPortRanges := portRangesFromSlice(forward.TargetPorts)
 	for _, targetPortRange := range targetPortRanges {
 		targetPortRangeStr := portRangeStr(targetPortRange, "-")
-		snatRules = append(snatRules, map[string]interface{}{
+		snatRules = append(snatRules, map[string]any{
 			"ipFamily":    ipFamily,
 			"protocol":    forward.Protocol,
 			"targetHost":  targetAddressStr,
@@ -517,7 +517,7 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 			}
 		}
 
-		dnatRules = append(dnatRules, map[string]interface{}{
+		dnatRules = append(dnatRules, map[string]any{
 			"ipFamily":      ipFamily,
 			"protocol":      forward.Protocol,
 			"listenAddress": listenAddressStr,
@@ -527,7 +527,7 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 	}
 
 	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"chainPrefix":    "", // Empty prefix for backwards compatibility with existing device chains.
@@ -566,7 +566,7 @@ func (d Nftables) InstanceClearProxyNAT(projectName string, instanceName string,
 
 // applyNftConfig loads the specified config template and then applies it to the common template before sending to
 // the nft command to be atomically applied to the system.
-func (d Nftables) applyNftConfig(tpl *template.Template, tplFields map[string]interface{}) error {
+func (d Nftables) applyNftConfig(tpl *template.Template, tplFields map[string]any) error {
 	// Load the specified template into the common template's parse tree under the nftableContentTemplate
 	// name so that the nftableContentTemplate template can use it with the generic name.
 	_, err := nftablesCommonTable.AddParseTree(nftablesContentTemplate, tpl.Tree)
@@ -633,7 +633,7 @@ func (d Nftables) removeChains(families []string, chainSuffix string, chains ...
 // InstanceSetupRPFilter activates reverse path filtering for the specified instance device on the host interface.
 func (d Nftables) InstanceSetupRPFilter(projectName string, instanceName string, deviceName string, hostName string) error {
 	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"deviceLabel":    deviceLabel,
@@ -694,7 +694,7 @@ func (d Nftables) NetworkApplyACLRules(networkName string, rules []ACLRule) erro
 		}
 	}
 
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"networkName":    networkName,
@@ -916,8 +916,8 @@ func (d Nftables) aclRulePortToACLMatch(direction string, portCriteria ...string
 
 // NetworkApplyForwards apply network address forward rules to firewall.
 func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForward) error {
-	var dnatRules []map[string]interface{}
-	var snatRules []map[string]interface{}
+	var dnatRules []map[string]any
+	var snatRules []map[string]any
 
 	// Build up rules, ordering by port specific listen rules first, followed by default target rules.
 	// This is so the generated firewall rules will apply the port specific rules first.
@@ -977,7 +977,7 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 						targetDest = fmt.Sprintf("[%s]:%d", targetAddressStr, targetPort)
 					}
 
-					dnatRules = append(dnatRules, map[string]interface{}{
+					dnatRules = append(dnatRules, map[string]any{
 						"ipFamily":      ipFamily,
 						"protocol":      rule.Protocol,
 						"listenAddress": listenAddressStr,
@@ -989,7 +989,7 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 
 					// Only add >1 hairpin NAT rules if multiple target ports being used.
 					if i == 0 || targetPortsLen != 1 {
-						snatRules = append(snatRules, map[string]interface{}{
+						snatRules = append(snatRules, map[string]any{
 							"ipFamily":    ipFamily,
 							"protocol":    rule.Protocol,
 							"targetHost":  targetAddressStr,
@@ -1005,14 +1005,14 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 					targetDest = fmt.Sprintf("[%s]", targetAddressStr)
 				}
 
-				dnatRules = append(dnatRules, map[string]interface{}{
+				dnatRules = append(dnatRules, map[string]any{
 					"ipFamily":      ipFamily,
 					"listenAddress": listenAddressStr,
 					"targetDest":    targetDest,
 					"targetHost":    targetAddressStr,
 				})
 
-				snatRules = append(snatRules, map[string]interface{}{
+				snatRules = append(snatRules, map[string]any{
 					"ipFamily":   ipFamily,
 					"targetHost": targetAddressStr,
 				})
@@ -1022,7 +1022,7 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 		}
 	}
 
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"namespace":      nftablesNamespace,
 		"chainSeparator": nftablesChainSeparator,
 		"chainPrefix":    "fwd", // Differentiate from proxy device forwards.

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -239,7 +239,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	}
 
 	// Track progress creating image.
-	metadata := make(map[string]interface{})
+	metadata := make(map[string]any)
 	imageProgressWriter := &ioprogress.ProgressWriter{
 		Tracker: &ioprogress.ProgressTracker{
 			Handler: func(value, speed int64) {
@@ -499,7 +499,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 	return info, nil
 }
 
-func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string, post *os.File, metadata map[string]interface{}) (*api.Image, error) {
+func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string, post *os.File, metadata map[string]any) (*api.Image, error) {
 	info := api.Image{}
 	var imageMeta *api.ImageMetadata
 	logger := logging.AddContext(logger.Log, log.Ctx{"function": "getImgPostInfo"})
@@ -822,7 +822,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 	fingerprint := r.Header.Get("X-LXD-fingerprint")
 	projectName := projectParam(r)
 
-	var imageMetadata map[string]interface{}
+	var imageMetadata map[string]any
 
 	if !trusted && (secret == "" || fingerprint == "") {
 		return response.Forbidden(nil)
@@ -906,7 +906,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 	if !imageUpload && req.Source.Mode == "push" {
 		cleanup(builddir, post)
 
-		metadata := map[string]interface{}{
+		metadata := map[string]any{
 			"aliases":    req.Aliases,
 			"expires_at": req.ExpiresAt,
 			"properties": req.Properties,
@@ -1026,7 +1026,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
-	var metadata interface{}
+	var metadata any
 
 	if imageUpload && imageMetadata != nil {
 		secret, _ := shared.RandomCryptoString()
@@ -1151,7 +1151,7 @@ func getImageMetadata(fname string) (*api.ImageMetadata, string, error) {
 	return &result, imageType, nil
 }
 
-func doImagesGet(d *Daemon, recursion bool, project string, public bool, clauses []filter.Clause) (interface{}, error) {
+func doImagesGet(d *Daemon, recursion bool, project string, public bool, clauses []filter.Clause) (any, error) {
 	results, err := d.cluster.GetImagesFingerprints(project, public)
 	if err != nil {
 		return []string{}, err
@@ -1842,7 +1842,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 			return
 		}
 
-		metadata := map[string]interface{}{"refreshed": result}
+		metadata := map[string]any{"refreshed": result}
 		op.UpdateMetadata(metadata)
 
 		// Sent a lifecycle event if the refresh actually happened.
@@ -2522,7 +2522,7 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 		return response.NotFound(fmt.Errorf("Image '%s' not found", info.Fingerprint))
 	}
 
-	etag := []interface{}{info.Public, info.AutoUpdate, info.Properties}
+	etag := []any{info.Public, info.AutoUpdate, info.Properties}
 	return response.SyncResponseETag(true, info, etag)
 }
 
@@ -2570,7 +2570,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate ETag
-	etag := []interface{}{info.Public, info.AutoUpdate, info.Properties}
+	etag := []any{info.Public, info.AutoUpdate, info.Properties}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)
@@ -2656,7 +2656,7 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate ETag
-	etag := []interface{}{info.Public, info.AutoUpdate, info.Properties}
+	etag := []any{info.Public, info.AutoUpdate, info.Properties}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -593,7 +593,7 @@ func (d *common) updateProgress(progress string) {
 
 	meta := d.op.Metadata()
 	if meta == nil {
-		meta = make(map[string]interface{})
+		meta = make(map[string]any)
 	}
 
 	if meta["container_progress"] != progress {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1320,7 +1320,7 @@ func (d *lxc) IdmappedStorage(path string) idmap.IdmapStorageType {
 	return mode
 }
 
-func (d *lxc) devlxdEventSend(eventType string, eventMessage map[string]interface{}) error {
+func (d *lxc) devlxdEventSend(eventType string, eventMessage map[string]any) error {
 	event := shared.Jmap{}
 	event["type"] = eventType
 	event["timestamp"] = time.Now()
@@ -3237,13 +3237,13 @@ func (d *lxc) getLxcState() (liblxc.State, error) {
 }
 
 // Render renders the state of the instance.
-func (d *lxc) Render(options ...func(response interface{}) error) (interface{}, interface{}, error) {
+func (d *lxc) Render(options ...func(response any) error) (any, any, error) {
 	// Ignore err as the arch string on error is correct (unknown)
 	architectureName, _ := osarch.ArchitectureName(d.architecture)
 
 	if d.IsSnapshot() {
 		// Prepare the ETag
-		etag := []interface{}{d.expiryDate}
+		etag := []any{d.expiryDate}
 
 		snapState := api.InstanceSnapshot{
 			CreatedAt:       d.creationDate,
@@ -3272,7 +3272,7 @@ func (d *lxc) Render(options ...func(response interface{}) error) (interface{}, 
 	}
 
 	// Prepare the ETag
-	etag := []interface{}{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
+	etag := []any{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
 
 	statusCode := d.statusCode()
 	instState := api.Instance{
@@ -3307,7 +3307,7 @@ func (d *lxc) Render(options ...func(response interface{}) error) (interface{}, 
 }
 
 // RenderFull renders the full state of the instance.
-func (d *lxc) RenderFull() (*api.InstanceFull, interface{}, error) {
+func (d *lxc) RenderFull() (*api.InstanceFull, any, error) {
 	if d.IsSnapshot() {
 		return nil, nil, fmt.Errorf("RenderFull only works with containers")
 	}
@@ -3629,7 +3629,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		}
 	}
 
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestored.Event(d, map[string]interface{}{"snapshot": sourceContainer.Name()}))
+	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestored.Event(d, map[string]any{"snapshot": sourceContainer.Name()}))
 	d.logger.Info("Restored container", ctxMap)
 
 	return nil
@@ -3928,9 +3928,9 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 
 	d.logger.Info("Renamed container", ctxMap)
 	if d.snapshot {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]interface{}{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
 	} else {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRenamed.Event(d, map[string]interface{}{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
 	}
 
 	revert.Success()
@@ -4617,7 +4617,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				continue
 			}
 
-			msg := map[string]interface{}{
+			msg := map[string]any{
 				"key":       key,
 				"old_value": oldExpandedConfig[key],
 				"value":     d.expandedConfig[key],
@@ -4631,7 +4631,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 
 		// Device changes
 		for k, m := range removeDevices {
-			msg := map[string]interface{}{
+			msg := map[string]any{
 				"action": "removed",
 				"name":   k,
 				"config": m,
@@ -4644,7 +4644,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		for k, m := range updateDevices {
-			msg := map[string]interface{}{
+			msg := map[string]any{
 				"action": "updated",
 				"name":   k,
 				"config": m,
@@ -4657,7 +4657,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		for k, m := range addDevices {
-			msg := map[string]interface{}{
+			msg := map[string]any{
 				"action": "added",
 				"name":   k,
 				"config": m,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -362,7 +362,7 @@ func (d *qemu) getAgentClient() (*http.Client, error) {
 	return agent, nil
 }
 
-func (d *qemu) getMonitorEventHandler() func(event string, data map[string]interface{}) {
+func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) {
 	// Create local variables from instance properties we need so as not to keep references to instance around
 	// after we have returned the callback function.
 	projectName := d.Project()
@@ -370,7 +370,7 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]inter
 	state := d.state
 	logger := d.logger
 
-	return func(event string, data map[string]interface{}) {
+	return func(event string, data map[string]any) {
 		if !shared.StringInSlice(event, []string{"SHUTDOWN", "RESET"}) {
 			return // Don't bother loading the instance from DB if we aren't going to handle the event.
 		}
@@ -2471,7 +2471,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	var sb *strings.Builder = &strings.Builder{}
 	var monHooks []monitorHook
 
-	err := qemuBase.Execute(sb, map[string]interface{}{
+	err := qemuBase.Execute(sb, map[string]any{
 		"architecture": d.architectureName,
 	})
 	if err != nil {
@@ -2483,7 +2483,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 		return "", nil, err
 	}
 
-	err = qemuDriveFirmware.Execute(sb, map[string]interface{}{
+	err = qemuDriveFirmware.Execute(sb, map[string]any{
 		"architecture": d.architectureName,
 		"roPath":       filepath.Join(d.ovmfPath(), "OVMF_CODE.fd"),
 		"nvramPath":    d.nvramPath(),
@@ -2492,7 +2492,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 		return "", nil, err
 	}
 
-	err = qemuControlSocket.Execute(sb, map[string]interface{}{
+	err = qemuControlSocket.Execute(sb, map[string]any{
 		"path": d.monitorPath(),
 	})
 	if err != nil {
@@ -2510,7 +2510,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	// total of 256 devices, but this assumes 32 chassis * 8 function. By using VFs for the internal fixed
 	// devices we avoid consuming a chassis for each one. See also the qemuPCIDeviceIDStart constant.
 	devBus, devAddr, multi := bus.allocate(busFunctionGroupGeneric)
-	err = qemuBalloon.Execute(sb, map[string]interface{}{
+	err = qemuBalloon.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2521,7 +2521,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuRNG.Execute(sb, map[string]interface{}{
+	err = qemuRNG.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2532,7 +2532,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuKeyboard.Execute(sb, map[string]interface{}{
+	err = qemuKeyboard.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2543,7 +2543,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuTablet.Execute(sb, map[string]interface{}{
+	err = qemuTablet.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2554,7 +2554,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuVsock.Execute(sb, map[string]interface{}{
+	err = qemuVsock.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2567,7 +2567,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuSerial.Execute(sb, map[string]interface{}{
+	err = qemuSerial.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2583,7 +2583,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	// s390x doesn't really have USB.
 	if d.architecture != osarch.ARCH_64BIT_S390_BIG_ENDIAN {
 		devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-		err = qemuUSB.Execute(sb, map[string]interface{}{
+		err = qemuUSB.Execute(sb, map[string]any{
 			"bus":           bus.name,
 			"devBus":        devBus,
 			"devAddr":       devAddr,
@@ -2596,7 +2596,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupNone)
-	err = qemuSCSI.Execute(sb, map[string]interface{}{
+	err = qemuSCSI.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2609,7 +2609,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	// Always export the config directory as a 9p config drive, in case the host or VM guest doesn't support
 	// virtio-fs.
 	devBus, devAddr, multi = bus.allocate(busFunctionGroup9p)
-	err = qemuDriveConfig.Execute(sb, map[string]interface{}{
+	err = qemuDriveConfig.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2628,7 +2628,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	configSockPath, _ := d.configVirtiofsdPaths()
 	if shared.PathExists(configSockPath) {
 		devBus, devAddr, multi = bus.allocate(busFunctionGroup9p)
-		err = qemuDriveConfig.Execute(sb, map[string]interface{}{
+		err = qemuDriveConfig.Execute(sb, map[string]any{
 			"bus":           bus.name,
 			"devBus":        devBus,
 			"devAddr":       devAddr,
@@ -2643,7 +2643,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupNone)
-	err = qemuGPU.Execute(sb, map[string]interface{}{
+	err = qemuGPU.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -2798,7 +2798,7 @@ func (d *qemu) addCPUMemoryConfig(sb *strings.Builder) (int, error) {
 		cpus = "1"
 	}
 
-	ctx := map[string]interface{}{
+	ctx := map[string]any{
 		"architecture":        d.architectureName,
 		"qemuMemObjectFormat": qemuMemObjectFormat,
 	}
@@ -2893,7 +2893,7 @@ func (d *qemu) addCPUMemoryConfig(sb *strings.Builder) (int, error) {
 	ctx["memory"] = nodeMemory
 
 	if sb != nil {
-		err = qemuMemory.Execute(sb, map[string]interface{}{
+		err = qemuMemory.Execute(sb, map[string]any{
 			"architecture": d.architectureName,
 			"memSizeBytes": memSizeBytes,
 		})
@@ -2985,7 +2985,7 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]*
 		devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
 
 		// Add virtio-fs device as this will be preferred over 9p.
-		err := qemuDriveDir.Execute(sb, map[string]interface{}{
+		err := qemuDriveDir.Execute(sb, map[string]any{
 			"bus":           bus.name,
 			"devBus":        devBus,
 			"devAddr":       devAddr,
@@ -3011,7 +3011,7 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]*
 
 	proxyFD := d.addFileDescriptor(fdFiles, os.NewFile(uintptr(fd), driveConf.DevName))
 
-	return qemuDriveDir.Execute(sb, map[string]interface{}{
+	return qemuDriveDir.Execute(sb, map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -3111,9 +3111,9 @@ func (d *qemu) addDriveConfig(fdFiles *[]*os.File, bootIndexes map[string]int, d
 
 	escapedDeviceName := filesystem.PathNameEncode(driveConf.DevName)
 
-	blockDev := map[string]interface{}{
+	blockDev := map[string]any{
 		"aio": aioMode,
-		"cache": map[string]interface{}{
+		"cache": map[string]any{
 			"direct":   directCache,
 			"no-flush": noFlushCache,
 		},
@@ -3239,7 +3239,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 		}
 	}
 
-	var qemuNetDev map[string]interface{}
+	var qemuNetDev map[string]any
 
 	// Detect MACVTAP interface types and figure out which tap device is being used.
 	// This is so we can open a file handle to the tap device and pass it to the qemu process.
@@ -3254,7 +3254,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 			return nil, fmt.Errorf("Error parsing tap device ifindex: %w", err)
 		}
 
-		qemuNetDev = map[string]interface{}{
+		qemuNetDev = map[string]any{
 			"id":    fmt.Sprintf("%s%s", qemuNetDevIDPrefix, escapedDeviceName),
 			"type":  "tap",
 			"vhost": true,
@@ -3271,7 +3271,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 		qemuDev["mac"] = devHwaddr
 	} else if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/tun_flags", nicName)) {
 		// Detect TAP (via TUN driver) device.
-		qemuNetDev = map[string]interface{}{
+		qemuNetDev = map[string]any{
 			"id":         fmt.Sprintf("%s%s", qemuNetDevIDPrefix, escapedDeviceName),
 			"type":       "tap",
 			"vhost":      true,
@@ -3415,7 +3415,7 @@ func (d *qemu) addPCIDevConfig(sb *strings.Builder, bus *qemuBus, pciConfig []de
 	}
 
 	devBus, devAddr, multi := bus.allocate(fmt.Sprintf("lxd_%s", devName))
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -3461,7 +3461,7 @@ func (d *qemu) addGPUDevConfig(sb *strings.Builder, bus *qemuBus, gpuConfig []de
 	}()
 
 	devBus, devAddr, multi := bus.allocate(fmt.Sprintf("lxd_%s", devName))
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"bus":           bus.name,
 		"devBus":        devBus,
 		"devAddr":       devAddr,
@@ -3505,7 +3505,7 @@ func (d *qemu) addGPUDevConfig(sb *strings.Builder, bus *qemuBus, gpuConfig []de
 			if strings.HasPrefix(iommuSlotName, prefix) && iommuSlotName != pciSlotName {
 				// Add VF device without VGA mode to qemu config.
 				devBus, devAddr, multi := bus.allocate(fmt.Sprintf("lxd_%s", devName))
-				tplFields := map[string]interface{}{
+				tplFields := map[string]any{
 					"bus":           bus.name,
 					"devBus":        devBus,
 					"devAddr":       devAddr,
@@ -3584,7 +3584,7 @@ func (d *qemu) addTPMDeviceConfig(sb *strings.Builder, tpmConfig []deviceConfig.
 		}
 	}
 
-	tplFields := map[string]interface{}{
+	tplFields := map[string]any{
 		"devName": devName,
 		"path":    socketPath,
 	}
@@ -3947,7 +3947,7 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 		}
 	}
 
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestored.Event(d, map[string]interface{}{"snapshot": source.Name()}))
+	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestored.Event(d, map[string]any{"snapshot": source.Name()}))
 	d.logger.Info("Restored instance", ctxMap)
 	return nil
 }
@@ -4104,9 +4104,9 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 	d.logger.Info("Renamed instance", ctxMap)
 
 	if d.snapshot {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]interface{}{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
 	} else {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRenamed.Event(d, map[string]interface{}{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
 	}
 
 	revert.Success()
@@ -4471,7 +4471,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 				continue
 			}
 
-			msg := map[string]interface{}{
+			msg := map[string]any{
 				"key":       key,
 				"old_value": oldExpandedConfig[key],
 				"value":     d.expandedConfig[key],
@@ -5447,10 +5447,10 @@ func (d *qemu) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, s
 }
 
 // Render returns info about the instance.
-func (d *qemu) Render(options ...func(response interface{}) error) (interface{}, interface{}, error) {
+func (d *qemu) Render(options ...func(response any) error) (any, any, error) {
 	if d.IsSnapshot() {
 		// Prepare the ETag
-		etag := []interface{}{d.expiryDate}
+		etag := []any{d.expiryDate}
 
 		snapState := api.InstanceSnapshot{
 			CreatedAt:       d.creationDate,
@@ -5479,7 +5479,7 @@ func (d *qemu) Render(options ...func(response interface{}) error) (interface{},
 	}
 
 	// Prepare the ETag
-	etag := []interface{}{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
+	etag := []any{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
 	statusCode := d.statusCode()
 
 	instState := api.Instance{
@@ -5514,7 +5514,7 @@ func (d *qemu) Render(options ...func(response interface{}) error) (interface{},
 }
 
 // RenderFull returns all info about the instance.
-func (d *qemu) RenderFull() (*api.InstanceFull, interface{}, error) {
+func (d *qemu) RenderFull() (*api.InstanceFull, any, error) {
 	if d.IsSnapshot() {
 		return nil, nil, fmt.Errorf("RenderFull doesn't work with snapshots")
 	}
@@ -6009,7 +6009,7 @@ func (d *qemu) cpuTopology(limit string) (int, int, int, map[uint64]uint64, map[
 	return nrSockets, nrCores, nrThreads, vcpus, numaNodes, nil
 }
 
-func (d *qemu) devlxdEventSend(eventType string, eventMessage map[string]interface{}) error {
+func (d *qemu) devlxdEventSend(eventType string, eventMessage map[string]any) error {
 	event := shared.Jmap{}
 	event["type"] = eventType
 	event["timestamp"] = time.Now()

--- a/lxd/instance/drivers/driver_qemu_bus.go
+++ b/lxd/instance/drivers/driver_qemu_bus.go
@@ -118,7 +118,7 @@ func (a *qemuBus) allocate(multiFunctionGroup string) (string, string, bool) {
 	if a.name == "pcie" {
 		if p.fn == 0 {
 			portName := fmt.Sprintf("%s%d", busDevicePortPrefix, a.portNum)
-			qemuPCIe.Execute(a.sb, map[string]interface{}{
+			qemuPCIe.Execute(a.sb, map[string]any{
 				"portName": portName,
 				"index":    a.portNum,
 				"addr":     fmt.Sprintf("%x.%d", p.bridgeDev, p.bridgeFn),

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -176,7 +176,7 @@ func (m *Monitor) RemoveFDFromFDSet(name string) error {
 			}
 
 			if opaque == name {
-				args := map[string]interface{}{
+				args := map[string]any{
 					"fdset-id": fdSet.ID,
 				}
 
@@ -351,7 +351,7 @@ func (m *Monitor) SetMemoryBalloonSizeBytes(sizeBytes int64) error {
 }
 
 // AddBlockDevice adds a block device.
-func (m *Monitor) AddBlockDevice(blockDev map[string]interface{}, device map[string]string) error {
+func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]string) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -362,7 +362,7 @@ func (m *Monitor) AddBlockDevice(blockDev map[string]interface{}, device map[str
 		}
 
 		revert.Add(func() {
-			blockDevDel := map[string]interface{}{
+			blockDevDel := map[string]any{
 				"node-name": blockDev["devName"],
 			}
 
@@ -447,7 +447,7 @@ func (m *Monitor) RemoveDevice(deviceID string) error {
 }
 
 // AddNIC adds a NIC device.
-func (m *Monitor) AddNIC(netDev map[string]interface{}, device map[string]string) error {
+func (m *Monitor) AddNIC(netDev map[string]any, device map[string]string) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -458,7 +458,7 @@ func (m *Monitor) AddNIC(netDev map[string]interface{}, device map[string]string
 		}
 
 		revert.Add(func() {
-			netDevDel := map[string]interface{}{
+			netDevDel := map[string]any{
 				"id": netDev["id"],
 			}
 

--- a/lxd/instance/drivers/qmp/monitor.go
+++ b/lxd/instance/drivers/qmp/monitor.go
@@ -28,7 +28,7 @@ type Monitor struct {
 	agentReadyMu  sync.Mutex
 	disconnected  bool
 	chDisconnect  chan struct{}
-	eventHandler  func(name string, data map[string]interface{})
+	eventHandler  func(name string, data map[string]any)
 	serialCharDev string
 }
 
@@ -42,7 +42,7 @@ func (m *Monitor) start() error {
 		}
 
 		// Read the ringbuffer.
-		args := map[string]interface{}{
+		args := map[string]any{
 			"device": m.serialCharDev,
 			"size":   RingbufSize,
 			"format": "utf8",
@@ -133,7 +133,7 @@ func (m *Monitor) ping() error {
 }
 
 // run executes a command.
-func (m *Monitor) run(cmd string, args interface{}, resp interface{}) error {
+func (m *Monitor) run(cmd string, args any, resp any) error {
 	// Check if disconnected
 	if m.disconnected {
 		return ErrMonitorDisconnect
@@ -141,8 +141,8 @@ func (m *Monitor) run(cmd string, args interface{}, resp interface{}) error {
 
 	// Run the command.
 	requestArgs := struct {
-		Execute   string      `json:"execute"`
-		Arguments interface{} `json:"arguments,omitempty"`
+		Execute   string `json:"execute"`
+		Arguments any    `json:"arguments,omitempty"`
 	}{
 		Execute:   cmd,
 		Arguments: args,
@@ -183,7 +183,7 @@ func (m *Monitor) run(cmd string, args interface{}, resp interface{}) error {
 }
 
 // Connect creates or retrieves an existing QMP monitor for the path.
-func Connect(path string, serialCharDev string, eventHandler func(name string, data map[string]interface{})) (*Monitor, error) {
+func Connect(path string, serialCharDev string, eventHandler func(name string, data map[string]any)) (*Monitor, error) {
 	monitorsLock.Lock()
 	defer monitorsLock.Unlock()
 

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -102,8 +102,8 @@ type Instance interface {
 	Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (Cmd, error)
 
 	// Status
-	Render(options ...func(response interface{}) error) (interface{}, interface{}, error)
-	RenderFull() (*api.InstanceFull, interface{}, error)
+	Render(options ...func(response any) error) (any, any, error)
+	RenderFull() (*api.InstanceFull, any, error)
 	RenderState() (*api.InstanceState, error)
 	IsRunning() bool
 	IsFrozen() bool

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -60,7 +60,7 @@ type consoleWs struct {
 	protocol string
 }
 
-func (s *consoleWs) Metadata() interface{} {
+func (s *consoleWs) Metadata() any {
 	fds := shared.Jmap{}
 	for fd, secret := range s.fds {
 		if fd == -1 {

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -52,7 +52,7 @@ type execWs struct {
 	s                     *state.State
 }
 
-func (s *execWs) Metadata() interface{} {
+func (s *execWs) Metadata() any {
 	fds := shared.Jmap{}
 	for fd, secret := range s.fds {
 		if fd == execWSControl {

--- a/lxd/instance_get.go
+++ b/lxd/instance_get.go
@@ -123,8 +123,8 @@ func instanceGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	var state interface{}
-	var etag interface{}
+	var state any
+	var etag any
 	if recursion == 0 {
 		state, etag, err = c.Render()
 	} else {

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -72,7 +72,7 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 	// be used internally by instanceRefreshTypes to terminate gracefully,
 	// otherwise we'll wrap instanceRefreshTypes in a goroutine and force
 	// returning in case the context expires.
-	_, hasCancellationSupport := interface{}(&http.Request{}).(util.ContextAwareRequest)
+	_, hasCancellationSupport := any(&http.Request{}).(util.ContextAwareRequest)
 	f := func(ctx context.Context) {
 		opRun := func(op *operations.Operation) error {
 			if hasCancellationSupport {
@@ -110,7 +110,7 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 
 func instanceRefreshTypes(ctx context.Context, d *Daemon) error {
 	// Attempt to download the new definitions
-	downloadParse := func(filename string, target interface{}) error {
+	downloadParse := func(filename string, target any) error {
 		url := fmt.Sprintf("https://images.linuxcontainers.org/meta/instance-types/%s", filename)
 
 		httpClient, err := util.HTTPClient("", d.proxy)
@@ -125,7 +125,7 @@ func instanceRefreshTypes(ctx context.Context, d *Daemon) error {
 
 		httpReq.Header.Set("User-Agent", version.UserAgent)
 
-		cancelableRequest, ok := interface{}(httpReq).(util.ContextAwareRequest)
+		cancelableRequest, ok := any(httpReq).(util.ContextAwareRequest)
 		if ok {
 			httpReq = cancelableRequest.WithContext(ctx)
 		}

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -77,7 +77,7 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag
-	etag := []interface{}{c.Architecture(), c.LocalConfig(), c.LocalDevices(), c.IsEphemeral(), c.Profiles()}
+	etag := []any{c.Architecture(), c.LocalConfig(), c.LocalDevices(), c.IsEphemeral(), c.Profiles()}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -78,7 +78,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag
-	etag := []interface{}{inst.Architecture(), inst.LocalConfig(), inst.LocalDevices(), inst.IsEphemeral(), inst.Profiles()}
+	etag := []any{inst.Architecture(), inst.LocalConfig(), inst.LocalDevices(), inst.IsEphemeral(), inst.Profiles()}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -426,7 +426,7 @@ func snapshotPatch(d *Daemon, r *http.Request, snapInst instance.Instance, name 
 //     $ref: "#/responses/InternalServerError"
 func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name string) response.Response {
 	// Validate the ETag
-	etag := []interface{}{snapInst.ExpiryDate()}
+	etag := []any{snapInst.ExpiryDate()}
 	err := util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)
@@ -547,7 +547,7 @@ func snapshotGet(s *state.State, snapInst instance.Instance, name string) respon
 		return response.SmartError(err)
 	}
 
-	etag := []interface{}{snapInst.ExpiryDate()}
+	etag := []any{snapInst.ExpiryDate()}
 	return response.SyncResponseETag(true, render.(*api.InstanceSnapshot), etag)
 }
 

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -232,7 +232,7 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 	return response.InternalError(fmt.Errorf("DB is locked"))
 }
 
-func doInstancesGet(d *Daemon, r *http.Request) (interface{}, error) {
+func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 	resultString := []string{}
 	resultList := []*api.Instance{}
 	resultFullList := []*api.InstanceFull{}

--- a/lxd/lifecycle/certificate.go
+++ b/lxd/lifecycle/certificate.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a Certificate.
-func (a CertificateAction) Event(fingerprint string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a CertificateAction) Event(fingerprint string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("certificate-%s", a)
 
 	u := fmt.Sprintf("/1.0/certificates/%s", url.PathEscape(fingerprint))

--- a/lxd/lifecycle/cluster.go
+++ b/lxd/lifecycle/cluster.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a cluster.
-func (a ClusterAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ClusterAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("cluster-%s", a)
 	u := fmt.Sprintf("/1.0/cluster/%s", url.PathEscape(name))
 

--- a/lxd/lifecycle/cluster_groups.go
+++ b/lxd/lifecycle/cluster_groups.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a cluster group.
-func (a ClusterGroupAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ClusterGroupAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("cluster-group-%s", a)
 	u := fmt.Sprintf("/1.0/cluster/groups/%s", url.PathEscape(name))
 

--- a/lxd/lifecycle/cluster_member.go
+++ b/lxd/lifecycle/cluster_member.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a cluster member.
-func (a ClusterMemberAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ClusterMemberAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("cluster-member-%s", a)
 	u := fmt.Sprintf("/1.0/cluster/members")
 	if name != "" {

--- a/lxd/lifecycle/config.go
+++ b/lxd/lifecycle/config.go
@@ -15,7 +15,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on the server configuration
-func (a ConfigAction) Event(requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ConfigAction) Event(requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("config-%s", a)
 	u := fmt.Sprintf("/1.0")
 

--- a/lxd/lifecycle/image.go
+++ b/lxd/lifecycle/image.go
@@ -22,7 +22,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an image.
-func (a ImageAction) Event(image string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ImageAction) Event(image string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("image-%s", a)
 	u := fmt.Sprintf("/1.0/images/%s", url.PathEscape(image))
 	if projectName != project.Default {

--- a/lxd/lifecycle/image_alias.go
+++ b/lxd/lifecycle/image_alias.go
@@ -20,7 +20,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an image alias.
-func (a ImageAliasAction) Event(image string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ImageAliasAction) Event(image string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("image-alias-%s", a)
 	u := fmt.Sprintf("/1.0/images/aliases/%s", url.PathEscape(image))
 	if projectName != project.Default {

--- a/lxd/lifecycle/instance.go
+++ b/lxd/lifecycle/instance.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an instance.
-func (a InstanceAction) Event(inst instance, ctx map[string]interface{}) api.EventLifecycle {
+func (a InstanceAction) Event(inst instance, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("instance-%s", a)
 	url := api.NewURL().Path(version.APIVersion, "instances", inst.Name()).Project(inst.Project())
 

--- a/lxd/lifecycle/instance_backup.go
+++ b/lxd/lifecycle/instance_backup.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an instance backup.
-func (a InstanceBackupAction) Event(name string, inst instance, ctx map[string]interface{}) api.EventLifecycle {
+func (a InstanceBackupAction) Event(name string, inst instance, ctx map[string]any) api.EventLifecycle {
 	parentName, instanceName, _ := shared.InstanceGetParentAndSnapshotName(name)
 	u := fmt.Sprintf("/1.0/instances/%s/backups/%s", url.PathEscape(parentName), url.PathEscape(instanceName))
 	eventType := fmt.Sprintf("instance-backup-%s", a)

--- a/lxd/lifecycle/instance_log.go
+++ b/lxd/lifecycle/instance_log.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an instance log.
-func (a InstanceLogAction) Event(file string, inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a InstanceLogAction) Event(file string, inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("instance-log-%s", a)
 	u := fmt.Sprintf("/1.0/instance/%s/logs/%s", url.PathEscape(inst.Name()), file)
 

--- a/lxd/lifecycle/instance_metadata.go
+++ b/lxd/lifecycle/instance_metadata.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on instance metadata.
-func (a InstanceMetadataAction) Event(inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a InstanceMetadataAction) Event(inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("instance-metadata-%s", a)
 	u := fmt.Sprintf("/1.0/instances/%s/metadata", url.PathEscape(inst.Name()))
 

--- a/lxd/lifecycle/instance_metadata_template.go
+++ b/lxd/lifecycle/instance_metadata_template.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on instance metadata templates.
-func (a InstanceMetadataTemplateAction) Event(inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a InstanceMetadataTemplateAction) Event(inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("instance-metadata-template-%s", a)
 	u := fmt.Sprintf("/1.0/instances/%s/metadata/templates", url.PathEscape(inst.Name()))
 

--- a/lxd/lifecycle/instance_snapshot.go
+++ b/lxd/lifecycle/instance_snapshot.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an instance snapshot.
-func (a InstanceSnapshotAction) Event(inst instance, ctx map[string]interface{}) api.EventLifecycle {
+func (a InstanceSnapshotAction) Event(inst instance, ctx map[string]any) api.EventLifecycle {
 	parentName, instanceName, _ := shared.InstanceGetParentAndSnapshotName(inst.Name())
 	u := fmt.Sprintf("/1.0/instances/%s/snapshots/%s", url.PathEscape(parentName), url.PathEscape(instanceName))
 	eventType := fmt.Sprintf("instance-snapshot-%s", a)

--- a/lxd/lifecycle/network.go
+++ b/lxd/lifecycle/network.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a network device.
-func (a NetworkAction) Event(n network, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a NetworkAction) Event(n network, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-%s", a)
 	u := fmt.Sprintf("/1.0/networks/%s", url.PathEscape(n.Name()))
 	if n.Project() != project.Default {

--- a/lxd/lifecycle/network_acl.go
+++ b/lxd/lifecycle/network_acl.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a network acl.
-func (a NetworkACLAction) Event(n networkACL, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a NetworkACLAction) Event(n networkACL, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-acl-%s", a)
 
 	u := fmt.Sprintf("/1.0/network-acls/%s", url.PathEscape(n.Info().Name))

--- a/lxd/lifecycle/network_forward.go
+++ b/lxd/lifecycle/network_forward.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a network forward.
-func (a NetworkForwardAction) Event(n network, listenAddress string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a NetworkForwardAction) Event(n network, listenAddress string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-%s", a)
 	u := fmt.Sprintf("/1.0/networks/%s/forwards/%s", url.PathEscape(n.Name()), url.PathEscape(listenAddress))
 

--- a/lxd/lifecycle/network_peer.go
+++ b/lxd/lifecycle/network_peer.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a network forward.
-func (a NetworkPeerAction) Event(n network, peerName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a NetworkPeerAction) Event(n network, peerName string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-%s", a)
 	u := fmt.Sprintf("/1.0/networks/%s/peers/%s", url.PathEscape(n.Name()), url.PathEscape(peerName))
 

--- a/lxd/lifecycle/network_zone.go
+++ b/lxd/lifecycle/network_zone.go
@@ -32,7 +32,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a network zone.
-func (a NetworkZoneAction) Event(n networkZone, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a NetworkZoneAction) Event(n networkZone, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-zone-%s", a)
 
 	u := fmt.Sprintf("/1.0/network-zones/%s", url.PathEscape(n.Info().Name))
@@ -49,7 +49,7 @@ func (a NetworkZoneAction) Event(n networkZone, requestor *api.EventLifecycleReq
 }
 
 // Event creates the lifecycle event for an action on a network zone record.
-func (a NetworkZoneRecordAction) Event(n networkZone, name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a NetworkZoneRecordAction) Event(n networkZone, name string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-zone-record-%s", a)
 
 	u := fmt.Sprintf("/1.0/network-zones/%s/records/%s", url.PathEscape(n.Info().Name), url.PathEscape(name))

--- a/lxd/lifecycle/operation.go
+++ b/lxd/lifecycle/operation.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an operation.
-func (a OperationAction) Event(op operation, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a OperationAction) Event(op operation, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("operation-%s", a)
 	u := fmt.Sprintf("/1.0/operations/%s", url.PathEscape(op.ID()))
 

--- a/lxd/lifecycle/profile.go
+++ b/lxd/lifecycle/profile.go
@@ -20,7 +20,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a profile.
-func (a ProfileAction) Event(name string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ProfileAction) Event(name string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("profile-%s", a)
 	u := fmt.Sprintf("/1.0/profiles/%s", url.PathEscape(name))
 	if projectName != project.Default {

--- a/lxd/lifecycle/project.go
+++ b/lxd/lifecycle/project.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a project.
-func (a ProjectAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a ProjectAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("project-%s", a)
 	u := fmt.Sprintf("/1.0/projects/%s", url.PathEscape(name))
 

--- a/lxd/lifecycle/storage_pool.go
+++ b/lxd/lifecycle/storage_pool.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on an storage pool.
-func (a StoragePoolAction) Event(name string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a StoragePoolAction) Event(name string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("storage-pool-%s", a)
 	u := fmt.Sprintf("/1.0/storage-pools/%s", url.PathEscape(name))
 

--- a/lxd/lifecycle/storage_volume.go
+++ b/lxd/lifecycle/storage_volume.go
@@ -28,7 +28,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a storage volume.
-func (a StorageVolumeAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]interface{}) api.EventLifecycle {
+func (a StorageVolumeAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("storage-volume-%s", a)
 	u := fmt.Sprintf("/1.0/storage-pools/%s/volumes", url.PathEscape(v.Pool()))
 	if volumeType != "" {

--- a/lxd/lifecycle/storage_volume_backup.go
+++ b/lxd/lifecycle/storage_volume_backup.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a storage volume backup.
-func (a StorageVolumeBackupAction) Event(poolName string, volumeType string, volumeName string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a StorageVolumeBackupAction) Event(poolName string, volumeType string, volumeName string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("storage-volume-backup-%s", a)
 	parentName, backupName, _ := shared.InstanceGetParentAndSnapshotName(volumeName)
 	u := fmt.Sprintf("/1.0/storage-pools/%s/volumes/%s/%s/backups", url.PathEscape(poolName), url.PathEscape(volumeType), url.PathEscape(parentName))

--- a/lxd/lifecycle/storage_volume_snapshot.go
+++ b/lxd/lifecycle/storage_volume_snapshot.go
@@ -22,7 +22,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a storage volume snapshot.
-func (a StorageVolumeSnapshotAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]interface{}) api.EventLifecycle {
+func (a StorageVolumeSnapshotAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("storage-volume-snapshot-%s", a)
 	parentName, snapshotName, _ := shared.InstanceGetParentAndSnapshotName(v.Name())
 	u := fmt.Sprintf("/1.0/storage-pools/%s/volumes/%s/%s/snapshots", url.PathEscape(v.Pool()), url.PathEscape(volumeType), url.PathEscape(parentName))

--- a/lxd/lifecycle/warning.go
+++ b/lxd/lifecycle/warning.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a warning.
-func (a WarningAction) Event(id string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+func (a WarningAction) Event(id string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("warning-%s", a)
 	u := fmt.Sprintf("/1.0/warnings/%s", url.PathEscape(id))
 

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -63,7 +63,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 
 	// Fill in the node configuration
 	config := initDataNode{}
-	config.Config = map[string]interface{}{}
+	config.Config = map[string]any{}
 
 	// Network listening
 	if c.flagNetworkAddress != "" {

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -31,7 +31,7 @@ import (
 func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*cmdInitData, error) {
 	// Initialize config
 	config := cmdInitData{}
-	config.Node.Config = map[string]interface{}{}
+	config.Node.Config = map[string]any{}
 	config.Node.Networks = []internalClusterPostNetwork{}
 	config.Node.StoragePools = []api.StoragePoolsPost{}
 	config.Node.Profiles = []api.ProfilesPost{

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -139,7 +139,7 @@ type migrationSourceWs struct {
 	allConnected chan struct{}
 }
 
-func (s *migrationSourceWs) Metadata() interface{} {
+func (s *migrationSourceWs) Metadata() any {
 	secrets := shared.Jmap{
 		"control": s.controlSecret,
 		"fs":      s.fsSecret,
@@ -320,7 +320,7 @@ func (c *migrationSink) connectWithSecret(secret string) (*websocket.Conn, error
 	return conn, err
 }
 
-func (s *migrationSink) Metadata() interface{} {
+func (s *migrationSink) Metadata() any {
 	secrets := shared.Jmap{
 		"control": s.dest.controlSecret,
 		"fs":      s.dest.fsSecret,

--- a/lxd/migration/migrate.pb.go
+++ b/lxd/migration/migrate.pb.go
@@ -1294,7 +1294,7 @@ func file_lxd_migration_migrate_proto_rawDescGZIP() []byte {
 
 var file_lxd_migration_migrate_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_lxd_migration_migrate_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
-var file_lxd_migration_migrate_proto_goTypes = []interface{}{
+var file_lxd_migration_migrate_proto_goTypes = []any{
 	(MigrationFSType)(0),      // 0: migration.MigrationFSType
 	(CRIUType)(0),             // 1: migration.CRIUType
 	(*IDMapType)(nil),         // 2: migration.IDMapType
@@ -1337,7 +1337,7 @@ func file_lxd_migration_migrate_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_lxd_migration_migrate_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*IDMapType); i {
 			case 0:
 				return &v.state
@@ -1349,7 +1349,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*Config); i {
 			case 0:
 				return &v.state
@@ -1361,7 +1361,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*Device); i {
 			case 0:
 				return &v.state
@@ -1373,7 +1373,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*Snapshot); i {
 			case 0:
 				return &v.state
@@ -1385,7 +1385,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*RsyncFeatures); i {
 			case 0:
 				return &v.state
@@ -1397,7 +1397,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*ZfsFeatures); i {
 			case 0:
 				return &v.state
@@ -1409,7 +1409,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*BtrfsFeatures); i {
 			case 0:
 				return &v.state
@@ -1421,7 +1421,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*MigrationHeader); i {
 			case 0:
 				return &v.state
@@ -1433,7 +1433,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*MigrationControl); i {
 			case 0:
 				return &v.state
@@ -1445,7 +1445,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*MigrationSync); i {
 			case 0:
 				return &v.state
@@ -1457,7 +1457,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*DumpStatsEntry); i {
 			case 0:
 				return &v.state
@@ -1469,7 +1469,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[11].Exporter = func(v any, i int) any {
 			switch v := v.(*RestoreStatsEntry); i {
 			case 0:
 				return &v.state
@@ -1481,7 +1481,7 @@ func file_lxd_migration_migrate_proto_init() {
 				return nil
 			}
 		}
-		file_lxd_migration_migrate_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+		file_lxd_migration_migrate_proto_msgTypes[12].Exporter = func(v any, i int) any {
 			switch v := v.(*StatsEntry); i {
 			case 0:
 				return &v.state

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -25,7 +25,7 @@ type VolumeSourceArgs struct {
 	TrackProgress     bool
 	MultiSync         bool
 	FinalSync         bool
-	Data              interface{} // Optional store to persist storage driver state between MultiSync phases.
+	Data              any // Optional store to persist storage driver state between MultiSync phases.
 	ContentType       string
 	AllowInconsistent bool
 }
@@ -197,7 +197,7 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 func progressWrapperRender(op *operations.Operation, key string, description string, progressInt int64, speedInt int64) {
 	meta := op.Metadata()
 	if meta == nil {
-		meta = make(map[string]interface{})
+		meta = make(map[string]any)
 	}
 
 	progress := fmt.Sprintf("%s (%s/s)", units.GetByteSizeString(progressInt, 2), units.GetByteSizeString(speedInt, 2))

--- a/lxd/network/acl/acl_interface.go
+++ b/lxd/network/acl/acl_interface.go
@@ -15,7 +15,7 @@ type NetworkACL interface {
 	ID() int64
 	Project() string
 	Info() *api.NetworkACL
-	Etag() []interface{}
+	Etag() []any
 	UsedBy() ([]string, error)
 
 	// GetLog.

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -78,7 +78,7 @@ func Exists(s *state.State, projectName string, name ...string) error {
 
 // UsedBy finds all networks, profiles and instance NICs that use any of the specified ACLs and executes usageFunc
 // once for each resource using one or more of the ACLs with info about the resource and matched ACLs being used.
-func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLNames []string, usageType interface{}, nicName string, nicConfig map[string]string) error, matchACLNames ...string) error {
+func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLNames []string, usageType any, nicName string, nicConfig map[string]string) error, matchACLNames ...string) error {
 	if len(matchACLNames) <= 0 {
 		return nil
 	}
@@ -260,7 +260,7 @@ func NetworkUsage(s *state.State, aclProjectName string, aclNames []string, aclN
 	supportedNetTypes := []string{"bridge", "ovn"}
 
 	// Find all networks and instance/profile NICs that use any of the specified Network ACLs.
-	err := UsedBy(s, aclProjectName, func(matchedACLNames []string, usageType interface{}, _ string, nicConfig map[string]string) error {
+	err := UsedBy(s, aclProjectName, func(matchedACLNames []string, usageType any, _ string, nicConfig map[string]string) error {
 		switch u := usageType.(type) {
 		case db.Instance, db.Profile:
 			networkID, network, _, err := s.Cluster.GetNetworkInAnyState(aclProjectName, nicConfig["network"])

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -742,7 +742,7 @@ func OVNApplyNetworkBaselineRules(client *openvswitch.OVN, switchName openvswitc
 // The combination of ignoring the specifified usage type and explicit keep ACLs allows the caller to ensure that
 // the desired ACLs are considered unused by the usage type even if the referring config has not yet been removed
 // from the database.
-func OVNPortGroupDeleteIfUnused(s *state.State, logger logger.Logger, client *openvswitch.OVN, aclProjectName string, ignoreUsageType interface{}, ignoreUsageNicName string, keepACLs ...string) error {
+func OVNPortGroupDeleteIfUnused(s *state.State, logger logger.Logger, client *openvswitch.OVN, aclProjectName string, ignoreUsageType any, ignoreUsageNicName string, keepACLs ...string) error {
 	// Get map of ACL names to DB IDs (used for generating OVN port group names).
 	aclNameIDs, err := s.Cluster.GetNetworkACLIDsByNames(aclProjectName)
 	if err != nil {
@@ -809,7 +809,7 @@ func OVNPortGroupDeleteIfUnused(s *state.State, logger logger.Logger, client *op
 	// Find alls ACLs that are either directly referred to by OVN entities (networks, instance/profile NICs)
 	// or indirectly by being referred to by a ruleset of another ACL that is itself in use by OVN entities.
 	// For the indirectly referred to ACLs, store a list of the ACLs that are referring to it.
-	err = UsedBy(s, aclProjectName, func(matchedACLNames []string, usageType interface{}, nicName string, nicConfig map[string]string) error {
+	err = UsedBy(s, aclProjectName, func(matchedACLNames []string, usageType any, nicName string, nicConfig map[string]string) error {
 		switch u := usageType.(type) {
 		case db.Instance:
 			ignoreInst, isIgnoreInst := ignoreUsageType.(instance.Instance)

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -124,7 +124,7 @@ func (d *common) usedBy(firstOnly bool) ([]string, error) {
 	usedBy := []string{}
 
 	// Find all networks, profiles and instance NICs that use this Network ACL.
-	err := UsedBy(d.state, d.projectName, func(_ []string, usageType interface{}, _ string, _ map[string]string) error {
+	err := UsedBy(d.state, d.projectName, func(_ []string, usageType any, _ string, _ map[string]string) error {
 		switch u := usageType.(type) {
 		case db.Instance:
 			uri := fmt.Sprintf("/%s/instances/%s", version.APIVersion, u.Name)
@@ -191,8 +191,8 @@ func (d *common) isUsed() (bool, error) {
 }
 
 // Etag returns the values used for etag generation.
-func (d *common) Etag() []interface{} {
-	return []interface{}{d.info.Name, d.info.Description, d.info.Ingress, d.info.Egress, d.info.Config}
+func (d *common) Etag() []any {
+	return []any{d.info.Name, d.info.Description, d.info.Ingress, d.info.Egress, d.info.Config}
 }
 
 // validateName checks name is valid.

--- a/lxd/network/zone/interface.go
+++ b/lxd/network/zone/interface.go
@@ -17,7 +17,7 @@ type NetworkZone interface {
 	ID() int64
 	Project() string
 	Info() *api.NetworkZone
-	Etag() []interface{}
+	Etag() []any
 	UsedBy() ([]string, error)
 	Content() (*strings.Builder, error)
 

--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -124,8 +124,8 @@ func (d *zone) isUsed() (bool, error) {
 }
 
 // Etag returns the values used for etag generation.
-func (d *zone) Etag() []interface{} {
-	return []interface{}{d.info.Name, d.info.Description, d.info.Config}
+func (d *zone) Etag() []any {
+	return []any{d.info.Name, d.info.Description, d.info.Config}
 }
 
 // validateName checks name is valid.
@@ -447,7 +447,7 @@ func (d *zone) Content() (*strings.Builder, error) {
 
 	// Template the zone file.
 	sb := &strings.Builder{}
-	err = zoneTemplate.Execute(sb, map[string]interface{}{
+	err = zoneTemplate.Execute(sb, map[string]any{
 		"primary":     primary,
 		"nameservers": nameservers,
 		"zone":        d.info.Name,

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -754,7 +754,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	etag := []interface{}{n.Name, n.Managed, n.Type, n.Description, n.Config}
+	etag := []any{n.Name, n.Managed, n.Type, n.Description, n.Config}
 
 	return response.SyncResponseETag(true, &n, etag)
 }
@@ -1056,7 +1056,7 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkRenamed.Event(n, requestor, map[string]interface{}{"old_name": name}))
+	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkRenamed.Event(n, requestor, map[string]any{"old_name": name}))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/networks/%s", version.APIVersion, req.Name))
 }
@@ -1143,7 +1143,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag.
-	etag := []interface{}{n.Name(), n.IsManaged(), n.Type(), n.Description(), etagConfig}
+	etag := []any{n.Name(), n.IsManaged(), n.Type(), n.Description(), etagConfig}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -109,17 +109,17 @@ func (c *Config) StorageImagesVolume() string {
 
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
-func (c *Config) Dump() map[string]interface{} {
+func (c *Config) Dump() map[string]any {
 	return c.m.Dump()
 }
 
 // Replace the current configuration with the given values.
-func (c *Config) Replace(values map[string]interface{}) (map[string]string, error) {
+func (c *Config) Replace(values map[string]any) (map[string]string, error) {
 	return c.update(values)
 }
 
 // Patch changes only the configuration keys in the given map.
-func (c *Config) Patch(patch map[string]interface{}) (map[string]string, error) {
+func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 	values := c.Dump() // Use current values as defaults
 	for name, value := range patch {
 		values[name] = value
@@ -240,7 +240,7 @@ func MetricsAddress(node *db.Node) (string, error) {
 	return config.MetricsAddress(), nil
 }
 
-func (c *Config) update(values map[string]interface{}) (map[string]string, error) {
+func (c *Config) update(values map[string]any) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {
 		return nil, err

--- a/lxd/node/config_test.go
+++ b/lxd/node/config_test.go
@@ -17,7 +17,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	config, err := node.ConfigLoad(tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 }
 
 // If the database contains invalid keys, they are ignored.
@@ -34,7 +34,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	config, err := node.ConfigLoad(tx)
 
 	require.NoError(t, err)
-	values := map[string]interface{}{"core.https_address": "127.0.0.1:666"}
+	values := map[string]any{"core.https_address": "127.0.0.1:666"}
 	assert.Equal(t, values, config.Dump())
 }
 
@@ -46,7 +46,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	config, err := node.ConfigLoad(tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 }
 
 // If some previously set values are missing from the ones passed to Replace(),
@@ -58,11 +58,11 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	config, err := node.ConfigLoad(tx)
 	require.NoError(t, err)
 
-	changed, err := config.Replace(map[string]interface{}{"core.https_address": "127.0.0.1:666"})
+	changed, err := config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": "127.0.0.1:666"}, changed)
 
-	changed, err = config.Replace(map[string]interface{}{})
+	changed, err = config.Replace(map[string]any{})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": ""}, changed)
 
@@ -82,10 +82,10 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	config, err := node.ConfigLoad(tx)
 	require.NoError(t, err)
 
-	_, err = config.Replace(map[string]interface{}{"core.https_address": "127.0.0.1:666"})
+	_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
 	assert.NoError(t, err)
 
-	_, err = config.Patch(map[string]interface{}{})
+	_, err = config.Patch(map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "127.0.0.1:666", config.HTTPSAddress())
@@ -108,7 +108,7 @@ func TestHTTPSAddress(t *testing.T) {
 	err = nodeDB.Transaction(func(tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		require.NoError(t, err)
-		_, err = config.Replace(map[string]interface{}{"core.https_address": "127.0.0.1:666"})
+		_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
 		require.NoError(t, err)
 		return nil
 	})
@@ -132,7 +132,7 @@ func TestClusterAddress(t *testing.T) {
 	err = nodeDB.Transaction(func(tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		require.NoError(t, err)
-		_, err = config.Replace(map[string]interface{}{"cluster.https_address": "127.0.0.1:666"})
+		_, err = config.Replace(map[string]any{"cluster.https_address": "127.0.0.1:666"})
 		require.NoError(t, err)
 		return nil
 	})

--- a/lxd/operations/linux.go
+++ b/lxd/operations/linux.go
@@ -69,7 +69,7 @@ func getServerName(op *Operation) (string, error) {
 	return serverName, nil
 }
 
-func (op *Operation) sendEvent(eventMessage interface{}) {
+func (op *Operation) sendEvent(eventMessage any) {
 	if op.events == nil {
 		return
 	}

--- a/lxd/operations/notlinux.go
+++ b/lxd/operations/notlinux.go
@@ -33,7 +33,7 @@ func getServerName(op *Operation) (string, error) {
 	return "", nil
 }
 
-func (op *Operation) sendEvent(eventMessage interface{}) {
+func (op *Operation) sendEvent(eventMessage any) {
 	if op.events == nil {
 		return
 	}

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -99,7 +99,7 @@ type Operation struct {
 	status      api.StatusCode
 	url         string
 	resources   map[string][]string
-	metadata    map[string]interface{}
+	metadata    map[string]any
 	err         string
 	readonly    bool
 	canceler    *cancel.Canceler
@@ -125,7 +125,7 @@ type Operation struct {
 
 // OperationCreate creates a new operation and returns it. If it cannot be
 // created, it returns an error.
-func OperationCreate(s *state.State, projectName string, opClass OperationClass, opType db.OperationType, opResources map[string][]string, opMetadata interface{}, onRun func(*Operation) error, onCancel func(*Operation) error, onConnect func(*Operation, *http.Request, http.ResponseWriter) error, r *http.Request) (*Operation, error) {
+func OperationCreate(s *state.State, projectName string, opClass OperationClass, opType db.OperationType, opResources map[string][]string, opMetadata any, onRun func(*Operation) error, onCancel func(*Operation) error, onConnect func(*Operation, *http.Request, http.ResponseWriter) error, r *http.Request) (*Operation, error) {
 	// Don't allow new operations when LXD is shutting down.
 	if s != nil && s.ShutdownCtx.Err() == context.Canceled {
 		return nil, fmt.Errorf("LXD is shutting down")
@@ -558,7 +558,7 @@ func (op *Operation) UpdateResources(opResources map[string][]string) error {
 
 // UpdateMetadata updates the metadata of the operation. It returns an error
 // if the operation is not pending or running, or the operation is read-only.
-func (op *Operation) UpdateMetadata(opMetadata interface{}) error {
+func (op *Operation) UpdateMetadata(opMetadata any) error {
 	if op.status != api.Pending && op.status != api.Running {
 		return fmt.Errorf("Only pending or running operations can be updated")
 	}
@@ -589,7 +589,7 @@ func (op *Operation) UpdateMetadata(opMetadata interface{}) error {
 
 // ExtendMetadata updates the metadata of the operation with the additional data provided.
 // It returns an error if the operation is not pending or running, or the operation is read-only.
-func (op *Operation) ExtendMetadata(metadata interface{}) error {
+func (op *Operation) ExtendMetadata(metadata any) error {
 	// Quick checks.
 	if op.status != api.Pending && op.status != api.Running {
 		return fmt.Errorf("Only pending or running operations can be updated")
@@ -641,7 +641,7 @@ func (op *Operation) ID() string {
 }
 
 // Metadata returns the operation Metadata.
-func (op *Operation) Metadata() map[string]interface{} {
+func (op *Operation) Metadata() map[string]any {
 	return op.metadata
 }
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1034,7 +1034,7 @@ func patchStorageApi(name string, d *Daemon) error {
 		if err != nil {
 			return err
 		}
-		_, err = config.Patch(map[string]interface{}{
+		_, err = config.Patch(map[string]any{
 			"storage.lvm_fstype":           "",
 			"storage.lvm_mount_options":    "",
 			"storage.lvm_thinpool_name":    "",

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -145,7 +145,7 @@ func profilesGet(d *Daemon, r *http.Request) response.Response {
 
 	recursion := util.IsRecursionRequest(r)
 
-	var result interface{}
+	var result any
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		filter := db.ProfileFilter{
 			Project: &projectName,
@@ -338,7 +338,7 @@ func profileGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	etag := []interface{}{resp.Config, resp.Description, resp.Devices}
+	etag := []any{resp.Config, resp.Description, resp.Devices}
 	return response.SyncResponseETag(true, resp, etag)
 }
 
@@ -416,7 +416,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag.
-	etag := []interface{}{profile.Config, profile.Description, profile.Devices}
+	etag := []any{profile.Config, profile.Description, profile.Devices}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)
@@ -511,7 +511,7 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag.
-	etag := []interface{}{profile.Config, profile.Description, profile.Devices}
+	etag := []any{profile.Config, profile.Description, profile.Devices}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -35,8 +35,8 @@ type Response interface {
 // Sync response
 type syncResponse struct {
 	success   bool
-	etag      interface{}
-	metadata  interface{}
+	etag      any
+	metadata  any
 	location  string
 	code      int
 	headers   map[string]string
@@ -44,21 +44,21 @@ type syncResponse struct {
 }
 
 // EmptySyncResponse represents an empty syncResponse.
-var EmptySyncResponse = &syncResponse{success: true, metadata: make(map[string]interface{})}
+var EmptySyncResponse = &syncResponse{success: true, metadata: make(map[string]any)}
 
 // SyncResponse returns a new syncResponse with the success and metadata fields
 // set to the provided values.
-func SyncResponse(success bool, metadata interface{}) Response {
+func SyncResponse(success bool, metadata any) Response {
 	return &syncResponse{success: success, metadata: metadata}
 }
 
 // SyncResponseETag returns a new syncResponse with an etag.
-func SyncResponseETag(success bool, metadata interface{}, etag interface{}) Response {
+func SyncResponseETag(success bool, metadata any, etag any) Response {
 	return &syncResponse{success: success, metadata: metadata, etag: etag}
 }
 
 // SyncResponseLocation returns a new syncResponse with a location.
-func SyncResponseLocation(success bool, metadata interface{}, location string) Response {
+func SyncResponseLocation(success bool, metadata any, location string) Response {
 	return &syncResponse{success: success, metadata: metadata, location: location}
 }
 
@@ -69,7 +69,7 @@ func SyncResponseRedirect(address string) Response {
 }
 
 // SyncResponseHeaders returns a new syncResponse with headers.
-func SyncResponseHeaders(success bool, metadata interface{}, headers map[string]string) Response {
+func SyncResponseHeaders(success bool, metadata any, headers map[string]string) Response {
 	return &syncResponse{success: success, metadata: metadata, headers: headers}
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1506,7 +1506,7 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) f
 	return func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
 		var tracker *ioprogress.ProgressTracker
 		if op != nil { // Not passed when being done as part of pre-migration setup.
-			metadata := make(map[string]interface{})
+			metadata := make(map[string]any)
 			tracker = &ioprogress.ProgressTracker{
 				Handler: func(percent, speed int64) {
 					shared.SetProgressMetadata(metadata, "create_instance_from_image_unpack", "Unpack", percent, 0, speed)

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -536,7 +536,7 @@ func (d *ceph) rbdListVolumeSnapshots(vol Volume) ([]string, error) {
 		return []string{}, err
 	}
 
-	var data []map[string]interface{}
+	var data []map[string]any
 	err = json.Unmarshal([]byte(msg), &data)
 	if err != nil {
 		return []string{}, err

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -884,8 +884,8 @@ func FallbackMigrationType(contentType drivers.ContentType) migration.MigrationF
 
 // RenderSnapshotUsage can be used as an optional argument to Instance.Render() to return snapshot usage.
 // As this is a relatively expensive operation it is provided as an optional feature rather than on by default.
-func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(response interface{}) error {
-	return func(response interface{}) error {
+func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(response any) error {
+	return func(response any) error {
 		apiRes, ok := response.(*api.InstanceSnapshot)
 		if !ok {
 			return nil

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -614,7 +614,7 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 		poolAPI.Status = pool.LocalStatus()
 	}
 
-	etag := []interface{}{pool.Name, pool.Driver, poolAPI.Config}
+	etag := []any{pool.Name, pool.Driver, poolAPI.Config}
 
 	return response.SyncResponseETag(true, &poolAPI, etag)
 }
@@ -696,7 +696,7 @@ func storagePoolPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag.
-	etag := []interface{}{pool.Name(), pool.Driver().Info().Name, etagConfig}
+	etag := []any{pool.Name(), pool.Driver().Info().Name, etagConfig}
 
 	err = util.EtagCheck(r, etag)
 	if err != nil {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1304,7 +1304,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 	}
 	volume.UsedBy = project.FilterUsedBy(r, volumeUsedBy)
 
-	etag := []interface{}{volumeName, volume.Type, volume.Config}
+	etag := []any{volumeName, volume.Type, volume.Config}
 
 	return response.SyncResponseETag(true, volume, etag)
 }
@@ -1399,7 +1399,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag
-	etag := []interface{}{volumeName, vol.Type, vol.Config}
+	etag := []any{volumeName, vol.Type, vol.Config}
 
 	err = util.EtagCheck(r, etag)
 	if err != nil {
@@ -1556,7 +1556,7 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the ETag.
-	etag := []interface{}{volumeName, vol.Type, vol.Config}
+	etag := []any{volumeName, vol.Type, vol.Config}
 
 	err = util.EtagCheck(r, etag)
 	if err != nil {

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -627,7 +627,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 	snapshot.ExpiresAt = &expiry
 	snapshot.ContentType = volume.ContentType
 
-	etag := []interface{}{snapshot.Description, expiry}
+	etag := []any{snapshot.Description, expiry}
 	return response.SyncResponseETag(true, &snapshot, etag)
 }
 
@@ -725,7 +725,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 	}
 
 	// Validate the ETag
-	etag := []interface{}{vol.Description, expiry}
+	etag := []any{vol.Description, expiry}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)
@@ -835,7 +835,7 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 	}
 
 	// Validate the ETag
-	etag := []interface{}{vol.Description, expiry}
+	etag := []any{vol.Description, expiry}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -41,7 +41,7 @@ func DebugJSON(title string, r *bytes.Buffer, logger logger.Logger) {
 
 // WriteJSON encodes the body as JSON and sends it back to the client
 // Accepts optional debugLogger that activates debug logging if non-nil.
-func WriteJSON(w http.ResponseWriter, body interface{}, debugLogger logger.Logger) error {
+func WriteJSON(w http.ResponseWriter, body any, debugLogger logger.Logger) error {
 	var output io.Writer
 	var captured *bytes.Buffer
 
@@ -63,7 +63,7 @@ func WriteJSON(w http.ResponseWriter, body interface{}, debugLogger logger.Logge
 }
 
 // EtagHash hashes the provided data and returns the sha256
-func EtagHash(data interface{}) (string, error) {
+func EtagHash(data any) (string, error) {
 	etag := sha256.New()
 	err := json.NewEncoder(etag).Encode(data)
 	if err != nil {
@@ -75,7 +75,7 @@ func EtagHash(data interface{}) (string, error) {
 
 // EtagCheck validates the hash of the current state with the hash
 // provided by the client
-func EtagCheck(r *http.Request, data interface{}) error {
+func EtagCheck(r *http.Request, data any) error {
 	match := r.Header.Get("If-Match")
 	if match == "" {
 		return nil

--- a/shared/api/error.go
+++ b/shared/api/error.go
@@ -7,7 +7,7 @@ import (
 )
 
 // StatusErrorf returns a new StatusError containing the specified status and message.
-func StatusErrorf(status int, format string, a ...interface{}) StatusError {
+func StatusErrorf(status int, format string, a ...any) StatusError {
 	var msg string
 	if len(a) > 0 {
 		msg = fmt.Sprintf(format, a...)

--- a/shared/api/event.go
+++ b/shared/api/event.go
@@ -44,7 +44,7 @@ func (event *Event) ToLogging() (EventLogRecord, error) {
 			return EventLogRecord{}, err
 		}
 
-		ctx := []interface{}{}
+		ctx := []any{}
 		for k, v := range e.Context {
 			ctx = append(ctx, k)
 			ctx = append(ctx, v)
@@ -64,7 +64,7 @@ func (event *Event) ToLogging() (EventLogRecord, error) {
 			return EventLogRecord{}, err
 		}
 
-		ctx := []interface{}{}
+		ctx := []any{}
 		for k, v := range e.Context {
 			ctx = append(ctx, k)
 			ctx = append(ctx, v)
@@ -95,7 +95,7 @@ func (event *Event) ToLogging() (EventLogRecord, error) {
 			Time: event.Timestamp,
 			Lvl:  "info",
 			Msg:  fmt.Sprintf("ID: %s, Class: %s, Description: %s", e.ID, e.Class, e.Description),
-			Ctx: []interface{}{
+			Ctx: []any{
 				"CreatedAt", e.CreatedAt,
 				"UpdatedAt", e.UpdatedAt,
 				"Status", e.Status,
@@ -118,7 +118,7 @@ type EventLogRecord struct {
 	Time time.Time
 	Lvl  string
 	Msg  string
-	Ctx  []interface{}
+	Ctx  []any
 }
 
 // EventLogging represents a logging type event entry (admin only)
@@ -132,9 +132,9 @@ type EventLogging struct {
 //
 // API extension: event_lifecycle
 type EventLifecycle struct {
-	Action  string                 `yaml:"action" json:"action"`
-	Source  string                 `yaml:"source" json:"source"`
-	Context map[string]interface{} `yaml:"context,omitempty" json:"context,omitempty"`
+	Action  string         `yaml:"action" json:"action"`
+	Source  string         `yaml:"source" json:"source"`
+	Context map[string]any `yaml:"context,omitempty" json:"context,omitempty"`
 
 	// API extension: event_lifecycle_requestor
 	Requestor *EventLifecycleRequestor `yaml:"requestor,omitempty" json:"requestor,omitempty"`

--- a/shared/api/network_forward.go
+++ b/shared/api/network_forward.go
@@ -131,8 +131,8 @@ type NetworkForward struct {
 }
 
 // Etag returns the values used for etag generation.
-func (f *NetworkForward) Etag() []interface{} {
-	return []interface{}{f.ListenAddress, f.Description, f.Config, f.Ports}
+func (f *NetworkForward) Etag() []any {
+	return []any{f.ListenAddress, f.Description, f.Config, f.Ports}
 }
 
 // Writable converts a full NetworkForward struct into a NetworkForwardPut struct (filters read-only fields).

--- a/shared/api/network_peer.go
+++ b/shared/api/network_peer.go
@@ -71,8 +71,8 @@ type NetworkPeer struct {
 }
 
 // Etag returns the values used for etag generation.
-func (p *NetworkPeer) Etag() []interface{} {
-	return []interface{}{p.Name, p.Description, p.Config}
+func (p *NetworkPeer) Etag() []any {
+	return []any{p.Name, p.Description, p.Config}
 }
 
 // Writable converts a full NetworkPeer struct into a NetworkPeerPut struct (filters read-only fields).

--- a/shared/api/operation.go
+++ b/shared/api/operation.go
@@ -52,7 +52,7 @@ type Operation struct {
 
 	// Operation specific metadata
 	// Example: {"command": ["bash"], "environment": {"HOME": "/root", "LANG": "C.UTF-8", "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM": "xterm", "USER": "root"}, "fds": {"0": "da3046cf02c0116febf4ef3fe4eaecdf308e720c05e5a9c730ce1a6f15417f66", "1": "05896879d8692607bd6e4a09475667da3b5f6714418ab0ee0e5720b4c57f754b"}, "interactive": true}
-	Metadata map[string]interface{} `json:"metadata" yaml:"metadata"`
+	Metadata map[string]any `json:"metadata" yaml:"metadata"`
 
 	// Whether the operation can be canceled
 	// Example: false
@@ -71,9 +71,9 @@ type Operation struct {
 
 // ToCertificateAddToken creates a certificate add token from the operation metadata.
 func (op *Operation) ToCertificateAddToken() (*CertificateAddToken, error) {
-	req, ok := op.Metadata["request"].(map[string]interface{})
+	req, ok := op.Metadata["request"].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("Operation request is type %T not map[string]interface{}", op.Metadata["request"])
+		return nil, fmt.Errorf("Operation request is type %T not map[string]any", op.Metadata["request"])
 	}
 
 	clientName, ok := req["name"].(string)
@@ -91,9 +91,9 @@ func (op *Operation) ToCertificateAddToken() (*CertificateAddToken, error) {
 		return nil, fmt.Errorf("Operation fingerprint is type %T not string", op.Metadata["fingerprint"])
 	}
 
-	addresses, ok := op.Metadata["addresses"].([]interface{})
+	addresses, ok := op.Metadata["addresses"].([]any)
 	if !ok {
-		return nil, fmt.Errorf("Operation addresses is type %T not []interface{}", op.Metadata["addresses"])
+		return nil, fmt.Errorf("Operation addresses is type %T not []any", op.Metadata["addresses"])
 	}
 
 	joinToken := CertificateAddToken{
@@ -132,9 +132,9 @@ func (op *Operation) ToClusterJoinToken() (*ClusterMemberJoinToken, error) {
 		return nil, fmt.Errorf("Operation fingerprint is type %T not string", op.Metadata["fingerprint"])
 	}
 
-	addresses, ok := op.Metadata["addresses"].([]interface{})
+	addresses, ok := op.Metadata["addresses"].([]any)
 	if !ok {
-		return nil, fmt.Errorf("Operation addresses is type %T not []interface{}", op.Metadata["addresses"])
+		return nil, fmt.Errorf("Operation addresses is type %T not []any", op.Metadata["addresses"])
 	}
 
 	joinToken := ClusterMemberJoinToken{

--- a/shared/api/response.go
+++ b/shared/api/response.go
@@ -19,7 +19,7 @@ type ResponseRaw struct {
 	Code  int    `json:"error_code" yaml:"error_code"`
 	Error string `json:"error" yaml:"error"`
 
-	Metadata interface{} `json:"metadata" yaml:"metadata"`
+	Metadata any `json:"metadata" yaml:"metadata"`
 }
 
 // Response represents a LXD operation
@@ -42,8 +42,8 @@ type Response struct {
 }
 
 // MetadataAsMap parses the Response metadata into a map
-func (r *Response) MetadataAsMap() (map[string]interface{}, error) {
-	ret := map[string]interface{}{}
+func (r *Response) MetadataAsMap() (map[string]any, error) {
+	ret := map[string]any{}
 	err := r.MetadataAsStruct(&ret)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (r *Response) MetadataAsStringSlice() ([]string, error) {
 }
 
 // MetadataAsStruct parses the Response metadata into a provided struct
-func (r *Response) MetadataAsStruct(target interface{}) error {
+func (r *Response) MetadataAsStruct(target any) error {
 	return json.Unmarshal(r.Metadata, &target)
 }
 

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -148,7 +148,7 @@ type ServerStorageDriverInfo struct {
 type ServerPut struct {
 	// Server configuration map (refer to doc/server.md)
 	// Example: {"core.https_address": ":8443", "core.trust_password": true}
-	Config map[string]interface{} `json:"config" yaml:"config"`
+	Config map[string]any `json:"config" yaml:"config"`
 }
 
 // ServerUntrusted represents a LXD server for an untrusted client

--- a/shared/idmap/idmapset_linux.go
+++ b/shared/idmap/idmapset_linux.go
@@ -1061,7 +1061,7 @@ func JSONMarshal(idmapSet *IdmapSet) (string, error) {
 func GetIdmapSet() *IdmapSet {
 	idmapSet, err := DefaultIdmapSet("", "")
 	if err != nil {
-		logger.Warn("Error reading default uid/gid map", map[string]interface{}{"err": err.Error()})
+		logger.Warn("Error reading default uid/gid map", map[string]any{"err": err.Error()})
 		logger.Warnf("Only privileged containers will be able to run")
 		idmapSet = nil
 	} else {

--- a/shared/instancewriter/instance_file_info.go
+++ b/shared/instancewriter/instance_file_info.go
@@ -40,7 +40,7 @@ func (f *FileInfo) IsDir() bool {
 }
 
 // Sys returns further unix attributes for a file owned by root.
-func (f *FileInfo) Sys() interface{} {
+func (f *FileInfo) Sys() any {
 	return &tar.Header{
 		Uid:        0,
 		Gid:        0,

--- a/shared/json.go
+++ b/shared/json.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-type Jmap map[string]interface{}
+type Jmap map[string]any
 
 func (m Jmap) GetString(key string) (string, error) {
 	if val, ok := m[key]; !ok {
@@ -19,7 +19,7 @@ func (m Jmap) GetString(key string) (string, error) {
 func (m Jmap) GetMap(key string) (Jmap, error) {
 	if val, ok := m[key]; !ok {
 		return nil, fmt.Errorf("Response was missing `%s`", key)
-	} else if val, ok := val.(map[string]interface{}); !ok {
+	} else if val, ok := val.(map[string]any); !ok {
 		return nil, fmt.Errorf("`%s` was not a map, got %T", key, m[key])
 	} else {
 		return val, nil

--- a/shared/logger/format.go
+++ b/shared/logger/format.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Pretty will attempt to convert any Go structure into a string suitable for logging
-func Pretty(input interface{}) string {
+func Pretty(input any) string {
 	pretty, err := json.MarshalIndent(input, "\t", "\t")
 	if err != nil {
 		return fmt.Sprintf("%v", input)

--- a/shared/logger/log.go
+++ b/shared/logger/log.go
@@ -9,11 +9,11 @@ import (
 
 // Logger is the main logging interface
 type Logger interface {
-	Debug(msg string, ctx ...interface{})
-	Info(msg string, ctx ...interface{})
-	Warn(msg string, ctx ...interface{})
-	Error(msg string, ctx ...interface{})
-	Crit(msg string, ctx ...interface{})
+	Debug(msg string, ctx ...any)
+	Info(msg string, ctx ...any)
+	Warn(msg string, ctx ...any)
+	Error(msg string, ctx ...any)
+	Crit(msg string, ctx ...any)
 }
 
 // Log contains the logger used by all the logging functions
@@ -21,81 +21,81 @@ var Log Logger
 
 type nullLogger struct{}
 
-func (nl nullLogger) Debug(msg string, ctx ...interface{}) {}
-func (nl nullLogger) Info(msg string, ctx ...interface{})  {}
-func (nl nullLogger) Warn(msg string, ctx ...interface{})  {}
-func (nl nullLogger) Error(msg string, ctx ...interface{}) {}
-func (nl nullLogger) Crit(msg string, ctx ...interface{})  {}
+func (nl nullLogger) Debug(msg string, ctx ...any) {}
+func (nl nullLogger) Info(msg string, ctx ...any)  {}
+func (nl nullLogger) Warn(msg string, ctx ...any)  {}
+func (nl nullLogger) Error(msg string, ctx ...any) {}
+func (nl nullLogger) Crit(msg string, ctx ...any)  {}
 
 func init() {
 	Log = nullLogger{}
 }
 
 // Debug logs a message (with optional context) at the DEBUG log level
-func Debug(msg string, ctx ...interface{}) {
+func Debug(msg string, ctx ...any) {
 	if Log != nil {
 		Log.Debug(msg, ctx...)
 	}
 }
 
 // Info logs a message (with optional context) at the INFO log level
-func Info(msg string, ctx ...interface{}) {
+func Info(msg string, ctx ...any) {
 	if Log != nil {
 		Log.Info(msg, ctx...)
 	}
 }
 
 // Warn logs a message (with optional context) at the WARNING log level
-func Warn(msg string, ctx ...interface{}) {
+func Warn(msg string, ctx ...any) {
 	if Log != nil {
 		Log.Warn(msg, ctx...)
 	}
 }
 
 // Error logs a message (with optional context) at the ERROR log level
-func Error(msg string, ctx ...interface{}) {
+func Error(msg string, ctx ...any) {
 	if Log != nil {
 		Log.Error(msg, ctx...)
 	}
 }
 
 // Crit logs a message (with optional context) at the CRITICAL log level
-func Crit(msg string, ctx ...interface{}) {
+func Crit(msg string, ctx ...any) {
 	if Log != nil {
 		Log.Crit(msg, ctx...)
 	}
 }
 
 // Infof logs at the INFO log level using a standard printf format string
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	if Log != nil {
 		Log.Info(fmt.Sprintf(format, args...))
 	}
 }
 
 // Debugf logs at the DEBUG log level using a standard printf format string
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	if Log != nil {
 		Log.Debug(fmt.Sprintf(format, args...))
 	}
 }
 
 // Warnf logs at the WARNING log level using a standard printf format string
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	if Log != nil {
 		Log.Warn(fmt.Sprintf(format, args...))
 	}
 }
 
 // Errorf logs at the ERROR log level using a standard printf format string
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	if Log != nil {
 		Log.Error(fmt.Sprintf(format, args...))
 	}
 }
 
 // Critf logs at the CRITICAL log level using a standard printf format string
-func Critf(format string, args ...interface{}) {
+func Critf(format string, args ...any) {
 	if Log != nil {
 		Log.Crit(fmt.Sprintf(format, args...))
 	}

--- a/shared/logger/log_debug.go
+++ b/shared/logger/log_debug.go
@@ -9,29 +9,29 @@ import (
 )
 
 type Logger interface {
-	Debug(msg string, ctx ...interface{})
-	Info(msg string, ctx ...interface{})
-	Warn(msg string, ctx ...interface{})
-	Error(msg string, ctx ...interface{})
-	Crit(msg string, ctx ...interface{})
+	Debug(msg string, ctx ...any)
+	Info(msg string, ctx ...any)
+	Warn(msg string, ctx ...any)
+	Error(msg string, ctx ...any)
+	Crit(msg string, ctx ...any)
 }
 
 var Log Logger
 
 type nullLogger struct{}
 
-func (nl nullLogger) Debug(msg string, ctx ...interface{}) {}
-func (nl nullLogger) Info(msg string, ctx ...interface{})  {}
-func (nl nullLogger) Warn(msg string, ctx ...interface{})  {}
-func (nl nullLogger) Error(msg string, ctx ...interface{}) {}
-func (nl nullLogger) Crit(msg string, ctx ...interface{})  {}
+func (nl nullLogger) Debug(msg string, ctx ...any) {}
+func (nl nullLogger) Info(msg string, ctx ...any)  {}
+func (nl nullLogger) Warn(msg string, ctx ...any)  {}
+func (nl nullLogger) Error(msg string, ctx ...any) {}
+func (nl nullLogger) Crit(msg string, ctx ...any)  {}
 
 func init() {
 	Log = nullLogger{}
 }
 
 // General wrappers around Logger interface functions.
-func Debug(msg string, ctx ...interface{}) {
+func Debug(msg string, ctx ...any) {
 	if Log != nil {
 		pc, fn, line, _ := runtime.Caller(1)
 		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
@@ -39,7 +39,7 @@ func Debug(msg string, ctx ...interface{}) {
 	}
 }
 
-func Info(msg string, ctx ...interface{}) {
+func Info(msg string, ctx ...any) {
 	if Log != nil {
 		pc, fn, line, _ := runtime.Caller(1)
 		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
@@ -47,7 +47,7 @@ func Info(msg string, ctx ...interface{}) {
 	}
 }
 
-func Warn(msg string, ctx ...interface{}) {
+func Warn(msg string, ctx ...any) {
 	if Log != nil {
 		pc, fn, line, _ := runtime.Caller(1)
 		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
@@ -55,7 +55,7 @@ func Warn(msg string, ctx ...interface{}) {
 	}
 }
 
-func Error(msg string, ctx ...interface{}) {
+func Error(msg string, ctx ...any) {
 	if Log != nil {
 		pc, fn, line, _ := runtime.Caller(1)
 		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
@@ -63,7 +63,7 @@ func Error(msg string, ctx ...interface{}) {
 	}
 }
 
-func Crit(msg string, ctx ...interface{}) {
+func Crit(msg string, ctx ...any) {
 	if Log != nil {
 		pc, fn, line, _ := runtime.Caller(1)
 		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
@@ -73,7 +73,7 @@ func Crit(msg string, ctx ...interface{}) {
 
 // Wrappers around Logger interface functions that send a string to the Logger
 // by running it through fmt.Sprintf().
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	if Log != nil {
 		msg := fmt.Sprintf(format, args...)
 		pc, fn, line, _ := runtime.Caller(1)
@@ -82,7 +82,7 @@ func Infof(format string, args ...interface{}) {
 	}
 }
 
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	if Log != nil {
 		msg := fmt.Sprintf(format, args...)
 		pc, fn, line, _ := runtime.Caller(1)
@@ -91,7 +91,7 @@ func Debugf(format string, args ...interface{}) {
 	}
 }
 
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	if Log != nil {
 		msg := fmt.Sprintf(format, args...)
 		pc, fn, line, _ := runtime.Caller(1)
@@ -100,7 +100,7 @@ func Warnf(format string, args ...interface{}) {
 	}
 }
 
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	if Log != nil {
 		msg := fmt.Sprintf(format, args...)
 		pc, fn, line, _ := runtime.Caller(1)
@@ -109,7 +109,7 @@ func Errorf(format string, args ...interface{}) {
 	}
 }
 
-func Critf(format string, args ...interface{}) {
+func Critf(format string, args ...any) {
 	if Log != nil {
 		msg := fmt.Sprintf(format, args...)
 		pc, fn, line, _ := runtime.Caller(1)

--- a/shared/logging/format.go
+++ b/shared/logging/format.go
@@ -70,7 +70,7 @@ func TerminalFormat() log.Format {
 // LogfmtFormat return a formatter for a text log file
 func LogfmtFormat() log.Format {
 	return log.FormatFunc(func(r *log.Record) []byte {
-		common := []interface{}{r.KeyNames.Time, r.Time, r.KeyNames.Lvl, r.Lvl, r.KeyNames.Msg, r.Msg}
+		common := []any{r.KeyNames.Time, r.Time, r.KeyNames.Lvl, r.Lvl, r.KeyNames.Msg, r.Msg}
 		buf := &bytes.Buffer{}
 
 		logfmt(buf, common, 0, false)
@@ -81,7 +81,7 @@ func LogfmtFormat() log.Format {
 	})
 }
 
-func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, sorted bool) {
+func logfmt(buf *bytes.Buffer, ctx []any, color int, sorted bool) {
 	entries := []string{}
 
 	for i := 0; i < len(ctx); i += 2 {
@@ -114,7 +114,7 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int, sorted bool) {
 	buf.WriteByte('\n')
 }
 
-func formatShared(value interface{}) (result interface{}) {
+func formatShared(value any) (result any) {
 	defer func() {
 		if err := recover(); err != nil {
 			if v := reflect.ValueOf(value); v.Kind() == reflect.Ptr && v.IsNil() {
@@ -141,7 +141,7 @@ func formatShared(value interface{}) (result interface{}) {
 }
 
 // formatValue formats a value for serialization
-func formatLogfmtValue(value interface{}) string {
+func formatLogfmtValue(value any) string {
 	if value == nil {
 		return "nil"
 	}

--- a/shared/util.go
+++ b/shared/util.go
@@ -701,7 +701,7 @@ func IsBlockdevPath(pathName string) bool {
 }
 
 // DeepCopy copies src to dest by using encoding/gob so its not that fast.
-func DeepCopy(src, dest interface{}) error {
+func DeepCopy(src, dest any) error {
 	buff := new(bytes.Buffer)
 	enc := gob.NewEncoder(buff)
 	dec := gob.NewDecoder(buff)
@@ -804,8 +804,8 @@ func TextEditor(inPath string, inContent []byte) ([]byte, error) {
 	return content, nil
 }
 
-func ParseMetadata(metadata interface{}) (map[string]interface{}, error) {
-	newMetadata := make(map[string]interface{})
+func ParseMetadata(metadata any) (map[string]any, error) {
+	newMetadata := make(map[string]any)
 	s := reflect.ValueOf(metadata)
 	if !s.IsValid() {
 		return nil, nil
@@ -978,7 +978,7 @@ func EscapePathFstab(path string) string {
 	return r.Replace(path)
 }
 
-func SetProgressMetadata(metadata map[string]interface{}, stage, displayPrefix string, percent, processed, speed int64) {
+func SetProgressMetadata(metadata map[string]any, stage, displayPrefix string, percent, processed, speed int64) {
 	progress := make(map[string]string)
 	// stage, percent, speed sent for API callers.
 	progress["stage"] = stage

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -259,7 +259,7 @@ func Uname() (*Utsname, error) {
 	}, nil
 }
 
-func intArrayToString(arr interface{}) string {
+func intArrayToString(arr any) string {
 	slice := reflect.ValueOf(arr)
 	s := ""
 	for i := 0; i < slice.Len(); i++ {

--- a/test/deps/devlxd-client.go
+++ b/test/deps/devlxd-client.go
@@ -57,7 +57,7 @@ func devlxdMonitor(c http.Client) {
 			return
 		}
 
-		message := make(map[string]interface{})
+		message := make(map[string]any)
 		err = json.Unmarshal(data, &message)
 		if err != nil {
 			return

--- a/test/macaroon-identity/auth.go
+++ b/test/macaroon-identity/auth.go
@@ -82,7 +82,7 @@ func (s *authService) thirdPartyChecker(ctx context.Context, req *http.Request, 
 	}, nil
 }
 
-func writeJSON(w http.ResponseWriter, code int, val interface{}) error {
+func writeJSON(w http.ResponseWriter, code int, val any) error {
 	data, err := json.Marshal(val)
 	if err != nil {
 		return err
@@ -143,6 +143,6 @@ func (s *authService) getRandomToken() string {
 	return base64.StdEncoding.EncodeToString(uuid)
 }
 
-func (s *authService) bakeryFail(w http.ResponseWriter, msg string, args ...interface{}) {
+func (s *authService) bakeryFail(w http.ResponseWriter, msg string, args ...any) {
 	httpbakery.WriteError(context.TODO(), w, fmt.Errorf(msg, args...))
 }

--- a/test/macaroon-identity/credentials.go
+++ b/test/macaroon-identity/credentials.go
@@ -14,8 +14,8 @@ func newCredentialsChecker() credentialsChecker {
 	return credentialsChecker{creds: map[string]string{}}
 }
 
-func (c *credentialsChecker) Check(form interface{}) bool {
-	m := form.(map[string]interface{})
+func (c *credentialsChecker) Check(form any) bool {
+	m := form.(map[string]any)
 	username := m["username"].(string)
 	password := m["password"].(string)
 	pass, ok := c.creds[username]

--- a/test/macaroon-identity/http.go
+++ b/test/macaroon-identity/http.go
@@ -52,6 +52,6 @@ func (s *httpService) LogRequest(req *http.Request) {
 }
 
 // Fail returns an HTTP error with the specified message
-func (s *httpService) Fail(w http.ResponseWriter, code int, msg string, args ...interface{}) {
+func (s *httpService) Fail(w http.ResponseWriter, code int, msg string, args ...any) {
 	http.Error(w, fmt.Sprintf(msg, args...), code)
 }


### PR DESCRIPTION
Go 1.18 has a new data type called `any` that represents `interface{}` in a clearer way.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>