### PR TITLE
lxd/instance/qemu: Fix bad topoext logic

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1253,7 +1253,7 @@ func (d *qemu) Start(stateful bool) error {
 
 		// x86_64 requires the use of topoext when SMT is used.
 		_, _, nrThreads, _, _, err := d.cpuTopology(d.expandedConfig["limits.cpu"])
-		if err != nil && nrThreads > 1 {
+		if err == nil && nrThreads > 1 {
 			cpuExtensions = append(cpuExtensions, "topoext")
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>