### PR TITLE
shared: allow EOPNOTSUPP from llistxattr()

### DIFF
--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -99,6 +99,9 @@ func GetAllXattr(path string) (xattrs map[string]string, err error) {
 	// two calls.
 	pre, err := llistxattr(path, nil)
 	if err != nil || pre < 0 {
+		if err == unix.EOPNOTSUPP {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if pre == 0 {


### PR DESCRIPTION
Some filesystems don't support llistxattr() for various reasons. Let's
interpret this as a set of no xattrs, instead of an error.

The goal here is to be able to use the idmap shifting code on xattr-less
filesystems, which is not currently possible, since there is the following
call graph:

github.com/lxc/lxd/shared/idmap.(*IdmapSet).doUidshiftIntoContainer.func1
-> github.com/lxc/lxd/shared/idmap.GetCaps
-> github.com/lxc/lxd/shared.GetAllXattr
-> github.com/lxc/lxd/shared.llistxattr

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>