### PR TITLE
VM: Fix stateful snapshot with QEMU >= 6.2

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1319,6 +1319,22 @@ func (d *qemu) Start(stateful bool) error {
 	if !stateful && d.state.OS.UnprivUser != "" {
 		qemuCmd = append(qemuCmd, "-runas", d.state.OS.UnprivUser)
 
+		// Ensure nvram file is writable by the QEMU process.
+		// This is needed because when doing stateful snapshots the QEMU process will reopen the file
+		// for writing.
+		nvRAMPath := d.nvramPath()
+		if shared.PathExists(nvRAMPath) {
+			err = os.Chown(nvRAMPath, int(d.state.OS.UnprivUID), -1)
+			if err != nil {
+				return err
+			}
+
+			err = os.Chmod(nvRAMPath, 0600)
+			if err != nil {
+				return err
+			}
+		}
+
 		// Change ownership of config directory files so they are accessible to the
 		// unprivileged qemu process so that the 9p share can work.
 		//
@@ -2493,10 +2509,17 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	if shared.StringInSlice("-bios", rawOptions) || shared.StringInSlice("-kernel", rawOptions) {
 		d.logger.Warn("Starting VM without default firmware (-bios or -kernel in raw.qemu)")
 	} else {
+		// Open the NVRAM file and pass it via file descriptor to QEMU.
+		// This is so the QEMU process can still read/write the file after it has dropped its user privs.
+		nvRAMFile, err := os.Open(d.nvramPath())
+		if err != nil {
+			return "", nil, fmt.Errorf("Failed opening NVRAM file: %w", err)
+		}
+
 		err = qemuDriveFirmware.Execute(sb, map[string]any{
 			"architecture": d.architectureName,
 			"roPath":       filepath.Join(d.ovmfPath(), "OVMF_CODE.fd"),
-			"nvramPath":    d.nvramPath(),
+			"nvramPath":    fmt.Sprintf("/dev/fd/%d", d.addFileDescriptor(fdFiles, nvRAMFile)),
 		})
 		if err != nil {
 			return "", nil, err


### PR DESCRIPTION
QEMU 6.2 attempts to reopen the nvram file for writing during stateful snapshot.
LXD was preventing this because the nvram file was only writable by root, but the QEMU process was normally run as `lxd`.

To fix this, we pass the nvram file by FD and make writable by the user that runs the QEMU process.

This allows the QEMU process to bypass the root:root 0700 restriction on the instance's directory, by opening /dev/fd/<n>, and the nvram file itself is writable by the user that QEMU process is run as.

Fixes https://github.com/lxc/lxd/issues/9875

Related to https://gitlab.com/qemu-project/qemu/-/issues/975