### PR TITLE
lxd/apparmor: Treat ramfs the same as tmpfs

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -78,6 +78,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Handle /run remounts.
   mount options=(rw,nosuid,nodev,remount) -> /run/,
 
+  # Handle ramfs (same as tmpfs)
+  mount fstype=ramfs,
+
   # Handle tmpfs
   mount fstype=tmpfs,
 


### PR DESCRIPTION
On a Focal host with kernel 5.13, starting an unpriv Jammy
container (security.nesting=false) with the /etc/systemd/
system-generators/lxc modified to NOT override LoadCredential,
the following denials are visible:

```
apparmor="DENIED" operation="mount" info="failed flags match" error=-13 profile="lxd-c1_</var/snap/lxd/common/lxd>" name="/dev/shm/" pid=2176973 comm="(sd-mkdcreds)" fstype="ramfs" srcname="ramfs" flags="rw, nosuid, nodev, noexec"
```

/dev/shm is showned as a tmpfs inside the container but for
some reason, its fstype is reported as ramfs in the host's logs.

```
$ lxc exec c1 -- mount | grep shm
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,uid=1000000,gid=1000000,inode64)
```

As such, let's treat ramfs the same as tmpfs.