### PR TITLE
lxd/certificates: Check token for trusted admins

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -513,12 +513,13 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// User isn't an admin and is already trusted, can't add more certs.
+	if trusted && req.Certificate == "" {
+		return response.BadRequest(fmt.Errorf("Client is already trusted"))
+	}
+
 	// Handle requests by non-admin users.
 	if !rbac.UserIsAdmin(r) {
-		if trusted {
-			return response.BadRequest(fmt.Errorf("Client is already trusted"))
-		}
-
 		// A password is required for non-admin users.
 		if req.Password == "" {
 			return response.Forbidden(nil)

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -507,16 +507,19 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Check if the user is already trusted.
 	trusted, _, _, err := d.Authenticate(nil, r)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	// Handle requests by non-admin users.
 	if !rbac.UserIsAdmin(r) {
 		if trusted {
 			return response.BadRequest(fmt.Errorf("Client is already trusted"))
 		}
 
+		// A password is required for non-admin users.
 		if req.Password == "" {
 			return response.Forbidden(nil)
 		}


### PR DESCRIPTION
This checks the supplied token/password for trusted admins as well. In
the past this was not done which would return a misleading error
("Invalid certificate type") when trying to add a client certificate
twice.

This fixes #10350.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
