### PR TITLE
gomod: Update github.com/canonical/go-dqlite to v1.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Rican7/retry v0.3.1
 	github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a
 	github.com/canonical/candid v1.11.0
-	github.com/canonical/go-dqlite v1.11.0
+	github.com/canonical/go-dqlite v1.11.1
 	github.com/digitalocean/go-qemu v0.0.0-20210326154740-ac9e0b687001
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/canonical/candid v1.11.0 h1:t71M9zQBsfAsXkLJGP7RntO+XYuxUgjon+2JF23nz
 github.com/canonical/candid v1.11.0/go.mod h1:644Yfy3EGWwTo1PInNqJFu83NLTzFmBjxtNyuSQem6Q=
 github.com/canonical/go-dqlite v1.11.0 h1:qGGtp1uMUd0A/05eMvkL70nQTBCVb8Aeg7rdjTHZiEE=
 github.com/canonical/go-dqlite v1.11.0/go.mod h1:KDFMv4rdNwRzBZhabKjKDN2oOyPjHqQz1Epc6VOgbLs=
+github.com/canonical/go-dqlite v1.11.1 h1:bvxtIv+Wm3lFrBBXPOrANsgJQ+5/3DZCnjTBkimtc20=
+github.com/canonical/go-dqlite v1.11.1/go.mod h1:KDFMv4rdNwRzBZhabKjKDN2oOyPjHqQz1Epc6VOgbLs=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=


### PR DESCRIPTION
For compatibility with https://github.com/canonical/dqlite/pull/366

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>