### PR TITLE
lxc/config: no name shown when editing the instance's config

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -107,7 +107,6 @@ func (c *cmdConfigEdit) helpTemplate() string {
 ### Any line starting with a '# will be ignored.
 ###
 ### A sample configuration looks like:
-### name: instance1
 ### profiles:
 ### - default
 ### config:
@@ -117,9 +116,7 @@ func (c *cmdConfigEdit) helpTemplate() string {
 ###     path: /extra
 ###     source: /home/user
 ###     type: disk
-### ephemeral: false
-###
-### Note that the name is shown but cannot be changed`)
+### ephemeral: false`)
 }
 
 func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -116,9 +115,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### Dies ist eine Darstellung der Konfiguration in yaml.\n"
 "### Jede Zeile die mit '# beginnt wird ignoriert.\n"
@@ -559,7 +556,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -583,7 +580,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -669,7 +666,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
@@ -1066,7 +1063,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1168,8 +1165,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1232,8 +1229,8 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1634,8 +1631,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2383,7 +2380,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -4060,8 +4057,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4647,12 +4644,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -4937,7 +4934,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5317,7 +5314,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5493,7 +5490,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6742,7 +6739,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6760,7 +6757,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -6768,7 +6765,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -6876,7 +6873,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -806,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -903,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -964,8 +961,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1341,8 +1338,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2051,7 +2048,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3637,8 +3634,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4192,11 +4189,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4391,7 +4388,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4468,7 +4465,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4826,7 +4823,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4999,7 +4996,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5709,7 +5706,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5717,11 +5714,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5812,7 +5809,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -112,7 +112,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -122,9 +121,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### Esta es una representación yaml de la configuración.\n"
 "### Cualquier línea que empiece con un '# será ignorada..\n"
@@ -553,7 +550,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -575,7 +572,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -647,7 +644,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1024,7 +1021,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1122,8 +1119,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1185,8 +1182,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1569,8 +1566,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2285,7 +2282,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3895,8 +3892,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4460,11 +4457,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4659,7 +4656,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4736,7 +4733,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5098,7 +5095,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5273,7 +5270,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6104,7 +6101,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6114,12 +6111,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6214,7 +6211,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -118,9 +117,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### Ceci est une réprésentation yaml de la configuration.\n"
 "### Toute ligne commençant par un '# sera ignorée.\n"
@@ -556,7 +553,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "--empty cannot be combined with an image name"
 msgstr "L'argument --empty ne peut pas être combiné avec un nom d'image"
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -576,7 +573,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -669,7 +666,7 @@ msgstr "TYPE"
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
@@ -1067,7 +1064,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1166,8 +1163,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1238,8 +1235,8 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1662,8 +1659,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2418,7 +2415,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4161,8 +4158,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4770,12 +4767,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4979,7 +4976,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -5068,7 +5065,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -5455,7 +5452,7 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5632,7 +5629,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6983,7 +6980,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -7007,7 +7004,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -7015,7 +7012,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -7127,7 +7124,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -81,9 +80,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -345,7 +342,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -365,7 +362,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -435,7 +432,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -804,7 +801,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -901,8 +898,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -962,8 +959,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1336,8 +1333,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2038,7 +2035,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3607,8 +3604,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4158,11 +4155,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4352,7 +4349,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4424,7 +4421,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4782,7 +4779,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4954,7 +4951,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5658,7 +5655,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5666,11 +5663,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5758,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -117,7 +117,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -127,9 +126,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### Questa è una rappresentazione yaml di un pool di storage.\n"
 "### Le linee che iniziano con '# saranno ignorate.\n"
@@ -549,7 +546,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -569,7 +566,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -641,7 +638,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1016,7 +1013,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1114,8 +1111,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1175,8 +1172,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1560,8 +1557,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2275,7 +2272,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3889,8 +3886,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4454,11 +4451,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4651,7 +4648,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4728,7 +4725,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5092,7 +5089,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5267,7 +5264,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6098,7 +6095,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -6108,12 +6105,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -6208,7 +6205,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -94,12 +94,12 @@ msgstr ""
 "### Any line starting with a '# will be ignored."
 
 #: lxc/config.go:105
+#, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -109,9 +109,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -541,7 +539,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -561,7 +559,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -632,7 +630,7 @@ msgstr "AUTH TYPE"
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -1016,7 +1014,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1114,8 +1112,8 @@ msgstr "クラスターメンバー %s がクラスターグループ %s に追�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1179,8 +1177,8 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1561,8 +1559,8 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2312,7 +2310,7 @@ msgstr "クラスターメンバーの設定値を取得します"
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
@@ -4066,8 +4064,8 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4636,11 +4634,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4871,7 +4869,7 @@ msgstr "イメージのプロパティを表示します"
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -4943,7 +4941,7 @@ msgstr "ストレージボリュームの状態を表示します"
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -5324,7 +5322,7 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:20.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5502,7 +5500,7 @@ msgstr "デバイスの設定を削除します"
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -6223,7 +6221,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -6231,11 +6229,11 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
@@ -6344,7 +6342,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-05-09 17:39-0400\n"
+        "POT-Creation-Date: 2022-05-10 16:11-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -62,7 +62,6 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
         "### A sample configuration looks like:\n"
-        "### name: instance1\n"
         "### profiles:\n"
         "### - default\n"
         "### config:\n"
@@ -72,9 +71,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "###     path: /extra\n"
         "###     source: /home/user\n"
         "###     type: disk\n"
-        "### ephemeral: false\n"
-        "###\n"
-        "### Note that the name is shown but cannot be changed"
+        "### ephemeral: false"
 msgstr  ""
 
 #: lxc/image.go:380
@@ -322,7 +319,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -342,7 +339,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675 lxc/info.go:446
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672 lxc/info.go:446
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -410,7 +407,7 @@ msgstr  ""
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid   "Access the expanded configuration"
 msgstr  ""
 
@@ -769,7 +766,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -865,7 +862,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47 lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168 lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1530 lxc/storage_volume.go:1562 lxc/storage_volume.go:1678 lxc/storage_volume.go:1769 lxc/storage_volume.go:1862 lxc/storage_volume.go:1899 lxc/storage_volume.go:1993 lxc/storage_volume.go:2065 lxc/storage_volume.go:2204
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47 lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168 lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1530 lxc/storage_volume.go:1562 lxc/storage_volume.go:1678 lxc/storage_volume.go:1769 lxc/storage_volume.go:1862 lxc/storage_volume.go:1899 lxc/storage_volume.go:1993 lxc/storage_volume.go:2065 lxc/storage_volume.go:2204
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -908,7 +905,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307 lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512 lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307 lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512 lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1255,7 +1252,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201 lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378 lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709 lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063 lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:229 lxc/config_trust.go:341 lxc/config_trust.go:422 lxc/config_trust.go:513 lxc/config_trust.go:556 lxc/config_trust.go:627 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38 lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490 lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303 lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1260 lxc/storage_volume.go:1342 lxc/storage_volume.go:1526 lxc/storage_volume.go:1559 lxc/storage_volume.go:1672 lxc/storage_volume.go:1760 lxc/storage_volume.go:1859 lxc/storage_volume.go:1893 lxc/storage_volume.go:1991 lxc/storage_volume.go:2058 lxc/storage_volume.go:2199 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201 lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378 lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709 lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063 lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:229 lxc/config_trust.go:341 lxc/config_trust.go:422 lxc/config_trust.go:513 lxc/config_trust.go:556 lxc/config_trust.go:627 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38 lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490 lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1303 lxc/image.go:1382 lxc/image.go:1441 lxc/image.go:1493 lxc/image.go:1549 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1260 lxc/storage_volume.go:1342 lxc/storage_volume.go:1526 lxc/storage_volume.go:1559 lxc/storage_volume.go:1672 lxc/storage_volume.go:1760 lxc/storage_volume.go:1859 lxc/storage_volume.go:1893 lxc/storage_volume.go:1991 lxc/storage_volume.go:2058 lxc/storage_volume.go:2199 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1856,7 +1853,7 @@ msgstr  ""
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
@@ -3348,7 +3345,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675 lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675 lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3884,11 +3881,11 @@ msgstr  ""
 msgid   "Set image properties"
 msgstr  ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4058,7 +4055,7 @@ msgstr  ""
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -4130,7 +4127,7 @@ msgstr  ""
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -4478,7 +4475,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655 lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652 lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -4643,7 +4640,7 @@ msgstr  ""
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -5316,7 +5313,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -5324,11 +5321,11 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
@@ -5411,7 +5408,7 @@ msgid   "lxc config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -110,7 +110,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -120,9 +119,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### Dit is een yaml weergave van de configuratie.\n"
 "### Elke regel beginnende met een '# zal worden genegeerd.\n"
@@ -536,7 +533,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -556,7 +553,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -626,7 +623,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -995,7 +992,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1092,8 +1089,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1153,8 +1150,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1527,8 +1524,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2229,7 +2226,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3798,8 +3795,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4349,11 +4346,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4543,7 +4540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4615,7 +4612,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4973,7 +4970,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5145,7 +5142,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5849,7 +5846,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5857,11 +5854,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5952,7 +5949,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -116,7 +116,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -126,9 +125,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### To jest przedstawienie konfiguracji w yaml.\n"
 "### Każdy wiersz zaczynający się od '# zostanie pominięty.\n"
@@ -566,7 +563,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -586,7 +583,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -656,7 +653,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1025,7 +1022,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1122,8 +1119,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1183,8 +1180,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1557,8 +1554,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2259,7 +2256,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3828,8 +3825,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4379,11 +4376,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4573,7 +4570,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4645,7 +4642,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5003,7 +5000,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5175,7 +5172,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5879,7 +5876,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5887,11 +5884,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5982,7 +5979,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -112,7 +112,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -122,9 +121,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### Esta é uma representação em yaml da configuração.\n"
 "### Qualquer linha que inicie com '#' será ignorada.\n"
@@ -558,7 +555,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -583,7 +580,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -655,7 +652,7 @@ msgstr "TIPO DE AUTENTICAÇÃO"
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
@@ -1041,7 +1038,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1139,8 +1136,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1209,8 +1206,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1608,8 +1605,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2332,7 +2329,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3946,8 +3943,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4524,12 +4521,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4729,7 +4726,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -4811,7 +4808,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5177,7 +5174,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5354,7 +5351,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6118,7 +6115,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6126,11 +6123,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -6223,7 +6220,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -114,7 +114,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -124,9 +123,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### Это представление конфигурации в формате YAML. \n"
 "### Любая строка начинающаяся с '#' будет игнорироваться.\n"
@@ -563,7 +560,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -583,7 +580,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -667,7 +664,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1046,7 +1043,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1144,8 +1141,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1205,8 +1202,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1600,8 +1597,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2323,7 +2320,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3954,8 +3951,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4521,11 +4518,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4722,7 +4719,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4801,7 +4798,7 @@ msgstr "Копирование образа: %s"
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5165,7 +5162,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5339,7 +5336,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6535,7 +6532,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6551,7 +6548,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -6559,7 +6556,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -6666,7 +6663,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -81,9 +80,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -345,7 +342,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -365,7 +362,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -435,7 +432,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -804,7 +801,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -901,8 +898,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -962,8 +959,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1336,8 +1333,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2038,7 +2035,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3607,8 +3604,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4158,11 +4155,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4352,7 +4349,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4424,7 +4421,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4782,7 +4779,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4954,7 +4951,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5658,7 +5655,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5666,11 +5663,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5758,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -81,9 +80,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -345,7 +342,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -365,7 +362,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -435,7 +432,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -804,7 +801,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -901,8 +898,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -962,8 +959,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1336,8 +1333,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2038,7 +2035,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3607,8 +3604,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4158,11 +4155,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4352,7 +4349,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4424,7 +4421,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4782,7 +4779,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4954,7 +4951,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5658,7 +5655,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5666,11 +5663,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5758,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -81,9 +80,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -345,7 +342,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -365,7 +362,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -435,7 +432,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -804,7 +801,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -901,8 +898,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -962,8 +959,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1336,8 +1333,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2038,7 +2035,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3607,8 +3604,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4158,11 +4155,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4352,7 +4349,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4424,7 +4421,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4782,7 +4779,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4954,7 +4951,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5658,7 +5655,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5666,11 +5663,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5758,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -110,12 +110,12 @@ msgstr ""
 "###   size: \"61203283968\""
 
 #: lxc/config.go:105
+#, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -125,9 +125,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 "### 这是一个YAML格式的配置\n"
 "### 任何开头带有‘#’的字符串将会被忽略.\n"
@@ -446,7 +444,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -466,7 +464,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -536,7 +534,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -905,7 +903,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1002,8 +1000,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1063,8 +1061,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1437,8 +1435,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2139,7 +2137,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3708,8 +3706,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4259,11 +4257,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4453,7 +4451,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4525,7 +4523,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4883,7 +4881,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5055,7 +5053,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5767,11 +5765,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5862,7 +5860,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-09 17:39-0400\n"
+"POT-Creation-Date: 2022-05-10 16:11-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -70,7 +70,6 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
-"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,9 +79,7 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false\n"
-"###\n"
-"### Note that the name is shown but cannot be changed"
+"### ephemeral: false"
 msgstr ""
 
 #: lxc/image.go:380
@@ -344,7 +341,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:413 lxc/config.go:649
+#: lxc/config.go:410 lxc/config.go:646
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -364,7 +361,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:152 lxc/config.go:397 lxc/config.go:532 lxc/config.go:675
+#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -434,7 +431,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:366
+#: lxc/config.go:363
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +800,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:549
+#: lxc/config.go:546
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +897,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:367 lxc/config.go:470
-#: lxc/config.go:617 lxc/config.go:736 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
+#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,8 +958,8 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:258
-#: lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
+#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
 #: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
@@ -1335,8 +1332,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363
-#: lxc/config.go:455 lxc/config.go:613 lxc/config.go:733
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
+#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196
 #: lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438
 #: lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651
@@ -2037,7 +2034,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:362 lxc/config.go:363
+#: lxc/config.go:359 lxc/config.go:360
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -3606,8 +3603,8 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:259
-#: lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
+#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
@@ -4157,11 +4154,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:451
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:452
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4351,7 +4348,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:612 lxc/config.go:613
+#: lxc/config.go:609 lxc/config.go:610
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4423,7 +4420,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:616
+#: lxc/config.go:613
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4781,7 +4778,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4953,7 +4950,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:732 lxc/config.go:733
+#: lxc/config.go:729 lxc/config.go:730
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5657,7 +5654,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:611
+#: lxc/config.go:90 lxc/config.go:608
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5665,11 +5662,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:361 lxc/config.go:731
+#: lxc/config.go:358 lxc/config.go:728
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:453
+#: lxc/config.go:450
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5757,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:460
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"


### PR DESCRIPTION
```
$ EDITOR=cat lxc config edit lxd-test | grep name
### name: instance1
### Note that the name is shown but cannot be changed
```