### PR TITLE
lxd/instance/drivers/qemu: Add serial key to device

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3142,6 +3142,7 @@ func (d *qemu) addDriveConfig(fdFiles *[]*os.File, bootIndexes map[string]int, d
 		"bus":     "qemu_scsi.0",
 		"channel": "0",
 		"lun":     "1",
+		"serial":  fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, escapedDeviceName),
 	}
 
 	if bootIndexes != nil {


### PR DESCRIPTION
This adds the serial key to the device. Having this key set will
populate /dev/disk/by-id.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
