### PR TITLE
lxd/sys: Fix vsockID detection

### DIFF
--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -169,9 +169,11 @@ func (s *OS) Init() ([]db.Warning, error) {
 	s.CGInfo = cgroup.GetInfo()
 
 	// Fill in the VsockID.
+	util.LoadModule("vhost_vsock")
 	vsockID, err := vsock.ContextID()
-	if err != nil {
-		// Fallback to the default ID for a host system.
+	if err != nil || vsockID > 2147483647 {
+		// Fallback to the default ID for a host system if we're getting
+		// an error or are getting a clearly invalid value.
 		vsockID = 2
 	}
 


### PR DESCRIPTION
The vsock package doesn't return an error when the module isn't loaded,
instead it returns an invalid value of 4294967295.

So fix the main issue by loading the module if possible and then treat
any value past signed-32bit as invalid.

Closes #10300

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>