### PR TITLE
lxc/instance/drivers: Do not update root device pool

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4166,6 +4166,13 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		if err != nil {
 			return fmt.Errorf("Invalid expanded devices: %w", err)
 		}
+
+		// Validate root device
+		_, oldRootDev, oldErr := shared.GetRootDiskDevice(oldExpandedDevices.CloneNative())
+		_, newRootDev, newErr := shared.GetRootDiskDevice(d.expandedDevices.CloneNative())
+		if oldErr == nil && newErr == nil && oldRootDev["pool"] != newRootDev["pool"] {
+			return fmt.Errorf("Cannot update root disk device pool name")
+		}
 	}
 
 	// Run through initLXC to catch anything we missed

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4336,6 +4336,13 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		if err != nil {
 			return fmt.Errorf("Invalid expanded devices: %w", err)
 		}
+
+		// Validate root device
+		_, oldRootDev, oldErr := shared.GetRootDiskDevice(oldExpandedDevices.CloneNative())
+		_, newRootDev, newErr := shared.GetRootDiskDevice(d.expandedDevices.CloneNative())
+		if oldErr == nil && newErr == nil && oldRootDev["pool"] != newRootDev["pool"] {
+			return fmt.Errorf("Cannot update root disk device pool name")
+		}
 	}
 
 	// If apparmor changed, re-validate the apparmor profile (even if not running).

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -544,4 +544,8 @@ test_basic_usage() {
   # Test renaming/deletion of the default profile
   ! lxc profile rename default foobar || false
   ! lxc profile delete default || false
+
+  lxc init testimage c1
+  ! lxc config device override c1 root pool bla || false
+  lxc rm -f c1
 }

--- a/test/suites/storage_profiles.sh
+++ b/test/suites/storage_profiles.sh
@@ -98,7 +98,7 @@ test_storage_profiles() {
 
     # Verify that we cannot create a container with profiles that have
     # contradicting root devices.
-    ! lxc launch testimage cConflictingProfiles --p test -p testDup -p testNoDup || false
+    ! lxc launch testimage cConflictingProfiles -p test -p testDup -p testNoDup || false
 
     # And that even with a local disk, a container can't have multiple root devices
     ! lxc launch testimage cConflictingProfiles -s "lxdtest-$(basename "${LXD_DIR}")-pool2" -p test -p testDup -p testNoDup || false


### PR DESCRIPTION
When updating an instance, the root device was updated as well. This
caused problems when doing migration and the names of the source and
target storage pools differed.

This fixes the issue by not updating the root device pool.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
