### PR TITLE
Instance: Refactor config generation (qemuBase)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2497,12 +2497,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	var sb *strings.Builder = &strings.Builder{}
 	var monHooks []monitorHook
 
-	err := qemuBase.Execute(sb, map[string]any{
-		"architecture": d.architectureName,
-	})
-	if err != nil {
-		return "", nil, err
-	}
+	qemuAppendSections(sb, qemuBaseSections(d.architectureName)...)
 
 	cpuCount, err := d.addCPUMemoryConfig(sb)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -1,0 +1,97 @@
+package drivers
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestQemuConfigTemplates(t *testing.T) {
+	indent := regexp.MustCompile(`(?m)^[ \t]+`)
+
+	stringifySections := func(sections ...cfgSection) string {
+		sb := &strings.Builder{}
+		qemuAppendSections(sb, sections...)
+
+		return sb.String()
+	}
+
+	normalize := func(s string) string {
+		return strings.TrimSpace(indent.ReplaceAllString(s, "$1"))
+	}
+
+	t.Run("qemu_base", func(t *testing.T) {
+		type args struct{ architecture string }
+		testCases := []struct {
+			args     args
+			expected string
+		}{{
+			args{"x86_64"},
+			`# Machine
+			[machine]
+			graphics = "off"
+			type = "q35"
+			accel = "kvm"
+			usb = "off"
+
+			[global]
+			driver = "ICH9-LPC"
+			property = "disable_s3"
+			value = "1"
+
+			[global]
+			driver = "ICH9-LPC"
+			property = "disable_s4"
+			value = "1"
+
+			[boot-opts]
+			strict = "on"`,
+		}, {
+			args{"aarch64"},
+			`# Machine
+			[machine]
+			graphics = "off"
+			type = "virt"
+			gic-version = "max"
+			accel = "kvm"
+			usb = "off"
+
+			[boot-opts]
+			strict = "on"`,
+		}, {
+			args{"ppc64le"},
+			`# Machine
+			[machine]
+			graphics = "off"
+			type = "pseries"
+			cap-large-decr = "off"
+			accel = "kvm"
+			usb = "off"
+
+			[boot-opts]
+			strict = "on"`,
+		}, {
+			args{"s390x"},
+			`# Machine
+			[machine]
+			graphics = "off"
+			type = "s390-ccw-virtio"
+			accel = "kvm"
+			usb = "off"
+
+			[boot-opts]
+			strict = "on"`,
+		}}
+
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuBaseSections(tc.args.architecture)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
+}

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -6,44 +6,6 @@ import (
 	"text/template"
 )
 
-// Base config. This is common for all VMs and has no variables in it.
-var qemuBase = template.Must(template.New("qemuBase").Parse(`
-# Machine
-[machine]
-graphics = "off"
-{{if eq .architecture "x86_64" -}}
-type = "q35"
-{{end -}}
-{{if eq .architecture "aarch64" -}}
-type = "virt"
-gic-version = "max"
-{{end -}}
-{{if eq .architecture "ppc64le" -}}
-type = "pseries"
-cap-large-decr = "off"
-{{end -}}
-{{if eq .architecture "s390x" -}}
-type = "s390-ccw-virtio"
-{{end -}}
-accel = "kvm"
-usb = "off"
-
-{{if eq .architecture "x86_64" -}}
-[global]
-driver = "ICH9-LPC"
-property = "disable_s3"
-value = "1"
-
-[global]
-driver = "ICH9-LPC"
-property = "disable_s4"
-value = "1"
-{{end -}}
-
-[boot-opts]
-strict = "on"
-`))
-
 type cfgEntry struct {
 	key   string
 	value string


### PR DESCRIPTION
I'm proposing a refactor of all code which generates qemu config by moving from `text/template` into a set of functions which build an in-memory structure which represents the config, along with another function which transforms the structure into the final config string. This PR contains a POC for the qemuBase section.

 While end goal is to move away from configs into QMP,  this is currently depending on external factors such as extra functionality being implemented in qemu upstream. Meanwhile I think this refactoring will bring the following advantages:

- Remove logic from template strings. There are many if/else/range  blocks inside template strings, which can be hard to maintain.
- Reuse config generation logic. Many templates are similar and  currently have repeated code. Devices for example, have similar  conditional blocks for pci/ccw/multifunction.
- Explicit arguments: Each template section is created by a function with arguments, instead of a generic template which receives a  map.
- Separation of config structure from string generation: First we build  a in-memory structure which represents the config, then we pass it to  a generic function which transforms into the final config string. This  design has multiple advantages, such as allowing easy processing of config data before the final config is generated.
- More easily testable. (I've added a test module which verifies the qemuBase function with multiple arguments)
