### PR TITLE
lxd/resources: Handle nested devices

### DIFF
--- a/lxd/resources/gpu.go
+++ b/lxd/resources/gpu.go
@@ -147,6 +147,11 @@ func loadNvidiaContainer() (map[string]*api.ResourcesGPUCardNvidia, error) {
 }
 
 func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGPUCardNvidia, pciDB *pcidb.PCIDB, uname unix.Utsname, card *api.ResourcesGPUCard) error {
+	// Handle nested devices.
+	if isDir(filepath.Join(devicePath, "device")) {
+		return gpuAddDeviceInfo(filepath.Join(devicePath, "device"), nvidiaCards, pciDB, uname, card)
+	}
+
 	// SRIOV
 	if sysfsExists(filepath.Join(devicePath, "sriov_numvfs")) {
 		sriov := api.ResourcesGPUCardSRIOV{}

--- a/lxd/resources/utils.go
+++ b/lxd/resources/utils.go
@@ -12,6 +12,15 @@ import (
 
 var sysBusPci = "/sys/bus/pci/devices"
 
+func isDir(name string) bool {
+	stat, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+
+	return stat.IsDir()
+}
+
 func readUint(path string) (uint64, error) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
With multi-port USB GPUs, it is possible to have a nested device path
with the top-level device just referring to an instance of the USB GPU.

Fixes: https://bugs.launchpad.net/maas/+bug/1970435

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>