### PR TITLE
shared/cert: Adds method for returning the public key as an x509 cert.

### DIFF
--- a/shared/cert.go
+++ b/shared/cert.go
@@ -122,6 +122,11 @@ func (c *CertInfo) PublicKey() []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: data})
 }
 
+// PublicKeyX509 is a convenience to return the underlying public key as an *x509.Certificate.
+func (c *CertInfo) PublicKeyX509() (*x509.Certificate, error) {
+	return x509.ParseCertificate(c.KeyPair().Certificate[0])
+}
+
 // PrivateKey is a convenience to encode the underlying private key.
 func (c *CertInfo) PrivateKey() []byte {
 	ecKey, ok := c.KeyPair().PrivateKey.(*ecdsa.PrivateKey)


### PR DESCRIPTION
When configuring TLS for a HTTP client in LXD cloud we need to extract the public key as an `*x509.Certificate` from a `*shared.CertInfo`. This PR adds a convenience function to avoid duplication. See https://github.com/canonical/lxd-cloud/pull/107#discussion_r857949374.