### PR TITLE
Allow overriding the cluster evacuation mode

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1668,3 +1668,8 @@ Adds ability to modify the set of profiles when image is copied.
 
 ## container\_syscall\_intercept\_sysinfo
 Adds the `security.syscalls.intercept.sysinfo` to allow the `sysinfo` syscall to be populated with cgroup-based resource usage information.
+
+## clustering\_evacuation\_mode
+This introduces a `mode` field to the evacuation request which allows
+for overriding the evacuation mode traditionally set through
+`cluster.evacuate`.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -458,6 +458,11 @@ definitions:
         example: evacuate
         type: string
         x-go-name: Action
+      mode:
+        description: Override the configured evacuation mode.
+        example: stop
+        type: string
+        x-go-name: Mode
     title: ClusterMemberStatePost represents the fields required to evacuate a cluster
       member.
     type: object

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1041,7 +1041,8 @@ func (c *cmdClusterUpdateCertificate) Run(cmd *cobra.Command, args []string) err
 type cmdClusterEvacuateAction struct {
 	global *cmdGlobal
 
-	flagForce bool
+	flagAction string
+	flagForce  bool
 }
 
 // Cluster member evacuation
@@ -1060,6 +1061,8 @@ func (c *cmdClusterEvacuate) Command() *cobra.Command {
 	cmd.Use = usage("evacuate", i18n.G("[<remote>:]<member>"))
 	cmd.Short = i18n.G("Evacuate cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Evacuate cluster member`))
+
+	cmd.Flags().StringVar(&c.action.flagAction, "action", "", i18n.G(`Force a particular evacuation action`)+"``")
 
 	return cmd
 }
@@ -1123,6 +1126,7 @@ func (c *cmdClusterEvacuateAction) Run(cmd *cobra.Command, args []string) error 
 
 	state := api.ClusterMemberStatePost{
 		Action: cmd.Name(),
+		Mode:   c.flagAction,
 	}
 
 	op, err := resource.server.UpdateClusterMemberState(resource.name, state)

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -506,7 +506,7 @@ msgstr "%s (%d mehr)"
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
@@ -516,7 +516,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1400,7 +1400,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1621,8 +1621,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1640,7 +1640,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1794,7 +1794,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1992,7 +1992,7 @@ msgstr "Flüchtiger Container"
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2001,7 +2001,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2105,22 +2105,22 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2130,7 +2130,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2140,17 +2140,17 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2189,7 +2189,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2204,7 +2204,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2226,7 +2226,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2429,22 +2433,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2610,12 +2614,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2629,7 +2633,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2682,7 +2686,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -2743,12 +2747,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3359,8 +3363,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3452,7 +3456,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3561,7 +3565,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3600,12 +3604,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4034,7 +4038,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4186,22 +4190,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4227,7 +4231,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4474,7 +4478,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4527,12 +4531,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -4594,7 +4598,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4772,19 +4776,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5132,12 +5136,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5416,7 +5420,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -5432,7 +5436,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6126,7 +6130,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6136,7 +6140,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -6182,8 +6186,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6875,20 +6879,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7064,8 +7068,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -7092,16 +7096,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -794,7 +794,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1328,8 +1328,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1347,7 +1347,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1680,11 +1680,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1780,22 +1780,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -1805,7 +1805,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1815,17 +1815,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1863,7 +1863,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1878,7 +1878,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1897,7 +1897,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2093,22 +2097,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2268,11 +2272,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2286,7 +2290,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2338,7 +2342,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2396,12 +2400,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2959,8 +2963,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3051,7 +3055,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3150,7 +3154,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3188,11 +3192,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3611,7 +3615,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3756,20 +3760,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3795,7 +3799,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4005,7 +4009,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4024,7 +4028,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4075,12 +4079,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4140,7 +4144,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4312,19 +4316,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4652,11 +4656,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4924,7 +4928,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4940,7 +4944,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5387,12 +5391,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5413,8 +5417,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5807,20 +5811,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5992,8 +5996,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6020,16 +6024,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -501,7 +501,7 @@ msgstr "%s (%d más)"
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
@@ -511,7 +511,7 @@ msgstr "%s no es un directorio"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -613,7 +613,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -766,7 +766,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1012,7 +1012,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1556,8 +1556,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1575,7 +1575,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1721,7 +1721,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1909,12 +1909,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -2013,22 +2013,22 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2038,7 +2038,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2048,17 +2048,17 @@ msgstr "Acepta certificado"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2112,7 +2112,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2131,7 +2131,11 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2328,22 +2332,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -2507,11 +2511,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2526,7 +2530,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2578,7 +2582,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -2638,12 +2642,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3209,8 +3213,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3301,7 +3305,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3407,7 +3411,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -3447,11 +3451,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -3869,7 +3873,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4018,20 +4022,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4057,7 +4061,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4270,7 +4274,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -4291,7 +4295,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -4343,12 +4347,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4408,7 +4412,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4580,19 +4584,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4921,11 +4925,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5198,7 +5202,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5214,7 +5218,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5713,13 +5717,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5745,8 +5749,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6210,20 +6214,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6395,8 +6399,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6423,16 +6427,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -504,7 +504,7 @@ msgstr "%s (%d de plus)"
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
@@ -514,7 +514,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompre encore deux fois pour forcer)"
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -625,7 +625,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -800,7 +800,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1406,7 +1406,7 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1648,8 +1648,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1667,7 +1667,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1815,7 +1815,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr "Conteneur éphémère"
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2027,7 +2027,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2139,22 +2139,22 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2164,7 +2164,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2174,17 +2174,17 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2224,7 +2224,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to get the new instance name"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2239,7 +2239,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2259,7 +2259,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2466,22 +2470,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2655,12 +2659,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2675,7 +2679,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2727,7 +2731,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -2788,12 +2792,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3440,8 +3444,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3535,7 +3539,7 @@ msgstr "Empreinte du certificat : %s"
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3645,7 +3649,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -3687,12 +3691,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4134,7 +4138,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4286,22 +4290,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4328,7 +4332,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -4555,7 +4559,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4593,7 +4597,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4646,12 +4650,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -4715,7 +4719,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4895,19 +4899,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5265,11 +5269,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5553,7 +5557,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5569,7 +5573,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6314,7 +6318,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6327,7 +6331,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -6385,8 +6389,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7124,20 +7128,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7331,8 +7335,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -7360,16 +7364,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1122,7 +1122,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1323,8 +1323,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1342,7 +1342,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1668,11 +1668,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1768,22 +1768,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1803,17 +1803,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1885,7 +1885,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2076,22 +2080,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2251,11 +2255,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2269,7 +2273,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2321,7 +2325,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2379,12 +2383,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2937,8 +2941,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3026,7 +3030,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3123,7 +3127,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3161,11 +3165,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3581,7 +3585,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3726,20 +3730,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3765,7 +3769,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3973,7 +3977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3992,7 +3996,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4042,12 +4046,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4106,7 +4110,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4274,19 +4278,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4608,11 +4612,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4880,7 +4884,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4896,7 +4900,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5336,12 +5340,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5362,8 +5366,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5756,20 +5760,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5941,8 +5945,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5969,16 +5973,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -498,7 +498,7 @@ msgstr "%s (altri %d)"
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
@@ -508,7 +508,7 @@ msgstr "%s non è una directory"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompi altre due volte per forzare)"
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -607,7 +607,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -760,7 +760,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1338,7 +1338,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1547,8 +1547,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1566,7 +1566,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1712,7 +1712,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1900,12 +1900,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -2003,22 +2003,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2028,7 +2028,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2038,17 +2038,17 @@ msgstr "Accetta certificato"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2086,7 +2086,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2101,7 +2101,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2121,7 +2121,11 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2317,22 +2321,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -2495,11 +2499,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2513,7 +2517,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2565,7 +2569,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -2626,12 +2630,12 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3203,8 +3207,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3294,7 +3298,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3400,7 +3404,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3439,11 +3443,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -3863,7 +3867,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4010,21 +4014,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4050,7 +4054,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4264,7 +4268,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -4285,7 +4289,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -4337,12 +4341,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4402,7 +4406,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4572,19 +4576,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4916,11 +4920,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5191,7 +5195,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5707,13 +5711,13 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -5739,8 +5743,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
@@ -6204,20 +6208,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6389,8 +6393,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6418,16 +6422,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -490,7 +490,7 @@ msgstr "%s (%d個使用可能)"
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
@@ -501,7 +501,7 @@ msgid "%v (interrupt two more times to force)"
 msgstr ""
 "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -598,7 +598,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -759,7 +759,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -978,7 +978,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1008,7 +1008,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1347,7 +1347,7 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1552,8 +1552,8 @@ msgstr "警告を削除します"
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1571,7 +1571,7 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1721,7 +1721,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -1916,11 +1916,11 @@ msgstr "Ephemeral インスタンス"
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -2031,22 +2031,22 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2056,7 +2056,7 @@ msgstr "インスタンスの SFTP への接続に失敗しました: %w"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr "証明書追加トークンのトークン変換操作に失敗しました: %w"
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2066,17 +2066,17 @@ msgstr "SSH ホスト鍵の生成に失敗しました: %w"
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2114,7 +2114,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to get the new instance name"
 msgstr "新しいインスタンス名が取得できません"
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2129,7 +2129,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2148,7 +2148,11 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2354,22 +2358,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -2538,11 +2542,11 @@ msgstr "入力するデータ"
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -2556,7 +2560,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -2609,7 +2613,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -2674,12 +2678,12 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3386,8 +3390,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -3479,7 +3483,7 @@ msgstr "証明書のフィンガープリントがありません"
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
@@ -3576,7 +3580,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -3617,13 +3621,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4044,7 +4048,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -4192,20 +4196,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -4231,7 +4235,7 @@ msgstr "ROLES"
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -4443,7 +4447,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -4465,7 +4469,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -4515,12 +4519,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -4579,7 +4583,7 @@ msgstr "サーバのバージョン: %s\n"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -4795,19 +4799,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -5130,11 +5134,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -5431,7 +5435,7 @@ msgstr "テンポラリファイルを作成できません: %v"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -5447,7 +5451,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -5895,13 +5899,13 @@ msgstr "[<remote>:]<instance>/<path>"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -5924,8 +5928,8 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
@@ -6352,7 +6356,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -6361,7 +6365,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -6371,7 +6375,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6633,8 +6637,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 "lxc storage volume show default data\n"
 "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
@@ -6668,16 +6672,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
@@ -8315,8 +8319,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect \"custom"
-#~ "\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect "
+#~ "\"custom\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-04-27 17:13-0400\n"
+        "POT-Creation-Date: 2022-04-27 19:56-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,7 +272,7 @@ msgstr  ""
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
@@ -282,7 +282,7 @@ msgstr  ""
 msgid   "%v (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -378,7 +378,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -521,7 +521,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -731,7 +731,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -760,7 +760,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1060,7 +1060,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1250,7 +1250,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201 lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378 lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709 lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062 lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:224 lxc/config_trust.go:336 lxc/config_trust.go:417 lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38 lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490 lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303 lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1257 lxc/storage_volume.go:1339 lxc/storage_volume.go:1523 lxc/storage_volume.go:1556 lxc/storage_volume.go:1669 lxc/storage_volume.go:1757 lxc/storage_volume.go:1856 lxc/storage_volume.go:1890 lxc/storage_volume.go:1988 lxc/storage_volume.go:2055 lxc/storage_volume.go:2196 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201 lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378 lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709 lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063 lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:224 lxc/config_trust.go:336 lxc/config_trust.go:417 lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38 lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490 lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303 lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1257 lxc/storage_volume.go:1339 lxc/storage_volume.go:1523 lxc/storage_volume.go:1556 lxc/storage_volume.go:1669 lxc/storage_volume.go:1757 lxc/storage_volume.go:1856 lxc/storage_volume.go:1890 lxc/storage_volume.go:1988 lxc/storage_volume.go:2055 lxc/storage_volume.go:2196 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1332,7 +1332,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1507,11 +1507,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1602,22 +1602,22 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -1627,7 +1627,7 @@ msgstr  ""
 msgid   "Failed converting token operation to certificate add token: %w"
 msgstr  ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -1637,17 +1637,17 @@ msgstr  ""
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -1685,7 +1685,7 @@ msgstr  ""
 msgid   "Failed to get the new instance name"
 msgstr  ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -1700,7 +1700,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -1718,7 +1718,11 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid   "Force a particular evacuation action"
+msgstr  ""
+
+#: lxc/cluster.go:1092
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -1897,22 +1901,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2069,11 +2073,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2087,7 +2091,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2139,7 +2143,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2194,12 +2198,12 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2823,7 +2827,7 @@ msgstr  ""
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110 lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110 lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -2883,7 +2887,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -2919,11 +2923,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3325,7 +3329,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -3464,20 +3468,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -3503,7 +3507,7 @@ msgstr  ""
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -3708,7 +3712,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -3726,7 +3730,7 @@ msgstr  ""
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -3776,12 +3780,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -3839,7 +3843,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -3983,19 +3987,19 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -4315,11 +4319,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -4573,7 +4577,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -4588,7 +4592,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5012,11 +5016,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -5036,7 +5040,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060 lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061 lxc/cluster.go:1082
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
@@ -5407,17 +5411,17 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -5588,16 +5592,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -486,7 +486,7 @@ msgstr "%s (en nog %d)"
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -496,7 +496,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -593,7 +593,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1514,8 +1514,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1533,7 +1533,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1859,11 +1859,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1959,22 +1959,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1984,7 +1984,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1994,17 +1994,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2042,7 +2042,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2076,7 +2076,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2267,22 +2271,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2442,11 +2446,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2460,7 +2464,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2512,7 +2516,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2570,12 +2574,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3128,8 +3132,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3217,7 +3221,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3314,7 +3318,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3352,11 +3356,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3772,7 +3776,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3917,20 +3921,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3956,7 +3960,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4164,7 +4168,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4183,7 +4187,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4233,12 +4237,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4297,7 +4301,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4465,19 +4469,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4799,11 +4803,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5071,7 +5075,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5087,7 +5091,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5527,12 +5531,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5553,8 +5557,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5947,20 +5951,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6132,8 +6136,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6160,16 +6164,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,7 +516,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -526,7 +526,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -623,7 +623,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1343,7 +1343,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1544,8 +1544,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1563,7 +1563,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1889,11 +1889,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1989,22 +1989,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2014,7 +2014,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2024,17 +2024,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2072,7 +2072,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2087,7 +2087,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2106,7 +2106,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2297,22 +2301,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2472,11 +2476,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2490,7 +2494,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2542,7 +2546,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2600,12 +2604,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3158,8 +3162,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3247,7 +3251,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3344,7 +3348,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3382,11 +3386,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3802,7 +3806,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3947,20 +3951,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3986,7 +3990,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4194,7 +4198,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4213,7 +4217,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4263,12 +4267,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4327,7 +4331,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4495,19 +4499,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4829,11 +4833,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5101,7 +5105,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5117,7 +5121,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5557,12 +5561,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5583,8 +5587,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5977,20 +5981,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6162,8 +6166,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6190,16 +6194,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -504,7 +504,7 @@ msgstr "%s (%d mais)"
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
@@ -514,7 +514,7 @@ msgstr "%s não é um diretório"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompa mais duas vezes para forçar)"
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -621,7 +621,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -777,7 +777,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1594,8 +1594,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1613,7 +1613,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1761,7 +1761,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1957,12 +1957,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2058,22 +2058,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2083,7 +2083,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2093,17 +2093,17 @@ msgstr "Aceitar certificado"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2175,7 +2175,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2376,22 +2380,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -2553,11 +2557,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2571,7 +2575,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2623,7 +2627,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -2683,12 +2687,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3261,8 +3265,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3354,7 +3358,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3458,7 +3462,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3497,11 +3501,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -3919,7 +3923,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4069,21 +4073,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4109,7 +4113,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4326,7 +4330,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -4351,7 +4355,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -4403,12 +4407,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4468,7 +4472,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4645,19 +4649,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4995,12 +4999,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5274,7 +5278,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5290,7 +5294,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5768,12 +5772,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -5795,8 +5799,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6217,20 +6221,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6402,8 +6406,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6430,16 +6434,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -513,7 +513,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -629,7 +629,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -787,7 +787,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1005,7 +1005,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1587,8 +1587,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1606,7 +1606,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1752,7 +1752,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -1951,7 +1951,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2052,22 +2052,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2077,7 +2077,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2087,17 +2087,17 @@ msgstr "Принять сертификат"
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2150,7 +2150,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2169,7 +2169,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2366,22 +2370,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2546,11 +2550,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2565,7 +2569,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2617,7 +2621,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -2677,12 +2681,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3262,8 +3266,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3355,7 +3359,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3462,7 +3466,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3501,11 +3505,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3928,7 +3932,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4073,20 +4077,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4112,7 +4116,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4330,7 +4334,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -4352,7 +4356,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -4404,12 +4408,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4469,7 +4473,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4641,19 +4645,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4991,11 +4995,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5264,7 +5268,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5280,7 +5284,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5937,7 +5941,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -5946,7 +5950,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -5987,8 +5991,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6665,20 +6669,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6850,8 +6854,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6878,16 +6882,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1122,7 +1122,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1323,8 +1323,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1342,7 +1342,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1668,11 +1668,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1768,22 +1768,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1803,17 +1803,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1885,7 +1885,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2076,22 +2080,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2251,11 +2255,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2269,7 +2273,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2321,7 +2325,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2379,12 +2383,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2937,8 +2941,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3026,7 +3030,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3123,7 +3127,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3161,11 +3165,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3581,7 +3585,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3726,20 +3730,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3765,7 +3769,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3973,7 +3977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3992,7 +3996,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4042,12 +4046,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4106,7 +4110,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4274,19 +4278,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4608,11 +4612,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4880,7 +4884,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4896,7 +4900,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5336,12 +5340,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5362,8 +5366,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5756,20 +5760,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5941,8 +5945,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5969,16 +5973,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1122,7 +1122,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1323,8 +1323,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1342,7 +1342,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1668,11 +1668,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1768,22 +1768,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1803,17 +1803,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1885,7 +1885,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2076,22 +2080,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2251,11 +2255,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2269,7 +2273,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2321,7 +2325,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2379,12 +2383,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2937,8 +2941,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3026,7 +3030,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3123,7 +3127,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3161,11 +3165,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3581,7 +3585,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3726,20 +3730,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3765,7 +3769,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3973,7 +3977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3992,7 +3996,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4042,12 +4046,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4106,7 +4110,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4274,19 +4278,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4608,11 +4612,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4880,7 +4884,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4896,7 +4900,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5336,12 +5340,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5362,8 +5366,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5756,20 +5760,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5941,8 +5945,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5969,16 +5973,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -295,7 +295,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1122,7 +1122,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1323,8 +1323,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1342,7 +1342,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1668,11 +1668,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1768,22 +1768,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1803,17 +1803,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1885,7 +1885,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2076,22 +2080,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2251,11 +2255,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2269,7 +2273,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2321,7 +2325,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2379,12 +2383,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2937,8 +2941,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3026,7 +3030,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3123,7 +3127,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3161,11 +3165,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3581,7 +3585,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3726,20 +3730,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3765,7 +3769,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3973,7 +3977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3992,7 +3996,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4042,12 +4046,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4106,7 +4110,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4274,19 +4278,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4608,11 +4612,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4880,7 +4884,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4896,7 +4900,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5336,12 +5340,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5362,8 +5366,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5756,20 +5760,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5941,8 +5945,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5969,16 +5973,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -396,7 +396,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
@@ -406,7 +406,7 @@ msgstr "%s 不是一个目录"
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -651,7 +651,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -864,7 +864,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -893,7 +893,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1424,8 +1424,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1443,7 +1443,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1587,7 +1587,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1769,11 +1769,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1869,22 +1869,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1894,7 +1894,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1904,17 +1904,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1967,7 +1967,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1986,7 +1986,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2177,22 +2181,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2352,11 +2356,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2370,7 +2374,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2422,7 +2426,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2480,12 +2484,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3038,8 +3042,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3127,7 +3131,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3224,7 +3228,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3262,11 +3266,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3682,7 +3686,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3827,20 +3831,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3866,7 +3870,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4074,7 +4078,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4093,7 +4097,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4143,12 +4147,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4207,7 +4211,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4375,19 +4379,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4709,11 +4713,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4981,7 +4985,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4997,7 +5001,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5437,12 +5441,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5463,8 +5467,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5857,20 +5861,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6042,8 +6046,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -6070,16 +6074,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-04-22 20:37-0400\n"
+"POT-Creation-Date: 2022-04-27 19:56-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -294,7 +294,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:864
+#: lxc/file.go:879
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:758
+#: lxc/file.go:773
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:425
+#: lxc/file.go:436
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1114
+#: lxc/cluster.go:1117
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:321
+#: lxc/file.go:331
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:501
+#: lxc/file.go:516
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:238 lxc/file.go:434
+#: lxc/file.go:244 lxc/file.go:445
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1322,8 +1322,8 @@ msgstr ""
 #: lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201
 #: lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378
 #: lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709
-#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1062
-#: lxc/cluster.go:1081 lxc/cluster_group.go:30 lxc/cluster_group.go:79
+#: lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063
+#: lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
@@ -1341,7 +1341,7 @@ msgstr ""
 #: lxc/config_trust.go:508 lxc/config_trust.go:551 lxc/config_trust.go:622
 #: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42
 #: lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169
-#: lxc/file.go:232 lxc/file.go:427 lxc/file.go:914 lxc/image.go:38
+#: lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38
 #: lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490
 #: lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303
 #: lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:922
+#: lxc/file.go:937
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1667,11 +1667,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1061 lxc/cluster.go:1062
+#: lxc/cluster.go:1062 lxc/cluster.go:1063
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1138
+#: lxc/cluster.go:1142
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1767,22 +1767,22 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1161
+#: lxc/file.go:1176
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1184
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:999
+#: lxc/file.go:1014
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1118
+#: lxc/file.go:1133
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -1802,17 +1802,17 @@ msgstr ""
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1138
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/file.go:1024
+#: lxc/file.go:1039
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1149
+#: lxc/file.go:1164
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -1850,7 +1850,7 @@ msgstr ""
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1135
+#: lxc/file.go:1150
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:753
+#: lxc/file.go:768
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1089
+#: lxc/cluster.go:1065
+msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/cluster.go:1092
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2075,22 +2079,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1233
+#: lxc/file.go:1248
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1222
+#: lxc/file.go:1237
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1048
+#: lxc/file.go:1063
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1058
+#: lxc/file.go:1073
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2250,11 +2254,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1050
+#: lxc/file.go:1065
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1224
+#: lxc/file.go:1239
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:971
+#: lxc/file.go:986
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:981
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2378,12 +2382,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:295
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:455
+#: lxc/file.go:466
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2936,8 +2940,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3025,7 +3029,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/cluster.go:1110 lxc/cluster_group.go:110
+#: lxc/cluster.go:629 lxc/cluster.go:1113 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:469 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:548
+#: lxc/file.go:563
 msgid "Missing target directory"
 msgstr ""
 
@@ -3160,11 +3164,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:281
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:913 lxc/file.go:914
+#: lxc/file.go:928 lxc/file.go:929
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3580,7 +3584,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1043
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -3725,20 +3729,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:231 lxc/file.go:232
+#: lxc/file.go:237 lxc/file.go:238
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:384 lxc/file.go:707
+#: lxc/file.go:394 lxc/file.go:722
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:426 lxc/file.go:427
+#: lxc/file.go:437 lxc/file.go:438
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:643 lxc/file.go:799
+#: lxc/file.go:658 lxc/file.go:814
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -3764,7 +3768,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:239 lxc/file.go:433
+#: lxc/file.go:245 lxc/file.go:444
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -3972,7 +3976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1080 lxc/cluster.go:1081
+#: lxc/cluster.go:1083 lxc/cluster.go:1084
 msgid "Restore cluster member"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1136
+#: lxc/cluster.go:1140
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4041,12 +4045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1154
+#: lxc/file.go:1169
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1155
+#: lxc/file.go:1170
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4105,7 +4109,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:923
+#: lxc/file.go:938
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4273,19 +4277,19 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:436
+#: lxc/file.go:447
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:437
+#: lxc/file.go:448
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:435
+#: lxc/file.go:446
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:921
+#: lxc/file.go:936
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4607,11 +4611,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:959
+#: lxc/file.go:974
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:953
+#: lxc/file.go:968
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1192
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:740
+#: lxc/file.go:755
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5335,12 +5339,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:230
+#: lxc/file.go:236
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:912
+#: lxc/file.go:927
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5361,8 +5365,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1060
-#: lxc/cluster.go:1079
+#: lxc/cluster.go:199 lxc/cluster.go:425 lxc/cluster.go:875 lxc/cluster.go:1061
+#: lxc/cluster.go:1082
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5755,20 +5759,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:931
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:429
+#: lxc/file.go:440
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -5940,8 +5944,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:412
@@ -5968,16 +5972,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1082
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1042
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:981
+#: lxc/file.go:996
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -244,6 +244,12 @@ type ClusterMemberStatePost struct {
 	// The action to be performed. Valid actions are "evacuate" and "restore".
 	// Example: evacuate
 	Action string `json:"action" yaml:"action"`
+
+	// Override the configured evacuation mode.
+	// Example: stop
+	//
+	// API extension: clustering_evacuate_mode
+	Mode string `json:"mode" yaml:"mode"`
 }
 
 // ClusterGroupsPost represents the fields available for a new cluster group.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -332,6 +332,7 @@ var APIExtensions = []string{
 	"instances_nic_host_name",
 	"image_copy_profile",
 	"container_syscall_intercept_sysinfo",
+	"clustering_evacuation_mode",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This is primarily useful to override to `stop` when one just wants to stop all instances on one or multiple server.

I'm going to need that when moving a rack full of server soon where I need all instances to be stopped but have their last state properly recorded so I can just restore the servers later on.