### PR TITLE
test: drop dependency on uuidgen

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -36,7 +36,7 @@ sudo apt install btrfs-progs
 To run the testsuite, you'll also need:
 
 ```bash
-sudo apt install curl gettext jq sqlite3 uuid-runtime socat bind9-dnsutils
+sudo apt install curl gettext jq sqlite3 socat bind9-dnsutils
 ```
 
 ### From Source: Building the latest version
@@ -114,4 +114,4 @@ group to talk to LXD; you can create your own group if you want):
 sudo -E PATH=${PATH} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} $(go env GOPATH)/bin/lxd --group sudo
 ```
 
-*Note: If `newuidmap/newgidmap` tools are present on your system and `/etc/subuid`, `etc/subgid` exist, they must be configured to allow the root user a contiguous range of at least 10M uid/gid.* 
+*Note: If `newuidmap/newgidmap` tools are present on your system and `/etc/subuid`, `etc/subgid` exist, they must be configured to allow the root user a contiguous range of at least 10M uid/gid.*

--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -45,7 +45,7 @@ gen_cert() {
     [ -f "${LXD_CONF}/${1}.crt" ] && return
     mv "${LXD_CONF}/client.crt" "${LXD_CONF}/client.crt.bak"
     mv "${LXD_CONF}/client.key" "${LXD_CONF}/client.key.bak"
-    echo y | lxc_remote remote add "$(uuidgen)" https://0.0.0.0 || true
+    echo y | lxc_remote remote add "remote-placeholder-$$" https://0.0.0.0 || true
     mv "${LXD_CONF}/client.crt" "${LXD_CONF}/${1}.crt"
     mv "${LXD_CONF}/client.key" "${LXD_CONF}/${1}.key"
     mv "${LXD_CONF}/client.crt.bak" "${LXD_CONF}/client.crt"

--- a/test/main.sh
+++ b/test/main.sh
@@ -40,7 +40,7 @@ import_subdir_files() {
 import_subdir_files includes
 
 echo "==> Checking for dependencies"
-check_dependencies lxd lxc curl dnsmasq jq git xgettext sqlite3 msgmerge msgfmt shuf setfacl uuidgen socat dig
+check_dependencies lxd lxc curl dnsmasq jq git xgettext sqlite3 msgmerge msgfmt shuf setfacl socat dig
 
 if [ "${USER:-'root'}" != "root" ]; then
   echo "The testsuite must be run as root." >&2


### PR DESCRIPTION
`uuidgen` was used to generate a single placeholder remote name.
If we ever want a UUID generator back, we should use:

  `systemd-id128 new -u`

Which doesn't depend on an additional package.