### PR TITLE
Client: Increase header timeout from 30s to 1 hour

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -26,7 +26,7 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 		Proxy:                 shared.ProxyFromEnvironment,
 		DisableKeepAlives:     true,
 		ExpectContinueTimeout: time.Second * 30,
-		ResponseHeaderTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
 	}
 
@@ -118,7 +118,7 @@ func unixHTTPClient(client *http.Client, path string) (*http.Client, error) {
 		Dial:                  unixDial,
 		DisableKeepAlives:     true,
 		ExpectContinueTimeout: time.Second * 30,
-		ResponseHeaderTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
 	}
 

--- a/lxd/cluster/tls.go
+++ b/lxd/cluster/tls.go
@@ -97,7 +97,7 @@ func tlsTransport(config *tls.Config) (*http.Transport, func()) {
 		DisableKeepAlives:     true,
 		MaxIdleConns:          0,
 		ExpectContinueTimeout: time.Second * 30,
-		ResponseHeaderTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
 	}
 	return transport, transport.CloseIdleConnections

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -122,7 +122,7 @@ func HTTPClient(certificate string, proxy proxyFunc) (*http.Client, error) {
 		Proxy:                 proxy,
 		DisableKeepAlives:     true,
 		ExpectContinueTimeout: time.Second * 30,
-		ResponseHeaderTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
 	}
 

--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -77,7 +77,7 @@ func HTTPClient(vsockID int, tlsClientCert string, tlsClientKey string, tlsServe
 		},
 		DisableKeepAlives:     true,
 		ExpectContinueTimeout: time.Second * 30,
-		ResponseHeaderTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
 	}
 

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -404,7 +404,7 @@ func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, 
 		Dial:                  RFC3493Dialer,
 		Proxy:                 ProxyFromEnvironment,
 		ExpectContinueTimeout: time.Second * 30,
-		ResponseHeaderTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
 	}
 


### PR DESCRIPTION
This effectively reverts https://github.com/lxc/lxd/pull/10351 (because now a real network issue will mean the image download will block for up to an hour).

But https://github.com/lxc/lxd/issues/10377 and https://discuss.linuxcontainers.org/t/lxd-broken-after-setting-custom-backups-storage/14102 have shown that despite LXD having the concept of async operations for long running processes, there are enough places where synchronous responses are used for (potentially) long running processes.

We should audit all the synchronous response types and agree upon a max-response time that we can use in the LXD client, and anything that can take longer than that should use an async operation.