### PR TITLE
Storage volume total size and used in a single query

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1651,3 +1651,6 @@ Adds the `security.syscalls.intercept.sched_setscheduler` to allow advanced proc
 Introduces the ability to specify the thinpool metadata volume size via `storage.thinpool_metadata_size`.
 
 If this is not specified then the default is to let LVM pick an appropriate thinpool metadata volume size.
+
+## storage\_volume\_state\_total
+This adds 'total' field to the `GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/state` API.

--- a/shared/api/storage_pool_volume_state.go
+++ b/shared/api/storage_pool_volume_state.go
@@ -19,4 +19,10 @@ type StorageVolumeStateUsage struct {
 	// Used space in bytes
 	// Example: 1693552640
 	Used uint64 `json:"used,omitempty" yaml:"used,omitempty"`
+
+	// Storage volume size in bytes
+	// Example: 5189222192
+	//
+	// API extension: storage_volume_state_total
+	Total int64 `json:"total" yaml:"total"`
 }

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -327,6 +327,7 @@ var APIExtensions = []string{
 	"cluster_ovn_chassis",
 	"container_syscall_intercept_sched_setscheduler",
 	"storage_lvm_thinpool_metadata_size",
+	"storage_volume_state_total",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Closes #10085

I was not sure about modifying `size` units. Maybe we should this in separate PR but what about backward compatibility?