### PR TITLE
Storage: Separate generation of backup config struct from writing it

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -756,7 +756,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 		return fmt.Errorf("No instance config in backup config")
 	}
 
-	instDBArgs := backupConf.ToInstanceDBArgs(projectName)
+	instDBArgs := backup.ConfigToInstanceDBArgs(backupConf, projectName)
 
 	_, instOp, err := instance.CreateInternal(d.State(), *instDBArgs, true, revert)
 	if err != nil {

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -479,7 +479,7 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 
 	internalImportRootDevicePopulate(pool.Name(), poolVol.Container.Devices, poolVol.Container.ExpandedDevices, profiles)
 
-	dbInst := poolVol.ToInstanceDBArgs(projectName)
+	dbInst := backup.ConfigToInstanceDBArgs(poolVol, projectName)
 
 	if dbInst.Type < 0 {
 		return nil, fmt.Errorf("Invalid instance type")

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/lxc/lxd/lxd/backup"
+	backupConfig "github.com/lxc/lxd/lxd/backup/config"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
@@ -142,7 +143,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 	}
 
 	// Used to store the unknown volumes for each pool & project.
-	poolsProjectVols := make(map[string]map[string][]*backup.Config)
+	poolsProjectVols := make(map[string]map[string][]*backupConfig.Config)
 
 	// Used to store a handle to each pool containing user supplied config.
 	pools := make(map[string]storagePools.Pool)
@@ -328,8 +329,8 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 
 			// Create missing storage pool DB record if neeed.
 			if pool.ID() == storagePools.PoolIDTemporary {
-				var instPoolVol *backup.Config // Instance volume used for new pool record.
-				var poolID int64               // Pool ID of created pool record.
+				var instPoolVol *backupConfig.Config // Instance volume used for new pool record.
+				var poolID int64                     // Pool ID of created pool record.
 
 				// Search unknown volumes looking for an instance volume that can be used to
 				// restore the pool DB config from. This is preferable over using the user
@@ -462,7 +463,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 }
 
 // internalRecoverImportInstance recreates the database records for an instance and returns the new instance.
-func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, projectName string, poolVol *backup.Config, profiles []api.Profile, revert *revert.Reverter) (instance.Instance, error) {
+func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, projectName string, poolVol *backupConfig.Config, profiles []api.Profile, revert *revert.Reverter) (instance.Instance, error) {
 	if poolVol.Container == nil {
 		return nil, fmt.Errorf("Pool volume is not an instance volume")
 	}
@@ -494,7 +495,7 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 }
 
 // internalRecoverImportInstance recreates the database records for an instance snapshot.
-func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Pool, projectName string, poolVol *backup.Config, snap *api.InstanceSnapshot, profiles []api.Profile, revert *revert.Reverter) error {
+func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Pool, projectName string, poolVol *backupConfig.Config, snap *api.InstanceSnapshot, profiles []api.Profile, revert *revert.Reverter) error {
 	if poolVol.Container == nil || snap == nil {
 		return fmt.Errorf("Pool volume is not an instance volume")
 	}

--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/lxc/lxd/lxd/backup/config"
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
@@ -16,17 +17,8 @@ import (
 	"github.com/lxc/lxd/shared/osarch"
 )
 
-// Config represents the config of a backup that can be stored in a backup.yaml file (or embedded in index.yaml).
-type Config struct {
-	Container       *api.Instance                `yaml:"container,omitempty"` // Used by VM backups too.
-	Snapshots       []*api.InstanceSnapshot      `yaml:"snapshots,omitempty"`
-	Pool            *api.StoragePool             `yaml:"pool,omitempty"`
-	Volume          *api.StorageVolume           `yaml:"volume,omitempty"`
-	VolumeSnapshots []*api.StorageVolumeSnapshot `yaml:"volume_snapshots,omitempty"`
-}
-
-// ToInstanceDBArgs converts the instance config in the backup config to DB InstanceArgs.
-func (c *Config) ToInstanceDBArgs(projectName string) *db.InstanceArgs {
+// ConfigToInstanceDBArgs converts the instance config in the backup config to DB InstanceArgs.
+func ConfigToInstanceDBArgs(c *config.Config, projectName string) *db.InstanceArgs {
 	if c.Container == nil {
 		return nil
 	}
@@ -54,13 +46,13 @@ func (c *Config) ToInstanceDBArgs(projectName string) *db.InstanceArgs {
 }
 
 // ParseConfigYamlFile decodes the YAML file at path specified into a Config.
-func ParseConfigYamlFile(path string) (*Config, error) {
+func ParseConfigYamlFile(path string) (*config.Config, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	backupConf := Config{}
+	backupConf := config.Config{}
 	if err := yaml.Unmarshal(data, &backupConf); err != nil {
 		return nil, err
 	}

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/lxc/lxd/lxd/backup/config"
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -39,15 +40,15 @@ func InstanceTypeToBackupType(instanceType api.InstanceType) Type {
 
 // Info represents exported backup information.
 type Info struct {
-	Project          string   `json:"-" yaml:"-"` // Project is set during import based on current project.
-	Name             string   `json:"name" yaml:"name"`
-	Backend          string   `json:"backend" yaml:"backend"`
-	Pool             string   `json:"pool" yaml:"pool"`
-	Snapshots        []string `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
-	OptimizedStorage *bool    `json:"optimized,omitempty" yaml:"optimized,omitempty"`               // Optional field to handle older optimized backups that don't have this field.
-	OptimizedHeader  *bool    `json:"optimized_header,omitempty" yaml:"optimized_header,omitempty"` // Optional field to handle older optimized backups that don't have this field.
-	Type             Type     `json:"type,omitempty" yaml:"type,omitempty"`                         // Type of backup.
-	Config           *Config  `json:"config,omitempty" yaml:"config,omitempty"`                     // Equivalent of backup.yaml but embedded in index for quick retrieval.
+	Project          string         `json:"-" yaml:"-"` // Project is set during import based on current project.
+	Name             string         `json:"name" yaml:"name"`
+	Backend          string         `json:"backend" yaml:"backend"`
+	Pool             string         `json:"pool" yaml:"pool"`
+	Snapshots        []string       `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
+	OptimizedStorage *bool          `json:"optimized,omitempty" yaml:"optimized,omitempty"`               // Optional field to handle older optimized backups that don't have this field.
+	OptimizedHeader  *bool          `json:"optimized_header,omitempty" yaml:"optimized_header,omitempty"` // Optional field to handle older optimized backups that don't have this field.
+	Type             Type           `json:"type,omitempty" yaml:"type,omitempty"`                         // Type of backup.
+	Config           *config.Config `json:"config,omitempty" yaml:"config,omitempty"`                     // Equivalent of backup.yaml but embedded in index for quick retrieval.
 }
 
 // GetInfo extracts backup information from a given ReadSeeker.

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"github.com/lxc/lxd/shared/api"
+)
+
+// Config represents the config of a backup that can be stored in a backup.yaml file (or embedded in index.yaml).
+type Config struct {
+	Container       *api.Instance                `yaml:"container,omitempty"` // Used by VM backups too.
+	Snapshots       []*api.InstanceSnapshot      `yaml:"snapshots,omitempty"`
+	Pool            *api.StoragePool             `yaml:"pool,omitempty"`
+	Volume          *api.StorageVolume           `yaml:"volume,omitempty"`
+	VolumeSnapshots []*api.StorageVolumeSnapshot `yaml:"volume_snapshots,omitempty"`
+}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -559,7 +559,7 @@ func LoadFromBackup(s *state.State, projectName string, instancePath string, app
 		return nil, fmt.Errorf("Failed parsing instance backup file from %q: %w", backupYamlPath, err)
 	}
 
-	instDBArgs := backupConf.ToInstanceDBArgs(projectName)
+	instDBArgs := backup.ConfigToInstanceDBArgs(backupConf, projectName)
 
 	if !applyProfiles {
 		// Stop instance.Load() from expanding profile config from DB, and apply expanded config from

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3989,7 +3989,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 			return err
 		}
 
-		revert.Add(func() { revert.Add(func() { VolumeDBDelete(b, projectName, fullSnapName, drivers.VolumeTypeCustom) }) })
+		revert.Add(func() { _ = VolumeDBDelete(b, projectName, fullSnapName, drivers.VolumeTypeCustom) })
 	}
 
 	// Get the volume name on storage.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/lxd/backup"
+	backupConfig "github.com/lxc/lxd/lxd/backup/config"
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
@@ -3945,7 +3946,7 @@ func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operat
 // ImportCustomVolume takes an existing custom volume on the storage backend and ensures that the DB records,
 // volume directories and symlinks are restored as needed to make it operational with LXD.
 // Used during the recovery import stage.
-func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backup.Config, op *operations.Operation) error {
+func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) error {
 	if poolVol.Volume == nil {
 		return fmt.Errorf("Invalid pool volume config supplied")
 	}
@@ -4309,8 +4310,8 @@ func (b *lxdBackend) createStorageStructure(path string) error {
 	return nil
 }
 
-// GenerateCustomVolumeBackupConfig returns the backup.Config entry for this volume.
-func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backup.Config, error) {
+// GenerateCustomVolumeBackupConfig returns the backup config entry for this volume.
+func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	vol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return nil, err
@@ -4320,7 +4321,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 		return nil, fmt.Errorf("Unsupported volume type %q", vol.Type)
 	}
 
-	config := &backup.Config{
+	config := &backupConfig.Config{
 		Volume: vol,
 	}
 
@@ -4351,8 +4352,8 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 	return config, nil
 }
 
-// GenerateInstanceBackupConfig returns the backup.Config entry for this instance.
-func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backup.Config, error) {
+// GenerateInstanceBackupConfig returns the backup config entry for this instance.
+func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	// We only write backup files out for actual instances.
 	if inst.IsSnapshot() {
 		return nil, fmt.Errorf("Cannot generate backup config for snapshots")
@@ -4379,7 +4380,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		return nil, err
 	}
 
-	config := &backup.Config{
+	config := &backupConfig.Config{
 		Container: ci.(*api.Instance),
 		Pool:      &b.db,
 		Volume:    volume,
@@ -4503,7 +4504,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, op *operat
 // config are removed from the storage device, and any snapshots that exist in the backup config but do not exist
 // on the storage device are ignored. The remaining set of snapshots that exist on both the storage device and the
 // backup config are returned. They set can be used to re-create the snapshot database entries when importing.
-func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backup.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
+func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
 	l := logger.AddContext(b.logger, logger.Ctx{"project": projectName, "instance": backupConf.Container.Name, "deleteMissing": deleteMissing})
 	l.Debug("CheckInstanceBackupFileSnapshots started")
 	defer l.Debug("CheckInstanceBackupFileSnapshots finished")
@@ -4602,7 +4603,7 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backup.Config,
 
 // ListUnknownVolumes returns volumes that exist on the storage pool but don't have records in the database.
 // Returns the unknown volumes parsed/generated backup config in a slice (keyed on project name).
-func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backup.Config, error) {
+func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error) {
 	// Get a list of volumes on the storage pool. We only expect to get 1 volume per logical LXD volume.
 	// So for VMs we only expect to get the block volume for a VM and not its filesystem one too. This way we
 	// can operate on the volume using the existing storage pool functions and let the pool then handle the
@@ -4612,7 +4613,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 		return nil, fmt.Errorf("Failed getting pool volumes: %w", err)
 	}
 
-	projectVols := make(map[string][]*backup.Config)
+	projectVols := make(map[string][]*backupConfig.Config)
 
 	for _, poolVol := range poolVols {
 		volType := poolVol.Type()
@@ -4641,7 +4642,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 // detectUnknownInstanceVolume detects if a volume is unknown and if so attempts to mount the volume and parse the
 // backup stored on it. It then runs a series of consistency checks that compare the contents of the backup file to
 // the state of the volume on disk, and if all checks out, it adds the parsed backup file contents to projectVols.
-func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVols map[string][]*backup.Config, op *operations.Operation) error {
+func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
 	volType := vol.Type()
 
 	volDBType, err := VolumeTypeToDBType(volType)
@@ -4678,7 +4679,7 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 	}
 
 	backupYamlPath := filepath.Join(vol.MountPath(), "backup.yaml")
-	var backupConf *backup.Config
+	var backupConf *backupConfig.Config
 
 	// If the instance is running, it should already be mounted, so check if the backup file
 	// is already accessible, and if so parse it directly, without disturbing the mount count.
@@ -4760,7 +4761,7 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 
 	// Add to volume to unknown volumes list for the project.
 	if projectVols[projectName] == nil {
-		projectVols[projectName] = []*backup.Config{backupConf}
+		projectVols[projectName] = []*backupConfig.Config{backupConf}
 	} else {
 		projectVols[projectName] = append(projectVols[projectName], backupConf)
 	}
@@ -4798,7 +4799,7 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 // detectUnknownCustomVolume detects if a volume is unknown and if so attempts to discover the filesystem of the
 // volume (for filesystem volumes). It then runs a series of consistency checks, and if all checks out, it adds
 // generates a simulated backup config for the custom volume and adds it to projectVols.
-func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols map[string][]*backup.Config, op *operations.Operation) error {
+func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols map[string][]*backupConfig.Config, op *operations.Operation) error {
 	volType := vol.Type()
 
 	volDBType, err := VolumeTypeToDBType(volType)
@@ -4874,7 +4875,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 		return fmt.Errorf("Failed custom volume validation: %w", err)
 	}
 
-	backupConf := &backup.Config{
+	backupConf := &backupConfig.Config{
 		Volume: &api.StorageVolume{
 			Name:        volName,
 			Type:        db.StoragePoolVolumeTypeNameCustom,
@@ -4896,7 +4897,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 
 	// Add to volume to unknown volumes list for the project.
 	if projectVols[projectName] == nil {
-		projectVols[projectName] = []*backup.Config{backupConf}
+		projectVols[projectName] = []*backupConfig.Config{backupConf}
 	} else {
 		projectVols[projectName] = append(projectVols[projectName], backupConf)
 	}
@@ -4908,7 +4909,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 // and symlinks are restored as needed to make it operational with LXD. Used during the recovery import stage.
 // If the instance exists on the local cluster member then the local mount status is restored as needed.
 // If the optional poolVol argument is provided then it is used to create the storage volume database records.
-func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backup.Config, op *operations.Operation) error {
+func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) error {
 	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
 	l.Debug("ImportInstance started")
 	defer l.Debug("ImportInstance finished")

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -137,6 +137,10 @@ func (b *mockBackend) UpdateInstance(inst instance.Instance, newDesc string, new
 	return nil
 }
 
+func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backup.Config, error) {
+	return nil, nil
+}
+
 func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/backup"
+	backupConfig "github.com/lxc/lxd/lxd/backup/config"
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/migration"
@@ -137,11 +138,11 @@ func (b *mockBackend) UpdateInstance(inst instance.Instance, newDesc string, new
 	return nil
 }
 
-func (b *mockBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backup.Config, error) {
+func (b *mockBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
-func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backup.Config, error) {
+func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backupConfig.Config, error) {
 	return nil, nil
 }
 
@@ -149,15 +150,15 @@ func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, op *opera
 	return nil
 }
 
-func (b *mockBackend) CheckInstanceBackupFileSnapshots(backupConf *backup.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
+func (b *mockBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
 	return nil, nil
 }
 
-func (b *mockBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backup.Config, error) {
+func (b *mockBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error) {
 	return nil, nil
 }
 
-func (b *mockBackend) ImportInstance(inst instance.Instance, poolVol *backup.Config, op *operations.Operation) error {
+func (b *mockBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) error {
 	return nil
 }
 
@@ -277,7 +278,7 @@ func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, op
 	return true, nil
 }
 
-func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backup.Config, op *operations.Operation) error {
+func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -137,6 +137,10 @@ func (b *mockBackend) UpdateInstance(inst instance.Instance, newDesc string, new
 	return nil
 }
 
+func (b *mockBackend) GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backup.Config, error) {
+	return nil, nil
+}
+
 func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backup.Config, error) {
 	return nil, nil
 }

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -102,6 +102,7 @@ type Pool interface {
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 	ImportCustomVolume(projectName string, poolVol *backup.Config, op *operations.Operation) error
 	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
+	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backup.Config, error)
 
 	// Custom volume snapshots.
 	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newExpiryDate time.Time, op *operations.Operation) error

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/backup"
+	backupConfig "github.com/lxc/lxd/lxd/backup/config"
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/migration"
@@ -62,9 +63,9 @@ type Pool interface {
 	DeleteInstance(inst instance.Instance, op *operations.Operation) error
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error
-	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backup.Config, error)
-	CheckInstanceBackupFileSnapshots(backupConf *backup.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error)
-	ImportInstance(inst instance.Instance, poolVol *backup.Config, op *operations.Operation) error
+	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
+	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error)
+	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) error
 
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error
@@ -100,9 +101,9 @@ type Pool interface {
 	GetCustomVolumeUsage(projectName string, volName string) (int64, error)
 	MountCustomVolume(projectName string, volName string, op *operations.Operation) error
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
-	ImportCustomVolume(projectName string, poolVol *backup.Config, op *operations.Operation) error
+	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) error
 	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
-	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backup.Config, error)
+	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
 
 	// Custom volume snapshots.
 	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newExpiryDate time.Time, op *operations.Operation) error
@@ -121,5 +122,5 @@ type Pool interface {
 	CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) error
 
 	// Storage volume recovery.
-	ListUnknownVolumes(op *operations.Operation) (map[string][]*backup.Config, error)
+	ListUnknownVolumes(op *operations.Operation) (map[string][]*backupConfig.Config, error)
 }

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -62,6 +62,7 @@ type Pool interface {
 	DeleteInstance(inst instance.Instance, op *operations.Operation) error
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error
+	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backup.Config, error)
 	CheckInstanceBackupFileSnapshots(backupConf *backup.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error)
 	ImportInstance(inst instance.Instance, poolVol *backup.Config, op *operations.Operation) error
 


### PR DESCRIPTION
This will allow us to generate a migration index header containing the same config used for backups.

Also includes a change to include the backup config in the backup `index.yaml` file to allow the unpack process full access to config to rebuild storage volumes (even for optimized backups) in the future.