### PR TITLE
Recursive rlock shutdown

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -256,7 +256,9 @@ func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts f
 				return
 			}
 			defer client.Close()
-			leader, err := client.Leader(context.Background())
+			ctx, cancel := context.WithTimeout(g.ctx, 3*time.Second)
+			defer cancel()
+			leader, err := client.Leader(ctx)
 			if err != nil {
 				http.Error(w, "500 failed to get leader address", http.StatusInternalServerError)
 				return
@@ -844,7 +846,9 @@ func (g *Gateway) isLeader() (bool, error) {
 		return false, fmt.Errorf("Failed to get dqlite client: %w", err)
 	}
 	defer client.Close()
-	leader, err := client.Leader(context.Background())
+	ctx, cancel := context.WithTimeout(g.ctx, 3*time.Second)
+	defer cancel()
+	leader, err := client.Leader(ctx)
 	if err != nil {
 		return false, fmt.Errorf("Failed to get leader address: %w", err)
 	}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -156,12 +156,12 @@ func setDqliteVersionHeader(request *http.Request) {
 func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts func() map[cluster.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
 	database := func(w http.ResponseWriter, r *http.Request) {
 		g.lock.RLock()
-		defer g.lock.RUnlock()
-
 		if !tlsCheckCert(r, g.networkCert, g.serverCert(), trustedCerts()) {
+			g.lock.RUnlock()
 			http.Error(w, "403 invalid client certificate", http.StatusForbidden)
 			return
 		}
+		g.lock.RUnlock()
 
 		// Compare the dqlite version of the connecting client
 		// with our own one.
@@ -177,12 +177,14 @@ func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts f
 		}
 		if version != dqliteVersion {
 			if version > dqliteVersion {
+				g.lock.Lock()
 				if !g.upgradeTriggered {
 					err = triggerUpdate()
 					if err == nil {
 						g.upgradeTriggered = true
 					}
 				}
+				g.lock.Unlock()
 				http.Error(w, "503 unsupported dqlite version", http.StatusServiceUnavailable)
 			} else {
 				http.Error(w, "426 dqlite version too old ", http.StatusUpgradeRequired)
@@ -206,7 +208,9 @@ func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts f
 				return
 			}
 
+			g.lock.RLock()
 			isLeader, err := g.isLeader()
+			g.lock.RUnlock()
 			if err != nil {
 				logger.Error("Failed checking if leader", logger.Ctx{"err": err})
 				http.Error(w, "500 Failed checking if leader", http.StatusInternalServerError)
@@ -234,10 +238,13 @@ func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts f
 
 		// From here on we require that this node is part of the raft
 		// cluster.
+		g.lock.RLock()
 		if g.server == nil || g.memoryDial != nil {
+			g.lock.RUnlock()
 			http.NotFound(w, r)
 			return
 		}
+		g.lock.RUnlock()
 
 		// NOTE: this is kept for backward compatibility when upgrading
 		// a cluster with version <= 4.2.
@@ -245,6 +252,8 @@ func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts f
 		// Once all nodes are on >= 4.3 this code is effectively
 		// unused.
 		if r.Method == "HEAD" {
+			g.lock.RLock()
+			defer g.lock.RUnlock()
 			// We can safely know about current leader only if we are a voter.
 			if g.info.Role != db.RaftVoter {
 				http.NotFound(w, r)


### PR DESCRIPTION
1. This fix prevents a deadlock in the following scenario:

- GET request comes in
- `HandlerFuncs` obtains `Rlock`
- `lxd shutdown` is called on the node handling the request, tries to take the `Lock`  https://github.com/lxc/lxd/blob/6fd49811c4792f26b9faa1c84a5cfb7de986c76c/lxd/cluster/gateway.go#L512 but blocks, because the `Rlock` is held by `HandlerFuncs`
- `HandlerFuncs` continues here https://github.com/lxc/lxd/blob/6fd49811c4792f26b9faa1c84a5cfb7de986c76c/lxd/cluster/gateway.go#L273 and tries to obtain `Rlock` (again, recursive) in `Leaderaddress`. This blocks because `Shutdown` is blocked on the `Lock`.
- Deadlock ensues

see https://pkg.go.dev/sync#RWMutex.RLock

```
func (*RWMutex) [RLock](https://cs.opensource.google/go/go/+/go1.18.1:src/sync/rwmutex.go;l=56) [¶](https://pkg.go.dev/sync#RWMutex.RLock)

func (rw *[RWMutex](https://pkg.go.dev/sync#RWMutex)) RLock()

RLock locks rw for reading.

It should not be used for recursive read locking; a blocked Lock call excludes new readers from acquiring the lock. See the documentation on the RWMutex type.
```

I have a small concern that not taking the lock at the top of the function might violate a requirement stated here: https://github.com/lxc/lxd/blob/6fd49811c4792f26b9faa1c84a5cfb7de986c76c/lxd/cluster/gateway.go#L235 i.e. what happens if a `Shutdown` comes in during the handling of the request.  I think it should be fine, but would like it if someone double checks.

Backtraces:
```
(dlv) bt
0  0x00000000004460d6 in runtime.gopark
    at /usr/lib/go-1.18/src/runtime/proc.go:362
1  0x0000000000456e93 in runtime.goparkunlock
    at /usr/lib/go-1.18/src/runtime/proc.go:367
2  0x0000000000456e93 in runtime.semacquire1
    at /usr/lib/go-1.18/src/runtime/sema.go:144
3  0x0000000000472b85 in sync.runtime_SemacquireMutex
    at /usr/lib/go-1.18/src/runtime/sema.go:71
4  0x0000000001094049 in sync.(*RWMutex).RLock
    at /usr/lib/go-1.18/src/sync/rwmutex.go:63
5  0x0000000001094049 in github.com/lxc/lxd/lxd/cluster.(*Gateway).LeaderAddress
    at ./lxd/lxd/cluster/gateway.go:590
6  0x0000000001091ff6 in github.com/lxc/lxd/lxd/cluster.(*Gateway).HandlerFuncs.func1
    at ./lxd/lxd/cluster/gateway.go:272
7  0x00000000006e596f in net/http.HandlerFunc.ServeHTTP
    at /usr/lib/go-1.18/src/net/http/server.go:2084
8  0x000000000072c48f in github.com/gorilla/mux.(*Router).ServeHTTP
    at ./go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210
9  0x0000000001357fcb in main.(*lxdHttpServer).ServeHTTP
    at ./lxd/lxd/api.go:158
10  0x00000000006e8f5b in net/http.serverHandler.ServeHTTP
    at /usr/lib/go-1.18/src/net/http/server.go:2916
11  0x00000000006e4417 in net/http.(*conn).serve
    at /usr/lib/go-1.18/src/net/http/server.go:1966
12  0x00000000006e98ae in net/http.(*Server).Serve.func3
    at /usr/lib/go-1.18/src/net/http/server.go:3071
13  0x0000000000476ba1 in runtime.goexit
    at /usr/lib/go-1.18/src/runtime/asm_amd64.s:1571


(dlv) bt
0  0x00000000004460d6 in runtime.gopark
    at /usr/lib/go-1.18/src/runtime/proc.go:362
1  0x0000000000456e93 in runtime.goparkunlock
    at /usr/lib/go-1.18/src/runtime/proc.go:367
2  0x0000000000456e93 in runtime.semacquire1
    at /usr/lib/go-1.18/src/runtime/sema.go:144
3  0x0000000000472b85 in sync.runtime_SemacquireMutex
    at /usr/lib/go-1.18/src/runtime/sema.go:71
4  0x0000000000482271 in sync.(*RWMutex).Lock
    at /usr/lib/go-1.18/src/sync/rwmutex.go:144
5  0x0000000001093865 in github.com/lxc/lxd/lxd/cluster.(*Gateway).Shutdown
    at ./lxd/lxd/cluster/gateway.go:512
6  0x00000000013a60be in main.(*Daemon).Stop
    at ./lxd/lxd/daemon.go:1724
7  0x0000000001378559 in main.internalShutdown.func1
    at ./lxd/lxd/api_internal.go:252
8  0x0000000000f10bec in github.com/lxc/lxd/lxd/response.(*manualResponse).Render
    at ./lxd/lxd/response/response.go:463
9  0x000000000139e582 in main.(*Daemon).createCmd.func1
    at ./lxd/lxd/daemon.go:696
10  0x00000000006e596f in net/http.HandlerFunc.ServeHTTP
    at /usr/lib/go-1.18/src/net/http/server.go:2084
11  0x000000000072c48f in github.com/gorilla/mux.(*Router).ServeHTTP
    at ./go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210
12  0x0000000001357fcb in main.(*lxdHttpServer).ServeHTTP
    at ./lxd/lxd/api.go:158
13  0x00000000006e8f5b in net/http.serverHandler.ServeHTTP
    at /usr/lib/go-1.18/src/net/http/server.go:2916
14  0x00000000006e4417 in net/http.(*conn).serve
    at /usr/lib/go-1.18/src/net/http/server.go:1966
15  0x00000000006e98ae in net/http.(*Server).Serve.func3
    at /usr/lib/go-1.18/src/net/http/server.go:3071
16  0x0000000000476ba1 in runtime.goexit
    at /usr/lib/go-1.18/src/runtime/asm_amd64.s:1571
```

2. I also replaced some `context.Background()` instances with smaller contexts bound to the gateway context.

