### PR TITLE
doc: make it explicit that automake is needed to build LXD

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -21,7 +21,7 @@ later to work. On ubuntu, you can get those with:
 
 ```bash
 sudo apt update
-sudo apt install acl attr autoconf dnsmasq-base git golang libacl1-dev libcap-dev liblxc1 liblxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
+sudo apt install acl attr autoconf automake dnsmasq-base git golang libacl1-dev libcap-dev liblxc1 liblxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
 ```
 
 There are a few storage backends for LXD besides the default "directory" backend.


### PR DESCRIPTION
This is useful mainly for those using apt's `--no-install-recommends`.