### PR TITLE
DB: Error status not found if "delete one" affects zero rows.

### DIFF
--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -218,8 +218,10 @@ func DeleteCertificate(ctx context.Context, tx *sql.Tx, fingerprint string) erro
 		return fmt.Errorf("Fetch affected rows: %w", err)
 	}
 
-	if n != 1 {
-		return fmt.Errorf("Query deleted %d rows instead of 1", n)
+	if n == 0 {
+		return api.StatusErrorf(http.StatusNotFound, "Certificate not found")
+	} else if n > 1 {
+		return fmt.Errorf("Query deleted %d Certificate rows instead of 1", n)
 	}
 
 	return nil

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -278,8 +278,10 @@ func DeleteProject(ctx context.Context, tx *sql.Tx, name string) error {
 		return fmt.Errorf("Fetch affected rows: %w", err)
 	}
 
-	if n != 1 {
-		return fmt.Errorf("Query deleted %d rows instead of 1", n)
+	if n == 0 {
+		return api.StatusErrorf(http.StatusNotFound, "Project not found")
+	} else if n > 1 {
+		return fmt.Errorf("Query deleted %d Project rows instead of 1", n)
 	}
 
 	return nil

--- a/lxd/db/generate/db/method_v2.go
+++ b/lxd/db/generate/db/method_v2.go
@@ -1004,8 +1004,10 @@ func (m *MethodV2) delete(buf *file.Buffer, deleteOne bool) error {
 
 	m.ifErrNotNil(buf, "fmt.Errorf(\"Fetch affected rows: %w\", err)")
 	if deleteOne {
-		buf.L("if n != 1 {")
-		buf.L("        return fmt.Errorf(\"Query deleted %%d rows instead of 1\", n)")
+		buf.L("if n == 0 {")
+		buf.L(`        return api.StatusErrorf(http.StatusNotFound, "%s not found")`, lex.Camel(m.entity))
+		buf.L("} else if n > 1 {")
+		buf.L("        return fmt.Errorf(\"Query deleted %%d %s rows instead of 1\", n)", lex.Camel(m.entity))
 		buf.L("}")
 	}
 


### PR DESCRIPTION
Similar to #10317, this change returns an `api.StatusError` with `http.StatusNotFound` if zero rows are affected when executing a delete statement on an entity.