### PR TITLE
doc: add link to multi-user video

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -1,5 +1,6 @@
 ---
 discourse: 13114
+relatedlinks: https://www.youtube.com/watch?v=6O0q3rSWr8A
 ---
 
 # Remote API authentication

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: https://www.youtube.com/watch?v=6O0q3rSWr8A
+---
+
 # Project configuration
 LXD supports projects as a way to split your LXD server.
 Each project holds its own set of instances and may also have its own images and profiles.


### PR DESCRIPTION
Add the link as a related link instead of a YouTube link, since the
video shows an example for how to use projects/authentication,
not how it works in general.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>