### PR TITLE
Adds simple wrapper for a cancellable context

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -406,7 +406,7 @@ type BackupFileRequest struct {
 	ProgressHandler func(progress ioprogress.ProgressData)
 
 	// A canceler that can be used to interrupt some part of the image download request
-	Canceler *cancel.Canceler
+	Canceler *cancel.HTTPRequestCanceller
 }
 
 // The BackupFileResponse struct is used as the response for backup downloads.
@@ -448,7 +448,7 @@ type ImageFileRequest struct {
 	ProgressHandler func(progress ioprogress.ProgressData)
 
 	// A canceler that can be used to interrupt some part of the image download request
-	Canceler *cancel.Canceler
+	Canceler *cancel.HTTPRequestCanceller
 
 	// Path retriever for image delta downloads
 	// If set, it must return the path to the image file or an empty string if not available

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -284,9 +284,9 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 		}
 	}
 
-	var canceler *cancel.Canceler
+	var canceler *cancel.HTTPRequestCanceller
 	if op != nil {
-		canceler = cancel.NewCanceler()
+		canceler = cancel.NewHTTPRequestCanceller()
 		op.SetCanceler(canceler)
 	}
 

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -101,7 +101,7 @@ type Operation struct {
 	metadata    map[string]any
 	err         string
 	readonly    bool
-	canceler    *cancel.Canceler
+	canceler    *cancel.HTTPRequestCanceller
 	description string
 	permission  string
 	dbOpType    db.OperationType
@@ -660,7 +660,7 @@ func (op *Operation) Resources() map[string][]string {
 }
 
 // SetCanceler sets a canceler.
-func (op *Operation) SetCanceler(canceler *cancel.Canceler) {
+func (op *Operation) SetCanceler(canceler *cancel.HTTPRequestCanceller) {
 	op.canceler = canceler
 }
 

--- a/shared/cancel/canceller.go
+++ b/shared/cancel/canceller.go
@@ -1,0 +1,19 @@
+package cancel
+
+import "context"
+
+// Canceller is a simple wrapper for a cancellable context which makes the associated context.CancelFunc more easily
+// accessible.
+type Canceller struct {
+	context.Context
+	Cancel context.CancelFunc
+}
+
+// New returns a new canceller with the parent context.
+func New(ctx context.Context) *Canceller {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Canceller{
+		Context: ctx,
+		Cancel:  cancel,
+	}
+}

--- a/shared/cancel/http.go
+++ b/shared/cancel/http.go
@@ -6,15 +6,15 @@ import (
 	"sync"
 )
 
-// Canceler tracks a cancelable operation
-type Canceler struct {
+// HTTPRequestCanceller tracks a cancelable operation
+type HTTPRequestCanceller struct {
 	reqChCancel map[*http.Request]chan struct{}
 	lock        sync.Mutex
 }
 
-// NewCanceler returns a new Canceler struct
-func NewCanceler() *Canceler {
-	c := Canceler{}
+// NewHTTPRequestCanceller returns a new HTTPRequestCanceller struct
+func NewHTTPRequestCanceller() *HTTPRequestCanceller {
+	c := HTTPRequestCanceller{}
 
 	c.lock.Lock()
 	c.reqChCancel = make(map[*http.Request]chan struct{})
@@ -23,8 +23,8 @@ func NewCanceler() *Canceler {
 	return &c
 }
 
-// Cancelable indicates whether there are operations that support cancelation
-func (c *Canceler) Cancelable() bool {
+// Cancelable indicates whether there are operations that support cancellation
+func (c *HTTPRequestCanceller) Cancelable() bool {
 	c.lock.Lock()
 	length := len(c.reqChCancel)
 	c.lock.Unlock()
@@ -33,7 +33,7 @@ func (c *Canceler) Cancelable() bool {
 }
 
 // Cancel will attempt to cancel all ongoing operations
-func (c *Canceler) Cancel() error {
+func (c *HTTPRequestCanceller) Cancel() error {
 	if !c.Cancelable() {
 		return fmt.Errorf("This operation can't be canceled at this time")
 	}
@@ -49,7 +49,7 @@ func (c *Canceler) Cancel() error {
 }
 
 // CancelableDownload performs an http request and allows for it to be canceled at any time
-func CancelableDownload(c *Canceler, client *http.Client, req *http.Request) (*http.Response, chan bool, error) {
+func CancelableDownload(c *HTTPRequestCanceller, client *http.Client, req *http.Request) (*http.Response, chan bool, error) {
 	chDone := make(chan bool)
 	chCancel := make(chan struct{})
 	if c != nil {

--- a/shared/util.go
+++ b/shared/util.go
@@ -1025,7 +1025,7 @@ func SetProgressMetadata(metadata map[string]any, stage, displayPrefix string, p
 	}
 }
 
-func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent string, progress func(progress ioprogress.ProgressData), canceler *cancel.Canceler, filename string, url string, hash string, hashFunc hash.Hash, target io.WriteSeeker) (int64, error) {
+func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent string, progress func(progress ioprogress.ProgressData), canceler *cancel.HTTPRequestCanceller, filename string, url string, hash string, hashFunc hash.Hash, target io.WriteSeeker) (int64, error) {
 	// Always seek to the beginning
 	target.Seek(0, 0)
 


### PR DESCRIPTION
When a resource such as a database must advertise when it becomes ready, we can use a cancellable `context.Context`. This is useful because subsequent calls to the associated `CancelFunc` will not cause the goroutine to panic (whereas calling `close()` on a channel will). However this means that the resource must keep a reference to both the cancellable context and it's `CancelFunc` which is less desirable.

This change adds a simple wrapper to a cancellable context such that it can be used like:
```golang
canceller := cancel.New(ctx)
defer canceller.Close()
```

Additionally, the existing canceller was renamed and moved to `shared/cancel/http.go`.

Based on chat here https://github.com/canonical/lxd-cloud/pull/114#discussion_r860759810