### PR TITLE
cloud-init notification API

### DIFF
--- a/lxd/events.go
+++ b/lxd/events.go
@@ -146,7 +146,9 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 		}
 	}
 
-	listener, err := d.events.AddListener(projectName, allProjects, c, types, excludeSources, recvFunc, excludeLocations)
+	listenerConnection := events.NewWebsocketListenerConnection(c)
+
+	listener, err := d.events.AddListener(projectName, allProjects, listenerConnection, types, excludeSources, recvFunc, excludeLocations)
 	if err != nil {
 		return err
 	}

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -143,10 +143,3 @@ func (e *listenerCommon) WriteJSON(v any) error {
 	return e.Conn.WriteJSON(v)
 }
 
-// WriteMessage to the connection.
-func (e *listenerCommon) WriteMessage(messageType int, data []byte) error {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-
-	return e.Conn.WriteMessage(messageType, data)
-}

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -31,7 +31,7 @@ type listenerCommon struct {
 	recvFunc     EventHandler
 }
 
-func (e *listenerCommon) heartbeat() {
+func (e *listenerCommon) start() {
 	logger.Debug("Event listener server handler started", logger.Ctx{"id": e.id, "local": e.LocalAddr(), "remote": e.RemoteAddr()})
 
 	e.Reader(e.ctx, e.recvFunc)

--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -2,7 +2,14 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/lxc/lxd/shared/api"
 )
 
 // EventListenerConnection represents an event listener connection.
@@ -12,4 +19,106 @@ type EventListenerConnection interface {
 	Close() error
 	LocalAddr() net.Addr  // Used for logging
 	RemoteAddr() net.Addr // Used for logging
+}
+
+type websockListenerConnection struct {
+	*websocket.Conn
+
+	lock         sync.Mutex
+	pongsPending int
+}
+
+// NewWebsocketListenerConnection returns a new websocket listener connection.
+func NewWebsocketListenerConnection(connection *websocket.Conn) EventListenerConnection {
+	return &websockListenerConnection{
+		Conn: connection,
+	}
+}
+
+func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHandler) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	close := func() {
+		e.lock.Lock()
+		defer e.lock.Unlock()
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		_ = e.Close()
+		cancel()
+	}
+
+	defer close()
+
+	pingInterval := time.Second * 10
+	e.pongsPending = 0
+
+	e.SetPongHandler(func(msg string) error {
+		e.lock.Lock()
+		e.pongsPending = 0
+		e.lock.Unlock()
+		return nil
+	})
+
+	// Start reader from client.
+	go func() {
+		defer close()
+
+		if recvFunc != nil {
+			for {
+				var event api.Event
+				err := e.Conn.ReadJSON(&event)
+				if err != nil {
+					return // This detects if client has disconnected or sent invalid data.
+				}
+
+				// Pass received event to the handler.
+				recvFunc(event)
+			}
+		} else {
+			// Run a blocking reader to detect if the client has disconnected. We don't expect to get
+			// anything from the remote side, so this should remain blocked until disconnected.
+			_, _, _ = e.Conn.NextReader()
+		}
+	}()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		e.lock.Lock()
+		if e.pongsPending > 2 {
+			e.lock.Unlock()
+			return
+		}
+		err := e.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
+		if err != nil {
+			e.lock.Unlock()
+			return
+		}
+
+		e.pongsPending++
+		e.lock.Unlock()
+
+		select {
+		case <-time.After(pingInterval):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (e *websockListenerConnection) WriteJSON(event any) error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	err := e.Conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err != nil {
+		return fmt.Errorf("Failed setting write deadline: %w", err)
+	}
+
+	return e.Conn.WriteJSON(event)
 }

--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -1,0 +1,15 @@
+package events
+
+import (
+	"context"
+	"net"
+)
+
+// EventListenerConnection represents an event listener connection.
+type EventListenerConnection interface {
+	Reader(ctx context.Context, recvFunc EventHandler)
+	WriteJSON(event any) error
+	Close() error
+	LocalAddr() net.Addr  // Used for logging
+	RemoteAddr() net.Addr // Used for logging
+}

--- a/lxd/events/devlxdEvents.go
+++ b/lxd/events/devlxdEvents.go
@@ -56,7 +56,7 @@ func (s *DevLXDServer) AddListener(instanceID int, connection EventListenerConne
 
 	s.listeners[listener.id] = listener
 
-	go listener.heartbeat()
+	go listener.start()
 
 	return listener, nil
 }

--- a/lxd/events/devlxdEvents.go
+++ b/lxd/events/devlxdEvents.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pborman/uuid"
 
-	"github.com/gorilla/websocket"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -34,16 +33,16 @@ func NewDevLXDServer(debug bool, verbose bool) *DevLXDServer {
 }
 
 // AddListener creates and returns a new event listener.
-func (s *DevLXDServer) AddListener(instanceID int, connection *websocket.Conn, messageTypes []string) (*DevLXDListener, error) {
+func (s *DevLXDServer) AddListener(instanceID int, connection EventListenerConnection, messageTypes []string) (*DevLXDListener, error) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 
 	listener := &DevLXDListener{
 		listenerCommon: listenerCommon{
-			Conn:         connection,
-			messageTypes: messageTypes,
-			ctx:          ctx,
-			ctxCancel:    ctxCancel,
-			id:           uuid.New(),
+			EventListenerConnection: connection,
+			messageTypes:            messageTypes,
+			ctx:                     ctx,
+			ctxCancel:               ctxCancel,
+			id:                      uuid.New(),
 		},
 		instanceID: instanceID,
 	}
@@ -100,7 +99,6 @@ func (s *DevLXDServer) broadcast(instanceID int, event api.Event) error {
 				return
 			}
 
-			_ = listener.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			err := listener.WriteJSON(event)
 			if err != nil {
 				// Remove the listener from the list

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -96,7 +96,7 @@ func (s *Server) AddListener(projectName string, allProjects bool, connection Ev
 
 	s.listeners[listener.id] = listener
 
-	go listener.heartbeat()
+	go listener.start()
 
 	return listener, nil
 }

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pborman/uuid"
 
-	"github.com/gorilla/websocket"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -65,7 +64,7 @@ func (s *Server) SetLocalLocation(location string) {
 }
 
 // AddListener creates and returns a new event listener.
-func (s *Server) AddListener(projectName string, allProjects bool, connection *websocket.Conn, messageTypes []string, excludeSources []EventSource, recvFunc EventHandler, excludeLocations []string) (*Listener, error) {
+func (s *Server) AddListener(projectName string, allProjects bool, connection EventListenerConnection, messageTypes []string, excludeSources []EventSource, recvFunc EventHandler, excludeLocations []string) (*Listener, error) {
 	if allProjects && projectName != "" {
 		return nil, fmt.Errorf("Cannot specify project name when listening for events on all projects")
 	}
@@ -74,12 +73,12 @@ func (s *Server) AddListener(projectName string, allProjects bool, connection *w
 
 	listener := &Listener{
 		listenerCommon: listenerCommon{
-			Conn:         connection,
-			messageTypes: messageTypes,
-			ctx:          ctx,
-			ctxCancel:    ctxCancel,
-			id:           uuid.New(),
-			recvFunc:     recvFunc,
+			EventListenerConnection: connection,
+			messageTypes:            messageTypes,
+			ctx:                     ctx,
+			ctxCancel:               ctxCancel,
+			id:                      uuid.New(),
+			recvFunc:                recvFunc,
 		},
 
 		allProjects:      allProjects,
@@ -205,7 +204,6 @@ func (s *Server) broadcast(event api.Event, eventSource EventSource) error {
 				return
 			}
 
-			_ = listener.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			err := listener.WriteJSON(event)
 			if err != nil {
 				// Remove the listener from the list

--- a/test/suites/devlxd.sh
+++ b/test/suites/devlxd.sh
@@ -25,8 +25,11 @@ test_devlxd() {
   lxc config set devlxd security.nesting true
   ! lxc exec devlxd devlxd-client security.nesting | grep true || false
 
-  lxc exec devlxd devlxd-client monitor > "${TEST_DIR}/devlxd.log" &
-  client=$!
+  lxc exec devlxd devlxd-client monitor-websocket > "${TEST_DIR}/devlxd-websocket.log" &
+  client_websocket=$!
+
+  lxc exec devlxd devlxd-client monitor-stream > "${TEST_DIR}/devlxd-stream.log" &
+  client_stream=$!
 
   (
     cat << EOF
@@ -67,14 +70,15 @@ EOF
     lxc config set devlxd user.foo bar
     lxc config set devlxd security.nesting true
 
-    true > "${TEST_DIR}/devlxd.log"
+    true > "${TEST_DIR}/devlxd-websocket.log"
+    true > "${TEST_DIR}/devlxd-stream.log"
 
     lxc config set devlxd user.foo baz
     lxc config set devlxd security.nesting false
     lxc config device add devlxd mnt disk source="${TEST_DIR}" path=/mnt
     lxc config device remove devlxd mnt
 
-    if [ "$(tr -d '\0' < "${TEST_DIR}/devlxd.log" | md5sum | cut -d' ' -f1)" != "$(md5sum "${TEST_DIR}/devlxd.expected" | cut -d' ' -f1)" ]; then
+    if [ "$(tr -d '\0' < "${TEST_DIR}/devlxd-websocket.log" | md5sum | cut -d' ' -f1)" != "$(md5sum "${TEST_DIR}/devlxd.expected" | cut -d' ' -f1)" ] || [ "$(tr -d '\0' < "${TEST_DIR}/devlxd-stream.log" | md5sum | cut -d' ' -f1)" != "$(md5sum "${TEST_DIR}/devlxd.expected" | cut -d' ' -f1)" ]; then
       sleep 0.5
       continue
     fi
@@ -83,7 +87,8 @@ EOF
     break
   done
 
-  kill -9 "${client}"
+  kill -9 "${client_websocket}"
+  kill -9 "${client_stream}"
   lxc delete devlxd --force
 
   [ "${MATCH}" = "1" ] || false


### PR DESCRIPTION
This adds http streaming support to the `/1.0/events` endpoint of devlxd. Clients can be notified about events without having to use websockets.