### PR TITLE
Update doc links

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,2 +1,2 @@
 The LXD team uses GitHub for issue and feature tracking, not for user support.
-For information on how to get support, see [Support](https://linuxcontainers.org/lxd/docs/master/support/).
+For information on how to get support, see [Support](https://linuxcontainers.org/lxd/docs/latest/support/).

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -120,7 +120,7 @@ exclude_patterns = ['html', 'README.md']
 
 # Open Graph configuration
 
-ogp_site_url = "https://linuxcontainers.org/lxd/docs/master/"
+ogp_site_url = "https://linuxcontainers.org/lxd/docs/latest/"
 ogp_site_name = "LXD documentation"
 ogp_image = "https://linuxcontainers.org/static/img/containers.png"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,4 +104,4 @@ When contributing, you must adhere to the Code of Conduct, which is available at
 
 ## More information
 
-For more information, see [Contributing](doc/contributing.md) in the documentation.
+For more information, see [Contributing](https://linuxcontainers.org/lxd/docs/latest/contributing/) in the documentation.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then if you want to run it locally, take a look at our [getting started guide](h
 
 - Release announcements: https://linuxcontainers.org/lxd/news/
 - Release tarballs: https://linuxcontainers.org/lxd/downloads/
-- Documentation: https://linuxcontainers.org/lxd/docs/master/
+- Documentation: https://linuxcontainers.org/lxd/docs/latest/
 
 <!-- Include end LXD intro -->
 
@@ -89,7 +89,7 @@ If you prefer live discussions, you can find us in [#lxc](https://kiwiirc.com/cl
 Commercial support for LXD can be obtained through [Canonical Ltd](https://www.canonical.com).
 
 ## Documentation
-The official documentation is available at: https://linuxcontainers.org/lxd/docs/master/
+The official documentation is available at: https://linuxcontainers.org/lxd/docs/latest/
 
 You can find additional resources on the [website](https://linuxcontainers.org/lxd/articles), on [YouTube](https://www.youtube.com/channel/UCuP6xPt0WTeZu32CkQPpbvA) and in the [Tutorials section](https://discuss.linuxcontainers.org/c/tutorials/) in the forum.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ MacOS               | [Homebrew](https://formulae.brew.sh/formula/lxc)  | brew i
 More instructions on installing LXD for a wide variety of Linux distributions and operating systems [can be found on our website](https://linuxcontainers.org/lxd/getting-started-cli/).
 <!-- Include end installing -->
 
-To install LXD from source, see [Installing LXD](doc/installing.md) in the documentation.
+To install LXD from source, see [Installing LXD](https://linuxcontainers.org/lxd/docs/latest/installing/) in the documentation.
 
 ## Security
 
@@ -56,7 +56,7 @@ Consider the following aspects to ensure that your LXD installation is secure:
 - Configure your network interfaces to be secure.
 <!-- Include end security -->
 
-See [Security](doc/security.md) for detailed information.
+See [Security](https://linuxcontainers.org/lxd/docs/latest/security/) for detailed information.
 
 **IMPORTANT:**
 <!-- Include start security note -->

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,14 +1,14 @@
 # LXD documentation
 
-The LXD documentation is available at: https://linuxcontainers.org/lxd/docs/master/
+The LXD documentation is available at: https://linuxcontainers.org/lxd/docs/latest/
 
-GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://linuxcontainers.org/lxd/docs/master/).
+GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://linuxcontainers.org/lxd/docs/latest/).
 
 ## Documentation format
 
 The documentation is written in [Markdown](https://commonmark.org/) with [MyST](https://myst-parser.readthedocs.io/) extensions.
 
-For syntax help and guidelines, see the [documentation cheat sheet](https://linuxcontainers.org/lxd/docs/master/doc-cheat-sheet/) ([source](doc-cheat-sheet.md?plain=1)).
+For syntax help and guidelines, see the [documentation cheat sheet](https://linuxcontainers.org/lxd/docs/latest/doc-cheat-sheet/) ([source](doc-cheat-sheet.md?plain=1)).
 
 ## Building the documentation
 

--- a/grafana/LXD.json
+++ b/grafana/LXD.json
@@ -75,7 +75,7 @@
       "targetBlank": true,
       "title": "Documentation",
       "type": "link",
-      "url": "https://linuxcontainers.org/lxd/docs/master/"
+      "url": "https://linuxcontainers.org/lxd/docs/latest/"
     }
   ],
   "liveNow": false,


### PR DESCRIPTION
As in general anything under doc/ isn't cleanly readable by normal markdown parsers, we shouldn't link to them from pages that are in clean markdown. Instead, link to the rendered documentation.

I've also updated all mention of `/master/` to use the now available `/latest/` symlink.