### PR TITLE
Generator fixes

### DIFF
--- a/lxd/db/generate/db.go
+++ b/lxd/db/generate/db.go
@@ -119,6 +119,7 @@ func newDbMapperMethod() *cobra.Command {
 	var database string
 	var pkg string
 	var entity string
+	var transaction string
 
 	cmd := &cobra.Command{
 		Use:   "method [kind] [param1=value1 ... paramN=valueN]",
@@ -139,7 +140,7 @@ func newDbMapperMethod() *cobra.Command {
 			// FIXME: Transition every entity to using V2, and then replace V1 with it.
 			var method file.Snippet
 			if config["version"] != "" {
-				method, err = db.NewMethodV2(database, pkg, entity, kind, config)
+				method, err = db.NewMethodV2(database, pkg, entity, kind, config, transaction)
 				if err != nil {
 					return err
 				}
@@ -160,6 +161,7 @@ func newDbMapperMethod() *cobra.Command {
 	flags.StringVarP(&database, "database", "d", "cluster", "target database")
 	flags.StringVarP(&pkg, "package", "p", "api", "Go package where the entity struct is declared")
 	flags.StringVarP(&entity, "entity", "e", "", "database entity to generate the method for")
+	flags.StringVarP(&transaction, "tx", "", "", "custom transaction argument in lieu of receiver")
 
 	return cmd
 }

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -34,6 +34,17 @@ func Packages() (map[string]*ast.Package, error) {
 	return packages, nil
 }
 
+// ParsePackage returns the the AST package in which to search for structs.
+func ParsePackage(pkgPath string) (*ast.Package, error) {
+	pkg, err := lex.Parse(pkgPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse package path %q: %w", pkgPath, err)
+	}
+
+	return pkg, nil
+
+}
+
 var defaultPackages = []string{
 	"shared/api",
 	"lxd/db",

--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -510,7 +510,11 @@ func naturalKeySelect(entity string, mapping *Mapping) string {
 // Output a line of code that registers the given statement and declares the
 // associated statement code global variable.
 func (s *Stmt) register(buf *file.Buffer, stmtName, sql string, filters ...string) {
-	buf.L("var %s = %s.RegisterStmt(`\n%s\n`)", stmtName, s.db, sql)
+	if s.db != "" {
+		buf.L("var %s = %s.RegisterStmt(`\n%s\n`)", stmtName, s.db, sql)
+	} else {
+		buf.L("var %s = RegisterStmt(`\n%s\n`)", stmtName, sql)
+	}
 }
 
 // Map of boilerplate statements.


### PR DESCRIPTION
Depends on #10225 

Makes the generator a bit more flexible by allowing us to pass a `--tx` flag which specifies a type for a custom transaction that will be used in lieu of the `ClusterTx` receiver. 

In practice, this will look like the following:
```go
//go:generate mapper method --tx *sql.Tx -p db -e cluster GetMany version=2
// Results in
func GetClusters(tx *sql.Tx, filter ClusterFilter) ([]*Cluster, error) {
...
}
```

Additionally changes the package parsing logic to only parse the current working directory, as opposed to `lxd/db/` and `shared/api`. 