### PR TITLE
Instance: Stop source instance from freezing when using --allow-inconsistent

### DIFF
--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -303,7 +303,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		instanceOnly := req.InstanceOnly || req.ContainerOnly
-		ws, err := newMigrationSource(inst, req.Live, instanceOnly)
+		ws, err := newMigrationSource(inst, req.Live, instanceOnly, req.AllowInconsistent)
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -654,7 +654,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 			}
 		}
 
-		ws, err := newMigrationSource(snapInst, reqNew.Live, true)
+		ws, err := newMigrationSource(snapInst, reqNew.Live, true, false)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -52,7 +52,8 @@ type migrationFields struct {
 	instance     instance.Instance
 
 	// storage specific fields
-	volumeOnly bool
+	volumeOnly        bool
+	allowInconsistent bool
 }
 
 func (c *migrationFields) send(m proto.Message) error {


### PR DESCRIPTION
Running `lxc copy c1 remote:c1 --stateless --allow-inconsistent` is currently causing the source container c1 to freeze. This change ensures that the container is not frozen for either `lxc copy c1 remote:c1 --allow-inconsistent` or `lxc copy remote:c1 c1 --allow-inconsistent`. 

Closes #10091 