### PR TITLE
lxd/db/generate/db: Returns a status error on create if entry already exists

### DIFF
--- a/lxd/db/generate/db/method_v2.go
+++ b/lxd/db/generate/db/method_v2.go
@@ -655,7 +655,7 @@ func (m *MethodV2) create(buf *file.Buffer, replace bool) error {
 				buf.L("exists, err := %s%sExists(ctx, tx, %s)", m.db, lex.Camel(m.entity), strings.Join(nkParams, ", "))
 				m.ifErrNotNil(buf, "-1", "fmt.Errorf(\"Failed to check for duplicates: %w\", err)")
 				buf.L("if exists {")
-				buf.L(`        return -1, fmt.Errorf("This \"%s\" entry already exists")`, entityTable(m.entity))
+				buf.L(`        return -1, api.StatusErrorf(http.StatusConflict, "This \"%s\" entry already exists")`, entityTable(m.entity))
 				buf.L("}")
 				buf.N()
 			}


### PR DESCRIPTION
@masnax @tomponline @stgraber what do you think about changing the error response of generated database create entity functions to use an `api.StatusError`? The status code would automatically be set using `response.SmartError` in that case. I've gone with `http.StatusConflict` here but could also have `http.BadRequest`.