### PR TITLE
Sql dump schema table

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -23,7 +23,6 @@ import (
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
-	"github.com/lxc/lxd/lxd/db/node"
 	"github.com/lxc/lxd/lxd/db/query"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
@@ -413,14 +412,11 @@ func internalSQLGet(d *Daemon, r *http.Request) response.Response {
 		schemaOnly = 0
 	}
 
-	var schema string
 	var db *sql.DB
 	if database == "global" {
 		db = d.db.Cluster.DB()
-		schema = cluster.FreshSchema()
 	} else {
 		db = d.db.Node.DB()
-		schema = node.FreshSchema()
 	}
 
 	tx, err := db.BeginTx(r.Context(), nil)
@@ -429,7 +425,7 @@ func internalSQLGet(d *Daemon, r *http.Request) response.Response {
 	}
 	defer tx.Rollback()
 
-	dump, err := query.Dump(r.Context(), tx, schema, schemaOnly == 1)
+	dump, err := query.Dump(r.Context(), tx, schemaOnly == 1)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed dump database %s: %w", database, err))
 	}

--- a/lxd/db/query/dump.go
+++ b/lxd/db/query/dump.go
@@ -4,96 +4,116 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
 )
 
 // Dump returns a SQL text dump of all rows across all tables, similar to
-// sqlite3's dump feature
-func Dump(ctx context.Context, tx *sql.Tx, schema string, schemaOnly bool) (string, error) {
-	schemas := dumpParseSchema(schema)
-
-	// Begin
-	dump := `PRAGMA foreign_keys=OFF;
-BEGIN TRANSACTION;
-`
-	// Schema table
-	tableDump, err := dumpTable(ctx, tx, "schema", dumpSchemaTable)
+// sqlite3's dump feature.
+func Dump(ctx context.Context, tx *sql.Tx, schemaOnly bool) (string, error) {
+	tablesSchemas, tableNames, err := getTablesSchemas(ctx, tx)
 	if err != nil {
-		return "", fmt.Errorf("Failed to dump table schema: %w", err)
+		return "", err
 	}
-	dump += tableDump
 
-	// All other tables
-	tables := make([]string, 0)
-	for table := range schemas {
-		tables = append(tables, table)
-	}
-	sort.Strings(tables)
-	for _, table := range tables {
-		if schemaOnly {
-			// Dump only the schema.
-			dump += schemas[table] + "\n"
-			continue
+	// Begin dump string.
+	var builder strings.Builder
+	builder.WriteString("PRAGMA foreign_keys=OFF;\n")
+	builder.WriteString("BEGIN TRANSACTION;\n")
+
+	// For each table, write the schema and optionally write the data.
+	for _, tableName := range tableNames {
+		builder.WriteString(tablesSchemas[tableName] + "\n")
+
+		if !schemaOnly {
+			tableData, err := getTableData(ctx, tx, tableName)
+			if err != nil {
+				return "", err
+			}
+
+			for _, stmt := range tableData {
+				builder.WriteString(stmt + "\n")
+			}
 		}
-
-		tableDump, err := dumpTable(ctx, tx, table, schemas[table])
-		if err != nil {
-			return "", fmt.Errorf("Failed to dump table %s: %w", table, err)
-		}
-
-		dump += tableDump
 	}
 
-	// Sequences (unless the schemaOnly flag is true)
+	// Sequences (unless the schemaOnly flag is true).
 	if !schemaOnly {
-		tableDump, err = dumpTable(ctx, tx, "sqlite_sequence", "DELETE FROM sqlite_sequence;")
+		builder.WriteString("DELETE FROM sqlite_sequence;\n")
+
+		tableData, err := getTableData(ctx, tx, "sqlite_sequence")
 		if err != nil {
 			return "", fmt.Errorf("Failed to dump table sqlite_sequence: %w", err)
 		}
 
-		dump += tableDump
-	}
-
-	// Commit
-	dump += "COMMIT;\n"
-
-	return dump, nil
-}
-
-// Return a map from table names to their schema definition, taking a full
-// schema SQL text generated with schema.Schema.Dump().
-func dumpParseSchema(schema string) map[string]string {
-	tables := map[string]string{}
-	for _, statement := range strings.Split(schema, ";") {
-		statement = strings.Trim(statement, " \n") + ";"
-		if !strings.HasPrefix(statement, "CREATE TABLE") {
-			continue
+		for _, stmt := range tableData {
+			builder.WriteString(stmt + "\n")
 		}
-		table := strings.Split(statement, " ")[2]
-		tables[table] = statement
 	}
-	return tables
+
+	// Commit.
+	builder.WriteString("COMMIT;\n")
+
+	return builder.String(), nil
 }
 
-// Dump a single table, returning a SQL text containing statements for its
-// schema and data.
-func dumpTable(ctx context.Context, tx *sql.Tx, table, schema string) (string, error) {
-	statements := []string{schema}
+// getTablesSchemas gets all the tables and their schema, as well as a list of table names in their default order from
+// the sqlite_master table.
+func getTablesSchemas(ctx context.Context, tx *sql.Tx) (map[string]string, []string, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY rowid`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Could not get table names and their schema: %w", err)
+	}
+
+	defer rows.Close()
+
+	tablesSchemas := make(map[string]string)
+	var names []string
+	for rows.Next() {
+		var name string
+		var schema string
+		err := rows.Scan(&name, &schema)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Could not scan table name and schema: %w", err)
+		}
+
+		names = append(names, name)
+
+		// Whether a table name is quoted or not can depend on if it was quoted when originally created, or if it
+		// collides with a keyword (and maybe more). Regardless, sqlite3 quotes table names in create statements when
+		// executing a dump. If the table name is already quoted, add the "IF NOT EXISTS" clause, else quote it and add
+		// the same clause.
+		isQuoted := strings.Contains(schema, fmt.Sprintf("TABLE %q", name))
+		if isQuoted {
+			schema = strings.Replace(schema, "TABLE", "TABLE IF NOT EXISTS", 1)
+		} else {
+			schema = strings.Replace(schema, name, fmt.Sprintf("IF NOT EXISTS %q", name), 1)
+		}
+
+		tablesSchemas[name] = schema + ";"
+	}
+
+	return tablesSchemas, names, nil
+}
+
+// getTableData gets all the data for a single table, returning a string slice where each element is an insert statement
+// for the data.
+func getTableData(ctx context.Context, tx *sql.Tx, table string) ([]string, error) {
+	var statements []string
 
 	// Query all rows.
 	rows, err := tx.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s ORDER BY rowid", table))
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch rows: %w", err)
+		return nil, fmt.Errorf("Failed to fetch rows for table %q: %w", table, err)
 	}
+
 	defer rows.Close()
 
-	// Figure column names
+	// Get the column names.
 	columns, err := rows.Columns()
 	if err != nil {
-		return "", fmt.Errorf("failed to get columns: %w", err)
+		return nil, fmt.Errorf("Failed to get columns for table %q: %w", table, err)
 	}
 
 	// Generate an INSERT statement for each row.
@@ -103,10 +123,12 @@ func dumpTable(ctx context.Context, tx *sql.Tx, table, schema string) (string, e
 		for i := range raw {
 			row[i] = &raw[i]
 		}
+
 		err := rows.Scan(row...)
 		if err != nil {
-			return "", fmt.Errorf("failed to scan row %d: %w", i, err)
+			return nil, fmt.Errorf("Failed to scan row %d in table %q: %w", i, table, err)
 		}
+
 		values := make([]string, len(columns))
 		for j, v := range raw {
 			switch v := v.(type) {
@@ -120,21 +142,16 @@ func dumpTable(ctx context.Context, tx *sql.Tx, table, schema string) (string, e
 				values[j] = strconv.FormatInt(v.Unix(), 10)
 			default:
 				if v != nil {
-					return "", fmt.Errorf("bad type in column %s of row %d", columns[j], i)
+					return nil, fmt.Errorf("Bad type in column %q of row %d in table %q", columns[j], i, table)
 				}
+
 				values[j] = "NULL"
 			}
 		}
+
 		statement := fmt.Sprintf("INSERT INTO %s VALUES(%s);", table, strings.Join(values, ","))
 		statements = append(statements, statement)
 	}
-	return strings.Join(statements, "\n") + "\n", nil
-}
 
-// Schema of the schema table.
-const dumpSchemaTable = `CREATE TABLE schema (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-    version    INTEGER NOT NULL,
-    updated_at DATETIME NOT NULL,
-    UNIQUE (version)
-);`
+	return statements, nil
+}

--- a/lxd/db/query/dump_export_test.go
+++ b/lxd/db/query/dump_export_test.go
@@ -1,5 +1,4 @@
 package query
 
-var DumpTable = dumpTable
-var DumpParseSchema = dumpParseSchema
-var DumpSchemaTable = dumpSchemaTable
+var GetTableData = getTableData
+var GetTablesSchemas = getTablesSchemas

--- a/test/suites/sql.sh
+++ b/test/suites/sql.sh
@@ -29,7 +29,7 @@ test_sql() {
   # Local database schema dump
   SQLITE_DUMP="${TEST_DIR}/dump.db"
   lxd sql local .schema | sqlite3 "${SQLITE_DUMP}"
-  sqlite3 "${SQLITE_DUMP}" "SELECT * FROM schema" | grep -q 1
+  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM schema' | wc -l)" = "0" ]
   [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM patches' | wc -l)" = "0" ]
   rm -f "${SQLITE_DUMP}"
 
@@ -42,7 +42,7 @@ test_sql() {
   # Global database schema dump
   SQLITE_DUMP="${TEST_DIR}/dump.db"
   lxd sql global .schema | sqlite3 "${SQLITE_DUMP}"
-  sqlite3 "${SQLITE_DUMP}" "SELECT * FROM schema" | grep -q 1
+  [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM schema' | wc -l)" = "0" ]
   [ "$(sqlite3 "${SQLITE_DUMP}" 'SELECT * FROM profiles' | wc -l)" = "0" ]
   rm -f "${SQLITE_DUMP}"
 


### PR DESCRIPTION
The `query.Dump` function does not work for other dqlite databases because it explicitly dumps the the `schema` table (expected for both node and cluster dbs). 

To allow a more general usage of this function, now all tables, their schema, and their data is collected directly from the db.