### PR TITLE
Storage: Updates genericVFSCopyVolume to not copy block volume files twice

### DIFF
--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -393,12 +393,10 @@ func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		return err
 	}
 
-	revertPath := true
-	defer func() {
-		if revertPath {
-			os.RemoveAll(snapPath)
-		}
-	}()
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() { os.RemoveAll(snapPath) })
 
 	bwlimit := d.config["rsync.bwlimit"]
 
@@ -408,7 +406,7 @@ func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		return err
 	}
 
-	revertPath = false
+	revert.Success()
 	return nil
 }
 

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -672,7 +672,7 @@ func regenerateFilesystemXFSUUID(devPath string) error {
 }
 
 // copyDevice copies one device path to another.
-func copyDevice(inputPath, outputPath string) error {
+func copyDevice(inputPath string, outputPath string) error {
 	from, err := os.Open(inputPath)
 	if err != nil {
 		return fmt.Errorf("Error opening file for reading %q: %w", inputPath, err)

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -690,6 +690,16 @@ func copyDevice(inputPath string, outputPath string) error {
 		return fmt.Errorf("Error copying file %q to %q: %w", inputPath, outputPath, err)
 	}
 
+	err = from.Close()
+	if err != nil {
+		return fmt.Errorf("Failed to close file %q: %w", inputPath, err)
+	}
+
+	err = to.Close()
+	if err != nil {
+		return fmt.Errorf("Failed to close file %q: %w", outputPath, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
For filesystem backed storage pools (dir and btrfs) this function was previously copying the block
volume files twice, first via rsync and then second using Go's io.Copy().

This commit changes it do behave more like genericVFSMigrateVolume where the rsync part of the
transfer excludes the block volume file.

Related to #10111

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>