### PR TITLE
Storage: Fix copy of running VM snapshot on non-thin LVM pool

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3002,7 +3002,7 @@ func (d *lxc) onStop(args map[string]string) error {
 
 		// Stop the storage for this container
 		op.Reset()
-		_, err = d.unmount()
+		err = d.unmount()
 		if err != nil {
 			err = fmt.Errorf("Failed unmounting instance: %w", err)
 			op.Done(err)
@@ -6137,37 +6137,37 @@ func (d *lxc) mount() (*storagePools.MountInfo, error) {
 }
 
 // unmount the instance's rootfs volume if needed.
-func (d *lxc) unmount() (bool, error) {
+func (d *lxc) unmount() error {
 	pool, err := d.getStoragePool()
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if d.IsSnapshot() {
-		unmounted, err := pool.UnmountInstanceSnapshot(d, nil)
+		_, err := pool.UnmountInstanceSnapshot(d, nil)
 		if err != nil {
-			return false, err
+			return err
 		}
 
-		return unmounted, nil
+		return nil
 	}
 
 	// Workaround for liblxc failures on startup when shiftfs is used.
 	diskIdmap, err := d.DiskIdmap()
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if d.IdmappedStorage(d.RootfsPath()) == idmap.IdmapStorageShiftfs && !d.IsPrivileged() && diskIdmap == nil {
 		unix.Unmount(d.RootfsPath(), unix.MNT_DETACH)
 	}
 
-	unmounted, err := pool.UnmountInstance(d, nil)
+	_, err = pool.UnmountInstance(d, nil)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	return unmounted, nil
+	return nil
 }
 
 // insertMountLXD inserts a mount into a LXD container.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3542,7 +3542,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		}
 	}
 
-	_, err = pool.UnmountInstance(d, nil)
+	err = pool.UnmountInstance(d, nil)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -6144,7 +6144,7 @@ func (d *lxc) unmount() error {
 	}
 
 	if d.IsSnapshot() {
-		_, err := pool.UnmountInstanceSnapshot(d, nil)
+		err = pool.UnmountInstanceSnapshot(d, nil)
 		if err != nil {
 			return err
 		}
@@ -6162,7 +6162,7 @@ func (d *lxc) unmount() error {
 		unix.Unmount(d.RootfsPath(), unix.MNT_DETACH)
 	}
 
-	_, err = pool.UnmountInstance(d, nil)
+	err = pool.UnmountInstance(d, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -444,7 +444,7 @@ func (d *qemu) unmount() error {
 		return err
 	}
 
-	_, err = pool.UnmountInstance(d, nil)
+	err = pool.UnmountInstance(d, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -181,8 +181,8 @@ func (b *mockBackend) MountInstance(inst instance.Instance, op *operations.Opera
 	return &MountInfo{}, nil
 }
 
-func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error) {
-	return true, nil
+func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) error {
+	return nil
 }
 
 func (b *mockBackend) CreateInstanceSnapshot(i instance.Instance, src instance.Instance, op *operations.Operation) error {
@@ -205,8 +205,8 @@ func (b *mockBackend) MountInstanceSnapshot(inst instance.Instance, op *operatio
 	return &MountInfo{}, nil
 }
 
-func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error) {
-	return true, nil
+func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
+	return nil
 }
 
 func (b *mockBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -770,11 +770,11 @@ func (d *lvm) deactivateVolume(vol Volume) (bool, error) {
 		parent, _, _ := shared.InstanceGetParentAndSnapshotName(vol.Name())
 		volDevPath = d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, parent)
 
-		// If parent is mounted then skip deactivating non-thinpool snapshot volume as it will fail due
-		// to parent being in use.
-		if vol.IsSnapshot() && vol.contentType == ContentTypeFS {
+		if vol.IsSnapshot() {
 			parentVol := NewVolume(d, d.name, vol.volType, vol.contentType, parent, nil, d.config)
-			if filesystem.IsMountPoint(parentVol.MountPath()) {
+
+			// If parent is in use then skip deactivating non-thinpool snapshot volume as it will fail.
+			if parentVol.MountInUse() || (parentVol.contentType == ContentTypeFS && filesystem.IsMountPoint(parentVol.MountPath())) {
 				return false, nil
 			}
 		}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -956,7 +956,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (func(), error),
 				_, snapName, _ := shared.InstanceGetParentAndSnapshotName(srcVol.name)
 
 				// Mount the source snapshot and copy it to the target main volume.
-				// A snapshot will then taken next so it is stored in the correct volume and
+				// A snapshot will then be taken next so it is stored in the correct volume and
 				// subsequent filesystem rsync transfers benefit from only transferring the files
 				// that changed between snapshots.
 				err := srcVol.MountTask(func(srcMountPath string, op *operations.Operation) error {

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -73,7 +73,7 @@ type Pool interface {
 	SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error
 
 	MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
-	UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error)
+	UnmountInstance(inst instance.Instance, op *operations.Operation) error
 
 	// Instance snapshots.
 	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
@@ -81,7 +81,7 @@ type Pool interface {
 	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
 	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
 	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
-	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error)
+	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
 	UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
 	// Images.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -852,18 +852,17 @@ func InstanceMount(pool Pool, inst instance.Instance, op *operations.Operation) 
 	return mountInfo, nil
 }
 
-// InstanceUnmount unmounts an instance's storage volume (if not in use). Returns if we unmounted the volume.
-func InstanceUnmount(pool Pool, inst instance.Instance, op *operations.Operation) (bool, error) {
+// InstanceUnmount unmounts an instance's storage volume (if not in use).
+func InstanceUnmount(pool Pool, inst instance.Instance, op *operations.Operation) error {
 	var err error
-	var ourUnmount bool
 
 	if inst.IsSnapshot() {
-		ourUnmount, err = pool.UnmountInstanceSnapshot(inst, op)
+		err = pool.UnmountInstanceSnapshot(inst, op)
 	} else {
-		ourUnmount, err = pool.UnmountInstance(inst, op)
+		err = pool.UnmountInstance(inst, op)
 	}
 
-	return ourUnmount, err
+	return err
 }
 
 // InstanceDiskBlockSize returns the block device size for the instance's disk.


### PR DESCRIPTION
Fixes #10302

Also removes unnecessary "ourUnmount" concept from instance unmount functions.