### PR TITLE
lxd/storage/drivers/zfs: send -w is possible since 0.8.0

### DIFF
--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -90,13 +90,13 @@ func (d *zfs) load() error {
 		zfsTrim = true
 	}
 
-	ver200, err := version.Parse("2.0.0")
+	ver080, err := version.Parse("0.8.0")
 	if err != nil {
 		return err
 	}
 
-	// If running 2.0.0 or newer, we can use the raw flag.
-	if ourVer.Compare(ver200) >= 0 {
+	// If running 0.8.0 or newer, we can use the raw flag.
+	if ourVer.Compare(ver080) >= 0 {
 		zfsRaw = true
 	}
 


### PR DESCRIPTION
The raw flag is available since ZFS 0.8.0:
https://github.com/openzfs/zfs/releases/tag/zfs-0.8.0