### PR TITLE
VM: Use qemu-img convert rather than qemu-img dd and use direct I/O where possible

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5212,12 +5212,38 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 
 	fPath := fmt.Sprintf("%s/rootfs.img", tmpPath)
 
-	// Run qemu-img with low priority to reduce CPU impact on other processes.
-	_, err = shared.RunCommand("nice", "-n19", "qemu-img", "convert", "-c", "-O", "qcow2", mountInfo.DiskPath, fPath)
-	if err != nil {
-		return meta, fmt.Errorf("Failed converting image to qcow2: %w", err)
+	// Convert to qcow2 image.
+	cmd := []string{
+		"nice", "-n19", // Run with low priority to reduce CPU impact on other processes.
+		"qemu-img", "convert", "-f", "raw", "-O", "qcow2", "-c",
 	}
 
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Check for Direct I/O support.
+	from, err := os.OpenFile(mountInfo.DiskPath, unix.O_DIRECT|unix.O_RDONLY, 0)
+	if err == nil {
+		cmd = append(cmd, "-T", "none")
+		from.Close()
+	}
+
+	to, err := os.OpenFile(fPath, unix.O_DIRECT|unix.O_CREAT, 0)
+	if err == nil {
+		cmd = append(cmd, "-t", "none")
+		to.Close()
+	}
+
+	revert.Add(func() { os.Remove(fPath) })
+
+	cmd = append(cmd, mountInfo.DiskPath, fPath)
+
+	_, err = shared.RunCommand(cmd[0], cmd[1:]...)
+	if err != nil {
+		return meta, fmt.Errorf("Failed converting instance to qcow2: %w", err)
+	}
+
+	// Read converted file info and write file to tarball.
 	fi, err := os.Lstat(fPath)
 	if err != nil {
 		return meta, err
@@ -5245,6 +5271,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 		return meta, err
 	}
 
+	revert.Success()
 	d.logger.Info("Exported instance", ctxMap)
 	return meta, nil
 }

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -495,18 +495,56 @@ func (d *dir) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 
 // RestoreVolume restores a volume from a snapshot.
 func (d *dir) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
-	srcPath := GetVolumeMountPath(d.name, vol.volType, GetSnapshotVolumeName(vol.name, snapshotName))
+	snapVol, err := vol.NewSnapshot(snapshotName)
+	if err != nil {
+		return err
+	}
+
+	srcPath := snapVol.MountPath()
 	if !shared.PathExists(srcPath) {
 		return fmt.Errorf("Snapshot not found")
 	}
 
 	volPath := vol.MountPath()
 
-	// Restore using rsync.
-	bwlimit := d.config["rsync.bwlimit"]
-	_, err := rsync.LocalCopy(srcPath, volPath, bwlimit, true)
-	if err != nil {
-		return fmt.Errorf("Failed to rsync volume: %w", err)
+	// Restore filesystem volume.
+	if vol.contentType != ContentTypeBlock || vol.volType != VolumeTypeCustom {
+		var rsyncArgs []string
+
+		if vol.IsVMBlock() {
+			rsyncArgs = append(rsyncArgs, "--exclude", genericVolumeDiskFile)
+		}
+
+		bwlimit := d.config["rsync.bwlimit"]
+		_, err := rsync.LocalCopy(srcPath, volPath, bwlimit, true, rsyncArgs...)
+		if err != nil {
+			return fmt.Errorf("Failed to rsync volume: %w", err)
+		}
+	}
+
+	// Restore block volume.
+	if vol.IsVMBlock() || vol.contentType == ContentTypeBlock && vol.volType == VolumeTypeCustom {
+		srcDevPath, err := d.GetVolumeDiskPath(snapVol)
+		if err != nil {
+			return err
+		}
+
+		targetDevPath, err := d.GetVolumeDiskPath(vol)
+		if err != nil {
+			return err
+		}
+
+		d.Logger().Debug("Restoring block volume", logger.Ctx{"srcDevPath": srcDevPath, "targetPath": targetDevPath})
+
+		err = ensureSparseFile(targetDevPath, 0)
+		if err != nil {
+			return err
+		}
+
+		err = copyDevice(srcDevPath, targetDevPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -391,15 +391,14 @@ func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	snapPath := snapVol.MountPath()
 	revert.Add(func() { os.RemoveAll(snapPath) })
 
-	bwlimit := d.config["rsync.bwlimit"]
-
-	var rsyncArgs []string
-
-	if snapVol.IsVMBlock() {
-		rsyncArgs = append(rsyncArgs, "--exclude", genericVolumeDiskFile)
-	}
-
 	if snapVol.contentType != ContentTypeBlock || snapVol.volType != VolumeTypeCustom {
+		var rsyncArgs []string
+
+		if snapVol.IsVMBlock() {
+			rsyncArgs = append(rsyncArgs, "--exclude", genericVolumeDiskFile)
+		}
+
+		bwlimit := d.config["rsync.bwlimit"]
 		srcPath := GetVolumeMountPath(d.name, snapVol.volType, parentName)
 		d.Logger().Debug("Copying fileystem volume", logger.Ctx{"sourcePath": srcPath, "targetPath": snapPath, "bwlimit": bwlimit, "rsyncArgs": rsyncArgs})
 

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -681,13 +681,13 @@ func copyDevice(inputPath string, outputPath string) error {
 	}
 
 	// Check for Direct I/O support.
-	from, err := os.OpenFile(inputPath, unix.O_DIRECT, 0)
+	from, err := os.OpenFile(inputPath, unix.O_DIRECT|unix.O_RDONLY, 0)
 	if err == nil {
 		cmd = append(cmd, "iflag=direct")
 		from.Close()
 	}
 
-	to, err := os.OpenFile(outputPath, unix.O_DIRECT, 0)
+	to, err := os.OpenFile(outputPath, unix.O_DIRECT|unix.O_RDONLY, 0)
 	if err == nil {
 		cmd = append(cmd, "oflag=direct")
 		to.Close()


### PR DESCRIPTION
To avoid polluting the page cache and improve performance:

- Use `qemu-img convert` in direct I/O mode where possible.
- Uses `dd`, in direct I/O mode where possible, for restoring block volume snapshots on `dir` storage pools, rather than rsync.

Also: 
- Protects calls to `qemu-img info` with `prlimit` and disables image format detection, for security.
