### PR TITLE
Storage: Fix unpacking image larger than default volume size for non-thin LVM pools

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -73,7 +73,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		}
 	}
 
-	err = d.runFiller(vol, rootBlockPath, filler)
+	err = d.runFiller(vol, rootBlockPath, filler, false)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -179,8 +179,23 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 				}
 			}
 
+			allowUnsafeResize := false
+			if vol.volType == VolumeTypeImage {
+				// Allow filler to resize initial image volume as needed.
+				// Some storage drivers don't normally allow image volumes to be resized due to
+				// them having read-only snapshots that cannot be resized. However when creating
+				// the initial image volume and filling it before the snapshot is taken resizing
+				// can be allowed and is required in order to support unpacking images larger than
+				// the default volume size. The filler function is still expected to obey any
+				// volume size restrictions configured on the pool.
+				// Unsafe resize is also needed to disable filesystem resize safety checks.
+				// This is safe because if for some reason an error occurs the volume will be
+				// discarded rather than leaving a corrupt filesystem.
+				allowUnsafeResize = true
+			}
+
 			// Run the filler.
-			err = d.runFiller(vol, devPath, filler)
+			err = d.runFiller(vol, devPath, filler, allowUnsafeResize)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -51,7 +51,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 	}
 
 	// Fill the volume.
-	err = d.runFiller(vol, "", filler)
+	err = d.runFiller(vol, "", filler, false)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -234,22 +234,9 @@ func (d *common) moveGPTAltHeader(devPath string) error {
 }
 
 // runFiller runs the supplied filler, and setting the returned volume size back into filler.
-func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) error {
+func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller, allowUnsafeResize bool) error {
 	if filler == nil || filler.Fill == nil {
 		return nil
-	}
-
-	allowUnsafeResize := false
-
-	// Allow filler to resize initial image volume as needed. Some storage drivers don't normally allow
-	// image volumes to be resized due to them having read-only snapshots that cannot be resized. However
-	// when creating the initial image volume and filling it before the snapshot is taken resizing can be
-	// allowed and is required in order to support unpacking images larger than the default volume size.
-	// The filler function is still expected to obey any volume size restrictions configured on the pool.
-	// Also needed allow unsafe resize to disable filesystem resize safety checks. This is safe because if for
-	// some reason an error occurs the volume will be discarded rather than leaving a corrupt filesystem.
-	if vol.Type() == VolumeTypeImage {
-		allowUnsafeResize = true
 	}
 
 	vol.driver.Logger().Debug("Running filler function", logger.Ctx{"dev": devPath, "path": vol.MountPath()})
@@ -259,5 +246,6 @@ func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) err
 	}
 
 	filler.Size = volSize
+
 	return nil
 }

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -55,7 +55,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	}
 
 	// Run the volume filler function if supplied.
-	err = d.runFiller(vol, rootBlockPath, filler)
+	err = d.runFiller(vol, rootBlockPath, filler, false)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -67,8 +67,23 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				}
 			}
 
+			allowUnsafeResize := false
+			if vol.volType == VolumeTypeImage || !d.usesThinpool() {
+				// Allow filler to resize initial image and non-thin volumes as needed.
+				// Some storage drivers don't normally allow image volumes to be resized due to
+				// them having read-only snapshots that cannot be resized. However when creating
+				// the initial volume and filling it unsafe resizing can be allowed and is required
+				// in order to support unpacking images larger than the default volume size.
+				// The filler function is still expected to obey any volume size restrictions
+				// configured on the pool.
+				// Unsafe resize is also needed to disable filesystem resize safety checks.
+				// This is safe because if for some reason an error occurs the volume will be
+				// discarded rather than leaving a corrupt filesystem.
+				allowUnsafeResize = true
+			}
+
 			// Run the filler.
-			err = d.runFiller(vol, devPath, filler)
+			err = d.runFiller(vol, devPath, filler, allowUnsafeResize)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -216,8 +216,23 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				}
 			}
 
+			allowUnsafeResize := false
+			if vol.volType == VolumeTypeImage {
+				// Allow filler to resize initial image volume as needed.
+				// Some storage drivers don't normally allow image volumes to be resized due to
+				// them having read-only snapshots that cannot be resized. However when creating
+				// the initial image volume and filling it before the snapshot is taken resizing
+				// can be allowed and is required in order to support unpacking images larger than
+				// the default volume size. The filler function is still expected to obey any
+				// volume size restrictions configured on the pool.
+				// Unsafe resize is also needed to disable filesystem resize safety checks.
+				// This is safe because if for some reason an error occurs the volume will be
+				// discarded rather than leaving a corrupt filesystem.
+				allowUnsafeResize = true
+			}
+
 			// Run the filler.
-			err = d.runFiller(vol, devPath, filler)
+			err = d.runFiller(vol, devPath, filler, allowUnsafeResize)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -463,7 +463,7 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 			// If the target volume's size is smaller than the image unpack size, then we need to
 			// increase the target volume's size.
 			if volSizeBytes < imgInfo.VirtualSize {
-				l.Debug("Increasing volume size", logger.Ctx{"imgPath": imgPath, "dstPath": dstPath, "oldSize": volSizeBytes, "newSize": newVolSize})
+				l.Debug("Increasing volume size", logger.Ctx{"imgPath": imgPath, "dstPath": dstPath, "oldSize": volSizeBytes, "newSize": newVolSize, "allowUnsafeResize": allowUnsafeResize})
 				err = vol.SetQuota(newVolSize, allowUnsafeResize, nil)
 				if err != nil {
 					return -1, fmt.Errorf("Error increasing volume size: %w", err)


### PR DESCRIPTION
This PR moves the unsafe resizing mode logic into each driver rather than do it in common.

This allows non-thin LVM pools to use unsafe resizing mode for normal volumes as well as image volumes, as they don't use cached image volumes.

Fixes #10343 

Tested on: Dir, BTRFS, ZFS, LVM, LVM thin