### PR TITLE
Instance: Convert more qemu config templates

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2497,7 +2497,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	var sb *strings.Builder = &strings.Builder{}
 	var monHooks []monitorHook
 
-	qemuAppendSections(sb, qemuBaseSections(d.architectureName)...)
+	qemuAppendSections(sb, qemuBaseSections(&qemuBaseOpts{d.architectureName})...)
 
 	cpuCount, err := d.addCPUMemoryConfig(sb)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2618,18 +2618,17 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuSerial.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-
-		"chardevName":      qemuSerialChardevName,
-		"ringbufSizeBytes": qmp.RingbufSize,
-	})
-	if err != nil {
-		return "", nil, err
+	serialOpts := qemuSerialOpts{
+		dev: qemuDevOpts{
+			busName:       bus.name,
+			devBus:        devBus,
+			devAddr:       devAddr,
+			multifunction: multi,
+		},
+		charDevName:      qemuSerialChardevName,
+		ringbufSizeBytes: qmp.RingbufSize,
 	}
+	qemuAppendSections(sb, qemuSerialSections(&serialOpts)...)
 
 	// s390x doesn't really have USB.
 	if d.architecture != osarch.ARCH_64BIT_S390_BIG_ENDIAN {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2686,17 +2686,16 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupNone)
-	err = qemuGPU.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-
-		"architecture": d.architectureName,
-	})
-	if err != nil {
-		return "", nil, err
+	gpuOpts := qemuGpuOpts{
+		dev: qemuDevOpts{
+			busName:       bus.name,
+			devBus:        devBus,
+			devAddr:       devAddr,
+			multifunction: multi,
+		},
+		architecture: d.architectureName,
 	}
+	qemuAppendSections(sb, qemuGPUSections(&gpuOpts)...)
 
 	// Dynamic devices.
 	bootIndexes, err := d.deviceBootPriorities()

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2601,17 +2601,16 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuVsock.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-
-		"vsockID": d.vsockID(),
-	})
-	if err != nil {
-		return "", nil, err
+	vsockOpts := qemuVsockOpts{
+		dev: qemuDevOpts{
+			busName:       bus.name,
+			devBus:        devBus,
+			devAddr:       devAddr,
+			multifunction: multi,
+		},
+		vsockID: d.vsockID(),
 	}
+	qemuAppendSections(sb, qemuVsockSections(&vsockOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 	serialOpts := qemuSerialOpts{

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2570,15 +2570,13 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	qemuAppendSections(sb, qemuBalloonSections(&balloonOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuRNG.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-	})
-	if err != nil {
-		return "", nil, err
+	rngOpts := qemuDevOpts{
+		busName:       bus.name,
+		devBus:        devBus,
+		devAddr:       devAddr,
+		multifunction: multi,
 	}
+	qemuAppendSections(sb, qemuRNGSections(&rngOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 	err = qemuKeyboard.Execute(sb, map[string]any{

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2579,15 +2579,13 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	qemuAppendSections(sb, qemuRNGSections(&rngOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuKeyboard.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-	})
-	if err != nil {
-		return "", nil, err
+	keyboardOpts := qemuDevOpts{
+		busName:       bus.name,
+		devBus:        devBus,
+		devAddr:       devAddr,
+		multifunction: multi,
 	}
+	qemuAppendSections(sb, qemuKeyboardSections(&keyboardOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 	err = qemuTablet.Execute(sb, map[string]any{

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2561,15 +2561,13 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	// total of 256 devices, but this assumes 32 chassis * 8 function. By using VFs for the internal fixed
 	// devices we avoid consuming a chassis for each one. See also the qemuPCIDeviceIDStart constant.
 	devBus, devAddr, multi := bus.allocate(busFunctionGroupGeneric)
-	err = qemuBalloon.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-	})
-	if err != nil {
-		return "", nil, err
+	balloonOpts := qemuDevOpts{
+		busName:       bus.name,
+		devBus:        devBus,
+		devAddr:       devAddr,
+		multifunction: multi,
 	}
+	qemuAppendSections(sb, qemuBalloonSections(&balloonOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 	err = qemuRNG.Execute(sb, map[string]any{

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2588,15 +2588,13 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	qemuAppendSections(sb, qemuKeyboardSections(&keyboardOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
-	err = qemuTablet.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-	})
-	if err != nil {
-		return "", nil, err
+	tabletOpts := qemuDevOpts{
+		busName:       bus.name,
+		devBus:        devBus,
+		devAddr:       devAddr,
+		multifunction: multi,
 	}
+	qemuAppendSections(sb, qemuTabletSections(&tabletOpts)...)
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 	vsockOpts := qemuVsockOpts{

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2646,15 +2646,13 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupNone)
-	err = qemuSCSI.Execute(sb, map[string]any{
-		"bus":           bus.name,
-		"devBus":        devBus,
-		"devAddr":       devAddr,
-		"multifunction": multi,
-	})
-	if err != nil {
-		return "", nil, err
+	scsiOpts := qemuDevOpts{
+		busName:       bus.name,
+		devBus:        devBus,
+		devAddr:       devAddr,
+		multifunction: multi,
 	}
+	qemuAppendSections(sb, qemuSCSISections(&scsiOpts)...)
 
 	// Always export the config directory as a 9p config drive, in case the host or VM guest doesn't support
 	// virtio-fs.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2938,20 +2938,13 @@ func (d *qemu) addCPUMemoryConfig(sb *strings.Builder) (int, error) {
 	}
 
 	// Determine per-node memory limit.
-	memSizeBytes = memSizeBytes / 1024 / 1024
-	nodeMemory := int64(memSizeBytes / int64(len(hostNodes)))
-	memSizeBytes = nodeMemory * int64(len(hostNodes))
+	memSizeMB := memSizeBytes / 1024 / 1024
+	nodeMemory := int64(memSizeMB / int64(len(hostNodes)))
+	memSizeMB = nodeMemory * int64(len(hostNodes))
 	ctx["memory"] = nodeMemory
 
 	if sb != nil {
-		err = qemuMemory.Execute(sb, map[string]any{
-			"architecture": d.architectureName,
-			"memSizeBytes": memSizeBytes,
-		})
-
-		if err != nil {
-			return -1, err
-		}
+		qemuAppendSections(sb, qemuMemorySections(&qemuMemoryOpts{memSizeMB})...)
 
 		err = qemuCPU.Execute(sb, ctx)
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu_bus.go
+++ b/lxd/instance/drivers/driver_qemu_bus.go
@@ -118,14 +118,14 @@ func (a *qemuBus) allocate(multiFunctionGroup string) (string, string, bool) {
 	if a.name == "pcie" {
 		if p.fn == 0 {
 			portName := fmt.Sprintf("%s%d", busDevicePortPrefix, a.portNum)
-			_ = qemuPCIe.Execute(a.sb, map[string]any{
-				"portName": portName,
-				"index":    a.portNum,
-				"addr":     fmt.Sprintf("%x.%d", p.bridgeDev, p.bridgeFn),
-
+			pcieOpts := qemuPCIeOpts{
+				portName: portName,
+				index:    a.portNum,
+				devAddr:  fmt.Sprintf("%x.%d", p.bridgeDev, p.bridgeFn),
 				// First root port added on a bridge bus address needs multi-function enabled.
-				"multifunction": p.bridgeFn == 0,
-			})
+				multifunction: p.bridgeFn == 0,
+			}
+			qemuAppendSections(a.sb, qemuPCIeSections(&pcieOpts)...)
 			p.dev = portName
 			a.portNum++
 		}

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -245,4 +245,37 @@ func TestQemuConfigTemplates(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("qemu_balloon", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuDevOpts
+			expected string
+		}{{
+			qemuDevOpts{"pcie", "qemu_pcie0", "00.0", true},
+			`# Balloon driver
+			[device "qemu_balloon"]
+			driver = "virtio-balloon-pci"
+			bus = "qemu_pcie0"
+			addr = "00.0"
+			multifunction = "on"
+			`,
+		}, {
+			qemuDevOpts{"ccw", "qemu_pcie0", "00.0", false},
+			`# Balloon driver
+			[device "qemu_balloon"]
+			driver = "virtio-balloon-ccw"
+			`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuBalloonSections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
+
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -179,4 +179,38 @@ func TestQemuConfigTemplates(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("qemu_pcie", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuPCIeOpts
+			expected string
+		}{{
+			qemuPCIeOpts{"qemu_pcie0", 0, "1.0", true},
+			`[device "qemu_pcie0"]
+			driver = "pcie-root-port"
+			bus = "pcie.0"
+			addr = "1.0"
+			chassis = "0"
+			multifunction = "on"
+			`,
+		}, {
+			qemuPCIeOpts{"qemu_pcie2", 3, "2.0", false},
+			`[device "qemu_pcie2"]
+			driver = "pcie-root-port"
+			bus = "pcie.0"
+			addr = "2.0"
+			chassis = "3"
+			`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuPCIeSections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -320,4 +320,37 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}
 	})
 
+	t.Run("qemu_vsock", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuVsockOpts
+			expected string
+		}{{
+			qemuVsockOpts{qemuDevOpts{"pcie", "qemu_pcie0", "00.4", true}, 14},
+			`# Vsock
+			[device "qemu_vsock"]
+			driver = "vhost-vsock-pci"
+			bus = "qemu_pcie0"
+			addr = "00.4"
+			multifunction = "on"
+			guest-cid = "14"
+			`,
+		}, {
+			qemuVsockOpts{qemuDevOpts{"ccw", "qemu_pcie0", "00.4", false}, 3},
+			`# Vsock
+			[device "qemu_vsock"]
+			driver = "vhost-vsock-ccw"
+			guest-cid = "3"
+			`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuVsockSections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -278,4 +278,46 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}
 	})
 
+	t.Run("qemu_rng", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuDevOpts
+			expected string
+		}{{
+			qemuDevOpts{"pci", "qemu_pcie0", "00.1", false},
+			`# Random number generator
+			[object "qemu_rng"]
+			qom-type = "rng-random"
+			filename = "/dev/urandom"
+
+			[device "dev-qemu_rng"]
+			driver = "virtio-rng-pci"
+			bus = "qemu_pcie0"
+			addr = "00.1"
+			rng = "qemu_rng"
+			`,
+		}, {
+			qemuDevOpts{"ccw", "qemu_pcie0", "00.1", true},
+			`# Random number generator
+			[object "qemu_rng"]
+			qom-type = "rng-random"
+			filename = "/dev/urandom"
+
+			[device "dev-qemu_rng"]
+			driver = "virtio-rng-ccw"
+			multifunction = "on"
+			rng = "qemu_rng"
+			`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuRNGSections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
+
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -439,4 +439,37 @@ func TestQemuConfigTemplates(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("qemu_tablet", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuDevOpts
+			expected string
+		}{{
+			qemuDevOpts{"pci", "qemu_pcie0", "00.3", true},
+			`# Input
+			[device "qemu_tablet"]
+			driver = "virtio-tablet-pci"
+			bus = "qemu_pcie0"
+			addr = "00.3"
+			multifunction = "on"
+			`,
+		}, {
+			qemuDevOpts{"ccw", "qemu_pcie0", "00.3", true},
+			`# Input
+			[device "qemu_tablet"]
+			driver = "virtio-tablet-ccw"
+			multifunction = "on"
+			`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuTabletSections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -21,12 +21,11 @@ func TestQemuConfigTemplates(t *testing.T) {
 	}
 
 	t.Run("qemu_base", func(t *testing.T) {
-		type args struct{ architecture string }
 		testCases := []struct {
-			args     args
+			opts     qemuBaseOpts
 			expected string
 		}{{
-			args{"x86_64"},
+			qemuBaseOpts{"x86_64"},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -47,7 +46,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[boot-opts]
 			strict = "on"`,
 		}, {
-			args{"aarch64"},
+			qemuBaseOpts{"aarch64"},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -59,7 +58,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[boot-opts]
 			strict = "on"`,
 		}, {
-			args{"ppc64le"},
+			qemuBaseOpts{"ppc64le"},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -71,7 +70,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[boot-opts]
 			strict = "on"`,
 		}, {
-			args{"s390x"},
+			qemuBaseOpts{"s390x"},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -85,7 +84,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.expected, func(t *testing.T) {
-				sections := qemuBaseSections(tc.args.architecture)
+				sections := qemuBaseSections(&tc.opts)
 				actual := normalize(stringifySections(sections...))
 				expected := normalize(tc.expected)
 				if actual != expected {

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -396,4 +396,47 @@ func TestQemuConfigTemplates(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("qemu_keyboard", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuDevOpts
+			expected string
+		}{{
+			qemuDevOpts{"pci", "qemu_pcie3", "00.0", false},
+			`# Input
+			[device "qemu_keyboard"]
+			driver = "virtio-keyboard-pci"
+			bus = "qemu_pcie3"
+			addr = "00.0"`,
+		}, {
+			qemuDevOpts{"pcie", "qemu_pcie3", "00.0", true},
+			`# Input
+			[device "qemu_keyboard"]
+			driver = "virtio-keyboard-pci"
+			bus = "qemu_pcie3"
+			addr = "00.0"
+			multifunction = "on"`,
+		}, {
+			qemuDevOpts{"ccw", "qemu_pcie3", "00.0", false},
+			`# Input
+			[device "qemu_keyboard"]
+			driver = "virtio-keyboard-ccw"`,
+		}, {
+			qemuDevOpts{"ccw", "qemu_pcie3", "00.0", true},
+			`# Input
+			[device "qemu_keyboard"]
+			driver = "virtio-keyboard-ccw"
+			multifunction = "on"`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuKeyboardSections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -94,4 +94,31 @@ func TestQemuConfigTemplates(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("qemu_memory", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuMemoryOpts
+			expected string
+		}{{
+			qemuMemoryOpts{4096},
+			`# Memory
+			[memory]
+			size = "4096M"`,
+		}, {
+			qemuMemoryOpts{8192},
+			`# Memory
+			[memory]
+			size = "8192M"`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuMemorySections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -213,4 +213,36 @@ func TestQemuConfigTemplates(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("qemu_scsi", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuDevOpts
+			expected string
+		}{{
+			qemuDevOpts{"pci", "qemu_pcie1", "00.0", false},
+			`# SCSI controller
+			[device "qemu_scsi"]
+			driver = "virtio-scsi-pci"
+			bus = "qemu_pcie1"
+			addr = "00.0"
+			`,
+		}, {
+			qemuDevOpts{"ccw", "qemu_pcie2", "00.2", true},
+			`# SCSI controller
+			[device "qemu_scsi"]
+			driver = "virtio-scsi-ccw"
+			multifunction = "on"
+			`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuSCSISections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
 }

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -353,4 +353,47 @@ func TestQemuConfigTemplates(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("qemu_gpu", func(t *testing.T) {
+		testCases := []struct {
+			opts     qemuGpuOpts
+			expected string
+		}{{
+			qemuGpuOpts{qemuDevOpts{"pci", "qemu_pcie3", "00.0", true}, "x86_64"},
+			`# GPU
+			[device "qemu_gpu"]
+			driver = "virtio-vga"
+			bus = "qemu_pcie3"
+			addr = "00.0"
+			multifunction = "on"`,
+		}, {
+			qemuGpuOpts{qemuDevOpts{"pci", "qemu_pci3", "00.1", false}, "otherArch"},
+			`# GPU
+			[device "qemu_gpu"]
+			driver = "virtio-gpu-pci"
+			bus = "qemu_pci3"
+			addr = "00.1"`,
+		}, {
+			qemuGpuOpts{qemuDevOpts{"ccw", "devBus", "busAddr", true}, "arch"},
+			`# GPU
+			[device "qemu_gpu"]
+			driver = "virtio-gpu-ccw"
+			multifunction = "on"`,
+		}, {
+			qemuGpuOpts{qemuDevOpts{"ccw", "devBus", "busAddr", false}, "x86_64"},
+			`# GPU
+			[device "qemu_gpu"]
+			driver = "virtio-gpu-ccw"`,
+		}}
+		for _, tc := range testCases {
+			t.Run(tc.expected, func(t *testing.T) {
+				sections := qemuGPUSections(&tc.opts)
+				actual := normalize(stringifySections(sections...))
+				expected := normalize(tc.expected)
+				if actual != expected {
+					t.Errorf("Expected: %s. Got: %s", expected, actual)
+				}
+			})
+		}
+	})
 }

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -202,55 +202,6 @@ func qemuSerialSections(opts *qemuSerialOpts) []cfgSection {
 	}}
 }
 
-var qemuSerial = template.Must(template.New("qemuSerial").Parse(`
-# Virtual serial bus
-[device "dev-qemu_serial"]
-{{- if eq .bus "pci" "pcie"}}
-driver = "virtio-serial-pci"
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-serial-ccw"
-{{- end}}
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-
-# LXD serial identifier
-[chardev "{{.chardevName}}"]
-backend = "ringbuf"
-size = "{{.ringbufSizeBytes}}B"
-
-[device "qemu_serial"]
-driver = "virtserialport"
-name = "org.linuxcontainers.lxd"
-chardev = "{{.chardevName}}"
-bus = "dev-qemu_serial.0"
-
-# Spice agent
-[chardev "qemu_spice-chardev"]
-backend = "spicevmc"
-name = "vdagent"
-
-[device "qemu_spice"]
-driver = "virtserialport"
-name = "com.redhat.spice.0"
-chardev = "qemu_spice-chardev"
-bus = "dev-qemu_serial.0"
-
-# Spice folder
-[chardev "qemu_spicedir-chardev"]
-backend = "spiceport"
-name = "org.spice-space.webdav.0"
-
-[device "qemu_spicedir"]
-driver = "virtserialport"
-name = "org.spice-space.webdav.0"
-chardev = "qemu_spicedir-chardev"
-bus = "dev-qemu_serial.0"
-`))
-
 var qemuPCIe = template.Must(template.New("qemuPCIe").Parse(`
 [device "{{.portName}}"]
 driver = "pcie-root-port"

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -337,22 +337,6 @@ func qemuKeyboardSections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
-var qemuKeyboard = template.Must(template.New("qemuKeyboard").Parse(`
-# Input
-[device "qemu_keyboard"]
-{{- if eq .bus "pci" "pcie"}}
-driver = "virtio-keyboard-pci"
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-keyboard-ccw"
-{{- end}}
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuTablet = template.Must(template.New("qemuTablet").Parse(`
 # Input
 [device "qemu_tablet"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -351,22 +351,6 @@ func qemuTabletSections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
-var qemuTablet = template.Must(template.New("qemuTablet").Parse(`
-# Input
-[device "qemu_tablet"]
-{{- if eq .bus "pci" "pcie"}}
-driver = "virtio-tablet-pci"
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-tablet-ccw"
-{{- end}}
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuCPU = template.Must(template.New("qemuCPU").Parse(`
 # CPU
 [smp-opts]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -227,17 +227,6 @@ func qemuPCIeSections(opts *qemuPCIeOpts) []cfgSection {
 	}}
 }
 
-var qemuPCIe = template.Must(template.New("qemuPCIe").Parse(`
-[device "{{.portName}}"]
-driver = "pcie-root-port"
-bus = "pcie.0"
-addr = "{{.addr}}"
-chassis = "{{.index}}"
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuSCSI = template.Must(template.New("qemuSCSI").Parse(`
 # SCSI controller
 [device "qemu_scsi"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -241,6 +241,20 @@ func qemuSCSISections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
+func qemuBalloonSections(opts *qemuDevOpts) []cfgSection {
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     *opts,
+		pciName: "virtio-balloon-pci",
+		ccwName: "virtio-balloon-ccw",
+	}
+
+	return []cfgSection{{
+		name:    `device "qemu_balloon"`,
+		comment: "Balloon driver",
+		entries: qemuDeviceEntries(&entriesOpts),
+	}}
+}
+
 var qemuBalloon = template.Must(template.New("qemuBalloon").Parse(`
 # Balloon driver
 [device "qemu_balloon"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -93,6 +93,18 @@ func qemuBaseSections(architecture string) []cfgSection {
 		})
 }
 
+type qemuMemoryOpts struct {
+	memSizeMB int64
+}
+
+func qemuMemorySections(opts *qemuMemoryOpts) []cfgSection {
+	return []cfgSection{{
+		name:    "memory",
+		comment: "Memory",
+		entries: []cfgEntry{{key: "size", value: fmt.Sprintf("%dM", opts.memSizeMB)}},
+	}}
+}
+
 var qemuMemory = template.Must(template.New("qemuMemory").Parse(`
 # Memory
 [memory]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -255,22 +255,6 @@ func qemuBalloonSections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
-var qemuBalloon = template.Must(template.New("qemuBalloon").Parse(`
-# Balloon driver
-[device "qemu_balloon"]
-{{- if eq .bus "pci" "pcie"}}
-driver = "virtio-balloon-pci"
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-balloon-ccw"
-{{- end}}
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuRNG = template.Must(template.New("qemuRNG").Parse(`
 # Random number generator
 [object "qemu_rng"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -227,6 +227,20 @@ func qemuPCIeSections(opts *qemuPCIeOpts) []cfgSection {
 	}}
 }
 
+func qemuSCSISections(opts *qemuDevOpts) []cfgSection {
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     *opts,
+		pciName: "virtio-scsi-pci",
+		ccwName: "virtio-scsi-ccw",
+	}
+
+	return []cfgSection{{
+		name:    `device "qemu_scsi"`,
+		comment: "SCSI controller",
+		entries: qemuDeviceEntries(&entriesOpts),
+	}}
+}
+
 var qemuSCSI = template.Must(template.New("qemuSCSI").Parse(`
 # SCSI controller
 [device "qemu_scsi"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -323,26 +323,6 @@ func qemuGPUSections(opts *qemuGpuOpts) []cfgSection {
 	}}
 }
 
-var qemuGPU = template.Must(template.New("qemuGPU").Parse(`
-# GPU
-[device "qemu_gpu"]
-{{- if eq .bus "pci" "pcie"}}
-{{if eq .architecture "x86_64" -}}
-driver = "virtio-vga"
-{{- else}}
-driver = "virtio-gpu-pci"
-{{- end}}
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-gpu-ccw"
-{{- end}}
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuKeyboard = template.Must(template.New("qemuKeyboard").Parse(`
 # Input
 [device "qemu_keyboard"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -296,6 +296,33 @@ func qemuVsockSections(opts *qemuVsockOpts) []cfgSection {
 	}}
 }
 
+type qemuGpuOpts struct {
+	dev          qemuDevOpts
+	architecture string
+}
+
+func qemuGPUSections(opts *qemuGpuOpts) []cfgSection {
+	var pciName string
+
+	if opts.architecture == "x86_64" {
+		pciName = "virtio-vga"
+	} else {
+		pciName = "virtio-gpu-pci"
+	}
+
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     opts.dev,
+		pciName: pciName,
+		ccwName: "virtio-gpu-ccw",
+	}
+
+	return []cfgSection{{
+		name:    `device "qemu_gpu"`,
+		comment: "GPU",
+		entries: qemuDeviceEntries(&entriesOpts),
+	}}
+}
+
 var qemuGPU = template.Must(template.New("qemuGPU").Parse(`
 # GPU
 [device "qemu_gpu"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -202,6 +202,31 @@ func qemuSerialSections(opts *qemuSerialOpts) []cfgSection {
 	}}
 }
 
+type qemuPCIeOpts struct {
+	portName      string
+	index         int
+	devAddr       string
+	multifunction bool
+}
+
+func qemuPCIeSections(opts *qemuPCIeOpts) []cfgSection {
+	entries := []cfgEntry{
+		{key: "driver", value: "pcie-root-port"},
+		{key: "bus", value: "pcie.0"},
+		{key: "addr", value: opts.devAddr},
+		{key: "chassis", value: fmt.Sprintf("%d", opts.index)},
+	}
+
+	if opts.multifunction {
+		entries = append(entries, cfgEntry{key: "multifunction", value: "on"})
+	}
+
+	return []cfgSection{{
+		name:    fmt.Sprintf(`device "%s"`, opts.portName),
+		entries: entries,
+	}}
+}
+
 var qemuPCIe = template.Must(template.New("qemuPCIe").Parse(`
 [device "{{.portName}}"]
 driver = "pcie-root-port"

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -296,23 +296,6 @@ func qemuVsockSections(opts *qemuVsockOpts) []cfgSection {
 	}}
 }
 
-var qemuVsock = template.Must(template.New("qemuVsock").Parse(`
-# Vsock
-[device "qemu_vsock"]
-{{- if eq .bus "pci" "pcie"}}
-driver = "vhost-vsock-pci"
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "vhost-vsock-ccw"
-{{- end}}
-guest-cid = "{{.vsockID}}"
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuGPU = template.Must(template.New("qemuGPU").Parse(`
 # GPU
 [device "qemu_gpu"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -276,6 +276,26 @@ func qemuRNGSections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
+type qemuVsockOpts struct {
+	dev     qemuDevOpts
+	vsockID int
+}
+
+func qemuVsockSections(opts *qemuVsockOpts) []cfgSection {
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     opts.dev,
+		pciName: "vhost-vsock-pci",
+		ccwName: "vhost-vsock-ccw",
+	}
+
+	return []cfgSection{{
+		name:    `device "qemu_vsock"`,
+		comment: "Vsock",
+		entries: append(qemuDeviceEntries(&entriesOpts),
+			cfgEntry{key: "guest-cid", value: fmt.Sprintf("%d", opts.vsockID)}),
+	}}
+}
+
 var qemuVsock = template.Must(template.New("qemuVsock").Parse(`
 # Vsock
 [device "qemu_vsock"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -323,6 +323,20 @@ func qemuGPUSections(opts *qemuGpuOpts) []cfgSection {
 	}}
 }
 
+func qemuKeyboardSections(opts *qemuDevOpts) []cfgSection {
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     *opts,
+		pciName: "virtio-keyboard-pci",
+		ccwName: "virtio-keyboard-ccw",
+	}
+
+	return []cfgSection{{
+		name:    `device "qemu_keyboard"`,
+		comment: "Input",
+		entries: qemuDeviceEntries(&entriesOpts),
+	}}
+}
+
 var qemuKeyboard = template.Must(template.New("qemuKeyboard").Parse(`
 # Input
 [device "qemu_keyboard"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -276,27 +276,6 @@ func qemuRNGSections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
-var qemuRNG = template.Must(template.New("qemuRNG").Parse(`
-# Random number generator
-[object "qemu_rng"]
-qom-type = "rng-random"
-filename = "/dev/urandom"
-
-[device "dev-qemu_rng"]
-{{- if eq .bus "pci" "pcie"}}
-driver = "virtio-rng-pci"
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-rng-ccw"
-{{- end}}
-rng = "qemu_rng"
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuVsock = template.Must(template.New("qemuVsock").Parse(`
 # Vsock
 [device "qemu_vsock"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -36,12 +36,16 @@ func qemuAppendSections(sb *strings.Builder, sections ...cfgSection) {
 	}
 }
 
-func qemuBaseSections(architecture string) []cfgSection {
+type qemuBaseOpts struct {
+	architecture string
+}
+
+func qemuBaseSections(opts *qemuBaseOpts) []cfgSection {
 	machineType := ""
 	gicVersion := ""
 	capLargeDecr := ""
 
-	switch architecture {
+	switch opts.architecture {
 	case "x86_64":
 		machineType = "q35"
 	case "aarch64":
@@ -67,7 +71,7 @@ func qemuBaseSections(architecture string) []cfgSection {
 		},
 	}}
 
-	if architecture == "x86_64" {
+	if opts.architecture == "x86_64" {
 		sections = append(sections, []cfgSection{{
 			name: "global",
 			entries: []cfgEntry{

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -241,22 +241,6 @@ func qemuSCSISections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
-var qemuSCSI = template.Must(template.New("qemuSCSI").Parse(`
-# SCSI controller
-[device "qemu_scsi"]
-{{- if eq .bus "pci" "pcie"}}
-driver = "virtio-scsi-pci"
-bus = "{{.devBus}}"
-addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-scsi-ccw"
-{{- end}}
-{{if .multifunction -}}
-multifunction = "on"
-{{- end }}
-`))
-
 var qemuBalloon = template.Must(template.New("qemuBalloon").Parse(`
 # Balloon driver
 [device "qemu_balloon"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -337,6 +337,20 @@ func qemuKeyboardSections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
+func qemuTabletSections(opts *qemuDevOpts) []cfgSection {
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     *opts,
+		pciName: "virtio-tablet-pci",
+		ccwName: "virtio-tablet-ccw",
+	}
+
+	return []cfgSection{{
+		name:    `device "qemu_tablet"`,
+		comment: "Input",
+		entries: qemuDeviceEntries(&entriesOpts),
+	}}
+}
+
 var qemuTablet = template.Must(template.New("qemuTablet").Parse(`
 # Input
 [device "qemu_tablet"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -255,6 +255,27 @@ func qemuBalloonSections(opts *qemuDevOpts) []cfgSection {
 	}}
 }
 
+func qemuRNGSections(opts *qemuDevOpts) []cfgSection {
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     *opts,
+		pciName: "virtio-rng-pci",
+		ccwName: "virtio-rng-ccw",
+	}
+
+	return []cfgSection{{
+		name:    `object "qemu_rng"`,
+		comment: "Random number generator",
+		entries: []cfgEntry{
+			{key: "qom-type", value: "rng-random"},
+			{key: "filename", value: "/dev/urandom"},
+		},
+	}, {
+		name: `device "dev-qemu_rng"`,
+		entries: append(qemuDeviceEntries(&entriesOpts),
+			cfgEntry{key: "rng", value: "qemu_rng"}),
+	}}
+}
+
 var qemuRNG = template.Must(template.New("qemuRNG").Parse(`
 # Random number generator
 [object "qemu_rng"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -105,12 +105,6 @@ func qemuMemorySections(opts *qemuMemoryOpts) []cfgSection {
 	}}
 }
 
-var qemuMemory = template.Must(template.New("qemuMemory").Parse(`
-# Memory
-[memory]
-size = "{{.memSizeBytes}}M"
-`))
-
 var qemuSerial = template.Must(template.New("qemuSerial").Parse(`
 # Virtual serial bus
 [device "dev-qemu_serial"]


### PR DESCRIPTION
This is a follow up to #10445 which converts more templates to the style used in that PR.

I've used the same commit structure as #10445. For each template:

- The first commit implements the *Sections equivalent function + tests
- The second commit replaces the template.

There are a lot of changes here and if required I can split into multiple PRs, but it should be easy if each commit is reviewed individually.