### PR TITLE
Storage: Adds ref counting to volume snapshot mount/unmount

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2746,7 +2746,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 		return nil, err
 	}
 
-	_, err = b.driver.MountVolumeSnapshot(*vol, op)
+	err = b.driver.MountVolumeSnapshot(*vol, op)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -185,8 +185,8 @@ func (d *mock) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 }
 
 // MountVolumeSnapshot sets up a read-only mount on top of the snapshot to avoid accidental modifications.
-func (d *mock) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
-	return true, nil
+func (d *mock) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error {
+	return nil
 }
 
 // UnmountVolumeSnapshot removes the read-only mount placed on top of a snapshot.

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -63,9 +63,8 @@ type Driver interface {
 	// MountVolume mounts a storage volume (if not mounted) and increments reference counter.
 	MountVolume(vol Volume, op *operations.Operation) error
 
-	// MountVolumeSnapshot mounts a storage volume snapshot as readonly, returns true if we
-	// caused a new mount, false if already mounted.
-	MountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error)
+	// MountVolumeSnapshot mounts a storage volume snapshot as readonly.
+	MountVolumeSnapshot(snapVol Volume, op *operations.Operation) error
 
 	// UnmountVolume unmounts a storage volume, returns true if unmounted, false if was not
 	// mounted.

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -241,10 +241,9 @@ func (v Volume) MountTask(task func(mountPath string, op *operations.Operation) 
 	// If the volume is a snapshot then call the snapshot specific mount/unmount functions as
 	// these will mount the snapshot read only.
 	var err error
-	var ourMount bool
 
 	if v.IsSnapshot() {
-		ourMount, err = v.driver.MountVolumeSnapshot(v, op)
+		err = v.driver.MountVolumeSnapshot(v, op)
 	} else {
 		err = v.driver.MountVolume(v, op)
 	}
@@ -256,9 +255,7 @@ func (v Volume) MountTask(task func(mountPath string, op *operations.Operation) 
 
 	// Try and unmount, even on task error.
 	if v.IsSnapshot() {
-		if ourMount {
-			_, err = v.driver.UnmountVolumeSnapshot(v, op)
-		}
+		_, err = v.driver.UnmountVolumeSnapshot(v, op)
 	} else {
 		_, err = v.driver.UnmountVolume(v, false, op)
 	}


### PR DESCRIPTION
Brings `MountVolumeSnapshot` inline with `MountVolume`.

Tested with VM daily scripts too (except ceph).