### PR TITLE
lxd/secommp: Fix sysinfo syscall interception on 32 bit platforms

### DIFF
--- a/lxd/seccomp/sysinfo.go
+++ b/lxd/seccomp/sysinfo.go
@@ -1,0 +1,13 @@
+package seccomp
+
+// Sysinfo architecture independent sysinfo struct.
+type Sysinfo struct {
+	Uptime    int64
+	Totalram  uint64
+	Freeram   uint64
+	Sharedram uint64
+	Bufferram uint64
+	Totalswap uint64
+	Freeswap  uint64
+	Procs     uint16
+}

--- a/lxd/seccomp/sysinfo_32.go
+++ b/lxd/seccomp/sysinfo_32.go
@@ -1,0 +1,19 @@
+//go:build 386 || arm || ppc || s390 || mips || mipsle
+
+package seccomp
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// ToNative fills fields from s into native fields.
+func (s *Sysinfo) ToNative(n *unix.Sysinfo_t) {
+	n.Bufferram = uint32(s.Bufferram)
+	n.Freeram = uint32(s.Freeram)
+	n.Freeswap = uint32(s.Freeswap)
+	n.Procs = s.Procs
+	n.Sharedram = uint32(s.Sharedram)
+	n.Totalram = uint32(s.Totalram)
+	n.Totalswap = uint32(s.Totalswap)
+	n.Uptime = int32(s.Uptime)
+}

--- a/lxd/seccomp/sysinfo_64.go
+++ b/lxd/seccomp/sysinfo_64.go
@@ -1,0 +1,19 @@
+//go:build amd64 || ppc64 || ppc64le || arm64 || s390x || mips64 || mips64le || riscv64
+
+package seccomp
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// ToNative fills fields from s into native fields.
+func (s *Sysinfo) ToNative(n *unix.Sysinfo_t) {
+	n.Bufferram = s.Bufferram
+	n.Freeram = s.Freeram
+	n.Freeswap = s.Freeswap
+	n.Procs = s.Procs
+	n.Sharedram = s.Sharedram
+	n.Totalram = s.Totalram
+	n.Totalswap = s.Totalswap
+	n.Uptime = s.Uptime
+}


### PR DESCRIPTION
Fixes #10347

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>