### PR TITLE
lxd-agent/devlxd: Don't expand format strings

### DIFF
--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -186,7 +186,7 @@ func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devLxdRespons
 			util.WriteJSON(w, resp.content, debugLogger)
 		} else if resp.ctype != "websocket" {
 			w.Header().Set("Content-Type", "application/octet-stream")
-			fmt.Fprintf(w, resp.content.(string))
+			fmt.Fprint(w, resp.content.(string))
 		}
 	}
 }


### PR DESCRIPTION
Fixes #10422

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
