### PR TITLE
lxd/instance/drivers/qemu: Set conf option in rbd driver

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3266,6 +3266,7 @@ func (d *qemu) addDriveConfig(bootIndexes map[string]int, driveConf deviceConfig
 		blockDev["image"] = rbdImageName
 		blockDev["user"] = userName
 		blockDev["server"] = []map[string]string{}
+		blockDev["conf"] = fmt.Sprintf("/etc/ceph/%s.conf", poolName)
 
 		// Setup the Ceph cluster config (monitors and keyring).
 		monitors, err := storageDrivers.CephMonitors(clusterName)


### PR DESCRIPTION
Setting the conf option will make the rbd driver apply the config.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
