### PR TITLE
Network: Mark `sriov` network as available on successful start

### DIFF
--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -77,6 +77,11 @@ func (n *sriov) Start() error {
 		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
 	}
 
+	revert.Success()
+
+	// Ensure network is marked as available now its started.
+	n.setAvailable()
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #10272

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>