### PR TITLE
lxd/apparmor: Add mknod cap to archive

### DIFF
--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -28,11 +28,12 @@ profile "{{.name}}" {
   signal (receive) set=("term") peer=unconfined,
 
   # Capabilities
-  capability dac_read_search,
-  capability dac_override,
   capability chown,
-  capability fsetid,
+  capability dac_override,
+  capability dac_read_search,
   capability fowner,
+  capability fsetid,
+  capability mknod,
   capability setfcap,
 
 {{- if .snap }}


### PR DESCRIPTION
It was recently reported that the Ubuntu official images now require
mknod during unpack which wasn't previously allowed.

Closes #10449

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>