### PR TITLE
Storage: VM copy dir driver peformance improvements

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5203,7 +5203,9 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 	}
 
 	fPath := fmt.Sprintf("%s/rootfs.img", tmpPath)
-	_, err = shared.RunCommand("qemu-img", "convert", "-c", "-O", "qcow2", mountInfo.DiskPath, fPath)
+
+	// Run qemu-img with low priority to reduce CPU impact on other processes.
+	_, err = shared.RunCommand("nice", "-n19", "qemu-img", "convert", "-c", "-O", "qcow2", mountInfo.DiskPath, fPath)
 	if err != nil {
 		return meta, fmt.Errorf("Failed converting image to qcow2: %w", err)
 	}

--- a/lxd/main_forklimits.go
+++ b/lxd/main_forklimits.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"golang.org/x/sys/unix"
 
@@ -131,7 +130,7 @@ func (c *cmdForklimits) Run(cmd *cobra.Command, _ []string) error {
 
 	// Clear the cloexec flag on the file descriptors we are passing through.
 	for _, fd := range fds {
-		_, _, syscallErr := syscall.Syscall(unix.SYS_FCNTL, fd, syscall.F_SETFD, uintptr(0))
+		_, _, syscallErr := unix.Syscall(unix.SYS_FCNTL, fd, unix.F_SETFD, uintptr(0))
 		if syscallErr != 0 {
 			err := os.NewSyscallError(fmt.Sprintf("fcntl failed on FD %d", fd), syscallErr)
 			if err != nil {
@@ -140,5 +139,5 @@ func (c *cmdForklimits) Run(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	return syscall.Exec(cmdParts[0], cmdParts, os.Environ())
+	return unix.Exec(cmdParts[0], cmdParts, os.Environ())
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1085,6 +1085,13 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		return err
 	}
 
+	if len(srcSnapshotNames) > 0 {
+		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project(), inst.Name())
+		if err != nil {
+			return err
+		}
+	}
+
 	revert.Success()
 	return nil
 }

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -462,10 +462,10 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 			}
 		}
 
-		// Convert the qcow2 format to a raw block device using qemu's dd mode to avoid issues with
-		// loop backed storage pools. Use the MinBlockBoundary block size to speed up conversion.
+		// Convert the qcow2 format to a raw block device using qemu's dd mode runnig with low priority to
+		// reduce CPU impact. Use 16M buffer to speed up conversion by reducing syscalls.
 		l.Debug("Converting qcow2 image to raw disk", logger.Ctx{"imgPath": imgPath, "dstPath": dstPath})
-		_, err = shared.RunCommand("qemu-img", "dd", "-f", "qcow2", "-O", "raw", fmt.Sprintf("bs=%d", drivers.MinBlockBoundary), fmt.Sprintf("if=%s", imgPath), fmt.Sprintf("of=%s", dstPath))
+		_, err = shared.RunCommand("nice", "-n19", "qemu-img", "dd", "-f", "qcow2", "-O", "raw", "bs=16M", fmt.Sprintf("if=%s", imgPath), fmt.Sprintf("of=%s", dstPath))
 		if err != nil {
 			return -1, fmt.Errorf("Failed converting image to raw at %q: %w", dstPath, err)
 		}

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -14,7 +14,6 @@ import (
 	"reflect"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -638,7 +637,7 @@ func GetPollRevents(fd int, timeout int, flags int) (int, int, error) {
 again:
 	n, err := unix.Poll(pollFds, timeout)
 	if err != nil {
-		if err == syscall.EAGAIN || err == syscall.EINTR {
+		if err == unix.EAGAIN || err == unix.EINTR {
 			goto again
 		}
 
@@ -660,7 +659,7 @@ func ExitStatus(err error) (int, error) {
 	exitErr, isExitError := err.(*exec.ExitError)
 	if isExitError {
 		// If the process was signaled, extract the signal.
-		status, isWaitStatus := exitErr.Sys().(syscall.WaitStatus)
+		status, isWaitStatus := exitErr.Sys().(unix.WaitStatus)
 		if isWaitStatus && status.Signaled() {
 			return 128 + int(status.Signal()), nil // 128 + n == Fatal error signal "n"
 		}


### PR DESCRIPTION
- Fixes missing instance snapshot symlink not being created when copying instance in same pool.
- Changes `copyDevice()` function to use `dd` with direct I/O and 16MB byte size, running with a low priority, in order to reduce CPU impact to other processes on the system and to avoid expiring the filesystem cache when copying larger block images.
- Updates `dir` `CreateVolumeSnapshot` to use `copyDevice()` for copying block volume files rather than `rsync`.
- Runs `qemu-img` as low priority, and for image unpack uses a 16MB buffer size for `qemu-img dd` to improve performance.

Fixes #10111