### PR TITLE
Cluster: Allow member join when a project has `restricted.networks.subnets`

### DIFF
--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -6,7 +6,7 @@
 
 This will create a standalone OVN network that is connected to the parent network lxdbr0 for outbound connectivity.
 
-Install the OVN tools and configure the OVN integration bridge on the local node:
+Install the OVN tools and configure the OVN integration bridge on the local server:
 
 ```
 sudo apt install ovn-host ovn-central

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -76,7 +76,7 @@ ipv4.dhcp.expiry                     | string    | ipv4 dhcp             | 1h   
 ipv4.dhcp.gateway                    | string    | ipv4 dhcp             | ipv4.address              | Address of the gateway for the subnet
 ipv4.dhcp.ranges                     | string    | ipv4 dhcp             | all addresses             | Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)
 ipv4.firewall                        | boolean   | ipv4 address          | true                      | Whether to generate filtering firewall rules for this network
-ipv4.nat                             | boolean   | ipv4 address          | false                     | Whether to NAT (defaults to `true` for regular bridges where `ipv4.address` is generated and always defaults to `true` for fan bridges)
+ipv4.nat                             | boolean   | ipv4 address          | false                     | Whether to NAT (if unset when creating the network, set to `true` for regular bridges when `ipv4.address` is generated and always for fan bridges)
 ipv4.nat.address                     | string    | ipv4 address          | -                         | The source address used for outbound traffic from the bridge
 ipv4.nat.order                       | string    | ipv4 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
 ipv4.ovn.ranges                      | string    | -                     | -                         | Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
@@ -88,7 +88,7 @@ ipv6.dhcp.expiry                     | string    | ipv6 dhcp             | 1h   
 ipv6.dhcp.ranges                     | string    | ipv6 stateful dhcp    | all addresses             | Comma-separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)
 ipv6.dhcp.stateful                   | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 ipv6.firewall                        | boolean   | ipv6 address          | true                      | Whether to generate filtering firewall rules for this network
-ipv6.nat                             | boolean   | ipv6 address          | false                     | Whether to NAT (defaults to `true` if unset and a random `ipv6.address` is generated)
+ipv6.nat                             | boolean   | ipv6 address          | false                     | Whether to NAT (if unset when creating the network, set to `true` when `ipv6.address` is generated)
 ipv6.nat.address                     | string    | ipv6 address          | -                         | The source address used for outbound traffic from the bridge
 ipv6.nat.order                       | string    | ipv6 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
 ipv6.ovn.ranges                      | string    | -                     | -                         | Comma-separated list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -851,8 +851,8 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 	})
 }
 
-// clusterInitMember initialises storage pools and networks on this node. We pass two LXD client instances, one
-// connected to ourselves (the joining node) and one connected to the target cluster node to join.
+// clusterInitMember initialises storage pools and networks on this member. We pass two LXD client instances, one
+// connected to ourselves (the joining member) and one connected to the target cluster member to join.
 // Returns a revert function that can be used to undo the setup if a subsequent step fails.
 func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberConfig []api.ClusterMemberConfigKey) (func(), error) {
 	data := initDataNode{}
@@ -934,7 +934,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 					},
 				})
 				if err != nil {
-					return nil, fmt.Errorf("Failed to create local node project %q: %w", p.Name, err)
+					return nil, fmt.Errorf("Failed to create local member project %q: %w", p.Name, err)
 				}
 			} else if p.Name != project.Default {
 				// Update project features if not default project.
@@ -943,7 +943,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 					Config:      p.Config,
 				}, localProjectEtag)
 				if err != nil {
-					return nil, fmt.Errorf("Failed to update local node project %q: %w", p.Name, err)
+					return nil, fmt.Errorf("Failed to update local member project %q: %w", p.Name, err)
 				}
 			}
 		}

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -176,7 +176,7 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 
 	node := nodes[0]
 	if node.ID == localNodeID {
-		// Use local cluster member if volume belongs to this local node.
+		// Use local cluster member if volume belongs to this local member.
 		return nil, nil
 	}
 

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -196,7 +196,7 @@ func (hbState *APIHeartbeat) Send(ctx context.Context, networkCert *shared.CertI
 	}
 
 	for _, node := range nodes {
-		// Special case for the local node - just record the time now.
+		// Special case for the local member - just record the time now.
 		if node.Address == localAddress {
 			hbState.Lock()
 			hbNode := hbState.Members[node.ID]

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -262,10 +262,10 @@ func OpenCluster(closingCtx context.Context, name string, store driver.NodeStore
 			return fmt.Errorf("No node registered with address %s", address)
 		}
 
-		// Set the local node ID
+		// Set the local member ID
 		cluster.NodeID(nodeID)
 
-		// Delete any operation tied to this node
+		// Delete any operation tied to this member
 		err = tx.DeleteOperations(nodeID)
 		if err != nil {
 			return err

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -677,7 +677,7 @@ WHERE images.fingerprint = ?
 }
 
 // AddImageToLocalNode creates a new entry in the images_nodes table for
-// tracking that the local node has the given image.
+// tracking that the local member has the given image.
 func (c *Cluster) AddImageToLocalNode(project, fingerprint string) error {
 	imageID, _, err := c.GetImage(fingerprint, ImageFilter{Project: &project})
 	if err != nil {

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -246,7 +246,7 @@ SELECT nodes.id, nodes.address
 // cluster node address. Each node address has a slice of instances, where each instance is represented
 // as an array of length 2 in which element 0 is the project and element 1 is the instance name.
 //
-// The node address of instances running on the local node is set to the empty
+// The node address of instances running on the local member is set to the empty
 // string, to distinguish it from remote nodes.
 //
 // Instances whose node is down are added to the special address "0.0.0.0".
@@ -520,7 +520,7 @@ func (c *ClusterTx) UpdateInstanceNode(project, oldName string, newName string, 
 	return nil
 }
 
-// GetLocalInstancesInProject retuurns all instances of the given type on the local node within the given project.
+// GetLocalInstancesInProject retuurns all instances of the given type on the local member in the given project.
 // If projectName is empty then all instances in all projects are returned.
 func (c *ClusterTx) GetLocalInstancesInProject(filter InstanceFilter) ([]Instance, error) {
 	node, err := c.GetLocalNodeName()

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -21,7 +21,7 @@ func TestContainerList(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	nodeID2, err := tx.CreateNode("node2", "1.2.3.4:666")
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestContainerList_FilterByNode(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	nodeID2, err := tx.CreateNode("node2", "1.2.3.4:666")
 	require.NoError(t, err)
@@ -348,7 +348,7 @@ func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	nodeID2, err := tx.CreateNode("node2", "1.2.3.4:666")
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func TestGetInstanceToNodeMap(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	nodeID2, err := tx.CreateNode("node2", "1.2.3.4:666")
 	require.NoError(t, err)
@@ -436,7 +436,7 @@ func TestGetLocalInstancesInProject(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	nodeID2, err := tx.CreateNode("node2", "1.2.3.4:666")
 	require.NoError(t, err)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -16,8 +16,8 @@ import (
 )
 
 // GetNetworksLocalConfig returns a map associating each network name to its
-// node-specific config values on the local node (i.e. the ones where node_id
-// equals the ID of the local node).
+// node-specific config values on the local member (i.e. the ones where node_id
+// equals the ID of the local member).
 func (c *ClusterTx) GetNetworksLocalConfig() (map[string]map[string]string, error) {
 	names, err := query.SelectStrings(c.tx, "SELECT name FROM networks")
 	if err != nil {

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -355,7 +355,7 @@ func (c *ClusterTx) NodeIsOutdated() (bool, error) {
 		}
 	}
 	if version[0] == 0 || version[1] == 0 {
-		return false, fmt.Errorf("Inconsistency: local node not found")
+		return false, fmt.Errorf("Inconsistency: local member not found")
 	}
 
 	// Check if any of the other nodes is greater than us.
@@ -365,7 +365,7 @@ func (c *ClusterTx) NodeIsOutdated() (bool, error) {
 		}
 		n, err := util.CompareVersions(node.Version(), version)
 		if err != nil {
-			return false, fmt.Errorf("Failed to compare with version of node %s: %w", node.Name, err)
+			return false, fmt.Errorf("Failed to compare with version of member %s: %w", node.Name, err)
 		}
 
 		if n == 1 {
@@ -1205,7 +1205,7 @@ func nodeIsOffline(threshold time.Duration, heartbeat time.Time) bool {
 	return heartbeat.Before(offlineTime) || heartbeat.Equal(offlineTime)
 }
 
-// LocalNodeIsEvacuated returns whether the local node is in the evacuated state.
+// LocalNodeIsEvacuated returns whether the local member is in the evacuated state.
 func (c *Cluster) LocalNodeIsEvacuated() bool {
 	isEvacuated := false
 

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -387,7 +387,7 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `)
 	require.NoError(t, err)
 
-	// The local node is returned despite it has more containers.
+	// The local member is returned despite it has more containers.
 	name, err := tx.GetNodeWithLeastInstances([]int{localArch}, -1, "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "none", name)

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -31,7 +31,7 @@ const (
 )
 
 // GetRaftNodes returns information about all LXD nodes that are members of the
-// dqlite Raft cluster (possibly including the local node). If this LXD
+// dqlite Raft cluster (possibly including the local member). If this LXD
 // instance is not running in clustered mode, an empty list is returned.
 func (n *NodeTx) GetRaftNodes() ([]RaftNode, error) {
 	nodes := []RaftNode{}
@@ -52,7 +52,7 @@ func (n *NodeTx) GetRaftNodes() ([]RaftNode, error) {
 }
 
 // GetRaftNodeAddresses returns the addresses of all LXD nodes that are members of
-// the dqlite Raft cluster (possibly including the local node). If this LXD
+// the dqlite Raft cluster (possibly including the local member). If this LXD
 // instance is not running in clustered mode, an empty list is returned.
 func (n *NodeTx) GetRaftNodeAddresses() ([]string, error) {
 	return query.SelectStrings(n.tx, "SELECT address FROM raft_nodes")

--- a/lxd/db/snapshots_test.go
+++ b/lxd/db/snapshots_test.go
@@ -17,7 +17,7 @@ func TestGetInstanceSnapshots(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	addContainer(t, tx, nodeID1, "c1")
 	addContainer(t, tx, nodeID1, "c2")
@@ -65,7 +65,7 @@ func TestGetInstanceSnapshots_FilterByInstance(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	addContainer(t, tx, nodeID1, "c1")
 	addContainer(t, tx, nodeID1, "c2")

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -798,7 +798,7 @@ func (c *Cluster) getStoragePoolConfig(tx *ClusterTx, poolID int64, pool *api.St
 	}, poolID, c.nodeID)
 }
 
-// CreateStoragePool creates new storage pool. Also creates a local node entry with state storagePoolPending.
+// CreateStoragePool creates new storage pool. Also creates a local member entry with state storagePoolPending.
 func (c *Cluster) CreateStoragePool(poolName string, poolDescription string, poolDriver string, poolConfig map[string]string) (int64, error) {
 	var id int64
 	err := c.Transaction(func(tx *ClusterTx) error {

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -257,7 +257,7 @@ SELECT storage_volumes_all.name
 }
 
 // GetLocalStoragePoolVolumeSnapshotsWithType get all snapshots of a storage volume
-// attached to a given storage pool of a given volume type, on the local node.
+// attached to a given storage pool of a given volume type, on the local member.
 // Returns snapshots slice ordered by when they were created, oldest first.
 func (c *Cluster) GetLocalStoragePoolVolumeSnapshotsWithType(projectName string, volumeName string, volumeType int, poolID int64) ([]StorageVolumeArgs, error) {
 	remoteDrivers := StorageRemoteDriverNames()

--- a/lxd/db/storage_volumes_test.go
+++ b/lxd/db/storage_volumes_test.go
@@ -15,7 +15,7 @@ func TestGetStorageVolumeNodes(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	nodeID1 := int64(1) // This is the default local node
+	nodeID1 := int64(1) // This is the default local member
 
 	nodeID2, err := tx.CreateNode("node2", "1.2.3.4:666")
 	require.NoError(t, err)

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -71,7 +71,7 @@ INSERT INTO warnings (node_id, project_id, entity_type_code, entity_id, uuid, ty
   VALUES ((SELECT nodes.id FROM nodes WHERE nodes.name = ?), (SELECT projects.id FROM projects WHERE projects.name = ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `)
 
-// UpsertWarningLocalNode creates or updates a warning for the local node. Returns error if no local node name.
+// UpsertWarningLocalNode creates or updates a warning for the local member. Returns error if no local member name.
 func (c *Cluster) UpsertWarningLocalNode(projectName string, entityTypeCode int, entityID int, typeCode WarningType, message string) error {
 	var err error
 	var localName string

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -429,7 +429,7 @@ func (d *proxy) setupNAT() error {
 		}
 
 		// br_netfilter is enabled, so we need to enable hairpin mode on instance's bridge port otherwise
-		// the instances on the bridge will not be able to connect to the proxy device's listn IP and the
+		// the instances on the bridge will not be able to connect to the proxy device's listen IP and the
 		// NAT rule added by the firewall below to allow instance <-> instance traffic will also not work.
 		link := &ip.Link{Name: hostName}
 		err = link.BridgeLinkSetHairpin(true)

--- a/lxd/init.go
+++ b/lxd/init.go
@@ -82,7 +82,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Create the storagePool if doesn't exist.
 			err := d.CreateStoragePool(storagePool)
 			if err != nil {
-				return fmt.Errorf("Failed to create storage pool '%s': %w", storagePool.Name, err)
+				return fmt.Errorf("Failed to create storage pool %q: %w", storagePool.Name, err)
 			}
 
 			// Setup reverter.
@@ -95,12 +95,12 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Get the current storagePool.
 			currentStoragePool, etag, err := d.GetStoragePool(storagePool.Name)
 			if err != nil {
-				return fmt.Errorf("Failed to retrieve current storage pool '%s': %w", storagePool.Name, err)
+				return fmt.Errorf("Failed to retrieve current storage pool %q: %w", storagePool.Name, err)
 			}
 
 			// Quick check.
 			if currentStoragePool.Driver != storagePool.Driver {
-				return fmt.Errorf("Storage pool '%s' is of type '%s' instead of '%s'", currentStoragePool.Name, currentStoragePool.Driver, storagePool.Driver)
+				return fmt.Errorf("Storage pool %q is of type %q instead of %q", currentStoragePool.Name, currentStoragePool.Driver, storagePool.Driver)
 			}
 
 			// Setup reverter.
@@ -110,7 +110,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			newStoragePool := api.StoragePoolPut{}
 			err = shared.DeepCopy(currentStoragePool.Writable(), &newStoragePool)
 			if err != nil {
-				return fmt.Errorf("Failed to copy configuration of storage pool '%s': %w", storagePool.Name, err)
+				return fmt.Errorf("Failed to copy configuration of storage pool %q: %w", storagePool.Name, err)
 			}
 
 			// Description override.
@@ -126,7 +126,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Apply it.
 			err = d.UpdateStoragePool(currentStoragePool.Name, newStoragePool, etag)
 			if err != nil {
-				return fmt.Errorf("Failed to update storage pool '%s': %w", storagePool.Name, err)
+				return fmt.Errorf("Failed to update storage pool %q: %w", storagePool.Name, err)
 			}
 
 			return nil
@@ -164,7 +164,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Create the project if doesn't exist.
 			err := d.CreateProject(project)
 			if err != nil {
-				return fmt.Errorf("Failed to create local member project '%s': %w", project.Name, err)
+				return fmt.Errorf("Failed to create local member project %q: %w", project.Name, err)
 			}
 
 			// Setup reverter.
@@ -177,7 +177,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Get the current project.
 			currentProject, etag, err := d.GetProject(project.Name)
 			if err != nil {
-				return fmt.Errorf("Failed to retrieve current project '%s': %w", project.Name, err)
+				return fmt.Errorf("Failed to retrieve current project %q: %w", project.Name, err)
 			}
 
 			// Setup reverter.
@@ -187,7 +187,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			newProject := api.ProjectPut{}
 			err = shared.DeepCopy(currentProject.Writable(), &newProject)
 			if err != nil {
-				return fmt.Errorf("Failed to copy configuration of project '%s': %w", project.Name, err)
+				return fmt.Errorf("Failed to copy configuration of project %q: %w", project.Name, err)
 			}
 
 			// Description override.
@@ -203,7 +203,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Apply it.
 			err = d.UpdateProject(currentProject.Name, newProject, etag)
 			if err != nil {
-				return fmt.Errorf("Failed to update local member project '%s': %w", project.Name, err)
+				return fmt.Errorf("Failed to update local member project %q: %w", project.Name, err)
 			}
 
 			return nil
@@ -319,7 +319,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Create the profile if doesn't exist.
 			err := d.CreateProfile(profile)
 			if err != nil {
-				return fmt.Errorf("Failed to create profile '%s': %w", profile.Name, err)
+				return fmt.Errorf("Failed to create profile %q: %w", profile.Name, err)
 			}
 
 			// Setup reverter.
@@ -332,7 +332,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Get the current profile.
 			currentProfile, etag, err := d.GetProfile(profile.Name)
 			if err != nil {
-				return fmt.Errorf("Failed to retrieve current profile '%s': %w", profile.Name, err)
+				return fmt.Errorf("Failed to retrieve current profile %q: %w", profile.Name, err)
 			}
 
 			// Setup reverter.
@@ -342,7 +342,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			newProfile := api.ProfilePut{}
 			err = shared.DeepCopy(currentProfile.Writable(), &newProfile)
 			if err != nil {
-				return fmt.Errorf("Failed to copy configuration of profile '%s': %w", profile.Name, err)
+				return fmt.Errorf("Failed to copy configuration of profile %q: %w", profile.Name, err)
 			}
 
 			// Description override.
@@ -373,7 +373,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Apply it.
 			err = d.UpdateProfile(currentProfile.Name, newProfile, etag)
 			if err != nil {
-				return fmt.Errorf("Failed to update profile '%s': %w", profile.Name, err)
+				return fmt.Errorf("Failed to update profile %q: %w", profile.Name, err)
 			}
 
 			return nil

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -534,12 +534,12 @@ func instancePostClusteringMigrate(d *Daemon, r *http.Request, inst instance.Ins
 
 		sourceAddress, err = tx.GetLocalNodeAddress()
 		if err != nil {
-			return fmt.Errorf("Failed to get local node address: %w", err)
+			return fmt.Errorf("Failed to get local member address: %w", err)
 		}
 
 		node, err := tx.GetNodeByName(newNode)
 		if err != nil {
-			return fmt.Errorf("Failed to get new node address: %w", err)
+			return fmt.Errorf("Failed to get new member address: %w", err)
 		}
 		targetAddress = node.Address
 

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -206,7 +206,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 			go func(node db.NodeInfo) {
 				defer wgAction.Done()
 
-				// Special handling for the local node.
+				// Special handling for the local member.
 				if node.Address == localAddress {
 					err := localAction(false)
 					if err != nil {

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1793,7 +1793,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Perform any pre-update cleanup needed if local node network was already created.
+	// Perform any pre-update cleanup needed if local member network was already created.
 	if len(changedKeys) > 0 {
 		// Define a function which reverts everything.
 		revert.Add(func() {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2614,7 +2614,7 @@ func (n *ovn) Start() error {
 
 	// Handle chassis groups.
 	if chassisEnabled {
-		// Add local node's OVS chassis ID to logical chassis group.
+		// Add local member's OVS chassis ID to logical chassis group.
 		err = n.addChassisGroupEntry()
 		if err != nil {
 			return err

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -30,7 +30,7 @@ var SRIOVVirtualFunctionMutex sync.Mutex
 var sysClassNet = "/sys/class/net"
 
 // SRIOVGetHostDevicesInUse returns a map of host device names that have been used by devices in other instances
-// and networks on the local node. Used when selecting physical and SR-IOV VF devices to avoid conflicts.
+// and networks on the local member. Used when selecting physical and SR-IOV VF devices to avoid conflicts.
 func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	sriovReservedDevicesMutex.Lock()
 	defer sriovReservedDevicesMutex.Unlock()
@@ -42,7 +42,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	err = s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		localNode, err = tx.GetLocalNodeName()
 		if err != nil {
-			return fmt.Errorf("Failed to get local node name: %w", err)
+			return fmt.Errorf("Failed to get local member name: %w", err)
 		}
 
 		// Get all managed networks across all projects.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -502,7 +502,7 @@ func networksPostCluster(d *Daemon, projectName string, netInfo *api.Network, re
 			return fmt.Errorf("The network is already created")
 		}
 
-		// Check the requested network type matches the type created when adding the local node config.
+		// Check the requested network type matches the type created when adding the local member config.
 		if req.Type != netInfo.Type {
 			return fmt.Errorf("Requested network type %q doesn't match type in existing database record %q", req.Type, netInfo.Type)
 		}
@@ -562,7 +562,7 @@ func networksPostCluster(d *Daemon, projectName string, netInfo *api.Network, re
 		return err
 	}
 
-	// Load the network from the database for the local node.
+	// Load the network from the database for the local member.
 	n, err := network.LoadByName(d.State(), projectName, req.Name)
 	if err != nil {
 		return err
@@ -778,7 +778,7 @@ func doNetworkGet(d *Daemon, r *http.Request, allNodes bool, projectName string,
 	// Get some information.
 	n, _ := network.LoadByName(d.State(), projectName, networkName)
 
-	// Don't allow retrieving info about the local node interfaces when not using default project.
+	// Don't allow retrieving info about the local server interfaces when not using default project.
 	if projectName != project.Default && n == nil {
 		return api.Network{}, api.StatusErrorf(http.StatusNotFound, "Network not found")
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -295,7 +295,7 @@ func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newCo
 		return fmt.Errorf("Pool source cannot be changed when not in pending state")
 	}
 
-	// Apply changes to local node if both global pool and node are not pending and non-user config changed.
+	// Apply changes to local member if both global pool and node are not pending and non-user config changed.
 	// Otherwise just apply changes to DB (below) ready for the actual global create request to be initiated.
 	if len(changedConfig) > 0 && b.Status() != api.StoragePoolStatusPending && b.LocalStatus() != api.StoragePoolStatusPending && !userOnly {
 		err = b.driver.Update(changedConfig)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -729,12 +729,12 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 		return nil, nil
 	}
 
-	// Get local node name so we can check if the volume is attached to a remote node.
+	// Get local member name so we can check if the volume is attached to a remote node.
 	var localNode string
 	err = s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		localNode, err = tx.GetLocalNodeName()
 		if err != nil {
-			return fmt.Errorf("Failed to get local node name: %w", err)
+			return fmt.Errorf("Failed to get local member name: %w", err)
 		}
 
 		return nil

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -394,7 +394,7 @@ func storagePoolsPostCluster(d *Daemon, pool *api.StoragePool, req api.StoragePo
 			return fmt.Errorf("The storage pool is already created")
 		}
 
-		// Check the requested pool type matches the type created when adding the local node config.
+		// Check the requested pool type matches the type created when adding the local member config.
 		if req.Driver != pool.Driver {
 			return fmt.Errorf("Requested storage pool driver %q doesn't match driver in existing database record %q", req.Driver, pool.Driver)
 		}

--- a/lxd/warnings/warnings.go
+++ b/lxd/warnings/warnings.go
@@ -56,8 +56,8 @@ func ResolveWarningsByLocalNodeOlderThan(cluster *db.Cluster, date time.Time) er
 	return nil
 }
 
-// ResolveWarningsByLocalNodeAndType resolves warnings with the local node and type code.
-// Returns error if no local node name.
+// ResolveWarningsByLocalNodeAndType resolves warnings with the local member and type code.
+// Returns error if no local member name.
 func ResolveWarningsByLocalNodeAndType(cluster *db.Cluster, typeCode db.WarningType) error {
 	var err error
 	var localName string

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1021,7 +1021,7 @@ test_clustering_network() {
   ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" || false
   LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}" | grep status: | grep -q Errored # Check has errored status.
 
-  # Check each node status (expect both node1 and node2 to be pending as local node running created failed first).
+  # Check each node status (expect both node1 and node2 to be pending as local member running created failed first).
   LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'" | grep "| node1 | 0     |"
   LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'" | grep "| node2 | 0     |"
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -961,6 +961,14 @@ test_clustering_network() {
   # Add a newline at the end of each line. YAML as weird rules..
   cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
+  # Create a project with restricted.networks.subnets set to check the default networks are created before projects
+  # when a member joins the cluster.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network set "${bridge}" ipv4.routes=192.0.2.0/24
+  LXD_DIR="${LXD_ONE_DIR}" lxc project create foo \
+    -c restricted=true \
+    -c features.networks=true \
+    -c restricted.networks.subnets="${bridge}":192.0.2.0/24
+
   # Spawn a second node
   setup_clustering_netns 2
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
@@ -1115,6 +1123,8 @@ test_clustering_network() {
   LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net}"
   ! nsenter -n -t "${LXD_PID1}" -- ip link show "${net}" || false # Check bridge is removed.
   ! nsenter -n -t "${LXD_PID2}" -- ip link show "${net}" || false # Check bridge is removed.
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc project delete foo
 
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown


### PR DESCRIPTION
When joining a cluster, the local joining member will need to ensure it has the network configuration applied before completing the cluster join process.

For OVN networks inside a non-default project, this required that the non-default projects be created first, which was what was happening already.

However it was possible for a project to depend on a network in the default project by way of the `restricted.networks.subnets` setting.

This PR splits network config applying so that networks in the default project are applied first before projects, and then networks in non-default projects are applied after projects.

Fixes #10258