### PR TITLE
lxd/instance/qemu: Avoid conflicting vsock IDs

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5790,9 +5790,21 @@ func (d *qemu) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 	return nil
 }
 
-// vsockID returns the vsock context ID, 3 being the first ID that can be used.
+// vsockID returns the vsock Context ID for the VM.
 func (d *qemu) vsockID() int {
-	return d.id + 3
+	// We use the system's own VsockID as the base.
+	//
+	// This is either "2" for a physical system or the VM's own id if
+	// running inside of a VM.
+	//
+	// To this we add 1 for backward compatibility with prior logic
+	// which would start at id 3 rather than id 2. Removing that offset
+	// would cause conflicts between existing VMs until they're all rebooted.
+	//
+	// We then add the VM's own instance id (1 or higher) to give us a
+	// unique, non-clashing context ID for our guest.
+
+	return int(d.state.OS.VsockID) + 1 + d.id
 }
 
 // InitPID returns the instance's current process ID.

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/mdlayher/vsock"
+
 	"github.com/lxc/lxd/lxd/cgroup"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/storage/filesystem"
@@ -88,6 +90,9 @@ type OS struct {
 
 	// LXC features
 	LXCFeatures map[string]bool
+
+	// VM features
+	VsockID uint32
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.
@@ -163,6 +168,15 @@ func (s *OS) Init() ([]db.Warning, error) {
 	dbWarnings = s.initAppArmor()
 	cgroup.Init()
 	s.CGInfo = cgroup.GetInfo()
+
+	// Fill in the VsockID.
+	vsockID, err := vsock.ContextID()
+	if err != nil {
+		// Fallback to the default ID for a host system.
+		vsockID = 2
+	}
+
+	s.VsockID = vsockID
 
 	return dbWarnings, nil
 }


### PR DESCRIPTION
Closes #9426

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>