### PR TITLE
Instance: Show non-editable fields in `lxc config edit` screen without expanded config

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -107,6 +107,7 @@ func (c *cmdConfigEdit) helpTemplate() string {
 ### Any line starting with a '# will be ignored.
 ###
 ### A sample configuration looks like:
+### name: instance1
 ### profiles:
 ### - default
 ### config:
@@ -116,7 +117,9 @@ func (c *cmdConfigEdit) helpTemplate() string {
 ###     path: /extra
 ###     source: /home/user
 ###     type: disk
-### ephemeral: false`)
+### ephemeral: false
+###
+### Note that the name is shown but cannot be changed`)
 }
 
 func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -201,8 +201,11 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			brief := inst.Writable()
-			data, err = yaml.Marshal(&brief)
+			// Empty expanded config so it isn't shown in edit screen (relies on omitempty tag).
+			inst.ExpandedConfig = nil
+			inst.ExpandedDevices = nil
+
+			data, err = yaml.Marshal(&inst)
 			if err != nil {
 				return err
 			}
@@ -214,8 +217,11 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			brief := inst.Writable()
-			data, err = yaml.Marshal(&brief)
+			// Empty expanded config so it isn't shown in edit screen (relies on omitempty tag).
+			inst.ExpandedConfig = nil
+			inst.ExpandedDevices = nil
+
+			data, err = yaml.Marshal(&inst)
 			if err != nil {
 				return err
 			}
@@ -231,7 +237,6 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 			// Parse the text received from the editor
 			if isSnapshot {
 				newdata := api.InstanceSnapshotPut{}
-
 				err = yaml.Unmarshal(content, &newdata)
 				if err == nil {
 					var op lxd.Operation

--- a/lxd/filter/value.go
+++ b/lxd/filter/value.go
@@ -42,7 +42,8 @@ func ValueOf(obj any, field string) any {
 			parent = fieldValue.Interface()
 		}
 
-		if yaml == key {
+		yamlKey, _, _ := strings.Cut(yaml, ",")
+		if yamlKey == key {
 			v := fieldValue.Interface()
 			if len(parts) == 1 {
 				return v

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,6 +106,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -115,7 +116,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### Dies ist eine Darstellung der Konfiguration in yaml.\n"
 "### Jede Zeile die mit '# beginnt wird ignoriert.\n"
@@ -406,7 +409,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -556,7 +559,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -580,7 +583,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -666,7 +669,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
@@ -1063,7 +1066,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1165,8 +1168,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1229,11 +1232,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
@@ -1302,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,7 +1324,8 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1465,7 +1469,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1513,7 +1517,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
@@ -1599,7 +1603,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1631,8 +1635,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1679,10 +1683,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1933,7 +1937,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2299,7 +2303,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2380,7 +2384,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -2414,7 +2418,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3481,7 +3485,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3555,8 +3559,8 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3566,7 +3570,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3689,7 +3693,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -4057,11 +4061,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4103,27 +4107,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4364,7 +4368,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4413,7 +4417,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4644,12 +4648,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4732,11 +4736,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4851,7 +4855,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -4908,7 +4912,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4934,7 +4938,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5314,7 +5318,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5416,7 +5420,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5490,7 +5494,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -5534,7 +5538,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5726,7 +5730,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -6045,7 +6049,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6565,8 +6569,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -6598,7 +6602,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -6606,7 +6610,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -6622,7 +6626,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -6630,7 +6634,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -6737,7 +6741,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6755,7 +6759,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -6763,7 +6767,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -6875,7 +6879,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7028,7 +7032,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -803,7 +806,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -900,8 +903,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -961,11 +964,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1033,7 +1036,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1049,7 +1052,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1308,7 +1312,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1338,8 +1342,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1386,10 +1390,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1623,7 +1627,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit network zone record configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1969,7 +1973,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2048,7 +2052,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2080,7 +2084,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2702,7 +2706,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3146,8 +3150,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3156,7 +3160,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3271,7 +3275,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3634,11 +3638,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3680,27 +3684,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3925,7 +3929,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3971,7 +3975,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4189,11 +4193,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4275,11 +4279,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4441,7 +4445,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show network zone record configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4465,7 +4469,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4823,7 +4827,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4924,7 +4928,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4996,7 +5000,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5038,7 +5042,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5206,7 +5210,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5362,7 +5366,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5619,8 +5623,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5636,11 +5640,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5648,11 +5652,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5705,7 +5709,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5713,11 +5717,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5812,7 +5816,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5961,7 +5965,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -112,6 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -121,7 +122,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### Esta es una representación yaml de la configuración.\n"
 "### Cualquier línea que empiece con un '# será ignorada..\n"
@@ -409,7 +412,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -550,7 +553,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -572,7 +575,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -644,7 +647,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1021,7 +1024,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1119,8 +1122,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1182,11 +1185,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1254,7 +1257,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1270,7 +1273,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1408,7 +1412,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1452,7 +1456,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
@@ -1536,7 +1540,7 @@ msgstr "Perfil %s creado"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1566,8 +1570,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1614,10 +1618,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1852,7 +1856,7 @@ msgstr "Perfil %s creado"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2203,7 +2207,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2282,7 +2286,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2314,7 +2318,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2950,7 +2954,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3330,7 +3334,7 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
@@ -3402,8 +3406,8 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3531,7 +3535,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3892,11 +3896,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3938,27 +3942,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -4188,7 +4192,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4235,7 +4239,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4457,11 +4461,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4543,11 +4547,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4656,7 +4660,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4709,7 +4713,7 @@ msgstr "Perfil %s creado"
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4733,7 +4737,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5095,7 +5099,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5198,7 +5202,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5270,7 +5274,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5312,7 +5316,7 @@ msgstr "Perfil %s creado"
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5483,7 +5487,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -5677,7 +5681,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5993,8 +5997,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6014,12 +6018,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6029,12 +6033,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6100,7 +6104,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6110,12 +6114,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6214,7 +6218,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6363,7 +6367,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,6 +108,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -117,7 +118,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### Ceci est une réprésentation yaml de la configuration.\n"
 "### Toute ligne commençant par un '# sera ignorée.\n"
@@ -406,7 +409,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -553,7 +556,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "--empty cannot be combined with an image name"
 msgstr "L'argument --empty ne peut pas être combiné avec un nom d'image"
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -573,7 +576,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -666,7 +669,7 @@ msgstr "TYPE"
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
@@ -1064,7 +1067,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1163,8 +1166,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1235,11 +1238,11 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1308,7 +1311,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1327,7 +1330,8 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1488,7 +1492,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
@@ -1536,7 +1540,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1626,7 +1630,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1659,8 +1663,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1707,10 +1711,10 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1956,7 +1960,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2335,7 +2339,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2415,7 +2419,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2450,7 +2454,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3163,7 +3167,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3565,7 +3569,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3640,8 +3644,8 @@ msgstr "Résumé manquant."
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3651,7 +3655,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3777,7 +3781,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -4158,11 +4162,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 #, fuzzy
@@ -4205,27 +4209,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -4468,7 +4472,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
@@ -4518,7 +4522,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4767,12 +4771,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4856,12 +4860,12 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -5036,7 +5040,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
@@ -5065,7 +5069,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -5452,7 +5456,7 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5555,7 +5559,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -5629,7 +5633,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -5674,7 +5678,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -5865,7 +5869,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -6211,7 +6215,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6797,8 +6801,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -6830,7 +6834,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -6838,7 +6842,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -6854,7 +6858,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -6862,7 +6866,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -6975,7 +6979,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6999,7 +7003,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -7007,7 +7011,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -7123,7 +7127,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7294,7 +7298,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,6 +71,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,7 +81,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -233,7 +236,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -342,7 +345,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -362,7 +365,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -432,7 +435,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -801,7 +804,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -898,8 +901,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -959,11 +962,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1031,7 +1034,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1047,7 +1050,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1179,7 +1183,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1333,8 +1337,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1381,10 +1385,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1611,7 +1615,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1957,7 +1961,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2035,7 +2039,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2063,7 +2067,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,7 +2688,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3054,7 +3058,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3120,8 +3124,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3130,7 +3134,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3604,11 +3608,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3650,27 +3654,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3894,7 +3898,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3939,7 +3943,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4155,11 +4159,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4237,11 +4241,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4349,7 +4353,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4421,7 +4425,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4779,7 +4783,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4880,7 +4884,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4951,7 +4955,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4987,7 +4991,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5155,7 +5159,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5311,7 +5315,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5568,8 +5572,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5585,11 +5589,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5597,11 +5601,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5662,11 +5666,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5765,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5910,7 +5914,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -117,6 +117,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -126,7 +127,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### Questa è una rappresentazione yaml di un pool di storage.\n"
 "### Le linee che iniziano con '# saranno ignorate.\n"
@@ -406,7 +409,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -546,7 +549,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -566,7 +569,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -638,7 +641,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1013,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1111,8 +1114,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1172,11 +1175,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1244,7 +1247,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1260,7 +1263,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1399,7 +1403,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1443,7 +1447,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -1527,7 +1531,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1557,8 +1561,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1605,10 +1609,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1843,7 +1847,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2193,7 +2197,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2272,7 +2276,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2303,7 +2307,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2939,7 +2943,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3323,7 +3327,7 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
@@ -3395,8 +3399,8 @@ msgstr "Il nome del container è: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3406,7 +3410,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3523,7 +3527,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3886,11 +3890,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3932,27 +3936,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4182,7 +4186,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4229,7 +4233,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4451,11 +4455,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4535,11 +4539,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4648,7 +4652,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4701,7 +4705,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4725,7 +4729,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5089,7 +5093,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5191,7 +5195,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5264,7 +5268,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgstr "Creazione del container in corso"
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -5671,7 +5675,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
@@ -5987,8 +5991,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -6008,12 +6012,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "Creazione del container in corso"
@@ -6023,12 +6027,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -6094,7 +6098,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -6104,12 +6108,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -6208,7 +6212,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6357,7 +6361,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -100,6 +100,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -109,7 +110,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -397,7 +400,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -539,7 +542,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -559,7 +562,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -630,7 +633,7 @@ msgstr "AUTH TYPE"
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -1014,7 +1017,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1112,8 +1115,8 @@ msgstr "クラスターメンバー %s がクラスターグループ %s に追�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1177,11 +1180,11 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1253,7 +1256,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
@@ -1269,7 +1272,8 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1405,7 +1409,7 @@ msgstr "新たにネットワークゾーンを作成します"
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
@@ -1448,7 +1452,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1529,7 +1533,7 @@ msgstr "ネットワークゾーンを削除します"
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
@@ -1559,8 +1563,8 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1607,10 +1611,10 @@ msgstr "警告を削除します"
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1845,7 +1849,7 @@ msgstr "ネットワークゾーン設定をYAMLで編集します"
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
@@ -2232,7 +2236,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2310,7 +2314,7 @@ msgstr "クラスターメンバーの設定値を取得します"
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
@@ -2338,7 +2342,7 @@ msgstr "ネットワークゾーンの設定値を取得します"
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
@@ -3083,7 +3087,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr "証明書の使用を制限するプロジェクトのリスト"
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
@@ -3504,7 +3508,7 @@ msgstr "クラスターメンバー名がありません"
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -3570,8 +3574,8 @@ msgstr "ピア名を指定する必要があります"
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
@@ -3580,7 +3584,7 @@ msgstr "プロファイル名を指定する必要があります"
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
@@ -3701,7 +3705,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -4064,11 +4068,11 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4112,27 +4116,27 @@ msgstr "製品名: %v (%v)"
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -4357,7 +4361,7 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
@@ -4403,7 +4407,7 @@ msgstr "ネットワーク ACL 名を変更します"
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
@@ -4634,11 +4638,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4740,11 +4744,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4869,7 +4873,7 @@ msgstr "イメージのプロパティを表示します"
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -4917,7 +4921,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
@@ -4941,7 +4945,7 @@ msgstr "ストレージボリュームの状態を表示します"
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -5322,7 +5326,7 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:20.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5429,7 +5433,7 @@ msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr "USED BY"
@@ -5500,7 +5504,7 @@ msgstr "デバイスの設定を削除します"
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -5536,7 +5540,7 @@ msgstr "ネットワークゾーンの設定を削除します"
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
@@ -5712,7 +5716,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -5868,7 +5872,7 @@ msgstr "[<remote>:]<instance> <device> [key=value...]"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
@@ -6135,8 +6139,8 @@ msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
@@ -6152,11 +6156,11 @@ msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
@@ -6164,11 +6168,11 @@ msgstr "[<remote>:]<profile> <key><value>..."
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
@@ -6221,7 +6225,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -6229,11 +6233,11 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
@@ -6347,7 +6351,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6584,7 +6588,7 @@ msgstr ""
 "c1 path=opt\n"
 "    ホストの /share/c1 をインスタンス内の /opt にマウントします。"
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-05-13 11:35-0400\n"
+        "POT-Creation-Date: 2022-05-13 20:00+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -62,6 +62,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
         "### A sample configuration looks like:\n"
+        "### name: instance1\n"
         "### profiles:\n"
         "### - default\n"
         "### config:\n"
@@ -71,7 +72,9 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "###     path: /extra\n"
         "###     source: /home/user\n"
         "###     type: disk\n"
-        "### ephemeral: false"
+        "### ephemeral: false\n"
+        "###\n"
+        "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
 #: lxc/image.go:380
@@ -213,7 +216,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -319,7 +322,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -339,7 +342,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672 lxc/info.go:446
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680 lxc/info.go:446
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -407,7 +410,7 @@ msgstr  ""
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid   "Access the expanded configuration"
 msgstr  ""
 
@@ -766,7 +769,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -862,7 +865,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47 lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168 lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1536 lxc/storage_volume.go:1568 lxc/storage_volume.go:1684 lxc/storage_volume.go:1775 lxc/storage_volume.go:1868 lxc/storage_volume.go:1905 lxc/storage_volume.go:1999 lxc/storage_volume.go:2071 lxc/storage_volume.go:2210
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475 lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47 lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168 lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:96 lxc/storage.go:340 lxc/storage.go:401 lxc/storage.go:604 lxc/storage.go:676 lxc/storage.go:759 lxc/storage_volume.go:335 lxc/storage_volume.go:523 lxc/storage_volume.go:602 lxc/storage_volume.go:844 lxc/storage_volume.go:1041 lxc/storage_volume.go:1129 lxc/storage_volume.go:1536 lxc/storage_volume.go:1568 lxc/storage_volume.go:1684 lxc/storage_volume.go:1775 lxc/storage_volume.go:1868 lxc/storage_volume.go:1905 lxc/storage_volume.go:1999 lxc/storage_volume.go:2071 lxc/storage_volume.go:2210
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -905,7 +908,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307 lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512 lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263 lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307 lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512 lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -966,7 +969,7 @@ msgstr  ""
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid   "Copy profiles"
 msgstr  ""
 
@@ -982,7 +985,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251 lxc/storage_volume.go:338
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1113,7 +1116,7 @@ msgstr  ""
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid   "Create profiles"
 msgstr  ""
 
@@ -1152,7 +1155,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1044 lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956 lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581 lxc/storage_volume.go:1442
+#: lxc/cluster.go:183 lxc/cluster_group.go:428 lxc/image.go:1044 lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956 lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163 lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581 lxc/storage_volume.go:1442
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1232,7 +1235,7 @@ msgstr  ""
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid   "Delete profiles"
 msgstr  ""
 
@@ -1252,7 +1255,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201 lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378 lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709 lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063 lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202 lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444 lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657 lxc/config_device.go:729 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:229 lxc/config_trust.go:341 lxc/config_trust.go:422 lxc/config_trust.go:513 lxc/config_trust.go:559 lxc/config_trust.go:630 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38 lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490 lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1309 lxc/image.go:1388 lxc/image.go:1447 lxc/image.go:1499 lxc/image.go:1555 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1260 lxc/storage_volume.go:1342 lxc/storage_volume.go:1532 lxc/storage_volume.go:1565 lxc/storage_volume.go:1678 lxc/storage_volume.go:1766 lxc/storage_volume.go:1865 lxc/storage_volume.go:1899 lxc/storage_volume.go:1997 lxc/storage_volume.go:2064 lxc/storage_volume.go:2205 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:201 lxc/cluster.go:250 lxc/cluster.go:297 lxc/cluster.go:349 lxc/cluster.go:378 lxc/cluster.go:428 lxc/cluster.go:511 lxc/cluster.go:596 lxc/cluster.go:709 lxc/cluster.go:779 lxc/cluster.go:877 lxc/cluster.go:956 lxc/cluster.go:1063 lxc/cluster.go:1084 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261 lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518 lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368 lxc/config.go:460 lxc/config.go:618 lxc/config.go:738 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202 lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444 lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657 lxc/config_device.go:729 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:229 lxc/config_trust.go:341 lxc/config_trust.go:422 lxc/config_trust.go:513 lxc/config_trust.go:559 lxc/config_trust.go:630 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:238 lxc/file.go:438 lxc/file.go:929 lxc/image.go:38 lxc/image.go:146 lxc/image.go:314 lxc/image.go:365 lxc/image.go:490 lxc/image.go:649 lxc/image.go:870 lxc/image.go:1005 lxc/image.go:1309 lxc/image.go:1388 lxc/image.go:1447 lxc/image.go:1499 lxc/image.go:1555 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:884 lxc/network.go:976 lxc/network.go:1045 lxc/network.go:1095 lxc/network.go:1165 lxc/network.go:1227 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:719 lxc/network_zone.go:769 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:953 lxc/network_zone.go:980 lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162 lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587 lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832 lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:575 lxc/remote.go:611 lxc/remote.go:697 lxc/remote.go:767 lxc/remote.go:821 lxc/remote.go:859 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:337 lxc/storage.go:397 lxc/storage.go:523 lxc/storage.go:598 lxc/storage.go:672 lxc/storage.go:756 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:520 lxc/storage_volume.go:599 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1038 lxc/storage_volume.go:1126 lxc/storage_volume.go:1260 lxc/storage_volume.go:1342 lxc/storage_volume.go:1532 lxc/storage_volume.go:1565 lxc/storage_volume.go:1678 lxc/storage_volume.go:1766 lxc/storage_volume.go:1865 lxc/storage_volume.go:1899 lxc/storage_volume.go:1997 lxc/storage_volume.go:2064 lxc/storage_volume.go:2205 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1452,7 +1455,7 @@ msgstr  ""
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
@@ -1777,7 +1780,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780 lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:343 lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89 lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525 lxc/storage_volume.go:1360 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:780 lxc/cluster_group.go:376 lxc/config_template.go:241 lxc/config_trust.go:343 lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89 lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525 lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -1853,7 +1856,7 @@ msgstr  ""
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
@@ -1881,7 +1884,7 @@ msgstr  ""
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
@@ -2484,7 +2487,7 @@ msgstr  ""
 msgid   "List of projects to restrict the certificate to"
 msgstr  ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid   "List profiles"
 msgstr  ""
 
@@ -2843,7 +2846,7 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/config_metadata.go:103 lxc/config_metadata.go:201 lxc/config_template.go:92 lxc/config_template.go:135 lxc/config_template.go:177 lxc/config_template.go:264 lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201 lxc/profile.go:664
+#: lxc/config_metadata.go:103 lxc/config_metadata.go:201 lxc/config_template.go:92 lxc/config_template.go:135 lxc/config_template.go:177 lxc/config_template.go:264 lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201 lxc/profile.go:671
 msgid   "Missing instance name"
 msgstr  ""
 
@@ -2879,7 +2882,7 @@ msgstr  ""
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555 lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562 lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid   "Missing profile name"
 msgstr  ""
 
@@ -2887,7 +2890,7 @@ msgstr  ""
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid   "Missing source profile name"
 msgstr  ""
 
@@ -2991,7 +2994,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427 lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554 lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574 lxc/storage_volume.go:1441
+#: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427 lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554 lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630 lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574 lxc/storage_volume.go:1441
 msgid   "NAME"
 msgstr  ""
 
@@ -3345,7 +3348,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675 lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264 lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675 lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509 lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3385,27 +3388,27 @@ msgstr  ""
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
@@ -3628,7 +3631,7 @@ msgstr  ""
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid   "Remove profiles from instances"
 msgstr  ""
 
@@ -3672,7 +3675,7 @@ msgstr  ""
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid   "Rename profiles"
 msgstr  ""
 
@@ -3881,11 +3884,11 @@ msgstr  ""
 msgid   "Set image properties"
 msgstr  ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -3951,11 +3954,11 @@ msgstr  ""
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4055,7 +4058,7 @@ msgstr  ""
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -4103,7 +4106,7 @@ msgstr  ""
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid   "Show profile configurations"
 msgstr  ""
 
@@ -4127,7 +4130,7 @@ msgstr  ""
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -4475,7 +4478,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652 lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660 lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -4571,7 +4574,7 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140 lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582 lxc/storage_volume.go:1444
+#: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140 lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582 lxc/storage_volume.go:1444
 msgid   "USED BY"
 msgstr  ""
 
@@ -4640,7 +4643,7 @@ msgstr  ""
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -4676,7 +4679,7 @@ msgstr  ""
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
@@ -4833,7 +4836,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371 lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31 lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83 lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389 lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371 lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31 lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83 lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389 lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -4985,7 +4988,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
@@ -5229,7 +5232,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301 lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308 lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
@@ -5245,11 +5248,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid   "[<remote>:]<profile> <key><value>..."
 msgstr  ""
 
@@ -5257,11 +5260,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
@@ -5313,7 +5316,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -5321,11 +5324,11 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
@@ -5411,7 +5414,7 @@ msgid   "lxc config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
@@ -5536,7 +5539,7 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -110,6 +110,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -119,7 +120,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### Dit is een yaml weergave van de configuratie.\n"
 "### Elke regel beginnende met een '# zal worden genegeerd.\n"
@@ -392,7 +395,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -533,7 +536,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -553,7 +556,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -623,7 +626,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -992,7 +995,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1089,8 +1092,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1150,11 +1153,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1222,7 +1225,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1238,7 +1241,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1370,7 +1374,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1413,7 +1417,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1494,7 +1498,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1524,8 +1528,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1572,10 +1576,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1802,7 +1806,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2148,7 +2152,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2226,7 +2230,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2254,7 +2258,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2875,7 +2879,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3245,7 +3249,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3311,8 +3315,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3321,7 +3325,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3435,7 +3439,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3795,11 +3799,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3841,27 +3845,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4085,7 +4089,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4130,7 +4134,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4346,11 +4350,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4428,11 +4432,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4540,7 +4544,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4588,7 +4592,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4612,7 +4616,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4970,7 +4974,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5071,7 +5075,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5142,7 +5146,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5178,7 +5182,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5346,7 +5350,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5502,7 +5506,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5759,8 +5763,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5776,11 +5780,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5788,11 +5792,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5845,7 +5849,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5853,11 +5857,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5952,7 +5956,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6101,7 +6105,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -116,6 +116,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -125,7 +126,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### To jest przedstawienie konfiguracji w yaml.\n"
 "### Każdy wiersz zaczynający się od '# zostanie pominięty.\n"
@@ -418,7 +421,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -563,7 +566,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -583,7 +586,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -653,7 +656,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1022,7 +1025,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1119,8 +1122,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1180,11 +1183,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1252,7 +1255,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1268,7 +1271,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1400,7 +1404,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1443,7 +1447,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1524,7 +1528,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1554,8 +1558,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1602,10 +1606,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1832,7 +1836,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2178,7 +2182,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2256,7 +2260,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2284,7 +2288,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2905,7 +2909,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3275,7 +3279,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3341,8 +3345,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3351,7 +3355,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3465,7 +3469,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3825,11 +3829,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3871,27 +3875,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4115,7 +4119,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4160,7 +4164,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4376,11 +4380,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4458,11 +4462,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4570,7 +4574,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4642,7 +4646,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5000,7 +5004,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5101,7 +5105,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5172,7 +5176,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5208,7 +5212,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5376,7 +5380,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5532,7 +5536,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5789,8 +5793,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5806,11 +5810,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5818,11 +5822,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5875,7 +5879,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5883,11 +5887,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5982,7 +5986,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6131,7 +6135,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -112,6 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -121,7 +122,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### Esta é uma representação em yaml da configuração.\n"
 "### Qualquer linha que inicie com '#' será ignorada.\n"
@@ -409,7 +412,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -555,7 +558,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -580,7 +583,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -652,7 +655,7 @@ msgstr "TIPO DE AUTENTICAÇÃO"
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
@@ -1038,7 +1041,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1136,8 +1139,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1206,11 +1209,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1279,7 +1282,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
@@ -1295,7 +1298,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1440,7 +1444,7 @@ msgstr "Criar novas redes"
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr "Criar perfis"
 
@@ -1484,7 +1488,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1575,7 +1579,7 @@ msgstr "Criar novas redes"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1605,8 +1609,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1653,10 +1657,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1899,7 +1903,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
@@ -2248,7 +2252,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2329,7 +2333,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -2363,7 +2367,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3384,7 +3388,7 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3455,8 +3459,8 @@ msgstr "Nome de membro do cluster"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3465,7 +3469,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3582,7 +3586,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3943,11 +3947,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3989,27 +3993,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4293,7 +4297,7 @@ msgstr "Criar novas redes"
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4521,12 +4525,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4609,11 +4613,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4726,7 +4730,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -4783,7 +4787,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4808,7 +4812,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5174,7 +5178,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5276,7 +5280,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5351,7 +5355,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5395,7 +5399,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5567,7 +5571,7 @@ msgstr "Criar perfis"
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5741,7 +5745,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -6019,8 +6023,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
@@ -6037,11 +6041,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6049,11 +6053,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6114,7 +6118,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6122,11 +6126,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -6223,7 +6227,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6372,7 +6376,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -114,6 +114,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -123,7 +124,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### Это представление конфигурации в формате YAML. \n"
 "### Любая строка начинающаяся с '#' будет игнорироваться.\n"
@@ -415,7 +418,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -560,7 +563,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -580,7 +583,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -664,7 +667,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -1043,7 +1046,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1141,8 +1144,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1202,11 +1205,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1274,7 +1277,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1291,7 +1294,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1434,7 +1438,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1480,7 +1484,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1566,7 +1570,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1597,8 +1601,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1645,10 +1649,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1886,7 +1890,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2241,7 +2245,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2320,7 +2324,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2352,7 +2356,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2991,7 +2995,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3384,7 +3388,7 @@ msgstr "Копирование образа: %s"
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
@@ -3456,8 +3460,8 @@ msgstr "Имя контейнера: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3467,7 +3471,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3586,7 +3590,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3951,11 +3955,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3997,27 +4001,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4246,7 +4250,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4293,7 +4297,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4518,11 +4522,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4604,11 +4608,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4719,7 +4723,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4773,7 +4777,7 @@ msgstr "Копирование образа: %s"
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4798,7 +4802,7 @@ msgstr "Копирование образа: %s"
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5162,7 +5166,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5264,7 +5268,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5336,7 +5340,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5378,7 +5382,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5556,7 +5560,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -5864,7 +5868,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6361,8 +6365,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -6394,7 +6398,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -6402,7 +6406,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -6418,7 +6422,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -6426,7 +6430,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -6531,7 +6535,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6547,7 +6551,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -6555,7 +6559,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -6666,7 +6670,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6815,7 +6819,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -71,6 +71,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,7 +81,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -233,7 +236,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -342,7 +345,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -362,7 +365,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -432,7 +435,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -801,7 +804,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -898,8 +901,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -959,11 +962,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1031,7 +1034,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1047,7 +1050,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1179,7 +1183,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1333,8 +1337,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1381,10 +1385,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1611,7 +1615,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1957,7 +1961,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2035,7 +2039,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2063,7 +2067,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,7 +2688,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3054,7 +3058,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3120,8 +3124,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3130,7 +3134,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3604,11 +3608,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3650,27 +3654,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3894,7 +3898,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3939,7 +3943,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4155,11 +4159,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4237,11 +4241,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4349,7 +4353,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4421,7 +4425,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4779,7 +4783,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4880,7 +4884,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4951,7 +4955,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4987,7 +4991,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5155,7 +5159,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5311,7 +5315,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5568,8 +5572,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5585,11 +5589,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5597,11 +5601,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5662,11 +5666,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5765,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5910,7 +5914,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,6 +71,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,7 +81,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -233,7 +236,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -342,7 +345,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -362,7 +365,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -432,7 +435,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -801,7 +804,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -898,8 +901,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -959,11 +962,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1031,7 +1034,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1047,7 +1050,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1179,7 +1183,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1333,8 +1337,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1381,10 +1385,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1611,7 +1615,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1957,7 +1961,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2035,7 +2039,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2063,7 +2067,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,7 +2688,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3054,7 +3058,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3120,8 +3124,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3130,7 +3134,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3604,11 +3608,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3650,27 +3654,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3894,7 +3898,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3939,7 +3943,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4155,11 +4159,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4237,11 +4241,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4349,7 +4353,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4421,7 +4425,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4779,7 +4783,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4880,7 +4884,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4951,7 +4955,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4987,7 +4991,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5155,7 +5159,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5311,7 +5315,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5568,8 +5572,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5585,11 +5589,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5597,11 +5601,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5662,11 +5666,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5765,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5910,7 +5914,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -71,6 +71,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -80,7 +81,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -233,7 +236,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -342,7 +345,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -362,7 +365,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -432,7 +435,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -801,7 +804,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -898,8 +901,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -959,11 +962,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1031,7 +1034,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1047,7 +1050,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1179,7 +1183,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1333,8 +1337,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1381,10 +1385,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1611,7 +1615,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1957,7 +1961,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2035,7 +2039,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2063,7 +2067,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2684,7 +2688,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3054,7 +3058,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3120,8 +3124,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3130,7 +3134,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3604,11 +3608,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3650,27 +3654,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3894,7 +3898,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3939,7 +3943,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4155,11 +4159,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4237,11 +4241,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4349,7 +4353,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4421,7 +4425,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4779,7 +4783,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4880,7 +4884,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4951,7 +4955,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4987,7 +4991,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5155,7 +5159,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5311,7 +5315,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5568,8 +5572,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5585,11 +5589,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5597,11 +5601,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5662,11 +5666,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5761,7 +5765,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5910,7 +5914,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -116,6 +116,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -125,7 +126,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 "### 这是一个YAML格式的配置\n"
 "### 任何开头带有‘#’的字符串将会被忽略.\n"
@@ -335,7 +338,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -444,7 +447,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -464,7 +467,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -534,7 +537,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -903,7 +906,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1000,8 +1003,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1061,11 +1064,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1133,7 +1136,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1149,7 +1152,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1281,7 +1285,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1324,7 +1328,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1405,7 +1409,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1435,8 +1439,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1483,10 +1487,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1713,7 +1717,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2059,7 +2063,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2137,7 +2141,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2165,7 +2169,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2786,7 +2790,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3156,7 +3160,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3222,8 +3226,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3232,7 +3236,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3346,7 +3350,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3706,11 +3710,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3752,27 +3756,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3996,7 +4000,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4041,7 +4045,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4257,11 +4261,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4339,11 +4343,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4451,7 +4455,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4499,7 +4503,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4523,7 +4527,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4881,7 +4885,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4982,7 +4986,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -5053,7 +5057,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5089,7 +5093,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5257,7 +5261,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5413,7 +5417,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5670,8 +5674,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5687,11 +5691,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5699,11 +5703,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5756,7 +5760,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5863,7 +5867,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6012,7 +6016,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-05-13 11:35-0400\n"
+"POT-Creation-Date: 2022-05-13 20:00+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -70,6 +70,7 @@ msgid ""
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
+"### name: instance1\n"
 "### profiles:\n"
 "### - default\n"
 "### config:\n"
@@ -79,7 +80,9 @@ msgid ""
 "###     path: /extra\n"
 "###     source: /home/user\n"
 "###     type: disk\n"
-"### ephemeral: false"
+"### ephemeral: false\n"
+"###\n"
+"### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: lxc/image.go:380
@@ -232,7 +235,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:419
+#: lxc/profile.go:426
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +344,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:410 lxc/config.go:646
+#: lxc/config.go:418 lxc/config.go:654
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -361,7 +364,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:149 lxc/config.go:394 lxc/config.go:529 lxc/config.go:672
+#: lxc/config.go:152 lxc/config.go:402 lxc/config.go:537 lxc/config.go:680
 #: lxc/info.go:446
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -431,7 +434,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/config.go:363
+#: lxc/config.go:371
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -800,7 +803,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:546
+#: lxc/config.go:554
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -897,8 +900,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:364 lxc/config.go:467
-#: lxc/config.go:614 lxc/config.go:733 lxc/copy.go:61 lxc/info.go:47
+#: lxc/cluster.go:710 lxc/config.go:98 lxc/config.go:372 lxc/config.go:475
+#: lxc/config.go:622 lxc/config.go:741 lxc/copy.go:61 lxc/info.go:47
 #: lxc/init.go:54 lxc/move.go:66 lxc/network.go:288 lxc/network.go:706
 #: lxc/network.go:764 lxc/network.go:1101 lxc/network.go:1168
 #: lxc/network.go:1230 lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -958,11 +961,11 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:255
-#: lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_trust.go:307
+#: lxc/cluster.go:677 lxc/cluster_group.go:333 lxc/config.go:263
+#: lxc/config.go:336 lxc/config_metadata.go:145 lxc/config_trust.go:307
 #: lxc/image.go:458 lxc/network.go:674 lxc/network_acl.go:582
 #: lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:512
-#: lxc/network_zone.go:1065 lxc/profile.go:501 lxc/project.go:312
+#: lxc/network_zone.go:1065 lxc/profile.go:508 lxc/project.go:312
 #: lxc/storage.go:307 lxc/storage_volume.go:977 lxc/storage_volume.go:1007
 #, c-format
 msgid "Config parsing error: %s"
@@ -1030,7 +1033,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:246 lxc/profile.go:247
+#: lxc/profile.go:248 lxc/profile.go:249
 msgid "Copy profiles"
 msgstr ""
 
@@ -1046,7 +1049,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
+#: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:302 lxc/profile.go:303
+#: lxc/profile.go:309 lxc/profile.go:310
 msgid "Create profiles"
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 #: lxc/image_alias.go:237 lxc/list.go:546 lxc/network.go:956
 #: lxc/network_acl.go:149 lxc/network_forward.go:145 lxc/network_peer.go:141
 #: lxc/network_zone.go:139 lxc/network_zone.go:702 lxc/operation.go:163
-#: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:581
+#: lxc/profile.go:631 lxc/project.go:473 lxc/storage.go:581
 #: lxc/storage_volume.go:1442
 msgid "DESCRIPTION"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:356 lxc/profile.go:357
+#: lxc/profile.go:363 lxc/profile.go:364
 msgid "Delete profiles"
 msgstr ""
 
@@ -1332,8 +1336,8 @@ msgstr ""
 #: lxc/cluster_group.go:152 lxc/cluster_group.go:209 lxc/cluster_group.go:261
 #: lxc/cluster_group.go:374 lxc/cluster_group.go:445 lxc/cluster_group.go:518
 #: lxc/cluster_group.go:564 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:360
-#: lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
+#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:368
+#: lxc/config.go:460 lxc/config.go:618 lxc/config.go:738
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:202
 #: lxc/config_device.go:280 lxc/config_device.go:351 lxc/config_device.go:444
 #: lxc/config_device.go:541 lxc/config_device.go:548 lxc/config_device.go:657
@@ -1380,10 +1384,10 @@ msgstr ""
 #: lxc/network_zone.go:1098 lxc/network_zone.go:1147 lxc/network_zone.go:1162
 #: lxc/network_zone.go:1208 lxc/operation.go:24 lxc/operation.go:56
 #: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
+#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310
+#: lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:538 lxc/profile.go:587
+#: lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:773 lxc/profile.go:832
+#: lxc/profile.go:886 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
 #: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
 #: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
 #: lxc/project.go:747 lxc/publish.go:33 lxc/query.go:33 lxc/remote.go:33
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:406 lxc/profile.go:407
+#: lxc/profile.go:413 lxc/profile.go:414
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 #: lxc/config_trust.go:424 lxc/image.go:1031 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:888 lxc/network.go:978 lxc/network_acl.go:99
 #: lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:89
-#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:584
+#: lxc/network_zone.go:653 lxc/operation.go:107 lxc/profile.go:591
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:615 lxc/storage.go:525
 #: lxc/storage_volume.go:1360 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2034,7 +2038,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:359 lxc/config.go:360
+#: lxc/config.go:367 lxc/config.go:368
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2062,7 +2066,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:530 lxc/profile.go:531
+#: lxc/profile.go:537 lxc/profile.go:538
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2683,7 +2687,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:579 lxc/profile.go:580
+#: lxc/profile.go:586 lxc/profile.go:587
 msgid "List profiles"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 #: lxc/config_template.go:92 lxc/config_template.go:135
 #: lxc/config_template.go:177 lxc/config_template.go:264
 #: lxc/config_template.go:322 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:664
+#: lxc/profile.go:671
 msgid "Missing instance name"
 msgstr ""
 
@@ -3119,8 +3123,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:327 lxc/profile.go:381 lxc/profile.go:455 lxc/profile.go:555
-#: lxc/profile.go:740 lxc/profile.go:793 lxc/profile.go:849
+#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:562
+#: lxc/profile.go:747 lxc/profile.go:800 lxc/profile.go:856
 msgid "Missing profile name"
 msgstr ""
 
@@ -3129,7 +3133,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:272
+#: lxc/profile.go:275
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3243,7 +3247,7 @@ msgstr ""
 #: lxc/cluster.go:178 lxc/cluster.go:860 lxc/cluster_group.go:427
 #: lxc/config_trust.go:399 lxc/config_trust.go:494 lxc/list.go:554
 #: lxc/network.go:951 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:623
+#: lxc/network_zone.go:138 lxc/network_zone.go:701 lxc/profile.go:630
 #: lxc/project.go:468 lxc/remote.go:674 lxc/storage.go:574
 #: lxc/storage_volume.go:1441
 msgid "NAME"
@@ -3603,11 +3607,11 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:256
-#: lxc/config.go:329 lxc/config_metadata.go:146 lxc/config_template.go:206
+#: lxc/cluster.go:678 lxc/cluster_group.go:334 lxc/config.go:264
+#: lxc/config.go:337 lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:308 lxc/image.go:459 lxc/network.go:675
 #: lxc/network_acl.go:583 lxc/network_forward.go:596 lxc/network_peer.go:574
-#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:502
+#: lxc/network_zone.go:513 lxc/network_zone.go:1066 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:308 lxc/storage_volume.go:978
 #: lxc/storage_volume.go:1008
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3649,27 +3653,27 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:340
+#: lxc/profile.go:347
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:391
+#: lxc/profile.go:398
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:674
+#: lxc/profile.go:681
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:699
+#: lxc/profile.go:706
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:750
+#: lxc/profile.go:757
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -3893,7 +3897,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/profile.go:639 lxc/profile.go:640
+#: lxc/profile.go:646 lxc/profile.go:647
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -3938,7 +3942,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:715 lxc/profile.go:716
+#: lxc/profile.go:722 lxc/profile.go:723
 msgid "Rename profiles"
 msgstr ""
 
@@ -4154,11 +4158,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:451
+#: lxc/config.go:459
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:452
+#: lxc/config.go:460
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4236,11 +4240,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:765
+#: lxc/profile.go:772
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:766
+#: lxc/profile.go:773
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4348,7 +4352,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:609 lxc/config.go:610
+#: lxc/config.go:617 lxc/config.go:618
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:824 lxc/profile.go:825
+#: lxc/profile.go:831 lxc/profile.go:832
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4420,7 +4424,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:613
+#: lxc/config.go:621
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -4778,7 +4782,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
+#: lxc/config.go:286 lxc/config.go:424 lxc/config.go:574 lxc/config.go:660
 #: lxc/copy.go:129 lxc/info.go:332 lxc/network.go:793 lxc/storage.go:429
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:957 lxc/network_acl.go:150 lxc/network_zone.go:140
-#: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:582
+#: lxc/profile.go:632 lxc/project.go:474 lxc/storage.go:582
 #: lxc/storage_volume.go:1444
 msgid "USED BY"
 msgstr ""
@@ -4950,7 +4954,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:737 lxc/config.go:738
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:878 lxc/profile.go:879
+#: lxc/profile.go:885 lxc/profile.go:886
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 #: lxc/cluster.go:116 lxc/cluster.go:777 lxc/cluster_group.go:371
 #: lxc/config_trust.go:338 lxc/config_trust.go:420 lxc/monitor.go:31
 #: lxc/network.go:881 lxc/network_acl.go:93 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:577 lxc/project.go:389
+#: lxc/operation.go:102 lxc/profile.go:584 lxc/project.go:389
 #: lxc/storage.go:520 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:638
+#: lxc/profile.go:102 lxc/profile.go:645
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -5567,8 +5571,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:301
-#: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:285 lxc/config_device.go:654 lxc/profile.go:308
+#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:830
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -5584,11 +5588,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:529 lxc/profile.go:877
+#: lxc/profile.go:536 lxc/profile.go:884
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:764
+#: lxc/profile.go:771
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -5596,11 +5600,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:713
+#: lxc/profile.go:720
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:244
+#: lxc/profile.go:246
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:90 lxc/config.go:608
+#: lxc/config.go:90 lxc/config.go:616
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5661,11 +5665,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:358 lxc/config.go:728
+#: lxc/config.go:366 lxc/config.go:736
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:450
+#: lxc/config.go:458
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -5760,7 +5764,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:457
+#: lxc/config.go:465
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -5909,7 +5913,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:409
+#: lxc/profile.go:416
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -170,11 +170,11 @@ type Instance struct {
 
 	// Expanded configuration (all profiles and local config merged)
 	// Example: {"security.nesting": "true"}
-	ExpandedConfig map[string]string `json:"expanded_config" yaml:"expanded_config"`
+	ExpandedConfig map[string]string `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
 
 	// Expanded devices (all profiles and local devices merged)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
-	ExpandedDevices map[string]map[string]string `json:"expanded_devices" yaml:"expanded_devices"`
+	ExpandedDevices map[string]map[string]string `json:"expanded_devices,omitempty" yaml:"expanded_devices,omitempty"`
 
 	// Instance name
 	// Example: foo

--- a/shared/api/instance_snapshot.go
+++ b/shared/api/instance_snapshot.go
@@ -88,11 +88,11 @@ type InstanceSnapshot struct {
 
 	// Expanded configuration (all profiles and local config merged)
 	// Example: {"security.nesting": "true"}
-	ExpandedConfig map[string]string `json:"expanded_config" yaml:"expanded_config"`
+	ExpandedConfig map[string]string `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
 
 	// Expanded devices (all profiles and local devices merged)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
-	ExpandedDevices map[string]map[string]string `json:"expanded_devices" yaml:"expanded_devices"`
+	ExpandedDevices map[string]map[string]string `json:"expanded_devices,omitempty" yaml:"expanded_devices,omitempty"`
 
 	// Last start timestamp
 	// Example: 2021-03-23T20:00:00-04:00

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -270,6 +270,15 @@ test_config_edit() {
     lxc init testimage foo -s "lxdtest-$(basename "${LXD_DIR}")"
     lxc config show foo | sed 's/^description:.*/description: bar/' | lxc config edit foo
     lxc config show foo | grep -q 'description: bar'
+
+    # Check instance name is included in edit screen.
+    cmd=$(unset -f lxc; command -v lxc)
+    output=$(EDITOR="cat" "${cmd}" config edit foo)
+    echo "${output}" | grep "name: foo"
+
+    # Check expanded config isn't included in edit screen.
+    ! echo "${output}" | grep "expanded" || false
+
     lxc delete foo
 }
 
@@ -346,6 +355,14 @@ test_container_snapshot_config() {
     # Remove expiry date using empty value
     echo 'expires_at:' | lxc config edit foo/snap0
     lxc config show foo/snap0 | grep -q 'expires_at: 0001-01-01T00:00:00Z'
+
+    # Check instance name is included in edit screen.
+    cmd=$(unset -f lxc; command -v lxc)
+    output=$(EDITOR="cat" "${cmd}" config edit foo/snap0)
+    echo "${output}" | grep "name: snap0"
+
+    # Check expanded config isn't included in edit screen.
+    ! echo "${output}"  | grep "expanded" || false
 
     lxc delete -f foo
 }


### PR DESCRIPTION
Following on from discussion here https://github.com/lxc/lxd/pull/10390#issuecomment-1123343345

This PR reverts the changes in https://github.com/lxc/lxd/pull/10390 and restores showing the non-editable fields in the `lxc config edit` screen (for consistency with edit screens for other types of entity, such as network, storage pools etc).

However avoids needing to show the expanded config by specifying those fields as `omitempty` and then manually clearing them in the `lxc config edit` command.