### PR TITLE
LXD: Replace use of ErrNotFound with api.StatusError with code set to http.StatusNotFound

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3305,10 +3305,6 @@ func clusterGroupGet(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		if response.IsNotFoundError(err) {
-			return response.NotFound(fmt.Errorf("Cluster group %q not found", name))
-		}
-
 		return response.SmartError(err)
 	}
 
@@ -3389,10 +3385,6 @@ func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	})
 	if err != nil {
-		if response.IsNotFoundError(err) {
-			return response.NotFound(fmt.Errorf("Cluster group %q not found", name))
-		}
-
 		return response.SmartError(err)
 	}
 

--- a/lxd/api_networks_test.go
+++ b/lxd/api_networks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/lxc/lxd/shared/api"
@@ -42,7 +43,8 @@ func TestNetworksCreate_TargetNode(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, err = client.GetNetwork("mynetwork")
-	require.EqualError(t, err, "not found")
+	_, matched := api.StatusErrorMatch(err, http.StatusNotFound)
+	require.True(t, matched)
 }
 
 // An error is returned when trying to create a new network in a cluster

--- a/lxd/api_storage_pools_test.go
+++ b/lxd/api_storage_pools_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/lxc/lxd/shared/api"
@@ -42,7 +43,8 @@ func TestStoragePoolsCreate_TargetNode(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, err = client.GetStoragePool("mypool")
-	require.EqualError(t, err, "not found")
+	_, matched := api.StatusErrorMatch(err, http.StatusNotFound)
+	require.True(t, matched)
 }
 
 // An error is returned when trying to create a new storage pool in a cluster

--- a/lxd/db/backups.go
+++ b/lxd/db/backups.go
@@ -6,8 +6,10 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -43,7 +45,8 @@ func (c *Cluster) getInstanceBackupID(name string) (int, error) {
 	arg2 := []any{&id}
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err == sql.ErrNoRows {
-		return -1, ErrNoSuchObject
+		return -1, api.StatusErrorf(http.StatusNotFound, "Instance backup not found")
+
 	}
 
 	return id, err
@@ -71,7 +74,7 @@ SELECT instances_backups.id, instances_backups.instance_id,
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return args, ErrNoSuchObject
+			return args, api.StatusErrorf(http.StatusNotFound, "Instance backup not found")
 		}
 
 		return args, err
@@ -110,7 +113,7 @@ SELECT instances_backups.name, instances_backups.instance_id,
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return args, ErrNoSuchObject
+			return args, api.StatusErrorf(http.StatusNotFound, "Instance backup not found")
 		}
 
 		return args, err
@@ -393,7 +396,7 @@ func (c *Cluster) getStoragePoolVolumeBackupID(name string) (int, error) {
 	arg2 := []any{&id}
 	err := dbQueryRowScan(c, q, arg1, arg2)
 	if err == sql.ErrNoRows {
-		return -1, ErrNoSuchObject
+		return -1, api.StatusErrorf(http.StatusNotFound, "Storage volume backup not found")
 	}
 
 	return id, err
@@ -436,7 +439,7 @@ WHERE projects.name=? AND backups.name=?
 	err := dbQueryRowScan(c, q, arg1, outfmt)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return args, ErrNoSuchObject
+			return args, api.StatusErrorf(http.StatusNotFound, "Storage volume backup not found")
 		}
 
 		return args, err
@@ -467,7 +470,7 @@ WHERE backups.id=?
 	err := dbQueryRowScan(c, q, arg1, outfmt)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return args, ErrNoSuchObject
+			return args, api.StatusErrorf(http.StatusNotFound, "Storage volume backup not found")
 		}
 
 		return args, err

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -5,6 +5,7 @@ package db
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
@@ -137,7 +138,7 @@ ORDER BY certificates.fingerprint
 	}
 
 	if len(fingerprints) == 0 {
-		return nil, ErrNoSuchObject
+		return nil, api.StatusErrorf(http.StatusNotFound, "Certificate not found")
 	}
 
 	cert, err = c.GetCertificate(fingerprints[0])

--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -6,6 +6,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"net/http"
 
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
@@ -130,7 +131,7 @@ func (c *ClusterTx) GetClusterGroup(name string) (*ClusterGroup, error) {
 
 	switch len(objects) {
 	case 0:
-		return nil, ErrNoSuchObject
+		return nil, api.StatusErrorf(http.StatusNotFound, "Cluster group not found")
 	case 1:
 		return &objects[0], nil
 	default:
@@ -150,7 +151,7 @@ func (c *ClusterTx) GetClusterGroupID(name string) (int64, error) {
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {
-		return -1, ErrNoSuchObject
+		return -1, api.StatusErrorf(http.StatusNotFound, "Cluster group not found")
 	}
 	var id int64
 	err = rows.Scan(&id)
@@ -173,7 +174,8 @@ func (c *ClusterTx) GetClusterGroupID(name string) (int64, error) {
 func (c *ClusterTx) ClusterGroupExists(name string) (bool, error) {
 	_, err := c.GetClusterGroupID(name)
 	if err != nil {
-		if err == ErrNoSuchObject {
+		_, matched := api.StatusErrorMatch(err, http.StatusNotFound)
+		if matched {
 			return false, nil
 		}
 		return false, err

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -234,7 +234,8 @@ func (s *dbTestSuite) Test_GetImageAlias_alias_does_not_exists() {
 	var err error
 
 	_, _, err = s.db.GetImageAlias("default", "whatever", true)
-	s.Equal(err, ErrNoSuchObject)
+	_, matched := api.StatusErrorMatch(err, http.StatusNotFound)
+	s.True(matched)
 }
 
 func (s *dbTestSuite) Test_CreateImageAlias() {
@@ -270,5 +271,6 @@ func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint_no_match() {
 	s.Nil(err)
 
 	_, err = s.db.GetCachedImageSourceFingerprint("server.remote", "lxd", "test", "container", 0)
-	s.Equal(err, ErrNoSuchObject)
+	_, matched := api.StatusErrorMatch(err, http.StatusNotFound)
+	s.True(matched)
 }

--- a/lxd/db/errors.go
+++ b/lxd/db/errors.go
@@ -9,14 +9,6 @@ var (
 	// for example a container.
 	ErrAlreadyDefined = fmt.Errorf("The record already exists")
 
-	// ErrNoSuchObject is in the case of joins (and probably other) queries,
-	// we don't get back sql.ErrNoRows when no rows are returned, even though we do
-	// on selects without joins. Instead, you can use this error to
-	// propagate up and generate proper 404s to the client when something
-	// isn't found so we don't abuse sql.ErrNoRows any more than we
-	// already do.
-	ErrNoSuchObject = fmt.Errorf("No such object")
-
 	// ErrNoClusterMember is used to indicate no cluster member has been found for a resource.
 	ErrNoClusterMember = fmt.Errorf("No cluster member found")
 )

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -118,7 +118,7 @@ func (c *ClusterTx) GetImageSource(imageID int) (int, api.ImageSource, error) {
 	}
 
 	if len(sources) == 0 {
-		return -1, api.ImageSource{}, ErrNoSuchObject
+		return -1, api.ImageSource{}, api.StatusErrorf(http.StatusNotFound, "Image source not found")
 	}
 
 	source := sources[0]
@@ -383,7 +383,7 @@ func (c *Cluster) GetCachedImageSourceFingerprint(server string, protocol string
 		return "", err
 	}
 	if len(fingerprints) == 0 {
-		return "", ErrNoSuchObject
+		return "", api.StatusErrorf(http.StatusNotFound, "Image source not found")
 	}
 
 	return fingerprints[0], nil
@@ -532,7 +532,7 @@ func (c *Cluster) GetImageFromAnyProject(fingerprint string) (int, *api.Image, e
 		}
 
 		if len(images) == 0 {
-			return ErrNoSuchObject
+			return api.StatusErrorf(http.StatusNotFound, "Image not found")
 		}
 
 		object = images[0]
@@ -765,7 +765,7 @@ func (c *Cluster) GetImageAlias(project, name string, isTrustedClient bool) (int
 		err = tx.tx.QueryRow(q, arg1...).Scan(arg2...)
 		if err != nil {
 			if err == sql.ErrNoRows {
-				return ErrNoSuchObject
+				return api.StatusErrorf(http.StatusNotFound, "Image alias not found")
 			}
 
 			return err

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -219,7 +219,7 @@ SELECT nodes.id, nodes.address
 	defer rows.Close()
 
 	if !rows.Next() {
-		return "", ErrNoSuchObject
+		return "", api.StatusErrorf(http.StatusNotFound, "Instance not found")
 	}
 
 	err = rows.Scan(&id, &address)
@@ -737,7 +737,7 @@ WHERE instances.id=?
 	})
 
 	if err == sql.ErrNoRows {
-		return "", "", ErrNoSuchObject
+		return "", "", api.StatusErrorf(http.StatusNotFound, "Instance not found")
 	}
 
 	return project, name, err
@@ -763,7 +763,7 @@ func (c *Cluster) GetInstanceConfig(id int, key string) (string, error) {
 		return tx.tx.QueryRow(q, id, key).Scan(&value)
 	})
 	if err == sql.ErrNoRows {
-		return "", ErrNoSuchObject
+		return "", api.StatusErrorf(http.StatusNotFound, "Instance config not found")
 	}
 
 	return value, err

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -228,7 +228,7 @@ SELECT nodes.id, nodes.address
 	}
 
 	if rows.Next() {
-		return "", fmt.Errorf("More than one node associated with instance")
+		return "", fmt.Errorf("More than one cluster member associated with instance")
 	}
 
 	err = rows.Err()

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
@@ -108,7 +109,7 @@ func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.Ne
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return -1, nil, ErrNoSuchObject
+			return -1, nil, api.StatusErrorf(http.StatusNotFound, "Network ACL not found")
 		}
 
 		return -1, nil, err
@@ -145,7 +146,7 @@ func (c *Cluster) GetNetworkACLNameAndProjectWithID(networkACLID int) (string, s
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return "", "", ErrNoSuchObject
+			return "", "", api.StatusErrorf(http.StatusNotFound, "Network ACL not found")
 		}
 
 		return "", "", err

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/lxc/lxd/shared/api"
@@ -147,7 +148,7 @@ func (c *Cluster) GetNetworkZone(name string) (int64, string, *api.NetworkZone, 
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return -1, "", nil, ErrNoSuchObject
+			return -1, "", nil, api.StatusErrorf(http.StatusNotFound, "Network zone not found")
 		}
 
 		return -1, "", nil, err
@@ -186,7 +187,7 @@ func (c *Cluster) GetNetworkZoneByProject(projectName string, name string) (int6
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return -1, nil, ErrNoSuchObject
+			return -1, nil, api.StatusErrorf(http.StatusNotFound, "Network zone not found")
 		}
 
 		return -1, nil, err
@@ -374,7 +375,7 @@ func (c *Cluster) GetNetworkZoneRecord(zone int64, name string) (int64, *api.Net
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return -1, nil, ErrNoSuchObject
+			return -1, nil, api.StatusErrorf(http.StatusNotFound, "Network zone record not found")
 		}
 
 		return -1, nil, err

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -125,7 +125,7 @@ func (c *Cluster) GetNetworkZone(name string) (int64, string, *api.NetworkZone, 
 	}
 
 	q := `
-		SELECT networks_zones.id, projects.Name, networks_zones.description
+		SELECT networks_zones.id, projects.name, networks_zones.description
 		FROM networks_zones
 		JOIN projects ON projects.id=networks_zones.project_id
 		WHERE networks_zones.name=?

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -188,7 +188,7 @@ func (c *ClusterTx) GetNetworkID(projectName string, name string) (int64, error)
 	}
 	switch len(ids) {
 	case 0:
-		return -1, ErrNoSuchObject
+		return -1, api.StatusErrorf(http.StatusNotFound, "Network not found")
 	case 1:
 		return int64(ids[0]), nil
 	default:
@@ -209,7 +209,7 @@ func (c *Cluster) GetNetworkNameAndProjectWithID(networkID int) (string, string,
 	err := dbQueryRowScan(c, q, inargs, outargs)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return "", "", ErrNoSuchObject
+			return "", "", api.StatusErrorf(http.StatusNotFound, "Network not found")
 		}
 
 		return "", "", err
@@ -394,7 +394,7 @@ func (c *ClusterTx) networkState(project string, name string, state NetworkState
 		return err
 	}
 	if n != 1 {
-		return ErrNoSuchObject
+		return api.StatusErrorf(http.StatusNotFound, "Network not found")
 	}
 	return nil
 }
@@ -416,7 +416,7 @@ func (c *ClusterTx) networkNodeState(networkID int64, state NetworkState) error 
 		return err
 	}
 	if n != 1 {
-		return ErrNoSuchObject
+		return api.StatusErrorf(http.StatusNotFound, "Network not found")
 	}
 
 	return nil

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -268,7 +268,7 @@ func (c *ClusterTx) GetNodeWithID(nodeID int) (NodeInfo, error) {
 	case 1:
 		return nodes[0], nil
 	default:
-		return null, fmt.Errorf("more than one node matches")
+		return null, fmt.Errorf("More than one cluster member matches")
 	}
 }
 
@@ -285,7 +285,7 @@ func (c *ClusterTx) GetPendingNodeByAddress(address string) (NodeInfo, error) {
 	case 1:
 		return nodes[0], nil
 	default:
-		return null, fmt.Errorf("more than one node matches")
+		return null, fmt.Errorf("More than one cluster member matches")
 	}
 }
 
@@ -302,7 +302,7 @@ func (c *ClusterTx) GetNodeByName(name string) (NodeInfo, error) {
 	case 1:
 		return nodes[0], nil
 	default:
-		return null, fmt.Errorf("more than one node matches")
+		return null, fmt.Errorf("More than one cluster member matches")
 	}
 }
 

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -6,6 +6,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -220,7 +221,7 @@ func (c *ClusterTx) GetNodeByAddress(address string) (NodeInfo, error) {
 	}
 	switch len(nodes) {
 	case 0:
-		return null, ErrNoSuchObject
+		return null, api.StatusErrorf(http.StatusNotFound, "Cluster member not found")
 	case 1:
 		return nodes[0], nil
 	default:
@@ -263,7 +264,7 @@ func (c *ClusterTx) GetNodeWithID(nodeID int) (NodeInfo, error) {
 	}
 	switch len(nodes) {
 	case 0:
-		return null, ErrNoSuchObject
+		return null, api.StatusErrorf(http.StatusNotFound, "Cluster member not found")
 	case 1:
 		return nodes[0], nil
 	default:
@@ -280,7 +281,7 @@ func (c *ClusterTx) GetPendingNodeByAddress(address string) (NodeInfo, error) {
 	}
 	switch len(nodes) {
 	case 0:
-		return null, ErrNoSuchObject
+		return null, api.StatusErrorf(http.StatusNotFound, "Cluster member not found")
 	case 1:
 		return nodes[0], nil
 	default:
@@ -297,7 +298,7 @@ func (c *ClusterTx) GetNodeByName(name string) (NodeInfo, error) {
 	}
 	switch len(nodes) {
 	case 0:
-		return null, ErrNoSuchObject
+		return null, api.StatusErrorf(http.StatusNotFound, "Cluster member not found")
 	case 1:
 		return nodes[0], nil
 	default:
@@ -931,7 +932,7 @@ func (c *ClusterTx) SetNodeHeartbeat(address string, heartbeat time.Time) error 
 	}
 
 	if n < 1 {
-		return ErrNoSuchObject
+		return api.StatusErrorf(http.StatusNotFound, "Cluster member not found")
 	} else if n > 1 {
 		return fmt.Errorf("Expected to update one row and not %d", n)
 	}

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -5,9 +5,11 @@ package db
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/canonical/go-dqlite/client"
 	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // RaftNode holds information about a single node in the dqlite raft cluster.
@@ -67,7 +69,7 @@ func (n *NodeTx) GetRaftNodeAddress(id int64) (string, error) {
 	}
 	switch len(addresses) {
 	case 0:
-		return "", ErrNoSuchObject
+		return "", api.StatusErrorf(http.StatusNotFound, "Raft member not found")
 	case 1:
 		return addresses[0], nil
 	default:
@@ -111,7 +113,7 @@ func (n *NodeTx) RemoveRaftNode(id int64) error {
 		return err
 	}
 	if !deleted {
-		return ErrNoSuchObject
+		return api.StatusErrorf(http.StatusNotFound, "Raft member not found")
 	}
 	return nil
 }

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -175,7 +175,7 @@ func (c *ClusterTx) GetStoragePoolID(name string) (int64, error) {
 	}
 	switch len(ids) {
 	case 0:
-		return -1, ErrNoSuchObject
+		return -1, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 	case 1:
 		return int64(ids[0]), nil
 	default:
@@ -192,7 +192,7 @@ func (c *ClusterTx) GetStoragePoolDriver(id int64) (string, error) {
 	}
 	switch len(drivers) {
 	case 0:
-		return "", ErrNoSuchObject
+		return "", api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 	case 1:
 		return drivers[0], nil
 	default:
@@ -477,7 +477,7 @@ func (c *ClusterTx) storagePoolState(name string, state StoragePoolState) error 
 		return err
 	}
 	if n != 1 {
-		return ErrNoSuchObject
+		return api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 	}
 	return nil
 }
@@ -530,7 +530,7 @@ func (c *ClusterTx) storagePoolNodeState(poolID int64, state StoragePoolState) e
 		return err
 	}
 	if n != 1 {
-		return ErrNoSuchObject
+		return api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 	}
 
 	return nil
@@ -614,7 +614,7 @@ func (c *Cluster) storagePools(where string, args ...any) ([]string, error) {
 	}
 
 	if len(result) == 0 {
-		return []string{}, ErrNoSuchObject
+		return []string{}, api.StatusErrorf(http.StatusNotFound, "Storage pool(s) not found")
 	}
 
 	pools := []string{}
@@ -639,7 +639,7 @@ func (c *Cluster) GetStoragePoolDrivers() ([]string, error) {
 	}
 
 	if len(result) == 0 {
-		return []string{}, ErrNoSuchObject
+		return []string{}, api.StatusErrorf(http.StatusNotFound, "Storage pool(s) not found")
 	}
 
 	drivers := []string{}
@@ -660,7 +660,7 @@ func (c *Cluster) GetStoragePoolID(poolName string) (int64, error) {
 	err := dbQueryRowScan(c, query, inargs, outargs)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return -1, ErrNoSuchObject
+			return -1, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 		}
 	}
 
@@ -872,7 +872,7 @@ func storagePoolDriverGet(tx *sql.Tx, id int64) (string, error) {
 	}
 	switch len(drivers) {
 	case 0:
-		return "", ErrNoSuchObject
+		return "", api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 	case 1:
 		return drivers[0], nil
 	default:

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -6,10 +6,12 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // CreateStorageVolumeSnapshot creates a new storage volume snapshot attached to a given
@@ -143,7 +145,7 @@ WHERE volumes.id=?
 	err := dbQueryRowScan(c, q, arg1, outfmt)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return args, ErrNoSuchObject
+			return args, api.StatusErrorf(http.StatusNotFound, "Storage pool volume snapshot not found")
 		}
 
 		return args, err
@@ -169,7 +171,7 @@ func (c *Cluster) GetStorageVolumeSnapshotExpiry(volumeID int64) (time.Time, err
 	err := dbQueryRowScan(c, query, inargs, outargs)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return expiry, ErrNoSuchObject
+			return expiry, api.StatusErrorf(http.StatusNotFound, "Storage pool volume snapshot not found")
 		}
 		return expiry, err
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -192,7 +192,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 		if len(ops) < 1 {
-			return db.ErrNoSuchObject
+			return api.StatusErrorf(http.StatusNotFound, "Operation not found")
 		}
 		if len(ops) > 1 {
 			return fmt.Errorf("More than one operation matches")
@@ -269,7 +269,7 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 		if len(ops) < 1 {
-			return db.ErrNoSuchObject
+			return api.StatusErrorf(http.StatusNotFound, "Operation not found")
 		}
 		if len(ops) > 1 {
 			return fmt.Errorf("More than one operation matches")
@@ -319,7 +319,7 @@ func operationCancel(d *Daemon, r *http.Request, projectName string, op *api.Ope
 			return fmt.Errorf("Failed loading operation %q: %w", op.ID, err)
 		}
 		if len(ops) < 1 {
-			return db.ErrNoSuchObject
+			return api.StatusErrorf(http.StatusNotFound, "Operation not found")
 		}
 		if len(ops) > 1 {
 			return fmt.Errorf("More than one operation matches")
@@ -888,7 +888,7 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 		if len(ops) < 1 {
-			return db.ErrNoSuchObject
+			return api.StatusErrorf(http.StatusNotFound, "Operation not found")
 		}
 		if len(ops) > 1 {
 			return fmt.Errorf("More than one operation matches")
@@ -1012,7 +1012,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 		if len(ops) < 1 {
-			return db.ErrNoSuchObject
+			return api.StatusErrorf(http.StatusNotFound, "Operation not found")
 		}
 		if len(ops) > 1 {
 			return fmt.Errorf("More than one operation matches")

--- a/lxd/response/smart.go
+++ b/lxd/response/smart.go
@@ -11,7 +11,7 @@ import (
 )
 
 var httpResponseErrors = map[int][]error{
-	http.StatusNotFound:  {os.ErrNotExist, sql.ErrNoRows, db.ErrNoSuchObject},
+	http.StatusNotFound:  {os.ErrNotExist, sql.ErrNoRows},
 	http.StatusForbidden: {os.ErrPermission},
 	http.StatusConflict:  {db.ErrAlreadyDefined},
 }

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
@@ -17,6 +18,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/units"
@@ -377,7 +379,7 @@ func (d *ceph) rbdListSnapshotClones(vol Volume, snapshotName string) ([]string,
 	msg = strings.TrimSpace(msg)
 	clones := strings.Fields(msg)
 	if len(clones) == 0 {
-		return nil, db.ErrNoSuchObject
+		return nil, api.StatusErrorf(http.StatusNotFound, "Ceph RBD volume snapshot not found")
 	}
 
 	return clones, nil
@@ -479,7 +481,7 @@ func (d *ceph) rbdGetVolumeParent(vol Volume) (string, error) {
 
 	idx := strings.Index(msg, "parent: ")
 	if idx == -1 {
-		return "", db.ErrNoSuchObject
+		return "", api.StatusErrorf(http.StatusNotFound, "Ceph RBD volume parent not found")
 	}
 
 	msg = msg[(idx + len("parent: ")):]
@@ -558,7 +560,7 @@ func (d *ceph) rbdListVolumeSnapshots(vol Volume) ([]string, error) {
 	}
 
 	if len(snapshots) == 0 {
-		return []string{}, db.ErrNoSuchObject
+		return []string{}, api.StatusErrorf(http.StatusNotFound, "Ceph RBD volume snapshot(s) not found")
 	}
 
 	return snapshots, nil

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -476,14 +476,14 @@ test_backup_rename() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  if ! lxc query -X POST /1.0/containers/c1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: Not Found" ; then
+  if ! lxc query -X POST /1.0/containers/c1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: Instance not found" ; then
     echo "invalid rename response for missing container"
     false
   fi
 
   lxc init testimage c1
 
-  if ! lxc query -X POST /1.0/containers/c1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error:.*No such object" ; then
+  if ! lxc query -X POST /1.0/containers/c1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: Load backup from database: Instance backup not found" ; then
     echo "invalid rename response for missing backup"
     false
   fi
@@ -708,7 +708,7 @@ test_backup_volume_rename_delete() {
   # Create test volume.
   lxc storage volume create "${pool}" vol1
 
-  if ! lxc query -X POST /1.0/storage-pools/"${pool}"/volumes/custom/vol1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Not Found" ; then
+  if ! lxc query -X POST /1.0/storage-pools/"${pool}"/volumes/custom/vol1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: Storage volume backup not found" ; then
     echo "invalid rename response for missing storage volume"
     false
   fi


### PR DESCRIPTION
We've been gradually moving away from using `ErrNotFound`, so this PR finishes off that migration.

Fixes https://github.com/lxc/lxd/issues/5548