### PR TITLE
Log errors returned by reverter hooks

### DIFF
--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -142,9 +142,7 @@ func reconfigureNetworkInterfaces() {
 		if err != nil {
 			return err
 		}
-		reverter.Add(func() {
-			link.SetUp()
-		})
+		reverter.Add(link.SetUp)
 
 		// Apply the name from the NIC config if needed.
 		if changeName {
@@ -152,9 +150,14 @@ func reconfigureNetworkInterfaces() {
 			if err != nil {
 				return err
 			}
-			reverter.Add(func() {
-				link.SetName(currentNIC.Name)
+			reverter.Add(func() error {
+				err := link.SetName(currentNIC.Name)
+				if err != nil {
+					return err
+				}
+
 				link.Name = currentNIC.Name
+				return nil
 			})
 
 			link.Name = nic.NICName
@@ -167,10 +170,15 @@ func reconfigureNetworkInterfaces() {
 			if err != nil {
 				return err
 			}
-			reverter.Add(func() {
+			reverter.Add(func() error {
 				currentMTU := fmt.Sprintf("%d", currentNIC.MTU)
-				link.SetMTU(currentMTU)
+				err := link.SetMTU(currentMTU)
+				if err != nil {
+					return err
+				}
+
 				link.MTU = currentMTU
+				return nil
 			})
 
 			link.MTU = newMTU

--- a/lxd-user/lxd.go
+++ b/lxd-user/lxd.go
@@ -155,7 +155,7 @@ func lxdSetupUser(uid uint32) error {
 	if err != nil {
 		return fmt.Errorf("Failed to create user directory: %w", err)
 	}
-	revert.Add(func() { os.RemoveAll(userPath) })
+	revert.Add(func() error { return os.RemoveAll(userPath) })
 
 	// Generate certificate.
 	err = shared.FindOrGenCert(filepath.Join(userPath, "client.crt"), filepath.Join(userPath, "client.key"), true, false)
@@ -202,7 +202,7 @@ func lxdSetupUser(uid uint32) error {
 			return fmt.Errorf("Unable to create project: %w", err)
 		}
 
-		revert.Add(func() { client.DeleteProject(projectName) })
+		revert.Add(func() error { return client.DeleteProject(projectName) })
 	}
 
 	// Parse the certificate.
@@ -225,7 +225,7 @@ func lxdSetupUser(uid uint32) error {
 		return fmt.Errorf("Unable to add user certificate: %w", err)
 	}
 
-	revert.Add(func() { client.DeleteCertificate(shared.CertFingerprint(x509Cert)) })
+	revert.Add(func() error { return client.DeleteCertificate(shared.CertFingerprint(x509Cert)) })
 
 	// Setup default profile.
 	err = client.UseProject(projectName).UpdateProfile("default", api.ProfilePut{

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -200,9 +200,10 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 				}
 			}()
 
-			revert.Add(func() {
+			revert.Add(func() error {
 				cleanupPool := pools[pool.Name()]
-				cleanupPool.Unmount() // Defer won't do it if record exists, so unmount on failure.
+				_, err := cleanupPool.Unmount() // Defer won't do it if record exists, so unmount on failure.
+				return err
 			})
 		}
 
@@ -360,8 +361,8 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 					}
 				}
 
-				revert.Add(func() {
-					dbStoragePoolDeleteAndUpdateCache(d.State(), pool.Name())
+				revert.Add(func() error {
+					return dbStoragePoolDeleteAndUpdateCache(d.State(), pool.Name())
 				})
 
 				// Set storage pool node to storagePoolCreated.

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -64,7 +64,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		return fmt.Errorf("Insert backup info into database: %w", err)
 	}
 
-	revert.Add(func() { s.DB.Cluster.DeleteInstanceBackup(args.Name) })
+	revert.Add(func() error { return s.DB.Cluster.DeleteInstanceBackup(args.Name) })
 
 	// Get the backup struct.
 	b, err := instance.BackupLoadByName(s, sourceInst.Project(), args.Name)
@@ -112,7 +112,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 			return err
 		}
 
-		revert.Add(func() { os.Remove(backupsPath) })
+		revert.Add(func() error { return os.Remove(backupsPath) })
 	}
 
 	target := shared.VarPath("backups", "instances", project.Instance(sourceInst.Project(), b.Name()))
@@ -124,7 +124,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		return fmt.Errorf("Error opening backup tarball for writing %q: %w", target, err)
 	}
 	defer tarFileWriter.Close()
-	revert.Add(func() { os.Remove(target) })
+	revert.Add(func() error { return os.Remove(target) })
 
 	// Get IDMap to unshift container as the tarball is created.
 	var idmap *idmap.IdmapSet
@@ -372,7 +372,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		return fmt.Errorf("Failed creating backup record: %w", err)
 	}
 
-	revert.Add(func() { s.DB.Cluster.DeleteStoragePoolVolumeBackup(args.Name) })
+	revert.Add(func() error { return s.DB.Cluster.DeleteStoragePoolVolumeBackup(args.Name) })
 
 	backupRow, err := s.DB.Cluster.GetStoragePoolVolumeBackup(projectName, poolName, args.Name)
 	if err != nil {
@@ -401,7 +401,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 			return err
 		}
 
-		revert.Add(func() { os.Remove(backupsPath) })
+		revert.Add(func() error { return os.Remove(backupsPath) })
 	}
 
 	target := shared.VarPath("backups", "custom", pool.Name(), project.StorageVolume(projectName, backupRow.Name))
@@ -413,7 +413,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		return fmt.Errorf("Error opening backup tarball for writing %q: %w", target, err)
 	}
 	defer tarFileWriter.Close()
-	revert.Add(func() { os.Remove(target) })
+	revert.Add(func() error { return os.Remove(target) })
 
 	// Create the tarball.
 	tarPipeReader, tarPipeWriter := io.Pipe()

--- a/lxd/backup/backup_volume.go
+++ b/lxd/backup/backup_volume.go
@@ -79,7 +79,7 @@ func (b *VolumeBackup) Rename(newName string) error {
 	if err != nil {
 		return err
 	}
-	revert.Add(func() { os.Rename(newBackupPath, oldBackupPath) })
+	revert.Add(func() error { return os.Rename(newBackupPath, oldBackupPath) })
 
 	// Check if we can remove the old parent directory.
 	empty, _ := shared.PathIsEmpty(oldParentBackupsPath)

--- a/lxd/bgp/server.go
+++ b/lxd/bgp/server.go
@@ -214,7 +214,7 @@ func (s *Server) reconfigure(address string, asn uint32, routerID net.IP) error 
 	// Check if we should start.
 	if address != "" && asn > 0 && routerID != nil {
 		// Restore old address on failure.
-		revert.Add(func() { s.start(oldAddress, oldASN, oldRouterID) })
+		revert.Add(func() error { return s.start(oldAddress, oldASN, oldRouterID) })
 
 		// Start the listener with the new address.
 		err = s.start(address, asn, routerID)

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -379,8 +379,9 @@ func eventsConnect(address string, networkCert *shared.CertInfo, serverCert *sha
 	}
 
 	revert := revert.New()
-	revert.Add(func() {
+	revert.Add(func() error {
 		client.Disconnect()
+		return nil
 	})
 
 	listener, err := client.GetEventsAllProjects()

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -1003,7 +1003,7 @@ func dqliteNetworkDial(ctx context.Context, name string, addr string, g *Gateway
 	if err != nil {
 		return nil, fmt.Errorf("Failed connecting to HTTP endpoint %q: %w", addr, err)
 	}
-	revert.Add(func() { conn.Close() })
+	revert.Add(conn.Close)
 
 	l := logger.AddContext(logger.Log, logger.Ctx{"name": name, "local": conn.LocalAddr(), "remote": conn.RemoteAddr()})
 	l.Info("Dqlite connected outbound")

--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -131,7 +131,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 				return nil, fmt.Errorf("Failed to create virtual gpu %q: %w", mdevUUID, err)
 			}
 
-			revert.Add(func() {
+			revert.Add(func() error {
 				path := fmt.Sprintf("/sys/bus/mdev/devices/%s", mdevUUID)
 
 				if shared.PathExists(path) {
@@ -140,6 +140,8 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 						d.logger.Error("Failed to remove vgpu", logger.Ctx{"device": mdevUUID, "err": err})
 					}
 				}
+
+				return nil
 			})
 		}
 	}

--- a/lxd/device/gpu_sriov.go
+++ b/lxd/device/gpu_sriov.go
@@ -196,7 +196,7 @@ func (d *gpuSRIOV) setupSriovParent(parentPCIAddress string, vfID int, volatile 
 		return vfPCIDev, err
 	}
 
-	revert.Add(func() { pcidev.DeviceProbe(vfPCIDev) })
+	revert.Add(func() error { return pcidev.DeviceProbe(vfPCIDev) })
 
 	// Register VF device with vfio-pci driver so it can be passed to VM.
 	err = pcidev.DeviceDriverOverride(vfPCIDev, "vfio-pci")
@@ -317,7 +317,7 @@ func (d *gpuSRIOV) restoreSriovParent(volatile map[string]string) error {
 
 	// However we return from this function, we must try to rebind the VF so its not orphaned.
 	// The OS won't let an already bound device be bound again so is safe to call twice.
-	revert.Add(func() { pcidev.DeviceProbe(vfPCIDev) })
+	revert.Add(func() error { return pcidev.DeviceProbe(vfPCIDev) })
 
 	// Bind VF device onto the host so that the settings will take effect.
 	err = pcidev.DeviceProbe(vfPCIDev)

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -166,8 +166,8 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 	saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
 
 	if shared.IsTrue(saveData["last_state.created"]) {
-		revert.Add(func() {
-			networkRemoveInterfaceIfNeeded(d.state, actualParentName, d.inst, d.config["parent"], d.config["vlan"])
+		revert.Add(func() error {
+			return networkRemoveInterfaceIfNeeded(d.state, actualParentName, d.inst, d.config["parent"], d.config["vlan"])
 		})
 	}
 
@@ -201,7 +201,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
-	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
+	revert.Add(func() error { return network.InterfaceRemove(saveData["host_name"]) })
 
 	// Set the MAC address.
 	if d.config["hwaddr"] != "" {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -355,7 +355,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 			}
 		}
 
-		revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
+		revert.Add(func() error { return network.InterfaceRemove(saveData["host_name"]) })
 	}
 
 	// Populate device config with volatile fields if needed.
@@ -775,8 +775,8 @@ func (d *nicOVN) setupHostNIC(revert *revert.Reverter, hostName string, uplink *
 		return fmt.Errorf("Failed setting up OVN port: %w", err)
 	}
 
-	revert.Add(func() {
-		d.network.InstanceDevicePortDelete("", &network.OVNInstanceNICStopOpts{
+	revert.Add(func() error {
+		return d.network.InstanceDevicePortDelete("", &network.OVNInstanceNICStopOpts{
 			InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 			DeviceName:   d.name,
 			DeviceConfig: d.config,
@@ -795,7 +795,7 @@ func (d *nicOVN) setupHostNIC(revert *revert.Reverter, hostName string, uplink *
 		return err
 	}
 
-	revert.Add(func() { ovs.BridgePortDelete(integrationBridge, hostName) })
+	revert.Add(func() error { return ovs.BridgePortDelete(integrationBridge, hostName) })
 
 	// Link OVS port to OVN logical port.
 	err = ovs.InterfaceAssociateOVNSwitchPort(hostName, logicalPortName)

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -108,7 +108,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
+	revert.Add(func() error { return network.InterfaceRemove(saveData["host_name"]) })
 
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -107,8 +107,8 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 		saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
 
 		if shared.IsTrue(saveData["last_state.created"]) {
-			revert.Add(func() {
-				networkRemoveInterfaceIfNeeded(d.state, saveData["host_name"], d.inst, d.config["parent"], d.config["vlan"])
+			revert.Add(func() error {
+				return networkRemoveInterfaceIfNeeded(d.state, saveData["host_name"], d.inst, d.config["parent"], d.config["vlan"])
 			})
 		}
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -284,8 +284,8 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 
 		// If we created a VLAN interface, we need to setup the sysctls on that interface.
 		if shared.IsTrue(saveData["last_state.created"]) {
-			revert.Add(func() {
-				networkRemoveInterfaceIfNeeded(d.state, d.effectiveParentName, d.inst, d.config["parent"], d.config["vlan"])
+			revert.Add(func() error {
+				return networkRemoveInterfaceIfNeeded(d.state, d.effectiveParentName, d.inst, d.config["parent"], d.config["vlan"])
 			})
 
 			err := d.setupParentSysctls(d.effectiveParentName)
@@ -332,7 +332,7 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
+	revert.Add(func() error { return network.InterfaceRemove(saveData["host_name"]) })
 
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
@@ -436,7 +436,7 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 					return nil, fmt.Errorf("Failed adding neighbour proxy %q to %q: %w", np.Addr.String(), np.DevName, err)
 				}
 
-				revert.Add(func() { np.Delete() })
+				revert.Add(func() error { return np.Delete() })
 			}
 		}
 

--- a/lxd/device/pci/pci.go
+++ b/lxd/device/pci/pci.go
@@ -107,11 +107,24 @@ func DeviceDriverOverride(pciDev Device, driverOverride string) error {
 		return err
 	}
 
-	revert.Add(func() {
+	revert.Add(func() error {
 		// Reset the driver override and rebind to original driver (if needed).
-		DeviceUnbind(pciDev)
-		DeviceSetDriverOverride(pciDev, pciDev.Driver)
-		DeviceProbe(pciDev)
+		err := DeviceUnbind(pciDev)
+		if err != nil {
+			return err
+		}
+
+		err = DeviceSetDriverOverride(pciDev, pciDev.Driver)
+		if err != nil {
+			return err
+		}
+
+		err = DeviceProbe(pciDev)
+		if err != nil {
+			return err
+		}
+
+		return nil
 	})
 
 	// Set driver override.

--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -112,7 +112,7 @@ func (d *tpm) startContainer() (*deviceConfig.RunConfig, error) {
 	defer revert.Fail()
 
 	// Stop the TPM emulator if anything goes wrong.
-	revert.Add(func() { proc.Stop() })
+	revert.Add(func() error { return proc.Stop() })
 
 	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
 
@@ -199,7 +199,7 @@ func (d *tpm) startVM() (*deviceConfig.RunConfig, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() { proc.Stop() })
+	revert.Add(func() error { return proc.Stop() })
 
 	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
 

--- a/lxd/dns/server.go
+++ b/lxd/dns/server.go
@@ -132,7 +132,7 @@ func (s *Server) reconfigure(address string) error {
 	// Check if we should start.
 	if address != "" {
 		// Restore old address on failure.
-		revert.Add(func() { s.start(oldAddress) })
+		revert.Add(func() error { return s.start(oldAddress) })
 
 		// Start the listener with the new address.
 		err = s.start(address)

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -929,7 +929,7 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 
 	revert := revert.New()
 	defer revert.Fail()
-	revert.Add(func() { d.InstanceClearProxyNAT(projectName, instanceName, deviceName) })
+	revert.Add(func() error { return d.InstanceClearProxyNAT(projectName, instanceName, deviceName) })
 
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -50,7 +50,7 @@ func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, 
 		return nil, fmt.Errorf("Failed creating instance: %w", err)
 	}
 
-	revert.Add(func() { inst.Delete(true) })
+	revert.Add(func() error { return inst.Delete(true) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {
@@ -170,7 +170,7 @@ func instanceCreateFromImage(d *Daemon, r *http.Request, args db.InstanceArgs, h
 		return nil, fmt.Errorf("Failed creating instance from image: %w", err)
 	}
 
-	revert.Add(func() { inst.Delete(true) })
+	revert.Add(func() error { return inst.Delete(true) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {
@@ -339,7 +339,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			return nil, fmt.Errorf("Create instance from copy: %w", err)
 		}
 
-		revert.Add(func() { inst.Delete(true) })
+		revert.Add(func() error { return inst.Delete(true) })
 
 		if opts.applyTemplateTrigger {
 			// Trigger the templates on next start.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -566,7 +566,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 		return fmt.Errorf("Create instance snapshot: %w", err)
 	}
 
-	revert.Add(func() { snap.Delete(true) })
+	revert.Add(func() error { return snap.Delete(true) })
 
 	// Mount volume for backup.yaml writing.
 	_, err = pool.MountInstance(inst, d.op)

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -322,12 +322,12 @@ func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]stri
 			return fmt.Errorf("Failed adding block device: %w", err)
 		}
 
-		revert.Add(func() {
+		revert.Add(func() error {
 			blockDevDel := map[string]any{
 				"node-name": blockDev["devName"],
 			}
 
-			m.run("blockdev-del", blockDevDel, nil)
+			return m.run("blockdev-del", blockDevDel, nil)
 		})
 	}
 
@@ -418,15 +418,12 @@ func (m *Monitor) AddNIC(netDev map[string]any, device map[string]string) error 
 			return fmt.Errorf("Failed adding NIC netdev: %w", err)
 		}
 
-		revert.Add(func() {
+		revert.Add(func() error {
 			netDevDel := map[string]any{
 				"id": netDev["id"],
 			}
 
-			err = m.run("netdev_del", netDevDel, nil)
-			if err != nil {
-				return
-			}
+			return m.run("netdev_del", netDevDel, nil)
 		})
 	}
 

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -1065,7 +1065,10 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 			return err
 		}
 
-		revert.Add(func() { op.Done(err) })
+		revert.Add(func() error {
+			op.Done(err)
+			return nil
+		})
 
 		return nil
 	})
@@ -1082,7 +1085,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 		return nil, nil, err
 	}
 
-	revert.Add(func() { s.DB.Cluster.DeleteInstance(dbInst.Project, dbInst.Name) })
+	revert.Add(func() error { return s.DB.Cluster.DeleteInstance(dbInst.Project, dbInst.Name) })
 
 	args = db.InstanceToArgs(&dbInst)
 	inst, err := Create(s, args, revert)

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -157,7 +157,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 	if err != nil {
 		return response.InternalError(err)
 	}
-	reverter.Add(func() { client.Close() })
+	reverter.Add(client.Close)
 
 	// Get the file stats.
 	stat, err := client.Lstat(path)
@@ -189,7 +189,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 		if err != nil {
 			return response.SmartError(err)
 		}
-		reverter.Add(func() { file.Close() })
+		reverter.Add(file.Close)
 
 		// Setup cleanup logic.
 		cleanup := reverter.Clone()
@@ -318,7 +318,7 @@ func instanceFileHead(s *state.State, inst instance.Instance, path string, r *ht
 	if err != nil {
 		return response.InternalError(err)
 	}
-	reverter.Add(func() { client.Close() })
+	reverter.Add(client.Close)
 
 	// Get the file stats.
 	stat, err := client.Lstat(path)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -616,7 +616,7 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 		return response.InternalError(err)
 	}
 	defer os.Remove(backupFile.Name())
-	revert.Add(func() { backupFile.Close() })
+	revert.Add(backupFile.Close)
 
 	// Stream uploaded backup data into temporary file.
 	_, err = io.Copy(backupFile, data)
@@ -751,7 +751,7 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 		}
 
 		// Clean up created instance if the post hook fails below.
-		runRevert.Add(func() { inst.Delete(true) })
+		runRevert.Add(func() error { return inst.Delete(true) })
 
 		// Run the storage post hook to perform any final actions now that the instance has been created
 		// in the database (this normally includes unmounting volumes that were mounted).

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -961,7 +961,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 		// Only delete entire instance on error if the pool volume creation has succeeded to avoid
 		// deleting an existing conflicting volume.
 		if !volTargetArgs.Refresh {
-			revert.Add(func() { args.Instance.Delete(true) })
+			revert.Add(func() error { return args.Instance.Delete(true) })
 		}
 
 		return nil

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -214,7 +214,7 @@ func OVNEnsureACLs(s *state.State, l logger.Logger, client *openvswitch.OVN, acl
 			if err != nil {
 				return nil, fmt.Errorf("Failed creating port group %q for referenced security ACL %q setup: %w", portGroupName, aclName, err)
 			}
-			revert.Add(func() { client.PortGroupDelete(portGroupName) })
+			revert.Add(func() error { return client.PortGroupDelete(portGroupName) })
 		}
 	}
 
@@ -227,7 +227,7 @@ func OVNEnsureACLs(s *state.State, l logger.Logger, client *openvswitch.OVN, acl
 		if err != nil {
 			return nil, fmt.Errorf("Failed creating port group %q for security ACL %q setup: %w", portGroupName, aclStatus.name, err)
 		}
-		revert.Add(func() { client.PortGroupDelete(portGroupName) })
+		revert.Add(func() error { return client.PortGroupDelete(portGroupName) })
 
 		// Create any per-ACL-per-network port groups needed.
 		for _, aclNet := range aclNets {
@@ -240,7 +240,7 @@ func OVNEnsureACLs(s *state.State, l logger.Logger, client *openvswitch.OVN, acl
 				return nil, fmt.Errorf("Failed creating port group %q for security ACL %q and network %q setup: %w", portGroupName, aclStatus.name, aclNet.Name, err)
 			}
 
-			revert.Add(func() { client.PortGroupDelete(netPortGroupName) })
+			revert.Add(func() error { return client.PortGroupDelete(netPortGroupName) })
 		}
 
 		// Now apply our ACL rules to port group (and any per-ACL-per-network port groups needed).
@@ -266,7 +266,7 @@ func OVNEnsureACLs(s *state.State, l logger.Logger, client *openvswitch.OVN, acl
 				return nil, fmt.Errorf("Failed creating port group %q for security ACL %q and network %q setup: %w", portGroupName, aclStatus.name, aclNet.Name, err)
 			}
 
-			revert.Add(func() { client.PortGroupDelete(netPortGroupName) })
+			revert.Add(func() error { return client.PortGroupDelete(netPortGroupName) })
 		}
 
 		// If aclInfo has been loaded, then we should use it to apply ACL rules to the existing port group

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -72,7 +72,10 @@ func (n *macvlan) Start() error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() { n.setUnavailable() })
+	revert.Add(func() error {
+		n.setUnavailable()
+		return nil
+	})
 
 	if !InterfaceExists(n.config["parent"]) {
 		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
@@ -118,9 +121,9 @@ func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientTyp
 	defer revert.Fail()
 
 	// Define a function which reverts everything.
-	revert.Add(func() {
+	revert.Add(func() error {
 		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, targetNode, clientType)
+		return n.common.update(oldNetwork, targetNode, clientType)
 	})
 
 	// Apply changes to all nodes and databse.

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -161,7 +161,10 @@ func (n *physical) Start() error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() { n.setUnavailable() })
+	revert.Add(func() error {
+		n.setUnavailable()
+		return nil
+	})
 
 	err := n.setup(nil)
 	if err != nil {
@@ -191,7 +194,7 @@ func (n *physical) setup(oldConfig map[string]string) error {
 		return err
 	}
 	if created {
-		revert.Add(func() { InterfaceRemove(hostName) })
+		revert.Add(func() error { return InterfaceRemove(hostName) })
 	}
 
 	// Set the MTU.
@@ -322,9 +325,9 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 	}
 
 	// Define a function which reverts everything.
-	revert.Add(func() {
+	revert.Add(func() error {
 		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, targetNode, clientType)
+		return n.common.update(oldNetwork, targetNode, clientType)
 	})
 
 	// Apply changes to all nodes and databse.

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -71,7 +71,10 @@ func (n *sriov) Start() error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() { n.setUnavailable() })
+	revert.Add(func() error {
+		n.setUnavailable()
+		return nil
+	})
 
 	if !InterfaceExists(n.config["parent"]) {
 		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
@@ -117,9 +120,9 @@ func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType 
 	defer revert.Fail()
 
 	// Define a function which reverts everything.
-	revert.Add(func() {
+	revert.Add(func() error {
 		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, targetNode, clientType)
+		return n.common.update(oldNetwork, targetNode, clientType)
 	})
 
 	// Apply changes to all nodes and databse.

--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -232,10 +232,15 @@ func (d *zone) Update(config *api.NetworkZonePut, clientType request.ClientType)
 		d.info.NetworkZonePut = *config
 		d.init(d.state, d.id, d.projectName, d.info)
 
-		revert.Add(func() {
-			d.state.DB.Cluster.UpdateNetworkZone(d.id, &oldConfig)
+		revert.Add(func() error {
+			err := d.state.DB.Cluster.UpdateNetworkZone(d.id, &oldConfig)
+			if err != nil {
+				return err
+			}
+
 			d.info.NetworkZonePut = oldConfig
 			d.init(d.state, d.id, d.projectName, d.info)
+			return nil
 		})
 
 		// Notify all other nodes to update the network zone if no target specified.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -447,7 +447,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Error inserting %q into database: %w", req.Name, err))
 	}
-	revert.Add(func() { d.db.Cluster.DeleteNetwork(projectName, req.Name) })
+	revert.Add(func() error { return d.db.Cluster.DeleteNetwork(projectName, req.Name) })
 
 	n, err := network.LoadByName(d.State(), projectName, req.Name)
 	if err != nil {
@@ -665,7 +665,7 @@ func doNetworksCreate(d *Daemon, n network.Network, clientType clusterRequest.Cl
 		return err
 	}
 
-	revert.Add(func() { n.Delete(clientType) })
+	revert.Add(func() error { return n.Delete(clientType) })
 
 	// Only start networks when not doing a cluster pre-join phase (this ensures that networks are only started
 	// once the node has fully joined the clustered database and has consistent config with rest of the nodes).

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -452,7 +452,7 @@ func patchThinpoolTypoFix(name string, d *Daemon) error {
 		return fmt.Errorf("Failed to begin transaction: %w", err)
 	}
 
-	revert.Add(func() { tx.Rollback() })
+	revert.Add(func() error { return tx.Rollback() })
 
 	// Fetch the IDs of all existing nodes.
 	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")

--- a/lxd/revert/revert_test.go
+++ b/lxd/revert/revert_test.go
@@ -10,8 +10,15 @@ func ExampleReverter_fail() {
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() { fmt.Println("1st step") })
-	revert.Add(func() { fmt.Println("2nd step") })
+	revert.Add(func() error {
+		fmt.Println("1st step")
+		return nil
+	})
+
+	revert.Add(func() error {
+		fmt.Println("2nd step")
+		return nil
+	})
 
 	return // Revert functions are run in reverse order on return.
 	// Output: 2nd step
@@ -22,8 +29,15 @@ func ExampleReverter_success() {
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() { fmt.Println("1st step") })
-	revert.Add(func() { fmt.Println("2nd step") })
+	revert.Add(func() error {
+		fmt.Println("1st step")
+		return nil
+	})
+
+	revert.Add(func() error {
+		fmt.Println("2nd step")
+		return nil
+	})
 
 	revert.Success() // Revert functions added are not run on return.
 	return

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -144,7 +144,7 @@ func (d *ceph) Create() error {
 			return err
 		}
 
-		revert.Add(func() { d.osdDeletePool() })
+		revert.Add(func() error { return d.osdDeletePool() })
 
 		// Initialize the pool. This is not necessary but allows the pool to be monitored.
 		_, err = shared.TryRunCommand("rbd",

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -21,7 +21,7 @@ func (d *dir) withoutGetVolID() Driver {
 
 // setupInitialQuota enables quota on a new volume and sets with an initial quota from config.
 // Returns a revert function that can be used to remove the quota if there is a subsequent error.
-func (d *dir) setupInitialQuota(vol Volume) (func(), error) {
+func (d *dir) setupInitialQuota(vol Volume) (revert.Hook, error) {
 	if vol.IsVMBlock() {
 		return nil, nil
 	}
@@ -38,7 +38,7 @@ func (d *dir) setupInitialQuota(vol Volume) (func(), error) {
 	defer revert.Fail()
 
 	// Define a function to revert the quota being setup.
-	revertFunc := func() { d.deleteQuota(volPath, volID) }
+	revertFunc := func() error { return d.deleteQuota(volPath, volID) }
 	revert.Add(revertFunc)
 
 	// Initialise the volume's project using the volume ID and set the quota.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -33,7 +33,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	if err != nil {
 		return err
 	}
-	revert.Add(func() { os.RemoveAll(volPath) })
+	revert.Add(func() error { return os.RemoveAll(volPath) })
 
 	// Create sparse loopback file if volume is block.
 	rootBlockPath := ""
@@ -390,7 +390,7 @@ func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	defer revert.Fail()
 
 	snapPath := snapVol.MountPath()
-	revert.Add(func() { os.RemoveAll(snapPath) })
+	revert.Add(func() error { return os.RemoveAll(snapPath) })
 
 	if snapVol.contentType != ContentTypeBlock || snapVol.volType != VolumeTypeCustom {
 		var rsyncArgs []string

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -202,7 +202,7 @@ func (v Volume) EnsureMountPath() error {
 		if err != nil {
 			return fmt.Errorf("Failed to create mount directory %q: %w", volPath, err)
 		}
-		revert.Add(func() { os.Remove(volPath) })
+		revert.Add(func() error { return os.Remove(volPath) })
 	}
 
 	// Set very restrictive mode 0100 for non-custom and non-image volumes.

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -75,7 +75,7 @@ func storagePoolCreateGlobal(state *state.State, req api.StoragePoolsPost, clien
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() { dbStoragePoolDeleteAndUpdateCache(state, req.Name) })
+	revert.Add(func() error { return dbStoragePoolDeleteAndUpdateCache(state, req.Name) })
 
 	_, err = storagePoolCreateLocal(state, id, req, clientType)
 	if err != nil {
@@ -111,7 +111,7 @@ func storagePoolCreateLocal(state *state.State, poolID int64, req api.StoragePoo
 		return nil, err
 	}
 
-	revert.Add(func() { pool.Delete(clientType, nil) })
+	revert.Add(func() error { return pool.Delete(clientType, nil) })
 
 	// Mount the pool.
 	_, err = pool.Mount()

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1189,7 +1189,9 @@ func storagePoolVolumeTypePostMove(d *Daemon, r *http.Request, poolName string, 
 		if err != nil {
 			return err
 		}
-		revert.Add(func() { storagePoolVolumeUpdateUsers(d, projectName, newPool.Name(), &newVol, pool.Name(), vol) })
+		revert.Add(func() error {
+			return storagePoolVolumeUpdateUsers(d, projectName, newPool.Name(), &newVol, pool.Name(), vol)
+		})
 
 		// Provide empty description and nil config to instruct CreateCustomVolumeFromCopy to copy it
 		// from source volume.
@@ -1781,7 +1783,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 		return response.InternalError(err)
 	}
 	defer os.Remove(backupFile.Name())
-	revert.Add(func() { backupFile.Close() })
+	revert.Add(backupFile.Close)
 
 	// Stream uploaded backup data into temporary file.
 	_, err = io.Copy(backupFile, data)


### PR DESCRIPTION
In relation to #10392 and https://github.com/lxc/lxd/issues/10392#issuecomment-1125842768 in order for the `errcheck` linter to pass, we need to inspect or explicitly ignore all errors. This change changes the type signature of `revert.Hook` to return an error which is logged during `revert.Fail` if non-nil.