### PR TITLE
lxd/storage/drivers/zfs: Close stderr after copy

### DIFF
--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -322,6 +322,7 @@ func (d *zfs) sendDataset(dataset string, parent string, volSrcArgs *migration.V
 		_, err := io.Copy(conn, stdoutPipe)
 		chStdoutPipe <- err
 		conn.Close()
+		stderr.Close()
 	}()
 
 	// Run the command.


### PR DESCRIPTION
In an error case, if `ioutil.ReadAll(stderr)` ran before the goroutine
ended, `ReadAll` would hang forever. It wouldn't happen every time,
but if called often enough it would eventually hang. This would make
it impossible for the source to clean up their instances since the
resource is busy.

This closes stderr at the end of the goroutine, making it impossible for
`ReadAll` to hang.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
