### PR TITLE
shared/network: Always return 0 on error

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -382,7 +382,7 @@ func (w *WebsocketIO) Read(p []byte) (n int, err error) {
 
 			mt, w.reader, err = w.Conn.NextReader()
 			if err != nil {
-				return -1, err
+				return 0, err
 			}
 
 			if mt == websocket.CloseMessage {
@@ -403,7 +403,7 @@ func (w *WebsocketIO) Read(p []byte) (n int, err error) {
 		}
 
 		if err != nil {
-			return -1, err
+			return 0, err
 		}
 
 		return n, nil


### PR DESCRIPTION
In some error cases, Read() would return -1 as its first value. This is
problematic as io.ReadAll() uses this first return value before
checking the error:

```go
func ReadAll(r Reader) ([]byte, error) {
	b := make([]byte, 0, 512)
	for {
		if len(b) == cap(b) {
			// Add more capacity (let append pick how much).
			b = append(b, 0)[:len(b)]
		}
		n, err := r.Read(b[len(b):cap(b)])
		b = b[:len(b)+n]
		if err != nil {
			if err == EOF {
				err = nil
			}
			return b, err
		}
	}
}
```

If `len(b)` equals 0, and `n` equals `-1`, it will panic with

    panic: runtime error: slice bounds out of range [:-1]

This commit changes the return value to always be 0 in case of an error.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
