### PR TITLE
lxd/resources: Handle unreadable VPD

### DIFF
--- a/lxd/resources/pci.go
+++ b/lxd/resources/pci.go
@@ -140,11 +140,11 @@ func GetPCI() (*api.ResourcesPCI, error) {
 		vpdSysPath := filepath.Join(devicePath, "vpd")
 		if sysfsExists(vpdSysPath) {
 			data, err := ioutil.ReadFile(vpdSysPath)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to read %q: %w", vpdSysPath, err)
-			}
 
-			device.VPD = parsePCIVPD(data)
+			// If the file is readable, parse the VPD data.
+			if err == nil {
+				device.VPD = parsePCIVPD(data)
+			}
 		}
 
 		pci.Devices = append(pci.Devices, device)


### PR DESCRIPTION
Closes #10412

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>