### PR TITLE
test: Skip seccomp notify tests if seccomp notify not supported

### DIFF
--- a/test/suites/container_syscall_interception.sh
+++ b/test/suites/container_syscall_interception.sh
@@ -2,6 +2,11 @@ test_container_syscall_interception() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
+  if [ "$(lxc query /1.0 | jq -r .environment.lxc_features.seccomp_notify)" != "true" ]; then
+    echo "==> SKIP: Seccomp notify not supported"
+    return
+  fi
+
   (
     cd syscall/sysinfo || return
     # Use -buildvcs=false here to prevent git complaining about untrusted directory when tests are run as root.


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>