### PR TITLE
Add/remove cluster role commands

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -93,6 +93,9 @@ func (c *cmdCluster) Command() *cobra.Command {
 	clusterGroupCmd := cmdClusterGroup{global: c.global, cluster: c}
 	cmd.AddCommand(clusterGroupCmd.Command())
 
+	clusterRoleCmd := cmdClusterRole{global: c.global, cluster: c}
+	cmd.AddCommand(clusterRoleCmd.Command())
+
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }

--- a/lxc/cluster_role.go
+++ b/lxc/cluster_role.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+	cli "github.com/lxc/lxd/shared/cmd"
+	"github.com/lxc/lxd/shared/i18n"
+)
+
+type cmdClusterRole struct {
+	global  *cmdGlobal
+	cluster *cmdCluster
+}
+
+func (c *cmdClusterRole) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("role")
+	cmd.Short = i18n.G("Manage cluster roles")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Manage cluster roles`))
+
+	// Add
+	clusterRoleAddCmd := cmdClusterRoleAdd{global: c.global, cluster: c.cluster, clusterRole: c}
+	cmd.AddCommand(clusterRoleAddCmd.Command())
+
+	// Remove
+	clusterRoleRemoveCmd := cmdClusterRoleRemove{global: c.global, cluster: c.cluster, clusterRole: c}
+	cmd.AddCommand(clusterRoleRemoveCmd.Command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
+	return cmd
+}
+
+type cmdClusterRoleAdd struct {
+	global      *cmdGlobal
+	cluster     *cmdCluster
+	clusterRole *cmdClusterRole
+}
+
+func (c *cmdClusterRoleAdd) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("add", i18n.G("[<remote>:]<member> <role[,role...]>"))
+	cmd.Short = i18n.G("Add roles to a cluster member")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Add roles to a cluster member`))
+
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+func (c *cmdClusterRoleAdd) Run(cmd *cobra.Command, args []string) error {
+	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	if exit {
+		return err
+	}
+
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return fmt.Errorf(i18n.G("Missing cluster member name"))
+	}
+
+	// Extract the current value
+	member, etag, err := resource.server.GetClusterMember(resource.name)
+	if err != nil {
+		return err
+	}
+
+	memberWritable := member.Writable()
+	newRoles := util.SplitNTrimSpace(args[1], ",", -1, false)
+	for _, newRole := range newRoles {
+		if shared.StringInSlice(newRole, memberWritable.Roles) {
+			return fmt.Errorf(i18n.G("Member %q already has role %q"), resource.name, newRole)
+		}
+	}
+
+	memberWritable.Roles = append(memberWritable.Roles, newRoles...)
+
+	return resource.server.UpdateClusterMember(resource.name, memberWritable, etag)
+}
+
+type cmdClusterRoleRemove struct {
+	global      *cmdGlobal
+	cluster     *cmdCluster
+	clusterRole *cmdClusterRole
+}
+
+func (c *cmdClusterRoleRemove) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("remove", i18n.G("[<remote>:]<member> <role[,role...]>"))
+	cmd.Short = i18n.G("Remove roles from a cluster member")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Remove roles from a cluster member`))
+
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+func (c *cmdClusterRoleRemove) Run(cmd *cobra.Command, args []string) error {
+	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	if exit {
+		return err
+	}
+
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return fmt.Errorf(i18n.G("Missing cluster member name"))
+	}
+
+	// Extract the current value
+	member, etag, err := resource.server.GetClusterMember(resource.name)
+	if err != nil {
+		return err
+	}
+
+	memberWritable := member.Writable()
+	rolesToRemove := util.SplitNTrimSpace(args[1], ",", -1, false)
+	for _, roleToRemove := range rolesToRemove {
+		if !shared.StringInSlice(roleToRemove, memberWritable.Roles) {
+			return fmt.Errorf(i18n.G("Member %q does not have role %q"), resource.name, roleToRemove)
+		}
+	}
+
+	memberWritable.Roles = shared.RemoveElementsFromStringSlice(memberWritable.Roles, rolesToRemove...)
+
+	return resource.server.UpdateClusterMember(resource.name, memberWritable, etag)
+}

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -483,7 +483,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -657,7 +657,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -739,6 +739,11 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "der Name des Ursprung Containers muss angegeben werden"
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 #, fuzzy
 msgid "Add rules to an ACL"
@@ -788,7 +793,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1140,7 +1145,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1155,7 +1160,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1175,7 +1180,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1219,7 +1224,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1327,27 +1332,27 @@ msgstr "Fehler: %v\n"
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1483,7 +1488,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1597,14 +1602,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1809,7 +1815,7 @@ msgstr " Prozessorauslastung:"
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1848,7 +1854,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -1933,11 +1939,11 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1970,7 +1976,7 @@ msgstr "Flüchtiger Container"
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -1979,7 +1985,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2066,7 +2072,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2204,7 +2210,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2212,7 +2218,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2229,7 +2235,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2253,7 +2259,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2329,7 +2335,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -2773,7 +2779,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2816,7 +2822,7 @@ msgstr "Aliasse:\n"
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2826,7 +2832,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3167,7 +3173,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -3209,6 +3215,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "Kein Zertifikat für diese Verbindung"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 #, fuzzy
@@ -3332,8 +3343,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3359,17 +3370,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, fuzzy, c-format
+msgid "Member %q already has role %q"
+msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: lxc/cluster_role.go:138
+#, fuzzy, c-format
+msgid "Member %q does not have role %q"
+msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: lxc/cluster.go:760
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3415,8 +3436,8 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3614,7 +3635,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3796,7 +3817,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3963,7 +3984,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3985,7 +4006,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -4160,7 +4181,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -4246,7 +4267,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4296,6 +4317,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "der Name des Ursprung Containers muss angegeben werden"
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 #, fuzzy
 msgid "Remove rules from an ACL"
@@ -4309,7 +4335,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4365,7 +4391,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4389,7 +4415,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4411,7 +4437,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4435,7 +4461,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4474,7 +4500,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4526,7 +4552,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -4743,7 +4769,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5020,7 +5046,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5055,7 +5081,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -5137,7 +5163,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5180,11 +5206,11 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5312,7 +5338,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -5376,7 +5402,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -5466,12 +5492,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5510,7 +5536,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5628,7 +5654,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5648,7 +5674,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -5665,7 +5691,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -5824,7 +5850,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6111,8 +6137,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6130,7 +6156,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6139,7 +6165,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6147,13 +6173,22 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
 "lxd %s <Name>\n"
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+#, fuzzy
+msgid "[<remote>:]<member> <role[,role...]>"
+msgstr ""
+"Löscht einen Container oder Container Sicherungspunkt.\n"
+"\n"
+"Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
+"Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
 #: lxc/network.go:1163 lxc/network_forward.go:84 lxc/network_peer.go:80
@@ -6693,7 +6728,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -6749,7 +6784,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6984,8 +7019,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -7041,16 +7076,16 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Akzeptiere Zertifikat"
 
@@ -7074,7 +7109,7 @@ msgstr ""
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Kein Zertifikat für diese Verbindung"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Profil %s wurde auf %s angewandt\n"
 
@@ -7998,7 +8033,7 @@ msgstr ""
 #~ msgid "Failed to connect to cluster member"
 #~ msgstr "kann nicht zum selben Container Namen kopieren"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %s"
 #~ msgstr "Alternatives config Verzeichnis."
 
@@ -8006,6 +8041,6 @@ msgstr ""
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "der Name des Ursprung Containers muss angegeben werden"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -500,6 +500,11 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "  Χρήση δικτύου:"
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -546,7 +551,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -875,7 +880,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -890,7 +895,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -910,7 +915,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -951,7 +956,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1054,27 +1059,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1195,7 +1200,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1304,14 +1309,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1506,7 +1512,7 @@ msgstr "  Χρήση CPU:"
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1545,7 +1551,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1622,11 +1628,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1658,11 +1664,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1741,7 +1747,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1875,7 +1881,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1883,7 +1889,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1923,7 +1929,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1998,7 +2004,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2422,7 +2428,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2463,7 +2469,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2471,7 +2477,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2785,7 +2791,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2825,6 +2831,11 @@ msgstr ""
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "  Χρήση δικτύου:"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
@@ -2932,8 +2943,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2957,17 +2968,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3014,8 +3035,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3196,7 +3217,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3377,7 +3398,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3540,7 +3561,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
@@ -3562,7 +3583,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3729,7 +3750,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3812,7 +3833,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3857,6 +3878,11 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "  Χρήση δικτύου:"
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3869,7 +3895,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3920,7 +3946,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3943,7 +3969,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3962,7 +3988,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3985,7 +4011,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4023,7 +4049,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4073,7 +4099,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -4283,7 +4309,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4541,7 +4567,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4576,7 +4602,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4652,7 +4678,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "  Χρήση δικτύου:"
@@ -4692,11 +4718,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4821,7 +4847,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4885,7 +4911,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -4969,11 +4995,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5011,7 +5037,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5109,7 +5135,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5121,7 +5147,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5129,7 +5155,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5206,7 +5232,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5343,8 +5369,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5352,16 +5378,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5636,7 +5666,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5687,7 +5717,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5918,8 +5948,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5975,12 +6005,12 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "  Χρήση δικτύου:"
 
@@ -5988,6 +6018,6 @@ msgstr ""
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "  Χρήση δικτύου:"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "  Χρήση δικτύου:"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -480,7 +480,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -635,7 +635,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -714,6 +714,11 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "Nombre del Miembro del Cluster"
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -761,7 +766,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1094,7 +1099,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1109,7 +1114,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1129,7 +1134,7 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1172,7 +1177,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1277,27 +1282,27 @@ msgstr "Expira: %s"
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1422,7 +1427,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1532,14 +1537,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1735,7 +1741,7 @@ msgstr "Uso del disco:"
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1774,7 +1780,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1851,11 +1857,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1887,12 +1893,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -1974,7 +1980,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2109,7 +2115,7 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2117,7 +2123,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2133,7 +2139,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2157,7 +2163,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2232,7 +2238,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
@@ -2664,7 +2670,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2707,7 +2713,7 @@ msgstr "Aliases:"
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
@@ -2717,7 +2723,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3035,7 +3041,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -3075,6 +3081,11 @@ msgstr ""
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
@@ -3182,8 +3193,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3208,17 +3219,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3264,8 +3285,8 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -3456,7 +3477,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3635,7 +3656,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3798,7 +3819,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
@@ -3820,7 +3841,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3990,7 +4011,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -4074,7 +4095,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4119,6 +4140,11 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "Nombre del Miembro del Cluster"
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -4131,7 +4157,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4183,7 +4209,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4207,7 +4233,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -4228,7 +4254,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -4251,7 +4277,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
@@ -4290,7 +4316,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4340,7 +4366,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -4550,7 +4576,7 @@ msgstr "Perfil %s creado"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4809,7 +4835,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4844,7 +4870,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4922,7 +4948,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
@@ -4962,11 +4988,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
@@ -5094,7 +5120,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -5158,7 +5184,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -5242,12 +5268,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5285,7 +5311,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5385,7 +5411,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5399,7 +5425,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5409,7 +5435,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5505,7 +5531,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5674,8 +5700,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5685,19 +5711,24 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+#, fuzzy
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -6036,7 +6067,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6088,7 +6119,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6319,8 +6350,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6376,16 +6407,16 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Nombre del Miembro del Cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Acepta certificado"
 
@@ -6477,11 +6508,10 @@ msgstr ""
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Certificado del cliente almacenado en el servidor: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "No se peude leer desde stdin: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %s"
 #~ msgstr "Nombre del contenedor es: %s"
 
@@ -6489,6 +6519,6 @@ msgstr ""
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Nombre del Miembro del Cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Nombre del Miembro del Cluster"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -481,7 +481,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -656,7 +656,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -747,6 +747,11 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr "Création du conteneur"
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "Vous devez fournir le nom d'un conteneur pour : "
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 #, fuzzy
 msgid "Add rules to an ACL"
@@ -795,7 +800,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1137,7 +1142,7 @@ msgstr "Profils %s appliqués à %s"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1152,7 +1157,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1172,7 +1177,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1224,7 +1229,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1333,27 +1338,27 @@ msgstr "erreur : %v"
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1505,7 +1510,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1624,14 +1629,15 @@ msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1830,7 +1836,7 @@ msgstr "  Disque utilisé :"
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -1870,7 +1876,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -1956,11 +1962,11 @@ msgstr "Clé de configuration invalide"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1993,7 +1999,7 @@ msgstr "Conteneur éphémère"
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2005,7 +2011,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2099,7 +2105,7 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2237,7 +2243,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2246,7 +2252,7 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2264,7 +2270,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2288,7 +2294,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2363,7 +2369,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2815,7 +2821,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2858,7 +2864,7 @@ msgstr "Alias :"
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2868,7 +2874,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3250,7 +3256,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -3291,6 +3297,11 @@ msgstr "Copie de l'image : %s"
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "Copie de l'image : %s"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
@@ -3413,8 +3424,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3440,17 +3451,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, fuzzy, c-format
+msgid "Member %q already has role %q"
+msgstr "Profil %s ajouté à %s"
+
+#: lxc/cluster_role.go:138
+#, fuzzy, c-format
+msgid "Member %q does not have role %q"
+msgstr "Profil %s ajouté à %s"
+
+#: lxc/cluster.go:760
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3498,8 +3519,8 @@ msgstr "Empreinte du certificat : %s"
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3701,7 +3722,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3885,7 +3906,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4063,7 +4084,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4085,7 +4106,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -4261,7 +4282,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr "SOURCE"
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -4349,7 +4370,7 @@ msgstr "Supprimer %s (oui/non) : "
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4399,6 +4420,11 @@ msgstr "Création du conteneur"
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "Vous devez fournir le nom d'un conteneur pour : "
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 #, fuzzy
 msgid "Remove rules from an ACL"
@@ -4412,7 +4438,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4467,7 +4493,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4492,7 +4518,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4530,7 +4556,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4554,7 +4580,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4593,7 +4619,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr "ÉTAT"
@@ -4647,7 +4673,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4866,7 +4892,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5150,7 +5176,7 @@ msgstr "Image copiée avec succès !"
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5187,7 +5213,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -5272,7 +5298,7 @@ msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5313,11 +5339,11 @@ msgstr "le périphérique indiqué ne correspond pas au réseau"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
@@ -5449,7 +5475,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr "URL"
 
@@ -5513,7 +5539,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -5606,12 +5632,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5650,7 +5676,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -5765,7 +5791,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5782,7 +5808,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -5802,7 +5828,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -5976,7 +6002,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6314,8 +6340,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6339,7 +6365,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6351,7 +6377,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6359,13 +6385,25 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+#, fuzzy
+msgid "[<remote>:]<member> <role[,role...]>"
+msgstr ""
+"Supprimer des conteneurs ou des instantanés.\n"
+"\n"
+"lxc delete [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
+"<snapshot>]...]\n"
+"\n"
+"Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
+"(configuration, instantanés, …)."
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
 #: lxc/network.go:1163 lxc/network_forward.go:84 lxc/network_peer.go:80
@@ -6935,7 +6973,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -6995,7 +7033,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7248,8 +7286,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -7306,19 +7344,19 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr "oui"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #~ msgid "Ips:"
 #~ msgstr "IPs :"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Échec lors de la génération de 'lxc.1': %v"
 
@@ -7345,11 +7383,11 @@ msgstr "oui"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Nom du réseau"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to create alias %s"
 #~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Profil %s ajouté à %s"
 
@@ -8825,7 +8863,7 @@ msgstr "oui"
 #~ "\n"
 #~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %w"
 #~ msgstr "Échec lors de la génération de 'lxc.1': %v"
 
@@ -8833,7 +8871,6 @@ msgstr "oui"
 #~ msgid "Remote disconnected"
 #~ msgstr "Mot de passe de l'administrateur distant"
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Impossible de lire depuis stdin : %s"
 
@@ -8841,7 +8878,7 @@ msgstr "oui"
 #~ msgid "Failed to connect to cluster member"
 #~ msgstr "Profil à appliquer au nouveau conteneur"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %s"
 #~ msgstr "Clé de configuration invalide"
 
@@ -8853,6 +8890,6 @@ msgstr "oui"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Vous devez fournir le nom d'un conteneur pour : "

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -274,7 +274,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -423,7 +423,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -500,6 +500,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -546,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -874,7 +878,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -909,7 +913,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -950,7 +954,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1053,27 +1057,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1300,14 +1304,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1498,7 +1503,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1537,7 +1542,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1611,11 +1616,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1647,11 +1652,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1730,7 +1735,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1864,7 +1869,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1872,7 +1877,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1888,7 +1893,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1912,7 +1917,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1987,7 +1992,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2406,7 +2411,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2447,7 +2452,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2455,7 +2460,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2768,7 +2773,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2807,6 +2812,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2912,8 +2921,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2937,17 +2946,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2991,8 +3010,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3350,7 +3369,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3513,7 +3532,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3701,7 +3720,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3784,7 +3803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3828,6 +3847,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3840,7 +3863,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3891,7 +3914,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3914,7 +3937,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3933,7 +3956,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3955,7 +3978,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3993,7 +4016,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4043,7 +4066,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4247,7 +4270,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4500,7 +4523,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4535,7 +4558,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4611,7 +4634,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4651,11 +4674,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4780,7 +4803,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4844,7 +4867,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4921,11 +4944,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4963,7 +4986,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5061,7 +5084,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5073,7 +5096,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5081,7 +5104,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5158,7 +5181,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5295,8 +5318,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5304,16 +5327,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5588,7 +5615,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5639,7 +5666,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5870,8 +5897,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5927,7 +5954,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -477,7 +477,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -629,7 +629,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -708,6 +708,11 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "Il nome del container è: %s"
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -755,7 +760,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1086,7 +1091,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1101,7 +1106,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1121,7 +1126,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1162,7 +1167,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1265,27 +1270,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1413,7 +1418,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1523,14 +1528,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1726,7 +1732,7 @@ msgstr "Utilizzo disco:"
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1765,7 +1771,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1842,11 +1848,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1878,12 +1884,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -1964,7 +1970,7 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2099,7 +2105,7 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2107,7 +2113,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2123,7 +2129,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2147,7 +2153,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2222,7 +2228,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2652,7 +2658,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2695,7 +2701,7 @@ msgstr "Alias:"
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
@@ -2705,7 +2711,7 @@ msgstr "Il nome del container è: %s"
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3025,7 +3031,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -3065,6 +3071,11 @@ msgstr ""
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "Il nome del container è: %s"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
@@ -3176,8 +3187,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3202,17 +3213,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3257,8 +3278,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
@@ -3448,7 +3469,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3627,7 +3648,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3792,7 +3813,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
@@ -3814,7 +3835,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3983,7 +4004,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -4067,7 +4088,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4113,6 +4134,11 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "Il nome del container è: %s"
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -4125,7 +4151,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4177,7 +4203,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4201,7 +4227,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -4222,7 +4248,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -4245,7 +4271,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
@@ -4284,7 +4310,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4334,7 +4360,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -4542,7 +4568,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4803,7 +4829,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4838,7 +4864,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4915,7 +4941,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
@@ -4956,11 +4982,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
@@ -5087,7 +5113,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -5151,7 +5177,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -5233,12 +5259,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5277,7 +5303,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5379,7 +5405,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5393,7 +5419,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
@@ -5403,7 +5429,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -5499,7 +5525,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "Creazione del container in corso"
@@ -5668,8 +5694,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
@@ -5679,19 +5705,24 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
+msgstr "Creazione del container in corso"
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+#, fuzzy
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -6030,7 +6061,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
@@ -6082,7 +6113,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6313,8 +6344,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6371,16 +6402,16 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr "si"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Il nome del container è: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Accetta certificato"
 
@@ -6481,11 +6512,10 @@ msgstr "si"
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Certificato del client salvato dal server: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Impossible leggere da stdin: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %s"
 #~ msgstr "Proprietà errata: %s"
 
@@ -6493,6 +6523,6 @@ msgstr "si"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Il nome del container è: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Il nome del container è: %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -467,7 +467,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -620,7 +620,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -709,6 +709,11 @@ msgstr "フォワードにポートを追加します"
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "クラスターメンバーをリストアします"
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
@@ -755,7 +760,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1091,7 +1096,7 @@ msgstr "クラスターグループ %s は現在 %s に適用されていませ�
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -1106,7 +1111,7 @@ msgstr "クラスターメンバー %s がクラスターグループ %s に追�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1126,7 +1131,7 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
@@ -1171,7 +1176,7 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1278,27 +1283,27 @@ msgstr "コア:"
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
@@ -1422,7 +1427,7 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1529,14 +1534,15 @@ msgstr "警告を削除します"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1733,7 +1739,7 @@ msgstr "ディスク:"
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -1774,7 +1780,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -1849,12 +1855,12 @@ msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1895,11 +1901,11 @@ msgstr "Ephemeral インスタンス"
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -1993,7 +1999,7 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
@@ -2127,7 +2133,7 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2135,7 +2141,7 @@ msgstr "ユーザーの確認なしで強制的に待避させます"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
@@ -2151,7 +2157,7 @@ msgstr "稼働中のインスタンスを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2190,7 +2196,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2265,7 +2271,7 @@ msgstr "イメージのプロパティを取得します"
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
@@ -2703,7 +2709,7 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
@@ -2744,7 +2750,7 @@ msgstr "エイリアスを一覧表示します"
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
@@ -2752,7 +2758,7 @@ msgstr "有効なクラスターへの join トークンをすべて一覧表示
 msgid "List all the cluster groups"
 msgstr "クラスタグループをすべて一覧表示します"
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
@@ -3204,7 +3210,7 @@ msgstr "MEMORY USAGE"
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
@@ -3244,6 +3250,11 @@ msgstr "クラスタグループを管理します"
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr "クラスタのメンバを管理します"
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "クラスタグループを管理します"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
@@ -3361,8 +3372,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -3390,17 +3401,27 @@ msgstr "VF の最大数: %d"
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, fuzzy, c-format
+msgid "Member %q already has role %q"
+msgstr "メンバ名 %s を %s に変更しました"
+
+#: lxc/cluster_role.go:138
+#, fuzzy, c-format
+msgid "Member %q does not have role %q"
+msgstr "メンバ名 %s を %s に変更しました"
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -3444,8 +3465,8 @@ msgstr "証明書のフィンガープリントがありません"
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
@@ -3631,7 +3652,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3812,7 +3833,7 @@ msgstr "指定するデバイスに適用する新しいキー/値"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3976,7 +3997,7 @@ msgstr "インクリメンタルコピーを実行します"
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
@@ -3997,7 +4018,7 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -4166,7 +4187,7 @@ msgstr "仮想マシンイメージを対象にします"
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr "ROLES"
 
@@ -4249,7 +4270,7 @@ msgstr "%s を消去しますか (yes/no): "
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
@@ -4293,6 +4314,11 @@ msgstr "インスタンスからプロファイルを削除します"
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "クラスタメンバの名前を変更します"
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr "ACL からルールを削除します"
@@ -4305,7 +4331,7 @@ msgstr "信頼済みクライアントを削除します"
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -4357,7 +4383,7 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
@@ -4383,7 +4409,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -4405,7 +4431,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -4427,7 +4453,7 @@ msgstr "イメージの取得中: %s"
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
@@ -4465,7 +4491,7 @@ msgstr "SSH クライアントが %q に接続されました"
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr "STATE"
@@ -4515,7 +4541,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
@@ -4768,7 +4794,7 @@ msgstr "クラスタグループの設定を表示します"
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -5021,7 +5047,7 @@ msgstr "ストレージボリュームの移動が成功しました!"
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
@@ -5056,7 +5082,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr "TOKEN"
 
@@ -5134,7 +5160,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -5179,11 +5205,11 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr "LXD サーバはすでにクラスターに属しています"
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
@@ -5327,7 +5353,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr "URL"
 
@@ -5391,7 +5417,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
@@ -5468,11 +5494,11 @@ msgstr "サポートされていないインスタンスタイプです: %s"
 msgid "Up delay"
 msgstr "Up delay"
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5513,7 +5539,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -5616,7 +5642,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5628,7 +5654,7 @@ msgstr "[<remote>:]"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
@@ -5636,7 +5662,7 @@ msgstr "[<remote>:] <cert.crt> <cert.key>"
 msgid "[<remote>:] <fingerprint>"
 msgstr "[<remote>:] <fingerprint>"
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -5713,7 +5739,7 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr "[<remote>:]<cluster member>"
 
@@ -5853,8 +5879,8 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
@@ -5862,17 +5888,22 @@ msgstr "[<remote>:]<member>"
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member> <key>"
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<member> <key>=<value>..."
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+#, fuzzy
+msgid "[<remote>:]<member> <role[,role...]>"
+msgstr "[<remote>:]<member> <group>"
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
 #: lxc/network.go:1163 lxc/network_forward.go:84 lxc/network_peer.go:80
@@ -6152,7 +6183,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
@@ -6209,7 +6240,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6556,8 +6587,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 "lxc storage volume show default data\n"
 "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
@@ -6622,19 +6653,18 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr "yes"
 
-#, c-format
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "クライアント %s の証明書追加トークン: %s"
 
 #~ msgid "Ips:"
 #~ msgstr "IPアドレス:"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "ピアのステータスの取得に失敗しました: %w"
 
@@ -6651,7 +6681,7 @@ msgstr "yes"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "ネットワークゾーンレコードエントリを管理します"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "メンバ %s の join トークン:"
 
@@ -8198,8 +8228,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect "
-#~ "\"custom\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect \"custom"
+#~ "\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"
@@ -8751,7 +8781,7 @@ msgstr "yes"
 #~ "lxc init ubuntu:18.04 u1 < config.yaml\n"
 #~ "    config.yaml の設定を使ってインスタンスを作成します"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %w"
 #~ msgstr "ピアのステータスの取得に失敗しました: %w"
 
@@ -8759,14 +8789,12 @@ msgstr "yes"
 #~ msgid "Remote disconnected"
 #~ msgstr "リモートの管理者パスワード"
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "標準入力から読み込めません: %s"
 
 #~ msgid "Failed to connect to cluster member"
 #~ msgstr "クラスタメンバへの接続に失敗しました"
 
-#, c-format
 #~ msgid "Invalid key=value configuration: %s"
 #~ msgstr "不適切な キー=値 の設定: %s"
 
@@ -8821,7 +8849,6 @@ msgstr "yes"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "クラスタグループからクラスタメンバを削除します"
 
-#, c-format
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "設定 %q はクラスタメンバー %q に存在しません"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-03-31 13:32-0400\n"
+        "POT-Creation-Date: 2022-04-01 18:00+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -252,7 +252,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -398,7 +398,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -471,6 +471,10 @@ msgstr  ""
 msgid   "Add profiles to instances"
 msgstr  ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid   "Add roles to a cluster member"
+msgstr  ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid   "Add rules to an ACL"
 msgstr  ""
@@ -517,7 +521,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -841,7 +845,7 @@ msgstr  ""
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
@@ -856,11 +860,11 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168 lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1527 lxc/storage_volume.go:1559 lxc/storage_volume.go:1675 lxc/storage_volume.go:1766 lxc/storage_volume.go:1859 lxc/storage_volume.go:1896 lxc/storage_volume.go:1990 lxc/storage_volume.go:2062 lxc/storage_volume.go:2201
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47 lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168 lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1527 lxc/storage_volume.go:1559 lxc/storage_volume.go:1675 lxc/storage_volume.go:1766 lxc/storage_volume.go:1859 lxc/storage_volume.go:1896 lxc/storage_volume.go:1990 lxc/storage_volume.go:2062 lxc/storage_volume.go:2201
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid   "Clustering enabled"
 msgstr  ""
 
@@ -899,7 +903,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302 lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512 lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302 lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512 lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -996,27 +1000,27 @@ msgstr  ""
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
@@ -1135,7 +1139,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040 lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956 lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581 lxc/storage_volume.go:1433
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040 lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956 lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581 lxc/storage_volume.go:1433
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1235,7 +1239,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198 lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375 lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706 lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059 lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:224 lxc/config_trust.go:336 lxc/config_trust.go:417 lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38 lxc/image.go:145 lxc/image.go:310 lxc/image.go:361 lxc/image.go:486 lxc/image.go:645 lxc/image.go:866 lxc/image.go:1001 lxc/image.go:1299 lxc/image.go:1378 lxc/image.go:1437 lxc/image.go:1489 lxc/image.go:1545 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1257 lxc/storage_volume.go:1339 lxc/storage_volume.go:1523 lxc/storage_volume.go:1556 lxc/storage_volume.go:1669 lxc/storage_volume.go:1757 lxc/storage_volume.go:1856 lxc/storage_volume.go:1890 lxc/storage_volume.go:1988 lxc/storage_volume.go:2055 lxc/storage_volume.go:2196 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201 lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378 lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709 lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062 lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49 lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:224 lxc/config_trust.go:336 lxc/config_trust.go:417 lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38 lxc/image.go:145 lxc/image.go:310 lxc/image.go:361 lxc/image.go:486 lxc/image.go:645 lxc/image.go:866 lxc/image.go:1001 lxc/image.go:1299 lxc/image.go:1378 lxc/image.go:1437 lxc/image.go:1489 lxc/image.go:1545 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1257 lxc/storage_volume.go:1339 lxc/storage_volume.go:1523 lxc/storage_volume.go:1556 lxc/storage_volume.go:1669 lxc/storage_volume.go:1757 lxc/storage_volume.go:1856 lxc/storage_volume.go:1890 lxc/storage_volume.go:1988 lxc/storage_volume.go:2055 lxc/storage_volume.go:2196 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1350,7 +1354,7 @@ msgstr  ""
 msgid   "Display instances from all projects"
 msgstr  ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1387,7 +1391,7 @@ msgstr  ""
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1460,11 +1464,11 @@ msgstr  ""
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1492,11 +1496,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1571,7 +1575,7 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
@@ -1703,7 +1707,7 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -1711,7 +1715,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
@@ -1727,7 +1731,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -1746,7 +1750,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777 lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338 lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89 lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525 lxc/storage_volume.go:1357 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780 lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338 lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89 lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525 lxc/storage_volume.go:1357 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -1814,7 +1818,7 @@ msgstr  ""
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
@@ -2226,7 +2230,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992 lxc/cluster_group.go:410
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995 lxc/cluster_group.go:410
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2266,7 +2270,7 @@ msgstr  ""
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
@@ -2274,7 +2278,7 @@ msgstr  ""
 msgid   "List all the cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid   "List all the cluster members"
 msgstr  ""
 
@@ -2575,7 +2579,7 @@ msgstr  ""
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid   "MESSAGE"
 msgstr  ""
 
@@ -2614,6 +2618,10 @@ msgstr  ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid   "Manage cluster members"
+msgstr  ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid   "Manage cluster roles"
 msgstr  ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2741,17 +2749,27 @@ msgstr  ""
 msgid   "Mdev profiles:"
 msgstr  ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid   "Member %q already has role %q"
+msgstr  ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid   "Member %q does not have role %q"
+msgstr  ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -2794,7 +2812,7 @@ msgstr  ""
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110 lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110 lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -2935,7 +2953,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427 lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567 lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574 lxc/storage_volume.go:1432
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427 lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567 lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574 lxc/storage_volume.go:1432
 msgid   "NAME"
 msgstr  ""
 
@@ -3105,7 +3123,7 @@ msgstr  ""
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
@@ -3268,7 +3286,7 @@ msgstr  ""
 msgid   "Please provide client name: "
 msgstr  ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
@@ -3289,7 +3307,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675 lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675 lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3450,7 +3468,7 @@ msgstr  ""
 msgid   "RESOURCE"
 msgstr  ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid   "ROLES"
 msgstr  ""
 
@@ -3532,7 +3550,7 @@ msgstr  ""
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
@@ -3576,6 +3594,10 @@ msgstr  ""
 msgid   "Remove remotes"
 msgstr  ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid   "Remove roles from a cluster member"
+msgstr  ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid   "Remove rules from an ACL"
 msgstr  ""
@@ -3588,7 +3610,7 @@ msgstr  ""
 msgid   "Rename a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -3638,7 +3660,7 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -3660,7 +3682,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -3678,7 +3700,7 @@ msgstr  ""
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -3700,7 +3722,7 @@ msgstr  ""
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
@@ -3738,7 +3760,7 @@ msgstr  ""
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958 lxc/network_peer.go:143 lxc/storage.go:583
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958 lxc/network_peer.go:143 lxc/storage.go:583
 msgid   "STATE"
 msgstr  ""
 
@@ -3787,7 +3809,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
@@ -3967,7 +3989,7 @@ msgstr  ""
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -4220,7 +4242,7 @@ msgstr  ""
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
@@ -4255,7 +4277,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid   "TOKEN"
 msgstr  ""
 
@@ -4327,7 +4349,7 @@ msgstr  ""
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
@@ -4366,11 +4388,11 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid   "This LXD server is already clustered"
 msgstr  ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
@@ -4486,7 +4508,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid   "URL"
 msgstr  ""
 
@@ -4547,7 +4569,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
@@ -4624,11 +4646,11 @@ msgstr  ""
 msgid   "Up delay"
 msgstr  ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
@@ -4663,7 +4685,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -4756,7 +4778,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371 lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31 lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83 lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389 lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371 lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31 lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83 lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389 lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -4764,7 +4786,7 @@ msgstr  ""
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
@@ -4772,7 +4794,7 @@ msgstr  ""
 msgid   "[<remote>:] <fingerprint>"
 msgstr  ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -4848,7 +4870,7 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid   "[<remote>:]<cluster member>"
 msgstr  ""
 
@@ -4980,7 +5002,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057 lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060 lxc/cluster.go:1079
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
@@ -4988,16 +5010,20 @@ msgstr  ""
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid   "[<remote>:]<member> <new-name>"
+msgstr  ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974 lxc/network.go:1163 lxc/network_forward.go:84 lxc/network_peer.go:80
@@ -5260,7 +5286,7 @@ msgstr  ""
 msgid   "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr  ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
@@ -5308,7 +5334,7 @@ msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -5557,7 +5583,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912 lxc/image.go:1095
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912 lxc/image.go:1095
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -465,7 +465,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -614,7 +614,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -691,6 +691,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -737,7 +741,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1100,7 +1104,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1141,7 +1145,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1244,27 +1248,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1384,7 +1388,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1491,14 +1495,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1689,7 +1694,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1728,7 +1733,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1802,11 +1807,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1838,11 +1843,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1921,7 +1926,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2055,7 +2060,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2063,7 +2068,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2079,7 +2084,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2103,7 +2108,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2178,7 +2183,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2597,7 +2602,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2638,7 +2643,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2646,7 +2651,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2959,7 +2964,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2998,6 +3003,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -3103,8 +3112,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3128,17 +3137,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3182,8 +3201,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3362,7 +3381,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3541,7 +3560,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3704,7 +3723,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3725,7 +3744,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3892,7 +3911,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3975,7 +3994,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4019,6 +4038,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -4031,7 +4054,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4082,7 +4105,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4105,7 +4128,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4124,7 +4147,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4146,7 +4169,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4184,7 +4207,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4234,7 +4257,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4438,7 +4461,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4691,7 +4714,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4726,7 +4749,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4802,7 +4825,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4842,11 +4865,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4971,7 +4994,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -5035,7 +5058,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5112,11 +5135,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5154,7 +5177,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5252,7 +5275,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5264,7 +5287,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5272,7 +5295,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5349,7 +5372,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5486,8 +5509,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5495,16 +5518,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5779,7 +5806,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5830,7 +5857,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6061,8 +6088,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6118,7 +6145,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,7 +495,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -644,7 +644,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -721,6 +721,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1095,7 +1099,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1110,7 +1114,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1130,7 +1134,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1171,7 +1175,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1274,27 +1278,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1521,14 +1525,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1719,7 +1724,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1758,7 +1763,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1832,11 +1837,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1868,11 +1873,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1951,7 +1956,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2085,7 +2090,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2093,7 +2098,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2109,7 +2114,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2133,7 +2138,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2208,7 +2213,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2627,7 +2632,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2668,7 +2673,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2676,7 +2681,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2989,7 +2994,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -3028,6 +3033,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -3133,8 +3142,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3158,17 +3167,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3212,8 +3231,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3392,7 +3411,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3571,7 +3590,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3734,7 +3753,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3755,7 +3774,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3922,7 +3941,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -4005,7 +4024,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4049,6 +4068,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -4061,7 +4084,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4112,7 +4135,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4135,7 +4158,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4154,7 +4177,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4176,7 +4199,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4214,7 +4237,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4264,7 +4287,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4468,7 +4491,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4721,7 +4744,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4756,7 +4779,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4832,7 +4855,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4872,11 +4895,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5001,7 +5024,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -5065,7 +5088,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5142,11 +5165,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5184,7 +5207,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5282,7 +5305,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5294,7 +5317,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5302,7 +5325,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5379,7 +5402,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5516,8 +5539,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5525,16 +5548,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5809,7 +5836,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5860,7 +5887,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6091,8 +6118,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6148,7 +6175,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -483,7 +483,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -643,7 +643,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "Nome de membro do cluster"
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 #, fuzzy
 msgid "Add rules to an ACL"
@@ -772,7 +777,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1110,7 +1115,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1125,7 +1130,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1145,7 +1150,7 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
@@ -1195,7 +1200,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1300,27 +1305,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1453,7 +1458,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1570,14 +1575,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1774,7 +1780,7 @@ msgstr "Uso de disco:"
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1813,7 +1819,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -1899,11 +1905,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1935,12 +1941,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2019,7 +2025,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2153,7 +2159,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2161,7 +2167,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2177,7 +2183,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2201,7 +2207,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2277,7 +2283,7 @@ msgstr "Editar propriedades da imagem"
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -2709,7 +2715,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2751,7 +2757,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
@@ -2761,7 +2767,7 @@ msgstr "Nome de membro do cluster"
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3078,7 +3084,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -3118,6 +3124,11 @@ msgstr ""
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "Nome de membro do cluster"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
@@ -3234,8 +3245,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3261,17 +3272,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3317,8 +3338,8 @@ msgstr "Certificado fingerprint: %s"
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
@@ -3506,7 +3527,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3685,7 +3706,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3848,7 +3869,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
@@ -3870,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -4042,7 +4063,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -4126,7 +4147,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4174,6 +4195,11 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "Nome de membro do cluster"
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 #, fuzzy
 msgid "Remove rules from an ACL"
@@ -4187,7 +4213,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4239,7 +4265,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4263,7 +4289,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -4288,7 +4314,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -4311,7 +4337,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
@@ -4350,7 +4376,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4400,7 +4426,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -4616,7 +4642,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4883,7 +4909,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4918,7 +4944,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4999,7 +5025,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
@@ -5039,11 +5065,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
@@ -5170,7 +5196,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -5234,7 +5260,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5324,12 +5350,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5368,7 +5394,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5467,7 +5493,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5480,7 +5506,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
@@ -5490,7 +5516,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:] <fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5579,7 +5605,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5724,8 +5750,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5734,19 +5760,24 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+#, fuzzy
+msgid "[<remote>:]<member> <role[,role...]>"
+msgstr "Editar templates de arquivo do container"
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
 #: lxc/network.go:1163 lxc/network_forward.go:84 lxc/network_peer.go:80
@@ -6043,7 +6074,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
@@ -6095,7 +6126,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6326,8 +6357,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6383,16 +6414,16 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr "sim"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Nome de membro do cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Aceitar certificado"
 
@@ -6408,7 +6439,7 @@ msgstr "sim"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Criar novas redes"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Versão do cliente: %s\n"
 
@@ -6434,11 +6465,10 @@ msgstr "sim"
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Certificado do cliente armazenado no servidor: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Não é possível ler stdin: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %s"
 #~ msgstr "par de chave=valor inválido %s"
 
@@ -6446,6 +6476,6 @@ msgstr "sim"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Nome de membro do cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Nome de membro do cluster"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -492,7 +492,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -655,7 +655,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -735,6 +735,11 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+#, fuzzy
+msgid "Add roles to a cluster member"
+msgstr "Копирование образа: %s"
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -782,7 +787,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1116,7 +1121,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1131,7 +1136,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1151,7 +1156,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1192,7 +1197,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1297,27 +1302,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1450,7 +1455,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1563,14 +1568,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1767,7 +1773,7 @@ msgstr " Использование диска:"
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1806,7 +1812,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1885,11 +1891,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1921,7 +1927,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -1929,7 +1935,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2013,7 +2019,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2147,7 +2153,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2155,7 +2161,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2171,7 +2177,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2195,7 +2201,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2270,7 +2276,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
@@ -2703,7 +2709,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2746,7 +2752,7 @@ msgstr "Псевдонимы:"
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
@@ -2756,7 +2762,7 @@ msgstr "Копирование образа: %s"
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3078,7 +3084,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -3119,6 +3125,11 @@ msgstr "Копирование образа: %s"
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
 msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+#, fuzzy
+msgid "Manage cluster roles"
+msgstr "Копирование образа: %s"
 
 #: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
@@ -3235,8 +3246,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3261,17 +3272,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3318,8 +3339,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
@@ -3511,7 +3532,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3692,7 +3713,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3857,7 +3878,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
@@ -3879,7 +3900,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -4046,7 +4067,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -4132,7 +4153,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4178,6 +4199,11 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+#, fuzzy
+msgid "Remove roles from a cluster member"
+msgstr "Копирование образа: %s"
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -4190,7 +4216,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4244,7 +4270,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4268,7 +4294,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -4290,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -4313,7 +4339,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
@@ -4352,7 +4378,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4402,7 +4428,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -4613,7 +4639,7 @@ msgstr "Копирование образа: %s"
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4880,7 +4906,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4915,7 +4941,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4991,7 +5017,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
@@ -5031,11 +5057,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5161,7 +5187,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -5225,7 +5251,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -5309,12 +5335,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5353,7 +5379,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5459,7 +5485,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5479,7 +5505,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -5495,7 +5521,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -5648,7 +5674,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -5917,8 +5943,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -5934,7 +5960,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -5942,7 +5968,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -5950,9 +5976,17 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+#, fuzzy
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -6486,7 +6520,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -6541,7 +6575,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6772,8 +6806,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6829,16 +6863,16 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr "да"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Копирование образа: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Принять сертификат"
 
@@ -7064,11 +7098,10 @@ msgstr "да"
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Сертификат клиента хранится на сервере: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %s"
 #~ msgstr "Имя контейнера: %s"
 
@@ -7076,6 +7109,6 @@ msgstr "да"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Копирование образа: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Копирование образа: %s"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -274,7 +274,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -423,7 +423,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -500,6 +500,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -546,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -874,7 +878,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -909,7 +913,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -950,7 +954,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1053,27 +1057,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1300,14 +1304,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1498,7 +1503,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1537,7 +1542,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1611,11 +1616,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1647,11 +1652,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1730,7 +1735,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1864,7 +1869,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1872,7 +1877,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1888,7 +1893,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1912,7 +1917,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1987,7 +1992,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2406,7 +2411,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2447,7 +2452,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2455,7 +2460,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2768,7 +2773,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2807,6 +2812,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2912,8 +2921,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2937,17 +2946,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2991,8 +3010,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3350,7 +3369,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3513,7 +3532,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3701,7 +3720,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3784,7 +3803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3828,6 +3847,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3840,7 +3863,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3891,7 +3914,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3914,7 +3937,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3933,7 +3956,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3955,7 +3978,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3993,7 +4016,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4043,7 +4066,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4247,7 +4270,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4500,7 +4523,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4535,7 +4558,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4611,7 +4634,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4651,11 +4674,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4780,7 +4803,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4844,7 +4867,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4921,11 +4944,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4963,7 +4986,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5061,7 +5084,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5073,7 +5096,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5081,7 +5104,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5158,7 +5181,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5295,8 +5318,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5304,16 +5327,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5588,7 +5615,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5639,7 +5666,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5870,8 +5897,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5927,7 +5954,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -274,7 +274,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -423,7 +423,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -500,6 +500,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -546,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -874,7 +878,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -909,7 +913,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -950,7 +954,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1053,27 +1057,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1300,14 +1304,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1498,7 +1503,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1537,7 +1542,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1611,11 +1616,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1647,11 +1652,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1730,7 +1735,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1864,7 +1869,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1872,7 +1877,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1888,7 +1893,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1912,7 +1917,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1987,7 +1992,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2406,7 +2411,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2447,7 +2452,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2455,7 +2460,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2768,7 +2773,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2807,6 +2812,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2912,8 +2921,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2937,17 +2946,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2991,8 +3010,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3350,7 +3369,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3513,7 +3532,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3701,7 +3720,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3784,7 +3803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3828,6 +3847,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3840,7 +3863,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3891,7 +3914,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3914,7 +3937,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3933,7 +3956,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3955,7 +3978,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3993,7 +4016,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4043,7 +4066,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4247,7 +4270,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4500,7 +4523,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4535,7 +4558,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4611,7 +4634,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4651,11 +4674,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4780,7 +4803,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4844,7 +4867,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4921,11 +4944,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4963,7 +4986,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5061,7 +5084,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5073,7 +5096,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5081,7 +5104,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5158,7 +5181,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5295,8 +5318,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5304,16 +5327,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5588,7 +5615,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5639,7 +5666,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5870,8 +5897,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5927,7 +5954,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -274,7 +274,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -423,7 +423,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -500,6 +500,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -546,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -874,7 +878,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -909,7 +913,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -950,7 +954,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1053,27 +1057,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1300,14 +1304,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1498,7 +1503,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1537,7 +1542,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1611,11 +1616,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1647,11 +1652,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1730,7 +1735,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1864,7 +1869,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1872,7 +1877,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1888,7 +1893,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1912,7 +1917,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1987,7 +1992,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2406,7 +2411,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2447,7 +2452,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2455,7 +2460,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2768,7 +2773,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2807,6 +2812,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2912,8 +2921,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2937,17 +2946,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2991,8 +3010,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3171,7 +3190,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3350,7 +3369,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3513,7 +3532,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3701,7 +3720,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3784,7 +3803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3828,6 +3847,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3840,7 +3863,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3891,7 +3914,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3914,7 +3937,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3933,7 +3956,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3955,7 +3978,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3993,7 +4016,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4043,7 +4066,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4247,7 +4270,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4500,7 +4523,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4535,7 +4558,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4611,7 +4634,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4651,11 +4674,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4780,7 +4803,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4844,7 +4867,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4921,11 +4944,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4963,7 +4986,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5061,7 +5084,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5073,7 +5096,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5081,7 +5104,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5158,7 +5181,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5295,8 +5318,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5304,16 +5327,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5588,7 +5615,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5639,7 +5666,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5870,8 +5897,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5927,7 +5954,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -375,7 +375,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -524,7 +524,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -601,6 +601,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -647,7 +651,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -975,7 +979,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -990,7 +994,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1051,7 +1055,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1154,27 +1158,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1294,7 +1298,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1401,14 +1405,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1599,7 +1604,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1638,7 +1643,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1712,11 +1717,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1748,11 +1753,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1831,7 +1836,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1965,7 +1970,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1973,7 +1978,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1989,7 +1994,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2013,7 +2018,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -2088,7 +2093,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2507,7 +2512,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2548,7 +2553,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2556,7 +2561,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2869,7 +2874,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2908,6 +2913,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -3013,8 +3022,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3038,17 +3047,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3092,8 +3111,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3272,7 +3291,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3451,7 +3470,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3614,7 +3633,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3635,7 +3654,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3802,7 +3821,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3885,7 +3904,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3929,6 +3948,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3941,7 +3964,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4015,7 +4038,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4034,7 +4057,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4056,7 +4079,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4094,7 +4117,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4144,7 +4167,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4348,7 +4371,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4601,7 +4624,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4636,7 +4659,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4712,7 +4735,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4752,11 +4775,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4881,7 +4904,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4945,7 +4968,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5022,11 +5045,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5064,7 +5087,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5162,7 +5185,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5174,7 +5197,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5182,7 +5205,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5259,7 +5282,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5396,8 +5419,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5405,16 +5428,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5689,7 +5716,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5740,7 +5767,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5971,8 +5998,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6028,7 +6055,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-03-31 13:32-0400\n"
+"POT-Creation-Date: 2022-04-01 18:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:605
+#: lxc/cluster.go:608
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1041 lxc/list.go:556
+#: lxc/cluster.go:181 lxc/image.go:1041 lxc/list.go:556
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -499,6 +499,10 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:49
+msgid "Add roles to a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:727 lxc/network_acl.go:728
 msgid "Add rules to an ACL"
 msgstr ""
@@ -545,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1111
+#: lxc/cluster.go:1114
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:935
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -888,7 +892,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:707 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
 #: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:53 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
@@ -908,7 +912,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:579
+#: lxc/cluster.go:582
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +953,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:674 lxc/cluster_group.go:333 lxc/config.go:258
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
 #: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:302
 #: lxc/image.go:454 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
@@ -1052,27 +1056,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:996
+#: lxc/cluster.go:999
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1000
+#: lxc/cluster.go:1003
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1005
+#: lxc/cluster.go:1008
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1010
+#: lxc/cluster.go:1013
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1027
+#: lxc/cluster.go:1030
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster_group.go:428 lxc/image.go:1040
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1040
 #: lxc/image_alias.go:237 lxc/list.go:559 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
@@ -1299,14 +1303,15 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:116 lxc/cluster.go:198
-#: lxc/cluster.go:247 lxc/cluster.go:294 lxc/cluster.go:346 lxc/cluster.go:375
-#: lxc/cluster.go:425 lxc/cluster.go:508 lxc/cluster.go:593 lxc/cluster.go:706
-#: lxc/cluster.go:776 lxc/cluster.go:874 lxc/cluster.go:953 lxc/cluster.go:1059
-#: lxc/cluster.go:1078 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
+#: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
+#: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
+#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
-#: lxc/cluster_group.go:564 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
+#: lxc/cluster_group.go:564 lxc/cluster_role.go:23 lxc/cluster_role.go:49
+#: lxc/cluster_role.go:103 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
 #: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
@@ -1497,7 +1502,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:433
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1536,7 +1541,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:592 lxc/cluster.go:593
+#: lxc/cluster.go:595 lxc/cluster.go:596
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1610,11 +1615,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:507
+#: lxc/cluster.go:510
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:508
+#: lxc/cluster.go:511
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1646,11 +1651,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1058 lxc/cluster.go:1059
+#: lxc/cluster.go:1061 lxc/cluster.go:1062
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1135
+#: lxc/cluster.go:1138
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1729,7 +1734,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:179
+#: lxc/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1089
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -1871,7 +1876,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:432
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1887,7 +1892,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:437
+#: lxc/cluster.go:440
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1911,7 +1916,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:118 lxc/cluster.go:777
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780
 #: lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:338
 #: lxc/config_trust.go:419 lxc/image.go:1027 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
@@ -1986,7 +1991,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:246
+#: lxc/cluster.go:249
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2405,7 +2410,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:811 lxc/cluster.go:901 lxc/cluster.go:992
+#: lxc/cluster.go:155 lxc/cluster.go:814 lxc/cluster.go:904 lxc/cluster.go:995
 #: lxc/cluster_group.go:410
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2446,7 +2451,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:775 lxc/cluster.go:776
+#: lxc/cluster.go:778 lxc/cluster.go:779
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2454,7 +2459,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:115 lxc/cluster.go:116
+#: lxc/cluster.go:118 lxc/cluster.go:119
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
@@ -2806,6 +2811,10 @@ msgstr ""
 
 #: lxc/cluster.go:29 lxc/cluster.go:30
 msgid "Manage cluster members"
+msgstr ""
+
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
+msgid "Manage cluster roles"
 msgstr ""
 
 #: lxc/alias.go:21 lxc/alias.go:22
@@ -2911,8 +2920,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -2936,17 +2945,27 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster_role.go:84
+#, c-format
+msgid "Member %q already has role %q"
+msgstr ""
+
+#: lxc/cluster_role.go:138
+#, c-format
+msgid "Member %q does not have role %q"
+msgstr ""
+
+#: lxc/cluster.go:760
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:492
+#: lxc/cluster.go:495
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:405
+#: lxc/cluster.go:408
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2990,8 +3009,8 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:626 lxc/cluster.go:1107 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:469
+#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster_group.go:469 lxc/cluster_role.go:71 lxc/cluster_role.go:125
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -3170,7 +3189,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:175 lxc/cluster.go:857 lxc/cluster_group.go:427
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:394 lxc/config_trust.go:489 lxc/list.go:567
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
@@ -3349,7 +3368,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:939
+#: lxc/cluster.go:942
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3512,7 +3531,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:731
+#: lxc/cluster.go:734
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3533,7 +3552,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/cluster_group.go:334 lxc/config.go:259
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
 #: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:303 lxc/image.go:455 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
@@ -3700,7 +3719,7 @@ msgstr ""
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/cluster.go:177
+#: lxc/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
@@ -3783,7 +3802,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:424 lxc/cluster.go:425
+#: lxc/cluster.go:427 lxc/cluster.go:428
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3827,6 +3846,10 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
+#: lxc/cluster_role.go:102 lxc/cluster_role.go:103
+msgid "Remove roles from a cluster member"
+msgstr ""
+
 #: lxc/network_acl.go:848 lxc/network_acl.go:849
 msgid "Remove rules from an ACL"
 msgstr ""
@@ -3839,7 +3862,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:374 lxc/cluster.go:375
+#: lxc/cluster.go:377 lxc/cluster.go:378
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3890,7 +3913,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:705 lxc/cluster.go:706
+#: lxc/cluster.go:708 lxc/cluster.go:709
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3913,7 +3936,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1077 lxc/cluster.go:1078
+#: lxc/cluster.go:1080 lxc/cluster.go:1081
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3932,7 +3955,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1133
+#: lxc/cluster.go:1136
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -3954,7 +3977,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:873
+#: lxc/cluster.go:876
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -3992,7 +4015,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/list.go:572 lxc/network.go:958
+#: lxc/cluster.go:184 lxc/list.go:572 lxc/network.go:958
 #: lxc/network_peer.go:143 lxc/storage.go:583
 msgid "STATE"
 msgstr ""
@@ -4042,7 +4065,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:296
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4246,7 +4269,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:197 lxc/cluster.go:198
+#: lxc/cluster.go:200 lxc/cluster.go:201
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4499,7 +4522,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1032
+#: lxc/cluster.go:1035
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4534,7 +4557,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:858 lxc/config_trust.go:490
+#: lxc/cluster.go:861 lxc/config_trust.go:490
 msgid "TOKEN"
 msgstr ""
 
@@ -4610,7 +4633,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:280
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -4650,11 +4673,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:562
+#: lxc/cluster.go:565
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:552
+#: lxc/cluster.go:555
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -4779,7 +4802,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/remote.go:675
+#: lxc/cluster.go:179 lxc/remote.go:675
 msgid "URL"
 msgstr ""
 
@@ -4843,7 +4866,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:348
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -4920,11 +4943,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:952
+#: lxc/cluster.go:955
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:954
+#: lxc/cluster.go:957
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -4962,7 +4985,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:456 lxc/delete.go:48
+#: lxc/cluster.go:459 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5060,7 +5083,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:113 lxc/cluster.go:774 lxc/cluster_group.go:371
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:333 lxc/config_trust.go:415 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
@@ -5072,7 +5095,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:950
+#: lxc/cluster.go:953
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -5080,7 +5103,7 @@ msgstr ""
 msgid "[<remote>:] <fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:506
+#: lxc/cluster.go:509
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5157,7 +5180,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:594
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5294,8 +5317,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:422 lxc/cluster.go:872 lxc/cluster.go:1057
-#: lxc/cluster.go:1076
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
+#: lxc/cluster.go:1079
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5303,16 +5326,20 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:344
+#: lxc/cluster.go:248 lxc/cluster.go:347
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:292
+#: lxc/cluster.go:295
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:372
+#: lxc/cluster.go:375
 msgid "[<remote>:]<member> <new-name>"
+msgstr ""
+
+#: lxc/cluster_role.go:47 lxc/cluster_role.go:101
+msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:357 lxc/network.go:578 lxc/network.go:759 lxc/network.go:974
@@ -5587,7 +5614,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/cluster.go:704
+#: lxc/cluster.go:707
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -5638,7 +5665,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:598
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5869,8 +5896,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5926,7 +5953,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:455 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
+#: lxc/cluster.go:458 lxc/delete.go:47 lxc/image.go:907 lxc/image.go:912
 #: lxc/image.go:1095
 msgid "yes"
 msgstr ""

--- a/shared/util.go
+++ b/shared/util.go
@@ -614,6 +614,28 @@ func StringInSlice(key string, list []string) bool {
 	return false
 }
 
+// RemoveElementsFromStringSlice returns a slice equivalent to removing the given elements from the given list.
+// Elements not present in the list are ignored.
+func RemoveElementsFromStringSlice(list []string, elements ...string) []string {
+	for i := len(elements) - 1; i >= 0; i-- {
+		element := elements[i]
+		match := false
+		for j := len(list) - 1; j >= 0; j-- {
+			if element == list[j] {
+				match = true
+				list = append(list[:j], list[j+1:]...)
+				break
+			}
+		}
+
+		if match {
+			elements = append(elements[:i], elements[i+1:]...)
+		}
+	}
+
+	return list
+}
+
 // StringHasPrefix returns true if value has one of the supplied prefixes.
 func StringHasPrefix(value string, prefixes ...string) bool {
 	for _, prefix := range prefixes {

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -208,3 +208,43 @@ func TestHasKey(t *testing.T) {
 	assert.True(t, HasKey(1, m2))
 	assert.False(t, HasKey(0, m2))
 }
+
+func TestRemoveElementsFromStringSlice(t *testing.T) {
+	type test struct {
+		elementsToRemove []string
+		list             []string
+		expectedList     []string
+	}
+	tests := []test{
+		{
+			elementsToRemove: []string{"one", "two", "three"},
+			list:             []string{"one", "two", "three", "four", "five"},
+			expectedList:     []string{"four", "five"},
+		},
+		{
+			elementsToRemove: []string{"two", "three", "four"},
+			list:             []string{"one", "two", "three", "four", "five"},
+			expectedList:     []string{"one", "five"},
+		},
+		{
+			elementsToRemove: []string{"two", "three", "four"},
+			list:             []string{"two", "three"},
+			expectedList:     []string{},
+		},
+		{
+			elementsToRemove: []string{"two", "two", "two"},
+			list:             []string{"two"},
+			expectedList:     []string{},
+		},
+		{
+			elementsToRemove: []string{"two", "two", "two"},
+			list:             []string{"one", "two", "three", "four", "five"},
+			expectedList:     []string{"one", "three", "four", "five"},
+		},
+	}
+
+	for _, tt := range tests {
+		gotList := RemoveElementsFromStringSlice(tt.list, tt.elementsToRemove...)
+		assert.ElementsMatch(t, tt.expectedList, gotList)
+	}
+}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3363,8 +3363,8 @@ test_clustering_events() {
   done
 
   # Switch into event-hub mode.
-  printf "roles: [\"database\", \"event-hub\"]\nfailure_domain: \"default\"\ngroups: [\"default\"]"  | LXD_DIR="${LXD_ONE_DIR}" lxc cluster edit node1
-  printf "roles: [\"database\", \"event-hub\"]\nfailure_domain: \"default\"\ngroups: [\"default\"]"  | LXD_DIR="${LXD_TWO_DIR}" lxc cluster edit node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster role add node1 event-hub
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster role add node2 event-hub
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -Fc event-hub | grep -Fx 2
 
@@ -3397,7 +3397,7 @@ test_clustering_events() {
   done
 
   # Switch into full-mesh mode by removing one event-hub role so there is <2 in the cluster.
-  printf "roles: [\"database\"]\nfailure_domain: \"default\"\ngroups: [\"default\"]"  | LXD_DIR="${LXD_ONE_DIR}" lxc cluster edit node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster role remove node1 event-hub
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -Fc event-hub | grep -Fx 1
 
   sleep 1 # Wait for notification heartbeat to distribute new roles.
@@ -3422,9 +3422,9 @@ test_clustering_events() {
   done
 
   # Switch back into event-hub mode by giving the role to node4 and node5.
-  printf "roles: [\"database\"]\nfailure_domain: \"default\"\ngroups: [\"default\"]"  | LXD_DIR="${LXD_TWO_DIR}" lxc cluster edit node2
-  printf "roles: [\"event-hub\"]\nfailure_domain: \"default\"\ngroups: [\"default\"]"  | LXD_DIR="${LXD_FOUR_DIR}" lxc cluster edit node4
-  printf "roles: [\"event-hub\"]\nfailure_domain: \"default\"\ngroups: [\"default\"]"  | LXD_DIR="${LXD_FIVE_DIR}" lxc cluster edit node5
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster role remove node2 event-hub
+  LXD_DIR="${LXD_FOUR_DIR}" lxc cluster role add node4 event-hub
+  LXD_DIR="${LXD_FIVE_DIR}" lxc cluster role add node5 event-hub
 
   sleep 1 # Wait for notification heartbeat to distribute new roles.
   LXD_DIR="${LXD_ONE_DIR}" lxc info | grep -F "server_event_mode: hub-client"


### PR DESCRIPTION
Adds a new `role` subcommand for `lxc cluster` to add and remove cluster roles without using `lxc cluster role edit <member>`.

Closes #10116. 