### PR TITLE
Sql dump all entities

### DIFF
--- a/lxd/db/query/dump.go
+++ b/lxd/db/query/dump.go
@@ -12,7 +12,7 @@ import (
 // Dump returns a SQL text dump of all rows across all tables, similar to
 // sqlite3's dump feature.
 func Dump(ctx context.Context, tx *sql.Tx, schemaOnly bool) (string, error) {
-	tablesSchemas, tableNames, err := getTablesSchemas(ctx, tx)
+	entitiesSchemas, entityNames, err := getEntitiesSchemas(ctx, tx)
 	if err != nil {
 		return "", err
 	}
@@ -23,10 +23,10 @@ func Dump(ctx context.Context, tx *sql.Tx, schemaOnly bool) (string, error) {
 	builder.WriteString("BEGIN TRANSACTION;\n")
 
 	// For each table, write the schema and optionally write the data.
-	for _, tableName := range tableNames {
-		builder.WriteString(tablesSchemas[tableName] + "\n")
+	for _, tableName := range entityNames {
+		builder.WriteString(entitiesSchemas[tableName][1] + "\n")
 
-		if !schemaOnly {
+		if !schemaOnly && entitiesSchemas[tableName][0] == "table" {
 			tableData, err := getTableData(ctx, tx, tableName)
 			if err != nil {
 				return "", err
@@ -58,28 +58,30 @@ func Dump(ctx context.Context, tx *sql.Tx, schemaOnly bool) (string, error) {
 	return builder.String(), nil
 }
 
-// getTablesSchemas gets all the tables and their schema, as well as a list of table names in their default order from
-// the sqlite_master table.
-func getTablesSchemas(ctx context.Context, tx *sql.Tx) (map[string]string, []string, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY rowid`)
+// getEntitiesSchemas gets all the tables, their kind, and their schema, as well as a list of entity names in their default order from
+// the sqlite_master table. The returned map values are arrays of length 2 whose first element contains the entity type and the second
+// contains it's schema.
+func getEntitiesSchemas(ctx context.Context, tx *sql.Tx) (map[string][2]string, []string, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT name, type, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY rowid`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Could not get table names and their schema: %w", err)
 	}
 
 	defer rows.Close()
 
-	tablesSchemas := make(map[string]string)
+	tablesSchemas := make(map[string][2]string)
 	var names []string
 	for rows.Next() {
 		var name string
+		var kind string
 		var schema string
-		err := rows.Scan(&name, &schema)
+		err := rows.Scan(&name, &kind, &schema)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Could not scan table name and schema: %w", err)
 		}
 
 		names = append(names, name)
-		tablesSchemas[name] = schema + ";"
+		tablesSchemas[name] = [2]string{kind, schema + ";"}
 	}
 
 	return tablesSchemas, names, nil

--- a/lxd/db/query/dump.go
+++ b/lxd/db/query/dump.go
@@ -79,18 +79,6 @@ func getTablesSchemas(ctx context.Context, tx *sql.Tx) (map[string]string, []str
 		}
 
 		names = append(names, name)
-
-		// Whether a table name is quoted or not can depend on if it was quoted when originally created, or if it
-		// collides with a keyword (and maybe more). Regardless, sqlite3 quotes table names in create statements when
-		// executing a dump. If the table name is already quoted, add the "IF NOT EXISTS" clause, else quote it and add
-		// the same clause.
-		isQuoted := strings.Contains(schema, fmt.Sprintf("TABLE %q", name))
-		if isQuoted {
-			schema = strings.Replace(schema, "TABLE", "TABLE IF NOT EXISTS", 1)
-		} else {
-			schema = strings.Replace(schema, name, fmt.Sprintf("IF NOT EXISTS %q", name), 1)
-		}
-
 		tablesSchemas[name] = schema + ";"
 	}
 

--- a/lxd/db/query/dump_export_test.go
+++ b/lxd/db/query/dump_export_test.go
@@ -1,4 +1,4 @@
 package query
 
 var GetTableData = getTableData
-var GetTablesSchemas = getTablesSchemas
+var GetEntitiesSchemas = getEntitiesSchemas

--- a/lxd/db/query/dump_test.go
+++ b/lxd/db/query/dump_test.go
@@ -16,20 +16,20 @@ func TestDump(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, `PRAGMA foreign_keys=OFF;
 BEGIN TRANSACTION;
-CREATE TABLE IF NOT EXISTS "schema" (
+CREATE TABLE schema (
     id         INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     version    INTEGER NOT NULL,
     updated_at DATETIME NOT NULL,
     UNIQUE (version)
 );
 INSERT INTO schema VALUES(1,37,1523946366);
-CREATE TABLE IF NOT EXISTS "config" (
+CREATE TABLE config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     key VARCHAR(255) NOT NULL,
     value TEXT,
     UNIQUE (key)
 );
-CREATE TABLE IF NOT EXISTS "patches" (
+CREATE TABLE patches (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     applied_at DATETIME NOT NULL,
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS "patches" (
 );
 INSERT INTO patches VALUES(1,'invalid_profile_names',1523946366);
 INSERT INTO patches VALUES(2,'leftover_profile_config',1523946366);
-CREATE TABLE IF NOT EXISTS "raft_nodes" (
+CREATE TABLE raft_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     address TEXT NOT NULL,
     UNIQUE (address)
@@ -52,14 +52,14 @@ COMMIT;
 func TestDumpTablePatches(t *testing.T) {
 	tx := newTxForDump(t, "local")
 
-	dump, _, err := query.GetTablesSchemas(context.Background(), tx)
+	dump, _, err := query.GetEntitiesSchemas(context.Background(), tx)
 	require.NoError(t, err)
-	assert.Equal(t, `CREATE TABLE IF NOT EXISTS "patches" (
+	assert.Equal(t, `CREATE TABLE patches (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     applied_at DATETIME NOT NULL,
     UNIQUE (name)
-);`, dump["patches"])
+);`, dump["patches"][1])
 	data, err := query.GetTableData(context.Background(), tx, "patches")
 	require.NoError(t, err)
 	assert.ElementsMatch(t, data, []string{
@@ -71,21 +71,21 @@ func TestDumpTablePatches(t *testing.T) {
 func TestDumpTableConfig(t *testing.T) {
 	tx := newTxForDump(t, "local")
 
-	dump, _, err := query.GetTablesSchemas(context.Background(), tx)
+	dump, _, err := query.GetEntitiesSchemas(context.Background(), tx)
 	require.NoError(t, err)
-	assert.Equal(t, `CREATE TABLE IF NOT EXISTS "config" (
+	assert.Equal(t, `CREATE TABLE config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     key VARCHAR(255) NOT NULL,
     value TEXT,
     UNIQUE (key)
-);`, dump["config"])
+);`, dump["config"][1])
 }
 
 func TestDumpTableStoragePoolsConfig(t *testing.T) {
 	tx := newTxForDump(t, "global")
-	dump, _, err := query.GetTablesSchemas(context.Background(), tx)
+	dump, _, err := query.GetEntitiesSchemas(context.Background(), tx)
 	require.NoError(t, err)
-	assert.Equal(t, `CREATE TABLE IF NOT EXISTS "storage_pools_config" (
+	assert.Equal(t, `CREATE TABLE storage_pools_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     storage_pool_id INTEGER NOT NULL,
     node_id INTEGER,
@@ -94,7 +94,7 @@ func TestDumpTableStoragePoolsConfig(t *testing.T) {
     UNIQUE (storage_pool_id, node_id, key),
     FOREIGN KEY (storage_pool_id) REFERENCES storage_pools (id) ON DELETE CASCADE,
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE
-);`, dump["storage_pools_config"])
+);`, dump["storage_pools_config"][1])
 	data, err := query.GetTableData(context.Background(), tx, "storage_pools_config")
 	require.NoError(t, err)
 	assert.Equal(t, data, []string{"INSERT INTO storage_pools_config VALUES(1,1,NULL,'k','v');"})

--- a/lxd/db/query/dump_test.go
+++ b/lxd/db/query/dump_test.go
@@ -42,6 +42,7 @@ CREATE TABLE raft_nodes (
     address TEXT NOT NULL,
     UNIQUE (address)
 );
+CREATE INDEX config_key_idx ON config (key);
 DELETE FROM sqlite_sequence;
 INSERT INTO sqlite_sequence VALUES('schema',1);
 INSERT INTO sqlite_sequence VALUES('patches',2);
@@ -147,6 +148,7 @@ CREATE TABLE raft_nodes (
     address TEXT NOT NULL,
     UNIQUE (address)
 );
+CREATE INDEX config_key_idx ON config (key);
 `,
 	"global": `
 CREATE TABLE certificates (

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -108,7 +108,7 @@ func (c *cmdSql) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse dump response: %w", err)
 		}
-		fmt.Printf(dump.Text)
+		fmt.Print(dump.Text)
 		return nil
 	}
 

--- a/test/suites/sql.sh
+++ b/test/suites/sql.sh
@@ -35,7 +35,11 @@ test_sql() {
 
   # Global database dump
   SQLITE_DUMP="${TEST_DIR}/dump.db"
-  lxd sql global .dump | sqlite3 "${SQLITE_DUMP}"
+  GLOBAL_DUMP=$(lxd sql global .dump)
+  echo "$GLOBAL_DUMP" | grep "CREATE TRIGGER" # ensure triggers are captured.
+  echo "$GLOBAL_DUMP" | grep "CREATE INDEX"   # ensure indices are captured.
+  echo "$GLOBAL_DUMP" | grep "CREATE VIEW"    # ensure views are captured.
+  echo "$GLOBAL_DUMP" | sqlite3 "${SQLITE_DUMP}"
   sqlite3 "${SQLITE_DUMP}" "SELECT * FROM profiles" | grep -q "Default LXD profile"
   rm -f "${SQLITE_DUMP}"
 


### PR DESCRIPTION
Following #10298 it was noted that
* Behaviour which quoted table names and added "IF NOT EXISTS" was inconsistent.
* Only tables were included in the database dump (no indices, view, or triggers).

This PR removes the quotation behaviour and collects all entities from the sqlite_master table into the dump. Tests are updated to check for the previously missing entities.