### PR TITLE
Move IP checks to startup time

### DIFF
--- a/lxd/device/device_interface.go
+++ b/lxd/device/device_interface.go
@@ -36,10 +36,6 @@ type Device interface {
 	Config() deviceConfig.Device
 	Name() string
 
-	// Add performs any host-side setup when a device is added to an instance.
-	// It is called irrespective of whether the instance is running or not.
-	Add() error
-
 	// PreStartCheck indicates if the device is available for starting.
 	PreStartCheck() error
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -367,17 +367,6 @@ func (d *nicBridged) UpdatableFields(oldDevice Type) []string {
 	return []string{"limits.ingress", "limits.egress", "limits.max", "ipv4.routes", "ipv6.routes", "ipv4.routes.external", "ipv6.routes.external", "ipv4.address", "ipv6.address", "security.mac_filtering", "security.ipv4_filtering", "security.ipv6_filtering"}
 }
 
-// Add is run when a device is added to a non-snapshot instance whether or not the instance is running.
-func (d *nicBridged) Add() error {
-	// Rebuild dnsmasq entry if needed and reload.
-	err := d.rebuildDnsmasqEntry()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // PreStartCheck checks the managed parent network is available (if relevant).
 func (d *nicBridged) PreStartCheck() error {
 	// Non-managed network NICs are not relevant for checking managed network availability.

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -477,6 +477,18 @@ func (d *nicBridged) PreStartCheck() error {
 		if err != nil {
 			return err
 		}
+
+		deviceStaticFileName := dnsmasq.StaticAllocationFileName(d.inst.Project(), d.inst.Name(), d.Name())
+		_, checkFileNonExistance := os.Stat(shared.VarPath("networks", d.config["parent"], "dnsmasq.hosts", deviceStaticFileName))
+
+		// Check if the device specific dnsmasq config file exists. If file doesn't exist its first start so we need to generate the dnsmasq config
+		if checkFileNonExistance != nil {
+			// Rebuild dnsmasq entry if needed and reload.
+			err := d.rebuildDnsmasqEntry()
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1094,8 +1094,9 @@ test_clustering_network() {
 
   # Check duplicate static DHCP allocation detection is working for same server as c1.
   LXD_DIR="${LXD_ONE_DIR}" lxc init --target node1 -n "${net}" testimage c2
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 ipv4.address=192.0.2.2 || false
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 ipv6.address=2001:db8::2 || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 ipv4.address=192.0.2.2
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 ipv6.address=2001:db8::2
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc start c2 || false
 
   # Check duplicate static DHCP allocation is allowed for instance on a different server.
   LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 -n "${net}" testimage c3
@@ -1104,7 +1105,8 @@ test_clustering_network() {
 
   # Check duplicate MAC address assignment detection is working using both network and parent keys.
   c1MAC=$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c1 volatile.eth0.hwaddr)
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 hwaddr="${c1MAC}" || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 hwaddr="${c1MAC}"
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc start c2 || false
   LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 eth0 hwaddr="${c1MAC}"
 
   # Check duplicate static MAC assignment detection is working for same server as c1.

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -562,6 +562,15 @@ test_container_devices_nic_bridged() {
   lxc config unset instances.nic.host_name
   lxc delete -f test-naming
 
+  # Test container copy
+  lxc copy "${ctName}" bar
+  lxc config device set bar eth0 ipv4.address=192.0.2.232
+  # Test container with static IP copy
+  lxc copy bar foo
+  lxc delete foo
+  lxc delete bar
+
+
   # Check we haven't left any NICS lying around.
   endNicCount=$(find /sys/class/net | wc -l)
   if [ "$startNicCount" != "$endNicCount" ]; then

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -197,6 +197,27 @@ snap_restore() {
 
   ##########################################################
 
+  # test restore with static IP
+  lxc launch testimage baz
+  lxc launch testimage qux
+
+  lxc config device override baz eth0 ipv4.address=192.0.2.101
+  lxc snapshot baz snap3
+  lxc config device set baz eth0 ipv4.address=192.0.2.102
+  lxc restore baz snap3
+  lxc info test001 | grep -q '192.0.2.101'
+
+  # test restore snapshot that has a static IP assigned to a NIC that conflicts with another instance
+  lxc config device set baz eth0 ipv4.address=192.0.2.102
+  lxc config device override qux eth0 ipv4.address=192.0.2.101
+  ! lxc restore baz snap3 || false
+
+  lxc stop baz
+  lxc restore baz snap3
+
+  lxc delete baz
+  lxc delete qux
+
   # test restore using full snapshot name
   restore_and_compare_fs snap1
 


### PR DESCRIPTION
Move validation of static IP addresses from setting the config to startup.
It allows to copy a container that has one or more static IP addresses:

fix issue: #10114 

Also, it allows setting up local already used IP to container by `lxc config device set`