### PR TITLE
lxd: Drop devPaths logic

### DIFF
--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -23,7 +23,6 @@ type instance interface {
 	Type() instancetype.Type
 	LogPath() string
 	Path() string
-	DevPaths() []string
 	DevicesPath() string
 }
 
@@ -183,14 +182,6 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 			return "", err
 		}
 
-		externalDevPaths := inst.DevPaths()
-		for i := range externalDevPaths {
-			externalDevPaths[i], err = filepath.EvalSymlinks(externalDevPaths[i])
-			if err != nil {
-				return "", err
-			}
-		}
-
 		ovmfPath := "/usr/share/OVMF"
 		if os.Getenv("LXD_OVMF_PATH") != "" {
 			ovmfPath = os.Getenv("LXD_OVMF_PATH")
@@ -208,17 +199,16 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 		}
 
 		err = qemuProfileTpl.Execute(sb, map[string]interface{}{
-			"externalDevPaths": externalDevPaths,
-			"devicesPath":      inst.DevicesPath(),
-			"exePath":          execPath,
-			"libraryPath":      strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
-			"logPath":          inst.LogPath(),
-			"name":             InstanceProfileName(inst),
-			"path":             path,
-			"raw":              rawContent,
-			"rootPath":         rootPath,
-			"snap":             shared.InSnap(),
-			"ovmfPath":         ovmfPath,
+			"devicesPath": inst.DevicesPath(),
+			"exePath":     execPath,
+			"libraryPath": strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
+			"logPath":     inst.LogPath(),
+			"name":        InstanceProfileName(inst),
+			"path":        path,
+			"raw":         rawContent,
+			"rootPath":    rootPath,
+			"snap":        shared.InSnap(),
+			"ovmfPath":    ovmfPath,
 		})
 		if err != nil {
 			return "", err

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -50,11 +50,6 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .path }}/** rwk,
   {{ .devicesPath }}/** rwk,
 
-  # Instance specific external device paths
-{{- range $index, $element := .externalDevPaths}}
-  {{$element}} rwk,
-{{- end }}
-
   # Needed for lxd fork commands
   {{ .exePath }} mr,
   @{PROC}/@{pid}/cmdline r,

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -45,7 +45,6 @@ type common struct {
 	creationDate    time.Time
 	dbType          instancetype.Type
 	description     string
-	devPaths        []string
 	ephemeral       bool
 	expandedConfig  map[string]string
 	expandedDevices deviceConfig.Devices
@@ -90,14 +89,6 @@ func (d *common) Type() instancetype.Type {
 // Description returns the instance's description.
 func (d *common) Description() string {
 	return d.description
-}
-
-// DevPaths() returns a list of /dev devices which the instance requires access to.
-// This is function is only safe to call from within the security
-// packages as called during instance startup, the rest of the time this
-// will likely return nil.
-func (d *common) DevPaths() []string {
-	return d.devPaths
 }
 
 // IsEphemeral returns whether the instanc is ephemeral or not.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1022,9 +1022,6 @@ func (d *qemu) Start(stateful bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Start accumulating external device paths.
-	d.devPaths = []string{}
-
 	// Rotate the log file.
 	logfile := d.LogFilePath()
 	if shared.PathExists(logfile) {
@@ -3022,7 +3019,7 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]*
 
 		"devName":  driveConf.DevName,
 		"mountTag": mountTag,
-		"proxyFD":  proxyFD, // Pass by file descriptor, so don't add to d.devPaths for apparmor access.
+		"proxyFD":  proxyFD, // Pass by file descriptor
 		"readonly": readonly,
 		"protocol": "9p",
 	})
@@ -3099,9 +3096,6 @@ func (d *qemu) addDriveConfig(fdFiles *[]*os.File, bootIndexes map[string]int, d
 			aioMode = "threads"
 			cacheMode = "unsafe" // Use host cache, but ignore all sync requests from guest.
 		}
-
-		// Add src path to external devPaths. This way, the path will be included in the apparmor profile.
-		d.devPaths = append(d.devPaths, srcDevPath)
 	}
 
 	// QMP uses two separate values for the cache.

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -89,9 +89,6 @@ type Instance interface {
 	Delete(force bool) error
 	Export(w io.Writer, properties map[string]string, expiration time.Time) (api.ImageMetadata, error)
 
-	// Used for security.
-	DevPaths() []string
-
 	// Live configuration.
 	CGroup() (*cgroup.CGroup, error)
 	VolatileSet(changes map[string]string) error


### PR DESCRIPTION
This removes the devPaths logic as disks and devices are not accessed by
QEMU directly but are given a file descriptor instead.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
