### PR TITLE
lxd/device/disk: Apply name length restriction to VM only

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -261,6 +261,8 @@ Every device entry is identified by a unique name. If the same name is used in
 a subsequent profile or in the instance's own configuration, the whole entry
 is overridden by the new definition.
 
+Device names are limited to a maximum of 64 characters.
+
 Device entries are added to an instance through:
 
 ```bash

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -137,11 +137,6 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		return ErrUnsupportedDevType
 	}
 
-	// QMP allows node names to be 31 characters. LXD prefixes any block device with `lxd_` which leaves the user with 27 characters.
-	if len(d.name) > 27 {
-		return fmt.Errorf("Device name too long, max. 27 characters")
-	}
-
 	// Supported propagation types.
 	// If an empty value is supplied the default behavior is to assume "private" mode.
 	// These come from https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha1"
 	"crypto/tls"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1789,7 +1791,7 @@ func (d *qemu) deviceDetachBlockDevice(deviceName string, rawConfig deviceConfig
 
 	escapedDeviceName := filesystem.PathNameEncode(deviceName)
 	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
-	blockDevName := fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, escapedDeviceName)
+	blockDevName := d.blockNodeName(escapedDeviceName)
 
 	err = monitor.RemoveFDFromFDSet(blockDevName)
 	if err != nil {
@@ -3144,7 +3146,7 @@ func (d *qemu) addDriveConfig(bootIndexes map[string]int, driveConf deviceConfig
 		},
 		"discard":   "unmap", // Forward as an unmap request. This is the same as `discard=on` in the qemu config file.
 		"driver":    "file",
-		"node-name": fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, escapedDeviceName), // Node names may only be 31 characters long.
+		"node-name": d.blockNodeName(escapedDeviceName),
 		"read-only": false,
 	}
 
@@ -6371,4 +6373,22 @@ func (d *qemu) deviceDetachUSB(usbDev deviceConfig.USBDeviceItem) error {
 	}
 
 	return nil
+}
+
+// Block node names may only be up to 31 characters long, so use a hash if longer.
+func (d *qemu) blockNodeName(name string) string {
+	if len(name) > 27 {
+		// If the name is too long, hash it as SHA-1 (20 bytes).
+		// Then encode the SHA-1 binary hash as Base64 (maximum 28 bytes).
+		// Finally strip the trailing base64 padding character giving us 27 chars.
+
+		hash := sha1.New()
+		hash.Write([]byte(name))
+		binaryHash := hash.Sum(nil)
+		base64Hash := base64.StdEncoding.EncodeToString(binaryHash)
+		name = base64Hash[0 : len(base64Hash)-1]
+	}
+
+	// Apply the lxd_ prefix.
+	return fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, name)
 }

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -81,11 +81,15 @@ func validDevices(state *state.State, projectName string, instanceType instancet
 	// Check each device individually using the device package.
 	// Use instConf.localDevices so that the cloned config is passed into the driver, so it cannot modify it.
 	for name, config := range instConf.localDevices {
+		// Enforce a maximum name length of 64 characters (safe maximum allowing use for sockets and other filesystem use).
+		if len(name) > 64 {
+			return fmt.Errorf("The maximum device name length is 64 characters")
+		}
+
 		err := device.Validate(instConf, state, name, config)
 		if err != nil {
 			return fmt.Errorf("Device validation failed for %q: %w", name, err)
 		}
-
 	}
 
 	// Check we have a root disk if in expanded validation mode.


### PR DESCRIPTION
Fixes to #10238

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>