### PR TITLE
lxd-generate: Appease errcheck linter in generated files

### DIFF
--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -128,7 +128,7 @@ func GetCertificateID(ctx context.Context, tx *sql.Tx, fingerprint string) (int6
 		return -1, fmt.Errorf("Failed to get \"certificates\" ID: %w", err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -29,7 +29,7 @@ func GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) 
 		return -1, fmt.Errorf("Failed to get \"profiles\" ID: %w", err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -221,7 +221,7 @@ func GetProjectID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
 		return -1, fmt.Errorf("Failed to get \"projects\" ID: %w", err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -441,7 +441,7 @@ func (m *Method) id(buf *file.Buffer) error {
 	buf.L("stmt := c.stmt(%s)", stmtCodeVar(m.entity, "ID"))
 	buf.L("rows, err := stmt.Query(%s)", mapping.FieldParams(nk))
 	m.ifErrNotNil(buf, "-1", fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" ID: %%w", err)`, entityTable(m.entity)))
-	buf.L("defer rows.Close()")
+	buf.L("defer func() { _ = rows.Close() }()")
 	buf.N()
 	buf.L("// Ensure we read one and only one row.")
 	buf.L("if !rows.Next() {")

--- a/lxd/db/generate/db/method_v2.go
+++ b/lxd/db/generate/db/method_v2.go
@@ -525,7 +525,7 @@ func (m *MethodV2) id(buf *file.Buffer) error {
 	buf.L("stmt := %sstmt(tx, %s)", m.db, stmtCodeVar(m.entity, "ID"))
 	buf.L("rows, err := stmt.Query(%s)", mapping.FieldParams(nk))
 	m.ifErrNotNil(buf, "-1", fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" ID: %%w", err)`, entityTable(m.entity)))
-	buf.L("defer rows.Close()")
+	buf.L("defer func() { _ = rows.Close() }()")
 	buf.N()
 	buf.L("// Ensure we read one and only one row.")
 	buf.L("if !rows.Next() {")

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -524,7 +524,7 @@ func (c *ClusterTx) GetInstanceID(project string, name string) (int64, error) {
 		return -1, fmt.Errorf("Failed to get \"instances\" ID: %w", err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -269,7 +269,7 @@ func (c *ClusterTx) GetProfileID(project string, name string) (int64, error) {
 		return -1, fmt.Errorf("Failed to get \"profiles\" ID: %w", err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {

--- a/lxd/db/snapshots.mapper.go
+++ b/lxd/db/snapshots.mapper.go
@@ -169,7 +169,7 @@ func (c *ClusterTx) GetInstanceSnapshotID(project string, instance string, name 
 		return -1, fmt.Errorf("Failed to get \"instances_snapshots\" ID: %w", err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {

--- a/lxd/db/warnings.mapper.go
+++ b/lxd/db/warnings.mapper.go
@@ -224,7 +224,7 @@ func (c *ClusterTx) GetWarningID(uuid string) (int64, error) {
 		return -1, fmt.Errorf("Failed to get \"warnings\" ID: %w", err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Ensure we read one and only one row.
 	if !rows.Next() {


### PR DESCRIPTION
Updates `lxd-generate` to explicitly ignore a `rows.Close()` error on a deferred execution and regenerates database functions. This is required for #10428 as these files shouldn't be changed manually.