### PR TITLE
Lower log level of "Detected poll(POLLNVAL) event" message

### DIFF
--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -457,11 +457,11 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 	// [1]: This function has just one job: Dealing with the case where we
 	// are running an interactive shell session where we put a process in
 	// the background that does hold stdin/stdout open, but does not
-	// generate any output at all. This case cannot be dealt with in the
+	// generate any output at all. This case cannot be dealt within the
 	// following function call. Here's why: Assume the above case, now the
 	// attached child (the shell in this example) exits. This will not
 	// generate any poll() event: We won't get POLLHUP because the
-	// background process is holding stdin/stdout open and noone is writing
+	// background process is holding stdin/stdout open and no one is writing
 	// to it. So we effectively block on GetPollRevents() in the function
 	// below. Hence, we use another go routine here who's only job is to
 	// handle that case: When we detect that the child has exited we check
@@ -487,7 +487,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 				// avoid an endless loop.
 			} else if (revents & unix.POLLNVAL) > 0 {
 				logger.Debugf("Detected poll(POLLNVAL) event.")
-				// Well, someone closed the fd havent they? So
+				// Well, someone closed the fd haven't they? So
 				// let's go home.
 			}
 		} else if ret == 0 {

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -477,21 +477,21 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 
 		ret, revents, err := GetPollRevents(fd, 0, (unix.POLLIN | unix.POLLPRI | unix.POLLERR | unix.POLLHUP | unix.POLLRDHUP | unix.POLLNVAL))
 		if ret < 0 {
-			logger.Errorf("Failed to poll(POLLIN | POLLPRI | POLLHUP | POLLRDHUP) on file descriptor: %s.", err)
+			logger.Errorf("Failed to poll(POLLIN | POLLPRI | POLLHUP | POLLRDHUP) on file descriptor: %s", err)
 			// Something went wrong so let's exited otherwise we
 			// end up in an endless loop.
 		} else if ret > 0 {
 			if (revents & unix.POLLERR) > 0 {
-				logger.Warnf("Detected poll(POLLERR) event.")
+				logger.Warnf("Detected poll(POLLERR) event")
 				// Read end has likely been closed so again,
 				// avoid an endless loop.
 			} else if (revents & unix.POLLNVAL) > 0 {
-				logger.Debugf("Detected poll(POLLNVAL) event.")
+				logger.Debugf("Detected poll(POLLNVAL) event")
 				// Well, someone closed the fd haven't they? So
 				// let's go home.
 			}
 		} else if ret == 0 {
-			logger.Debugf("No data in stdout: exiting.")
+			logger.Debugf("No data in stdout: exiting")
 		}
 	}()
 
@@ -511,7 +511,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 			if ret < 0 {
 				// This condition is only reached in cases where we are massively f*cked since we even handle
 				// EINTR in the underlying C wrapper around poll(). So let's exit here.
-				logger.Errorf("Failed to poll(POLLIN | POLLPRI | POLLERR | POLLHUP | POLLRDHUP) on file descriptor: %s. Exiting.", err)
+				logger.Errorf("Failed to poll(POLLIN | POLLPRI | POLLERR | POLLHUP | POLLRDHUP) on file descriptor: %s. Exiting", err)
 				return
 			}
 
@@ -520,16 +520,16 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 			// keep on reading from the pty file descriptor until we get a simple POLLHUP back.
 			both := ((revents & (unix.POLLIN | unix.POLLPRI)) > 0) && ((revents & (unix.POLLHUP | unix.POLLRDHUP)) > 0)
 			if both {
-				logger.Debugf("Detected poll(POLLIN | POLLPRI | POLLHUP | POLLRDHUP) event.")
+				logger.Debugf("Detected poll(POLLIN | POLLPRI | POLLHUP | POLLRDHUP) event")
 				read := buf[offset : offset+readSize]
 				nr, err = r.Read(read)
 			}
 
 			if (revents & unix.POLLERR) > 0 {
-				logger.Warnf("Detected poll(POLLERR) event: exiting.")
+				logger.Warnf("Detected poll(POLLERR) event: exiting")
 				return
 			} else if (revents & unix.POLLNVAL) > 0 {
-				logger.Warnf("Detected poll(POLLNVAL) event: exiting.")
+				logger.Warnf("Detected poll(POLLNVAL) event: exiting")
 				return
 			}
 
@@ -588,10 +588,10 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 					//   stdout is written out.
 					ret, revents, err := GetPollRevents(fd, 0, (unix.POLLIN | unix.POLLPRI | unix.POLLERR | unix.POLLHUP | unix.POLLRDHUP | unix.POLLNVAL))
 					if ret < 0 {
-						logger.Errorf("Failed to poll(POLLIN | POLLPRI | POLLERR | POLLHUP | POLLRDHUP) on file descriptor: %s. Exiting.", err)
+						logger.Errorf("Failed to poll(POLLIN | POLLPRI | POLLERR | POLLHUP | POLLRDHUP) on file descriptor: %s. Exiting", err)
 						return
 					} else if (revents & (unix.POLLHUP | unix.POLLRDHUP | unix.POLLERR | unix.POLLNVAL)) == 0 {
-						logger.Debugf("Exiting but background processes are still running.")
+						logger.Debugf("Exiting but background processes are still running")
 						return
 					}
 				}
@@ -602,7 +602,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 			// The attached process has exited and we have read all data that may have
 			// been buffered.
 			if ((revents & (unix.POLLHUP | unix.POLLRDHUP)) > 0) && !both {
-				logger.Debugf("Detected poll(POLLHUP) event: exiting.")
+				logger.Debugf("Detected poll(POLLHUP) event: exiting")
 				return
 			}
 

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -486,7 +486,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 				// Read end has likely been closed so again,
 				// avoid an endless loop.
 			} else if (revents & unix.POLLNVAL) > 0 {
-				logger.Warnf("Detected poll(POLLNVAL) event.")
+				logger.Debugf("Detected poll(POLLNVAL) event.")
 				// Well, someone closed the fd havent they? So
 				// let's go home.
 			}


### PR DESCRIPTION
This message often appears in my logs, sometimes around exiting `lxc shell` but not always. Anyway, since there is nothing to do about it from a user/admin perspective, I'd consider this to be debug info.