### PR TITLE
Client: Add some default timeouts

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/lxc/lxd/shared"
 )
@@ -20,10 +21,13 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 
 	// Define the http transport
 	transport := &http.Transport{
-		TLSClientConfig:   tlsConfig,
-		Dial:              shared.RFC3493Dialer,
-		Proxy:             shared.ProxyFromEnvironment,
-		DisableKeepAlives: true,
+		TLSClientConfig:       tlsConfig,
+		Dial:                  shared.RFC3493Dialer,
+		Proxy:                 shared.ProxyFromEnvironment,
+		DisableKeepAlives:     true,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 30,
+		TLSHandshakeTimeout:   time.Second * 5,
 	}
 
 	// Allow overriding the proxy

--- a/client/util.go
+++ b/client/util.go
@@ -115,8 +115,11 @@ func unixHTTPClient(client *http.Client, path string) (*http.Client, error) {
 
 	// Define the http transport
 	transport := &http.Transport{
-		Dial:              unixDial,
-		DisableKeepAlives: true,
+		Dial:                  unixDial,
+		DisableKeepAlives:     true,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 30,
+		TLSHandshakeTimeout:   time.Second * 5,
 	}
 
 	// Define the http client

--- a/lxd/cluster/tls.go
+++ b/lxd/cluster/tls.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/util"
@@ -92,9 +93,12 @@ func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *sha
 // used.
 func tlsTransport(config *tls.Config) (*http.Transport, func()) {
 	transport := &http.Transport{
-		TLSClientConfig:   config,
-		DisableKeepAlives: true,
-		MaxIdleConns:      0,
+		TLSClientConfig:       config,
+		DisableKeepAlives:     true,
+		MaxIdleConns:          0,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 30,
+		TLSHandshakeTimeout:   time.Second * 5,
 	}
 	return transport, transport.CloseIdleConnections
 }

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -117,10 +117,13 @@ func HTTPClient(certificate string, proxy proxyFunc) (*http.Client, error) {
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig:   tlsConfig,
-		Dial:              shared.RFC3493Dialer,
-		Proxy:             proxy,
-		DisableKeepAlives: true,
+		TLSClientConfig:       tlsConfig,
+		Dial:                  shared.RFC3493Dialer,
+		Proxy:                 proxy,
+		DisableKeepAlives:     true,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 30,
+		TLSHandshakeTimeout:   time.Second * 5,
 	}
 
 	myhttp := http.Client{

--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -75,7 +75,10 @@ func HTTPClient(vsockID int, tlsClientCert string, tlsClientKey string, tlsServe
 
 			return tlsConn, nil
 		},
-		DisableKeepAlives: true,
+		DisableKeepAlives:     true,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 30,
+		TLSHandshakeTimeout:   time.Second * 5,
 	}
 
 	// Setup redirect policy.

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -400,9 +400,12 @@ func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, 
 	tlsConfig.InsecureSkipVerify = true
 
 	tr := &http.Transport{
-		TLSClientConfig: tlsConfig,
-		Dial:            RFC3493Dialer,
-		Proxy:           ProxyFromEnvironment,
+		TLSClientConfig:       tlsConfig,
+		Dial:                  RFC3493Dialer,
+		Proxy:                 ProxyFromEnvironment,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 30,
+		TLSHandshakeTimeout:   time.Second * 5,
 	}
 
 	// Connect


### PR DESCRIPTION
Recently during an instability/outage in the LXC hosting infrastructure I noticed that the image download attempt that was being made hung for several minutes.

This sounds similar to the issue reported here https://github.com/lxc/lxd/issues/10279

This lead me to notice that several of the HTTP clients we use do not include any timeouts beyond establishing the initial TCP/Unix connection.

This is an attempt to introduce some (I hope) sensible defaults.