### PR TITLE
golangci-lint github action: deadcode

### DIFF
--- a/lxd/daemon_integration_test.go
+++ b/lxd/daemon_integration_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/sys"
-	"github.com/lxc/lxd/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,31 +44,6 @@ func newTestDaemon(t *testing.T) (*Daemon, func()) {
 	}
 
 	return daemon, cleanup
-}
-
-// Create the given numbers of test Daemon instances.
-//
-// Return a function that can be used to cleanup every associated state.
-func newDaemons(t *testing.T, n int) ([]*Daemon, func()) {
-	daemons := make([]*Daemon, n)
-	cleanups := make([]func(), n)
-
-	for i := 0; i < n; i++ {
-		daemons[i], cleanups[i] = newTestDaemon(t)
-		if i > 0 {
-			// Use a different server certificate
-			cert := shared.TestingAltKeyPair()
-			daemons[i].endpoints.NetworkUpdateCert(cert)
-		}
-	}
-
-	cleanup := func() {
-		for _, cleanup := range cleanups {
-			cleanup()
-		}
-	}
-
-	return daemons, cleanup
 }
 
 // Create a new DaemonConfig object for testing purposes.

--- a/lxd/response/swagger.go
+++ b/lxd/response/swagger.go
@@ -1,3 +1,6 @@
+// Package response contains helpers for rendering LXD HTTP responses.
+//
+//nolint:deadcode
 package response
 
 import (

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -26,6 +26,13 @@ test_static_analysis() {
       echo "shellcheck not found, shell static analysis disabled"
     fi
 
+    # golangci-lint
+    if command -v golangci-lint >/dev/null 2>&1; then
+      golangci-lint run --disable-all -E deadcode
+    else
+      echo "golangci-lint not found, some go linters will not run"
+    fi
+
     ## Functions starting by empty line
     OUT=$(grep -r --exclude-dir=.git "^$" -B1 . 2>/dev/null | grep "func " | grep -v "}$" | grep -v "./lxd/sqlite/" || true)
     if [ -n "${OUT}" ]; then


### PR DESCRIPTION
First of many PRs addressing #10392. This one fixes linting for one of the enabled by default linters - deadcode.