### PR TITLE
VM: Correctly detect disk source path filesystem

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3080,7 +3080,7 @@ func (d *qemu) addDriveConfig(fdFiles *[]*os.File, bootIndexes map[string]int, d
 		// Handle I/O mode configuration.
 		if shared.PathExists(srcDevPath) && !shared.IsBlockdevPath(srcDevPath) {
 			// Disk dev path is a file, check what the backing filesystem is.
-			fsType, err := filesystem.Detect(driveConf.DevPath)
+			fsType, err := filesystem.Detect(srcDevPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed detecting filesystem type of %q: %w", srcDevPath, err)
 			}


### PR DESCRIPTION
This was only working correctly for root disks and not for additional disks.
As these types of disks have their FD number as a path, e.g. 

https://github.com/lxc/lxd/blob/master/lxd/instance/drivers/driver_qemu.go#L3077

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>