### PR TITLE
lxd/certificates: Fix token request validation

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -514,12 +514,17 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// User isn't an admin and is already trusted, can't add more certs.
-	if trusted && req.Certificate == "" {
+	if trusted && req.Certificate == "" && !req.Token {
 		return response.BadRequest(fmt.Errorf("Client is already trusted"))
 	}
 
 	// Handle requests by non-admin users.
 	if !rbac.UserIsAdmin(r) {
+		// Non-admin cannot issue tokens.
+		if req.Token {
+			return response.Forbidden(nil)
+		}
+
 		// A password is required for non-admin users.
 		if req.Password == "" {
 			return response.Forbidden(nil)


### PR DESCRIPTION
After our latest cleanup of the access logic to the certificates API, we
mistakenly would reject any request from a trusted user which doesn't
provide a certificate, this blocked the generation of tokens.

Closes #10374

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>