### PR TITLE
Storage: Use TryUnmount without MNT_DETACH in DiskMountClear

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -119,7 +119,7 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 func DiskMountClear(mntPath string) error {
 	if shared.PathExists(mntPath) {
 		if filesystem.IsMountPoint(mntPath) {
-			err := unix.Unmount(mntPath, unix.MNT_DETACH)
+			err := storageDrivers.TryUnmount(mntPath, 0)
 			if err != nil {
 				return fmt.Errorf("Failed unmounting %q: %w", mntPath, err)
 			}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1374,8 +1374,8 @@ func (d *lxc) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (devi
 
 // deviceAdd loads a new device and calls its Add() function.
 func (d *lxc) deviceAdd(dev device.Device, instanceRunning bool) error {
-	logger := logger.AddContext(d.logger, logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
-	logger.Debug("Adding device")
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
+	l.Debug("Adding device")
 
 	if instanceRunning && !dev.CanHotPlug() {
 		return fmt.Errorf("Device cannot be added when instance is running")
@@ -1387,8 +1387,8 @@ func (d *lxc) deviceAdd(dev device.Device, instanceRunning bool) error {
 // deviceStart loads a new device and calls its Start() function.
 func (d *lxc) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfig.RunConfig, error) {
 	configCopy := dev.Config()
-	logger := logger.AddContext(d.logger, logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
-	logger.Debug("Starting device")
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
+	l.Debug("Starting device")
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -1559,8 +1559,8 @@ func (d *lxc) deviceUpdate(deviceName string, rawConfig deviceConfig.Device, old
 // container's network namespace is unmounted (which is required for NIC device cleanup).
 func (d *lxc) deviceStop(dev device.Device, instanceRunning bool, stopHookNetnsPath string) error {
 	configCopy := dev.Config()
-	logger := logger.AddContext(d.logger, logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
-	logger.Debug("Stopping device")
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
+	l.Debug("Stopping device")
 
 	if instanceRunning && !dev.CanHotPlug() {
 		return fmt.Errorf("Device cannot be stopped when instance is running")
@@ -1737,7 +1737,7 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 // deviceRemove loads a new device and calls its Remove() function.
 func (d *lxc) deviceRemove(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) error {
-	l := logger.AddContext(d.logger, logger.Ctx{"device": deviceName, "type": rawConfig["type"]})
+	l := d.logger.AddContext(logger.Ctx{"device": deviceName, "type": rawConfig["type"]})
 	l.Debug("Removing device")
 
 	dev, err := d.deviceLoad(deviceName, rawConfig)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1695,8 +1695,8 @@ func (d *qemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (dev
 // deviceStart loads a new device and calls its Start() function.
 func (d *qemu) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfig.RunConfig, error) {
 	configCopy := dev.Config()
-	logger := logger.AddContext(d.logger, logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
-	logger.Debug("Starting device")
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
+	l.Debug("Starting device")
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -1893,8 +1893,8 @@ func (d *qemu) deviceAttachNIC(deviceName string, configCopy map[string]string, 
 // deviceStop loads a new device and calls its Stop() function.
 func (d *qemu) deviceStop(dev device.Device, instanceRunning bool) error {
 	configCopy := dev.Config()
-	logger := logger.AddContext(d.logger, logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
-	logger.Debug("Stopping device")
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
+	l.Debug("Stopping device")
 
 	if instanceRunning && !dev.CanHotPlug() {
 		return fmt.Errorf("Device cannot be stopped when instance is running")
@@ -4939,8 +4939,8 @@ func (d *qemu) Delete(force bool) error {
 }
 
 func (d *qemu) deviceAdd(dev device.Device, instanceRunning bool) error {
-	logger := logger.AddContext(d.logger, logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
-	logger.Debug("Adding device")
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
+	l.Debug("Adding device")
 
 	if instanceRunning && !dev.CanHotPlug() {
 		return fmt.Errorf("Device cannot be added when instance is running")
@@ -4950,7 +4950,7 @@ func (d *qemu) deviceAdd(dev device.Device, instanceRunning bool) error {
 }
 
 func (d *qemu) deviceRemove(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) error {
-	l := logger.AddContext(d.logger, logger.Ctx{"device": deviceName, "type": rawConfig["type"]})
+	l := d.logger.AddContext(logger.Ctx{"device": deviceName, "type": rawConfig["type"]})
 	l.Debug("Removing device")
 
 	dev, err := d.deviceLoad(deviceName, rawConfig)

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -157,7 +157,7 @@ func (d *ceph) rbdMapVolume(vol Volume) (string, error) {
 
 	devPath = strings.TrimSpace(devPath[idx:])
 
-	d.logger.Debug("Activated RBD volume", logger.Ctx{"vol": rbdName, "dev": devPath})
+	d.logger.Debug("Activated RBD volume", logger.Ctx{"volName": rbdName, "dev": devPath})
 	return devPath, nil
 }
 
@@ -185,7 +185,7 @@ again:
 				if exitError.ExitCode() == 22 {
 					// EINVAL (already unmapped).
 					if ourDeactivate {
-						d.logger.Debug("Deactivated RBD volume", logger.Ctx{"vol": rbdVol})
+						d.logger.Debug("Deactivated RBD volume", logger.Ctx{"volName": rbdVol})
 					}
 
 					return nil
@@ -213,7 +213,7 @@ again:
 		goto again
 	}
 
-	d.logger.Debug("Deactivated RBD volume", logger.Ctx{"vol": rbdVol})
+	d.logger.Debug("Deactivated RBD volume", logger.Ctx{"volName": rbdVol})
 
 	return nil
 }

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -7,10 +7,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/units"
@@ -772,13 +774,34 @@ func (d *lvm) deactivateVolume(vol Volume) (bool, error) {
 		// Use parent for non-thinpool vols as deactivating the parent volume also activates its snapshots.
 		parent, _, _ := shared.InstanceGetParentAndSnapshotName(vol.Name())
 		volDevPath = d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, parent)
+
+		// If parent is mounted then skip deactivating non-thinpool snapshot volume as it will fail due
+		// to parent being in use.
+		if vol.IsSnapshot() && vol.contentType == ContentTypeFS {
+			parentVol := NewVolume(d, d.name, vol.volType, vol.contentType, parent, nil, d.config)
+			if filesystem.IsMountPoint(parentVol.MountPath()) {
+				return false, nil
+			}
+		}
 	}
 
 	if shared.PathExists(volDevPath) {
-		_, err := shared.RunCommand("lvchange", "--activate", "n", "--ignoreactivationskip", volDevPath)
+		// Keep trying to deactivate a few times in case the device is still being flushed.
+		var err error
+		for i := 0; i < 20; i++ {
+			_, err = shared.RunCommand("lvchange", "--activate", "n", "--ignoreactivationskip", volDevPath)
+			if err == nil {
+				break
+			}
+
+			logger.Debug("Failed to deactivate LVM logical volume", logger.Ctx{"path": volDevPath, "attempt": i, "err": err})
+			time.Sleep(500 * time.Millisecond)
+		}
+
 		if err != nil {
 			return false, fmt.Errorf("Failed to deactivate LVM logical volume %q: %w", volDevPath, err)
 		}
+
 		d.logger.Debug("Deactivated logical volume", logger.Ctx{"volName": vol.Name(), "dev": volDevPath})
 		return true, nil
 	}

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -601,7 +601,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 		// volumes with the same UUID to be mounted at the same time). This should be done before volume
 		// resize as some filesystems will need to mount the filesystem to resize.
 		if renegerateFilesystemUUIDNeeded(vol.ConfigBlockFilesystem()) {
-			_, err = d.activateVolume(volDevPath)
+			_, err = d.activateVolume(vol)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -136,18 +136,6 @@ func (d *lvm) CreateVolumeFromCopy(vol, srcVol Volume, copySnapshots bool, op *o
 		return nil
 	}
 
-	// Before doing a generic volume copy, we need to ensure volume (or snap volume parent) is activated to
-	// avoid failing with warnings about changing the origin of the snapshot when trying to activate it.
-	parent, _, _ := shared.InstanceGetParentAndSnapshotName(srcVol.Name())
-	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], srcVol.volType, srcVol.contentType, parent)
-	activated, err := d.activateVolume(volDevPath)
-	if err != nil {
-		return err
-	}
-	if activated {
-		defer d.deactivateVolume(volDevPath)
-	}
-
 	// Otherwise run the generic copy.
 	return genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, false, op)
 }
@@ -776,18 +764,6 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 
 // MigrateVolume sends a volume for migration.
 func (d *lvm) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
-	// Before doing a generic volume migration, we need to ensure volume (or snap volume parent) is activated
-	// to avoid failing with warnings about changing the origin of the snapshot when trying to activate it.
-	parent, _, _ := shared.InstanceGetParentAndSnapshotName(vol.Name())
-	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, parent)
-	activated, err := d.activateVolume(volDevPath)
-	if err != nil {
-		return err
-	}
-	if activated {
-		defer d.deactivateVolume(volDevPath)
-	}
-
 	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
 }
 

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -215,6 +215,11 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol Volume, conn io.ReadW
 			return fmt.Errorf("Error copying %q to migration connection: %w", path, err)
 		}
 
+		err = from.Close()
+		if err != nil {
+			return fmt.Errorf("Failed to close file %q: %w", path, err)
+		}
+
 		return nil
 	}
 

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -542,6 +542,11 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 				if err != nil {
 					return fmt.Errorf("Error copying %q as %q to tarball: %w", blockPath, name, err)
 				}
+
+				err = from.Close()
+				if err != nil {
+					return fmt.Errorf("Failed to close file %q: %w", blockPath, err)
+				}
 			} else {
 				logMsg := "Copying container filesystem volume"
 				if vol.volType == VolumeTypeCustom {

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/idmap"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 // MinBlockBoundary minimum block boundary size to use.
@@ -181,6 +182,7 @@ func TryUnmount(path string, flags int) error {
 			break
 		}
 
+		logger.Debug("Failed to unmount", logger.Ctx{"path": path, "attempt": i, "err": err})
 		time.Sleep(500 * time.Millisecond)
 	}
 

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -356,7 +356,7 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 // 	- Unpack metadata tarball into mountPath.
 //	- Check rootBlockPath is a file and convert qcow2 file into raw format in rootBlockPath.
 func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blockBackend bool, sysOS *sys.OS, allowUnsafeResize bool, tracker *ioprogress.ProgressTracker) (int64, error) {
-	l := logger.AddContext(logger.Log, logger.Ctx{"imageFile": imageFile, "vol": vol.Name()})
+	l := logger.AddContext(logger.Log, logger.Ctx{"imageFile": imageFile, "volName": vol.Name()})
 	l.Info("Image unpack started")
 	defer l.Info("Image unpack stopped")
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1099,7 +1099,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			if v.NodeID == localNodeID {
 				// Always include local volumes.
 				volumes = append(volumes, v)
-				logger.Debug("Scheduling local auto custom volume snapshot", logger.Ctx{"vol": v.Name, "project": v.ProjectName, "pool": v.PoolName})
+				logger.Debug("Scheduling local auto custom volume snapshot", logger.Ctx{"volName": v.Name, "project": v.ProjectName, "pool": v.PoolName})
 			} else if v.NodeID < 0 {
 				// Keep a separate list of remote volumes in order to select a member to perform
 				// the snapshot later.
@@ -1156,7 +1156,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 					if nodeCount > 1 {
 						selectedNodeID, err := util.GetStableRandomInt64FromList(int64(v.ID), onlineNodeIDs)
 						if err != nil {
-							logger.Error("Failed scheduling remote auto custom volume snapshot task", logger.Ctx{"vol": v.Name, "project": v.ProjectName, "pool": v.PoolName, "err": err})
+							logger.Error("Failed scheduling remote auto custom volume snapshot task", logger.Ctx{"volName": v.Name, "project": v.ProjectName, "pool": v.PoolName, "err": err})
 							continue
 						}
 
@@ -1166,7 +1166,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 						}
 					}
 
-					logger.Debug("Scheduling remote auto custom volume snapshot", logger.Ctx{"vol": v.Name, "project": v.ProjectName, "pool": v.PoolName})
+					logger.Debug("Scheduling remote auto custom volume snapshot", logger.Ctx{"volName": v.Name, "project": v.ProjectName, "pool": v.PoolName})
 					volumes = append(volumes, v)
 				}
 			}

--- a/shared/instancewriter/instance_tar_writer.go
+++ b/shared/instancewriter/instance_tar_writer.go
@@ -158,6 +158,11 @@ func (ctw *InstanceTarWriter) WriteFile(name string, srcPath string, fi os.FileI
 		if err != nil {
 			return fmt.Errorf("Failed to copy file content %q: %w", srcPath, err)
 		}
+
+		err = f.Close()
+		if err != nil {
+			return fmt.Errorf("Failed to close file %q: %w", srcPath, err)
+		}
 	}
 
 	return nil

--- a/test/includes/storage.sh
+++ b/test/includes/storage.sh
@@ -129,17 +129,3 @@ umount_loops() {
     fi
 }
 
-storage_compatible() {
-    if [ "${1}" = "cephfs" ] || [ "${1}" = "dir" ] || [ "${1}" = "btrfs" ] || [ "${1}" = "lvm" ] || [ "${1}" = "zfs" ] || [ "${1}" = "ceph" ]; then
-        if [ "${2}" = "cephfs" ] || [ "${2}" = "dir" ] || [ "${2}" = "btrfs" ] || [ "${2}" = "lvm" ] || [ "${2}" = "zfs" ] || [ "${2}" = "ceph" ]; then
-            true
-            return
-        else
-            false
-            return
-        fi
-    fi
-
-    true
-    return
-}

--- a/test/suites/incremental_copy.sh
+++ b/test/suites/incremental_copy.sh
@@ -1,28 +1,16 @@
 test_incremental_copy() {
-  # shellcheck disable=2039
-  local lxd_backend
-  lxd_backend=$(storage_backend "$LXD_DIR")
-
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   do_copy "" ""
 
   # cross-pool copy
-  if [ "${lxd_backend}" != 'dir' ]; then
-    # FIXME: Skip copies across old and new backends for now
-    if ! storage_compatible "dir" "${lxd_backend}"; then
-        true
-        return
-    fi
-
-    # shellcheck disable=2039
-    local source_pool
-    source_pool="lxdtest-$(basename "${LXD_DIR}")-dir-pool"
-    lxc storage create "${source_pool}" dir
-    do_copy "${source_pool}" "lxdtest-$(basename "${LXD_DIR}")"
-    lxc storage rm "${source_pool}"
-  fi
+  # shellcheck disable=2039
+  local source_pool
+  source_pool="lxdtest-$(basename "${LXD_DIR}")-dir-pool"
+  lxc storage create "${source_pool}" dir
+  do_copy "${source_pool}" "lxdtest-$(basename "${LXD_DIR}")"
+  lxc storage rm "${source_pool}"
 }
 
 do_copy() {

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -83,10 +83,6 @@ test_storage_local_volume_handling() {
 
     for source_driver in "btrfs" "ceph" "cephfs" "dir" "lvm" "zfs"; do
       for target_driver in "btrfs" "ceph" "cephfs" "dir" "lvm" "zfs"; do
-        # FIXME: Skip copies across old and new backends for now
-        storage_compatible "${source_driver}" "${target_driver}" || continue
-        storage_compatible "${target_driver}" "${source_driver}" || continue
-
         # shellcheck disable=SC2235
         if [ "$source_driver" != "$target_driver" ] \
             && ([ "$lxd_backend" = "$source_driver" ] || ([ "$lxd_backend" = "ceph" ] && [ "$source_driver" = "cephfs" ] && [ -n "${LXD_CEPH_CEPHFS:-}" ])) \


### PR DESCRIPTION
To fix VM shutdown problems due to `config.mount` bind mount being unmountable immediately after the QEMU process ends sometimes (such as when the VM has been exported).

In doing so I also noticed that errors from unmounts in `MountTask()` were not handled, and in changing that so they were, revealed some more bugs in the LVM non-thinpool driver, which are also fixed in this PR.

Fixes https://github.com/lxc/lxd/issues/10184
Fixes https://github.com/lxc/lxd/issues/10187