### PR TITLE
lxd/bgp: Enable multihop

### DIFF
--- a/lxd/bgp/server.go
+++ b/lxd/bgp/server.go
@@ -428,6 +428,12 @@ func (s *Server) addPeer(address net.IP, asn uint32, password string) error {
 			Enabled:     true,
 			RestartTime: 120,
 		},
+
+		// Always allow for the maximum multihop.
+		EbgpMultihop: &bgpAPI.EbgpMultihop{
+			Enabled:     true,
+			MultihopTtl: 255,
+		},
 	}
 
 	// Setup peer for dual-stack.


### PR DESCRIPTION
Set multihop to the maximum (255) so LXD can be used with a router that
isn't directly connected.

Closes #10440

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>