### PR TITLE
Database performance fixes

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/project"
@@ -136,7 +136,7 @@ func (s *lxdHttpServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if !strings.HasPrefix(req.URL.Path, "/internal") {
 		<-s.d.setupChan
 		err := s.d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			config, err := cluster.ConfigLoad(tx)
+			config, err := clusterConfig.ConfigLoad(tx)
 			if err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ func (s *lxdHttpServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	s.r.ServeHTTP(rw, req)
 }
 
-func setCORSHeaders(rw http.ResponseWriter, req *http.Request, config *cluster.Config) {
+func setCORSHeaders(rw http.ResponseWriter, req *http.Request, config *clusterConfig.Config) {
 	allowedOrigin := config.HTTPSAllowedOrigin()
 	origin := req.Header.Get("Origin")
 	if allowedOrigin != "" && origin != "" {

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -136,7 +136,7 @@ func (s *lxdHttpServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if !strings.HasPrefix(req.URL.Path, "/internal") {
 		<-s.d.setupChan
 		err := s.d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			config, err := clusterConfig.ConfigLoad(tx)
+			config, err := clusterConfig.Load(tx)
 			if err != nil {
 				return err
 			}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -240,11 +240,6 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 	srv.Auth = "trusted"
 
-	uname, err := shared.Uname()
-	if err != nil {
-		return response.InternalError(err)
-	}
-
 	address, err := node.HTTPSAddress(d.db.Node)
 	if err != nil {
 		return response.InternalError(err)
@@ -301,9 +296,9 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		Architectures:          architectures,
 		Certificate:            certificate,
 		CertificateFingerprint: certificateFingerprint,
-		Kernel:                 uname.Sysname,
-		KernelArchitecture:     uname.Machine,
-		KernelVersion:          uname.Release,
+		Kernel:                 d.os.Uname.Sysname,
+		KernelArchitecture:     d.os.Uname.Machine,
+		KernelVersion:          d.os.Uname.Release,
 		OSName:                 d.os.ReleaseInfo["NAME"],
 		OSVersion:              d.os.ReleaseInfo["VERSION_ID"],
 		Project:                projectName,

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/config"
 	"github.com/lxc/lxd/lxd/db"
 	instanceDrivers "github.com/lxc/lxd/lxd/instance/drivers"
@@ -196,7 +197,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	var localNodeName string
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the cluster config.
-		config, err := cluster.ConfigLoad(tx)
+		config, err := clusterConfig.ConfigLoad(tx)
 		if err != nil {
 			return err
 		}
@@ -435,10 +436,10 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		for key, value := range req.Config {
 			changed[key] = value.(string)
 		}
-		var config *cluster.Config
+		var config *clusterConfig.Config
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			config, err = cluster.ConfigLoad(tx)
+			config, err = clusterConfig.ConfigLoad(tx)
 			return err
 		})
 		if err != nil {
@@ -625,10 +626,10 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 	// Then deal with cluster wide configuration
 	var clusterChanged map[string]string
-	var newClusterConfig *cluster.Config
+	var newClusterConfig *clusterConfig.Config
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		newClusterConfig, err = cluster.ConfigLoad(tx)
+		newClusterConfig, err = clusterConfig.ConfigLoad(tx)
 		if err != nil {
 			return fmt.Errorf("Failed to load cluster config: %w", err)
 		}
@@ -682,7 +683,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	return response.EmptySyncResponse
 }
 
-func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *cluster.Config) error {
+func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *clusterConfig.Config) error {
 	// Don't apply changes to settings until daemon is full started.
 	<-d.readyChan
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -293,11 +293,6 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		projectName = project.Default
 	}
 
-	osInfo, err := osarch.GetLSBRelease()
-	if err != nil {
-		return response.InternalError(err)
-	}
-
 	env := api.ServerEnvironment{
 		Addresses:              addresses,
 		Architectures:          architectures,
@@ -306,8 +301,8 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		Kernel:                 uname.Sysname,
 		KernelArchitecture:     uname.Machine,
 		KernelVersion:          uname.Release,
-		OSName:                 osInfo["NAME"],
-		OSVersion:              osInfo["VERSION_ID"],
+		OSName:                 d.os.ReleaseInfo["NAME"],
+		OSVersion:              d.os.ReleaseInfo["VERSION_ID"],
 		Project:                projectName,
 		Server:                 "lxd",
 		ServerPid:              os.Getpid(),

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -197,7 +197,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	var localNodeName string
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the cluster config.
-		config, err := clusterConfig.ConfigLoad(tx)
+		config, err := clusterConfig.Load(tx)
 		if err != nil {
 			return err
 		}
@@ -439,7 +439,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		var config *clusterConfig.Config
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			config, err = clusterConfig.ConfigLoad(tx)
+			config, err = clusterConfig.Load(tx)
 			return err
 		})
 		if err != nil {
@@ -629,7 +629,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	var newClusterConfig *clusterConfig.Config
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		newClusterConfig, err = clusterConfig.ConfigLoad(tx)
+		newClusterConfig, err = clusterConfig.Load(tx)
 		if err != nil {
 			return fmt.Errorf("Failed to load cluster config: %w", err)
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
-	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	clusterRequest "github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
@@ -328,25 +327,27 @@ func clusterPut(d *Daemon, r *http.Request) response.Response {
 }
 
 func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
+	s := d.State()
+
 	logger.Info("Bootstrapping cluster", logger.Ctx{"serverName": req.ServerName})
 
 	run := func(op *operations.Operation) error {
 		// Start clustering tasks
 		d.startClusterTasks()
 
-		err := cluster.Bootstrap(d.State(), d.gateway, req.ServerName)
+		err := cluster.Bootstrap(s, d.gateway, req.ServerName)
 		if err != nil {
 			d.stopClusterTasks()
 			return err
 		}
 
 		// Restart the networks (to pickup forkdns and the like).
-		err = networkStartup(d.State())
+		err = networkStartup(s)
 		if err != nil {
 			return err
 		}
 
-		d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterEnabled.Event(req.ServerName, op.Requestor(), nil))
+		s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterEnabled.Event(req.ServerName, op.Requestor(), nil))
 
 		return nil
 	}
@@ -385,7 +386,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 		return response.SmartError(err)
 	}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterBootstrap, resources, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, db.OperationClusterBootstrap, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -397,6 +398,8 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 }
 
 func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
+	s := d.State()
+
 	logger.Info("Joining cluster", logger.Ctx{"serverName": req.ServerName})
 
 	// Make sure basic pre-conditions are met.
@@ -658,7 +661,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			nodes[i].Role = db.RaftRole(node.Role)
 		}
 
-		err = cluster.Join(d.State(), d.gateway, networkCert, serverCert, req.ServerName, nodes)
+		err = cluster.Join(s, d.gateway, networkCert, serverCert, req.ServerName, nodes)
 		if err != nil {
 			return err
 		}
@@ -668,15 +671,8 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		revert.Add(func() { d.stopClusterTasks() })
 
 		// Handle optional service integration on cluster join
-		var config *clusterConfig.Config
-
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-
-			config, err = clusterConfig.Load(tx)
-			if err != nil {
-				return err
-			}
 
 			// Add the new node to the default cluster group.
 			err = tx.AddNodeToClusterGroup("default", req.ServerName)
@@ -701,7 +697,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Connect to MAAS
-		url, key := config.MAASController()
+		url, key := s.GlobalConfig.MAASController()
 		machine := nodeConfig.MAASMachine()
 		err = d.setupMAASController(url, key, machine)
 		if err != nil {
@@ -709,8 +705,8 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Handle external authentication/RBAC
-		candidAPIURL, candidAPIKey, candidExpiry, candidDomains := config.CandidServer()
-		rbacAPIURL, rbacAPIKey, rbacExpiry, rbacAgentURL, rbacAgentUsername, rbacAgentPrivateKey, rbacAgentPublicKey := config.RBACServer()
+		candidAPIURL, candidAPIKey, candidExpiry, candidDomains := s.GlobalConfig.CandidServer()
+		rbacAPIURL, rbacAPIKey, rbacExpiry, rbacAgentURL, rbacAgentUsername, rbacAgentPrivateKey, rbacAgentPublicKey := s.GlobalConfig.RBACServer()
 
 		if rbacAPIURL != "" {
 			err = d.setupRBACServer(rbacAPIURL, rbacAPIKey, rbacExpiry, rbacAgentURL, rbacAgentUsername, rbacAgentPrivateKey, rbacAgentPublicKey)
@@ -728,7 +724,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Start up networks so any post-join changes can be applied now that we have a Node ID.
 		logger.Debug("Starting networks after cluster join")
-		err = networkStartup(d.State())
+		err = networkStartup(s)
 		if err != nil {
 			logger.Errorf("Failed starting networks: %v", err)
 		}
@@ -754,7 +750,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			logger.Warn("Failed to sync images")
 		}
 
-		d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberAdded.Event(req.ServerName, op.Requestor(), nil))
+		s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberAdded.Event(req.ServerName, op.Requestor(), nil))
 
 		revert.Success()
 		return nil
@@ -763,7 +759,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 	resources := map[string][]string{}
 	resources["cluster"] = []string{}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterJoin, resources, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, db.OperationClusterJoin, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -778,6 +774,8 @@ var clusterPutDisableMu sync.Mutex
 
 // Disable clustering on a node.
 func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
+	s := d.State()
+
 	logger.Info("Disabling clustering", logger.Ctx{"serverName": req.ServerName})
 
 	// Close the cluster database
@@ -810,7 +808,7 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterDisabled.Event(req.ServerName, requestor, nil))
+	s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterDisabled.Event(req.ServerName, requestor, nil))
 
 	// Stop database cluster connection.
 	d.gateway.Kill()
@@ -1096,7 +1094,7 @@ func clusterAcceptMember(client lxd.InstanceServer, name string, address string,
 //     $ref: "#/responses/InternalServerError"
 func clusterNodesGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
-	state := d.State()
+	s := d.State()
 
 	var err error
 	var nodes []db.NodeInfo
@@ -1121,7 +1119,7 @@ func clusterNodesGet(d *Daemon, r *http.Request) response.Response {
 	if recursion {
 		result := []api.ClusterMember{}
 		for _, node := range nodes {
-			member, err := node.ToAPI(state.DB.Cluster, state.DB.Node, leader)
+			member, err := node.ToAPI(s.DB.Cluster, s.DB.Node, leader)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -1171,6 +1169,8 @@ var clusterNodesPostMu sync.Mutex // Used to prevent races when creating cluster
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	req := api.ClusterMembersPost{}
 
 	// Parse the request.
@@ -1195,12 +1195,6 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	onlineNodeAddresses := make([]any, 0)
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		// Get the offline threshold.
-		config, err := clusterConfig.Load(tx)
-		if err != nil {
-			return fmt.Errorf("Failed to load LXD config: %w", err)
-		}
-
 		// Get the nodes.
 		nodes, err := tx.GetNodes()
 		if err != nil {
@@ -1209,7 +1203,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 
 		// Filter to online members.
 		for _, node := range nodes {
-			if node.State == db.ClusterMemberStateEvacuated || node.IsOffline(config.OfflineThreshold()) {
+			if node.State == db.ClusterMemberStateEvacuated || node.IsOffline(s.GlobalConfig.OfflineThreshold()) {
 				continue
 			}
 
@@ -1284,12 +1278,12 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	resources := map[string][]string{}
 	resources["cluster"] = []string{}
 
-	op, err := operations.OperationCreate(d.State(), project.Default, operations.OperationClassToken, db.OperationClusterJoinToken, resources, meta, nil, nil, nil, r)
+	op, err := operations.OperationCreate(s, project.Default, operations.OperationClassToken, db.OperationClusterJoinToken, resources, meta, nil, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterTokenCreated.Event("members", op.Requestor(), nil))
+	s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterTokenCreated.Event("members", op.Requestor(), nil))
 
 	return operations.OperationResponse(op)
 }
@@ -1329,12 +1323,12 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterNodeGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
 	}
-
-	state := d.State()
 
 	var nodes []db.NodeInfo
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -1360,7 +1354,7 @@ func clusterNodeGet(d *Daemon, r *http.Request) response.Response {
 			continue
 		}
 
-		member, err := node.ToAPI(state.DB.Cluster, state.DB.Node, leader)
+		member, err := node.ToAPI(s.DB.Cluster, s.DB.Node, leader)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -1439,12 +1433,12 @@ func clusterNodePut(d *Daemon, r *http.Request) response.Response {
 
 // updateClusterNode is shared between clusterNodePut and clusterNodePatch.
 func updateClusterNode(d *Daemon, r *http.Request, isPatch bool) response.Response {
+	s := d.State()
+
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
 	}
-
-	state := d.State()
 
 	var node db.NodeInfo
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -1465,7 +1459,7 @@ func updateClusterNode(d *Daemon, r *http.Request, isPatch bool) response.Respon
 		return response.InternalError(err)
 	}
 
-	member, err := node.ToAPI(state.DB.Cluster, state.DB.Node, leader)
+	member, err := node.ToAPI(s.DB.Cluster, s.DB.Node, leader)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -1565,12 +1559,12 @@ func updateClusterNode(d *Daemon, r *http.Request, isPatch bool) response.Respon
 	}
 
 	// If cluster roles changed, then distribute the info to all members.
-	if state.Endpoints != nil && clusterRolesChanged(node.Roles, newRoles) {
-		cluster.NotifyHeartbeat(state, d.gateway)
+	if s.Endpoints != nil && clusterRolesChanged(node.Roles, newRoles) {
+		cluster.NotifyHeartbeat(s, d.gateway)
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberUpdated.Event(name, requestor, nil))
+	s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberUpdated.Event(name, requestor, nil))
 
 	return response.EmptySyncResponse
 }
@@ -1658,6 +1652,8 @@ func clusterValidateConfig(config map[string]string) error {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterNodePost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -1679,7 +1675,7 @@ func clusterNodePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberRenamed.Event(req.ServerName, requestor, logger.Ctx{"old_name": name}))
+	s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberRenamed.Event(req.ServerName, requestor, logger.Ctx{"old_name": name}))
 
 	return response.EmptySyncResponse
 }
@@ -1703,6 +1699,8 @@ func clusterNodePost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	force, err := strconv.Atoi(r.FormValue("force"))
 	if err != nil {
 		force = 0
@@ -1844,7 +1842,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	// First check that the node is clear from containers and images and
 	// make it leave the database cluster, if it's part of it.
-	address, err := cluster.Leave(d.State(), d.gateway, name, force == 1)
+	address, err := cluster.Leave(s, d.gateway, name, force == 1)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1937,7 +1935,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberRemoved.Event(name, requestor, nil))
+	s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberRemoved.Event(name, requestor, nil))
 
 	return response.EmptySyncResponse
 }
@@ -1971,6 +1969,8 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterCertificatePut(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	req := api.ClusterCertificatePut{}
 
 	// Parse the request
@@ -2037,12 +2037,14 @@ func clusterCertificatePut(d *Daemon, r *http.Request) response.Response {
 	d.gateway.NetworkUpdateCert(cert)
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterCertificateUpdated.Event("certificate", requestor, nil))
+	s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterCertificateUpdated.Event("certificate", requestor, nil))
 
 	return response.EmptySyncResponse
 }
 
 func internalClusterPostAccept(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	req := internalClusterPostAcceptRequest{}
 
 	// Parse the request
@@ -2096,7 +2098,7 @@ func internalClusterPostAccept(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	nodes, err := cluster.Accept(d.State(), d.gateway, req.Name, req.Address, req.Schema, req.API, req.Architecture)
+	nodes, err := cluster.Accept(s, d.gateway, req.Name, req.Address, req.Schema, req.API, req.Architecture)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -2181,12 +2183,14 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 // Check if there's a dqlite node whose role should be changed, and post a
 // change role request if so.
 func rebalanceMemberRoles(d *Daemon, r *http.Request, unavailableMembers []string) error {
+	s := d.State()
+
 	if d.shutdownCtx.Err() != nil {
 		return nil
 	}
 
 again:
-	address, nodes, err := cluster.Rebalance(d.State(), d.gateway, unavailableMembers)
+	address, nodes, err := cluster.Rebalance(s, d.gateway, unavailableMembers)
 	if err != nil {
 		return err
 	}
@@ -2333,6 +2337,7 @@ findLeader:
 
 // Used to assign a new role to a the local dqlite node.
 func internalClusterPostAssign(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
 	req := internalClusterPostAssignRequest{}
 
 	// Parse the request
@@ -2353,7 +2358,8 @@ func internalClusterPostAssign(d *Daemon, r *http.Request) response.Response {
 		nodes[i].Role = db.RaftRole(node.Role)
 		nodes[i].Name = node.Name
 	}
-	err = cluster.Assign(d.State(), d.gateway, nodes)
+
+	err = cluster.Assign(s, d.gateway, nodes)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2368,6 +2374,7 @@ type internalClusterPostAssignRequest struct {
 
 // Used to to transfer the responsibilities of a member to another one
 func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
 	req := internalClusterPostHandoverRequest{}
 
 	// Parse the request
@@ -2410,7 +2417,7 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 	d.clusterMembershipMutex.Lock()
 	defer d.clusterMembershipMutex.Unlock()
 
-	target, nodes, err := cluster.Handover(d.State(), d.gateway, req.Address)
+	target, nodes, err := cluster.Handover(s, d.gateway, req.Address)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2656,6 +2663,8 @@ func evacuateClusterSetState(d *Daemon, name string, state int) error {
 }
 
 func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Response {
+	s := d.State()
+
 	nodeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -2679,7 +2688,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 	instances := make([]instance.Instance, len(dbInstances))
 
 	for i, dbInst := range dbInstances {
-		inst, err := instance.LoadByProjectAndName(d.State(), dbInst.Project, dbInst.Name)
+		inst, err := instance.LoadByProjectAndName(s, dbInst.Project, dbInst.Name)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to load instance: %w", err))
 		}
@@ -2839,7 +2848,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterMemberEvacuate, nil, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, db.OperationClusterMemberEvacuate, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -2848,6 +2857,8 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 }
 
 func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	originName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -2872,7 +2883,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 
 	for _, dbInst := range dbInstances {
 		if dbInst.Node == originName {
-			inst, err := instance.LoadByProjectAndName(d.State(), dbInst.Project, dbInst.Name)
+			inst, err := instance.LoadByProjectAndName(s, dbInst.Project, dbInst.Name)
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed to load instance: %w", err))
 			}
@@ -2887,7 +2898,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 			continue
 		}
 
-		inst, err := instance.LoadByProjectAndName(d.State(), dbInst.Project, dbInst.Name)
+		inst, err := instance.LoadByProjectAndName(s, dbInst.Project, dbInst.Name)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to load instance: %w", err))
 		}
@@ -3024,7 +3035,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Reload the instance after migration.
-			inst, err := instance.LoadByProjectAndName(d.State(), inst.Project(), inst.Name())
+			inst, err := instance.LoadByProjectAndName(s, inst.Project(), inst.Name())
 			if err != nil {
 				return fmt.Errorf("Failed to load instance: %w", err)
 			}
@@ -3065,7 +3076,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterMemberRestore, nil, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, db.OperationClusterMemberRestore, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -3101,6 +3112,8 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterGroupsPost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	clustered, err := cluster.Enabled(d.db.Node)
 	if err != nil {
 		return response.SmartError(err)
@@ -3143,7 +3156,7 @@ func clusterGroupsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(project.Default, lifecycle.ClusterGroupCreated.Event(req.Name, requestor, nil))
+	s.Events.SendLifecycle(project.Default, lifecycle.ClusterGroupCreated.Event(req.Name, requestor, nil))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/cluster/groups/%s", version.APIVersion, req.Name))
 }
@@ -3372,6 +3385,8 @@ func clusterGroupGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -3421,7 +3436,7 @@ func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(project.Default, lifecycle.ClusterGroupRenamed.Event(req.Name, requestor, logger.Ctx{"old_name": name}))
+	s.Events.SendLifecycle(project.Default, lifecycle.ClusterGroupRenamed.Event(req.Name, requestor, logger.Ctx{"old_name": name}))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/cluster/groups/%s", version.APIVersion, req.Name))
 }
@@ -3456,6 +3471,8 @@ func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -3544,7 +3561,7 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(project.Default, lifecycle.ClusterGroupUpdated.Event(name, requestor, logger.Ctx{"description": req.Description, "members": req.Members}))
+	s.Events.SendLifecycle(project.Default, lifecycle.ClusterGroupUpdated.Event(name, requestor, logger.Ctx{"description": req.Description, "members": req.Members}))
 
 	return response.EmptySyncResponse
 }
@@ -3579,6 +3596,8 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -3694,7 +3713,7 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(project.Default, lifecycle.ClusterGroupUpdated.Event(name, requestor, logger.Ctx{"description": req.Description, "members": req.Members}))
+	s.Events.SendLifecycle(project.Default, lifecycle.ClusterGroupUpdated.Event(name, requestor, logger.Ctx{"description": req.Description, "members": req.Members}))
 
 	return response.EmptySyncResponse
 }
@@ -3718,6 +3737,8 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func clusterGroupDelete(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -3747,7 +3768,7 @@ func clusterGroupDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	d.State().Events.SendLifecycle(name, lifecycle.ClusterGroupDeleted.Event(name, requestor, nil))
+	s.Events.SendLifecycle(name, lifecycle.ClusterGroupDeleted.Event(name, requestor, nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -332,6 +332,9 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 	logger.Info("Bootstrapping cluster", logger.Ctx{"serverName": req.ServerName})
 
 	run := func(op *operations.Operation) error {
+		// Update server name.
+		d.serverName = req.ServerName
+
 		// Start clustering tasks
 		d.startClusterTasks()
 
@@ -529,6 +532,10 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		revert := revert.New()
 		defer revert.Fail()
+
+		// Update server name.
+		d.serverName = req.ServerName
+		revert.Add(func() { d.serverName = "" })
 
 		localRevert, err := clusterInitMember(localClient, client, req.MemberConfig)
 		if err != nil {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -673,7 +673,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
 
-			config, err = clusterConfig.ConfigLoad(tx)
+			config, err = clusterConfig.Load(tx)
 			if err != nil {
 				return err
 			}
@@ -1196,7 +1196,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the offline threshold.
-		config, err := clusterConfig.ConfigLoad(tx)
+		config, err := clusterConfig.Load(tx)
 		if err != nil {
 			return fmt.Errorf("Failed to load LXD config: %w", err)
 		}

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
@@ -33,12 +32,7 @@ var metricsCmd = APIEndpoint{
 
 func allowMetrics(d *Daemon, r *http.Request) response.Response {
 	// Check if API is wide open.
-	isAuthenticated, err := clusterConfig.GetBool(d.db.Cluster, "core.metrics_authentication")
-	if err != nil {
-		return response.InternalError(err)
-	}
-
-	if !isAuthenticated {
+	if !d.State().GlobalConfig.MetricsAuthentication() {
 		return response.EmptySyncResponse
 	}
 

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -33,7 +33,7 @@ var metricsCmd = APIEndpoint{
 
 func allowMetrics(d *Daemon, r *http.Request) response.Response {
 	// Check if API is wide open.
-	isAuthenticated, err := clusterConfig.ConfigGetBool(d.db.Cluster, "core.metrics_authentication")
+	isAuthenticated, err := clusterConfig.GetBool(d.db.Cluster, "core.metrics_authentication")
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
@@ -33,7 +33,7 @@ var metricsCmd = APIEndpoint{
 
 func allowMetrics(d *Daemon, r *http.Request) response.Response {
 	// Check if API is wide open.
-	isAuthenticated, err := cluster.ConfigGetBool(d.db.Cluster, "core.metrics_authentication")
+	isAuthenticated, err := clusterConfig.ConfigGetBool(d.db.Cluster, "core.metrics_authentication")
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -95,7 +95,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		if p.Config["backups.compression_algorithm"] != "" {
 			compress = p.Config["backups.compression_algorithm"]
 		} else {
-			compress, err = clusterConfig.ConfigGetString(s.DB.Cluster, "backups.compression_algorithm")
+			compress, err = clusterConfig.GetString(s.DB.Cluster, "backups.compression_algorithm")
 			if err != nil {
 				return err
 			}
@@ -385,7 +385,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	if backupRow.CompressionAlgorithm != "" {
 		compress = backupRow.CompressionAlgorithm
 	} else {
-		compress, err = clusterConfig.ConfigGetString(s.DB.Cluster, "backups.compression_algorithm")
+		compress, err = clusterConfig.GetString(s.DB.Cluster, "backups.compression_algorithm")
 		if err != nil {
 			return err
 		}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/lxd/backup"
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
@@ -95,7 +95,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		if p.Config["backups.compression_algorithm"] != "" {
 			compress = p.Config["backups.compression_algorithm"]
 		} else {
-			compress, err = cluster.ConfigGetString(s.DB.Cluster, "backups.compression_algorithm")
+			compress, err = clusterConfig.ConfigGetString(s.DB.Cluster, "backups.compression_algorithm")
 			if err != nil {
 				return err
 			}
@@ -385,7 +385,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	if backupRow.CompressionAlgorithm != "" {
 		compress = backupRow.CompressionAlgorithm
 	} else {
-		compress, err = cluster.ConfigGetString(s.DB.Cluster, "backups.compression_algorithm")
+		compress, err = clusterConfig.ConfigGetString(s.DB.Cluster, "backups.compression_algorithm")
 		if err != nil {
 			return err
 		}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -503,7 +503,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Access check.
-	secret, err := clusterConfig.ConfigGetString(d.db.Cluster, "core.trust_password")
+	secret, err := clusterConfig.GetString(d.db.Cluster, "core.trust_password")
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	clusterRequest "github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
@@ -502,7 +503,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Access check.
-	secret, err := cluster.ConfigGetString(d.db.Cluster, "core.trust_password")
+	secret, err := clusterConfig.ConfigGetString(d.db.Cluster, "core.trust_password")
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -39,6 +39,11 @@ func Load(tx *db.ClusterTx) (*Config, error) {
 	return &Config{tx: tx, m: m}, nil
 }
 
+// MetricsAuthentication checks whether metrics API requires authentication.
+func (c *Config) MetricsAuthentication() bool {
+	return c.m.GetBool("core.metrics_authentication")
+}
+
 // BGPASN returns the BGP ASN setting.
 func (c *Config) BGPASN() int64 {
 	return c.m.GetInt64("core.bgp_asn")

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -1,4 +1,4 @@
-package cluster
+package config
 
 import (
 	"context"

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -22,9 +22,9 @@ type Config struct {
 	m  config.Map    // Low-level map holding the config values.
 }
 
-// ConfigLoad loads a new Config object with the current cluster configuration
+// Load loads a new Config object with the current cluster configuration
 // values fetched from the database.
-func ConfigLoad(tx *db.ClusterTx) (*Config, error) {
+func Load(tx *db.ClusterTx) (*Config, error) {
 	// Load current raw values from the database, any error is fatal.
 	values, err := tx.Config()
 	if err != nil {
@@ -196,12 +196,12 @@ func (c *Config) update(values map[string]any) (map[string]string, error) {
 	return changed, nil
 }
 
-// ConfigGetString is a convenience for loading the cluster configuration and
+// GetString is a convenience for loading the cluster configuration and
 // returning the value of a particular key.
 //
 // It's a deprecated API meant to be used by call sites that are not
 // interacting with the database in a transactional way.
-func ConfigGetString(cluster *db.Cluster, key string) (string, error) {
+func GetString(cluster *db.Cluster, key string) (string, error) {
 	config, err := configGet(cluster)
 	if err != nil {
 		return "", err
@@ -209,12 +209,12 @@ func ConfigGetString(cluster *db.Cluster, key string) (string, error) {
 	return config.m.GetString(key), nil
 }
 
-// ConfigGetBool is a convenience for loading the cluster configuration and
+// GetBool is a convenience for loading the cluster configuration and
 // returning the value of a particular boolean key.
 //
 // It's a deprecated API meant to be used by call sites that are not
 // interacting with the database in a transactional way.
-func ConfigGetBool(cluster *db.Cluster, key string) (bool, error) {
+func GetBool(cluster *db.Cluster, key string) (bool, error) {
 	config, err := configGet(cluster)
 	if err != nil {
 		return false, err
@@ -222,12 +222,12 @@ func ConfigGetBool(cluster *db.Cluster, key string) (bool, error) {
 	return config.m.GetBool(key), nil
 }
 
-// ConfigGetInt64 is a convenience for loading the cluster configuration and
+// GetInt64 is a convenience for loading the cluster configuration and
 // returning the value of a particular key.
 //
 // It's a deprecated API meant to be used by call sites that are not
 // interacting with the database in a transactional way.
-func ConfigGetInt64(cluster *db.Cluster, key string) (int64, error) {
+func GetInt64(cluster *db.Cluster, key string) (int64, error) {
 	config, err := configGet(cluster)
 	if err != nil {
 		return 0, err
@@ -239,7 +239,7 @@ func configGet(cluster *db.Cluster) (*Config, error) {
 	var config *Config
 	err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		config, err = ConfigLoad(tx)
+		config, err = Load(tx)
 		return err
 	})
 	return config, err

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +14,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := cluster.ConfigLoad(tx)
+	config, err := clusterConfig.Load(tx)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{}, config.Dump())
@@ -33,7 +33,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	config, err := cluster.ConfigLoad(tx)
+	config, err := clusterConfig.Load(tx)
 
 	require.NoError(t, err)
 	values := map[string]any{"core.proxy_http": "foo.bar"}
@@ -45,7 +45,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := cluster.ConfigLoad(tx)
+	config, err := clusterConfig.Load(tx)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{}, config.Dump())
@@ -56,7 +56,7 @@ func TestConfigLoad_OfflineThresholdValidator(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := cluster.ConfigLoad(tx)
+	config, err := clusterConfig.Load(tx)
 	require.NoError(t, err)
 
 	_, err = config.Patch(map[string]any{"cluster.offline_threshold": "2"})
@@ -69,7 +69,7 @@ func TestConfigLoad_MaxVotersValidator(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := cluster.ConfigLoad(tx)
+	config, err := clusterConfig.Load(tx)
 	require.NoError(t, err)
 
 	_, err = config.Patch(map[string]any{"cluster.max_voters": "4"})
@@ -83,7 +83,7 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := cluster.ConfigLoad(tx)
+	config, err := clusterConfig.Load(tx)
 	require.NoError(t, err)
 
 	changed, err := config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
@@ -106,7 +106,7 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := cluster.ConfigLoad(tx)
+	config, err := clusterConfig.Load(tx)
 	require.NoError(t, err)
 
 	_, err = config.Replace(map[string]any{"core.proxy_http": "foo.bar"})

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -1,4 +1,4 @@
-package cluster_test
+package config_test
 
 import (
 	"testing"

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -233,7 +233,7 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 	// Insert the new node into the nodes table.
 	var id int64
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := clusterConfig.ConfigLoad(tx)
+		config, err := clusterConfig.Load(tx)
 		if err != nil {
 			return fmt.Errorf("Load cluster configuration: %w", err)
 		}
@@ -999,7 +999,7 @@ func newRolesChanges(state *state.State, gateway *Gateway, nodes []db.RaftNode, 
 	var domains map[string]uint64
 
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := clusterConfig.ConfigLoad(tx)
+		config, err := clusterConfig.Load(tx)
 		if err != nil {
 			return fmt.Errorf("Load cluster configuration: %w", err)
 		}

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
 
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/node"
@@ -232,7 +233,7 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 	// Insert the new node into the nodes table.
 	var id int64
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := ConfigLoad(tx)
+		config, err := clusterConfig.ConfigLoad(tx)
 		if err != nil {
 			return fmt.Errorf("Load cluster configuration: %w", err)
 		}
@@ -998,7 +999,7 @@ func newRolesChanges(state *state.State, gateway *Gateway, nodes []db.RaftNode, 
 	var domains map[string]uint64
 
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := ConfigLoad(tx)
+		config, err := clusterConfig.ConfigLoad(tx)
 		if err != nil {
 			return fmt.Errorf("Load cluster configuration: %w", err)
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -375,7 +375,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	}
 
 	// Validate normal TLS access.
-	trustCACertificates, err := clusterConfig.ConfigGetBool(d.db.Cluster, "core.trust_ca_certificates")
+	trustCACertificates, err := clusterConfig.GetBool(d.db.Cluster, "core.trust_ca_certificates")
 	if err != nil {
 		return false, "", "", err
 	}
@@ -1278,7 +1278,7 @@ func (d *Daemon) init() error {
 	}
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := clusterConfig.ConfigLoad(tx)
+		config, err := clusterConfig.Load(tx)
 		if err != nil {
 			return err
 		}
@@ -1615,7 +1615,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		}
 
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			config, err := clusterConfig.ConfigLoad(tx)
+			config, err := clusterConfig.Load(tx)
 			if err != nil {
 				return err
 			}
@@ -2157,7 +2157,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		var maxVoters int64
 		var maxStandBy int64
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			config, err := clusterConfig.ConfigLoad(tx)
+			config, err := clusterConfig.Load(tx)
 			if err != nil {
 				return err
 			}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/bgp"
 	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/daemon"
 	"github.com/lxc/lxd/lxd/db"
 	clusterDB "github.com/lxc/lxd/lxd/db/cluster"
@@ -374,7 +375,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	}
 
 	// Validate normal TLS access.
-	trustCACertificates, err := cluster.ConfigGetBool(d.db.Cluster, "core.trust_ca_certificates")
+	trustCACertificates, err := clusterConfig.ConfigGetBool(d.db.Cluster, "core.trust_ca_certificates")
 	if err != nil {
 		return false, "", "", err
 	}
@@ -1277,7 +1278,7 @@ func (d *Daemon) init() error {
 	}
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := cluster.ConfigLoad(tx)
+		config, err := clusterConfig.ConfigLoad(tx)
 		if err != nil {
 			return err
 		}
@@ -1614,7 +1615,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		}
 
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			config, err := cluster.ConfigLoad(tx)
+			config, err := clusterConfig.ConfigLoad(tx)
 			if err != nil {
 				return err
 			}
@@ -2156,7 +2157,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		var maxVoters int64
 		var maxStandBy int64
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			config, err := cluster.ConfigLoad(tx)
+			config, err := clusterConfig.ConfigLoad(tx)
 			if err != nil {
 				return err
 			}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -454,7 +454,6 @@ func (d *Daemon) State() *state.State {
 		UpdateCertificateCache: func() { updateCertificateCache(d) },
 		InstanceTypes:          instanceTypes,
 		DevMonitor:             d.devmonitor,
-		KernelVersion:          d.kernelVersion,
 	}
 }
 
@@ -838,14 +837,6 @@ func (d *Daemon) init() error {
 
 	// Look for kernel features
 	logger.Infof("Kernel features:")
-
-	uname, _ := shared.Uname()
-	if uname != nil {
-		kernelVersion, err := version.Parse(strings.Split(uname.Release, "-")[0])
-		if err == nil {
-			d.kernelVersion = *kernelVersion
-		}
-	}
 
 	d.os.CloseRange = canUseCloseRange()
 	if d.os.CloseRange {

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/state"
@@ -15,7 +15,7 @@ func daemonConfigRender(state *state.State) (map[string]any, error) {
 
 	// Turn the config into a JSON-compatible map
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		clusterConfig, err := cluster.ConfigLoad(tx)
+		clusterConfig, err := clusterConfig.ConfigLoad(tx)
 		if err != nil {
 			return err
 		}
@@ -45,7 +45,7 @@ func daemonConfigRender(state *state.State) (map[string]any, error) {
 	return config, nil
 }
 
-func daemonConfigSetProxy(d *Daemon, config *cluster.Config) {
+func daemonConfigSetProxy(d *Daemon, config *clusterConfig.Config) {
 	// Update the cached proxy function
 	d.proxy = shared.ProxyFromConfig(
 		config.ProxyHTTPS(),

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -15,7 +15,7 @@ func daemonConfigRender(state *state.State) (map[string]any, error) {
 
 	// Turn the config into a JSON-compatible map
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		clusterConfig, err := clusterConfig.ConfigLoad(tx)
+		clusterConfig, err := clusterConfig.Load(tx)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/locking"
@@ -128,7 +128,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 	// server/protocol/alias, regardless of whether it's stale or
 	// not (we can assume that it will be not *too* stale since
 	// auto-update is on).
-	interval, err := cluster.ConfigGetInt64(d.db.Cluster, "images.auto_update_interval")
+	interval, err := clusterConfig.ConfigGetInt64(d.db.Cluster, "images.auto_update_interval")
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -128,7 +128,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 	// server/protocol/alias, regardless of whether it's stale or
 	// not (we can assume that it will be not *too* stale since
 	// auto-update is on).
-	interval, err := clusterConfig.ConfigGetInt64(d.db.Cluster, "images.auto_update_interval")
+	interval, err := clusterConfig.GetInt64(d.db.Cluster, "images.auto_update_interval")
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/device/device_common.go
+++ b/lxd/device/device_common.go
@@ -106,7 +106,7 @@ func (d *deviceCommon) Remove() error {
 // Accepts optional hwaddr MAC address to use for generating the interface name in mac mode.
 // In mac mode the interface prefix is always "lxd".
 func (d *deviceCommon) generateHostName(prefix string, hwaddr string) (string, error) {
-	hostNameMode, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "instances.nic.host_name")
+	hostNameMode, err := clusterConfig.GetString(d.state.DB.Cluster, "instances.nic.host_name")
 	if err != nil {
 		return "", fmt.Errorf(`Failed getting "instances.nic.host_name" config: %w`, err)
 	}

--- a/lxd/device/device_common.go
+++ b/lxd/device/device_common.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
@@ -106,7 +106,7 @@ func (d *deviceCommon) Remove() error {
 // Accepts optional hwaddr MAC address to use for generating the interface name in mac mode.
 // In mac mode the interface prefix is always "lxd".
 func (d *deviceCommon) generateHostName(prefix string, hwaddr string) (string, error) {
-	hostNameMode, err := cluster.ConfigGetString(d.state.DB.Cluster, "instances.nic.host_name")
+	hostNameMode, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "instances.nic.host_name")
 	if err != nil {
 		return "", fmt.Errorf(`Failed getting "instances.nic.host_name" config: %w`, err)
 	}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/mdlayher/netx/eui64"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	pcidev "github.com/lxc/lxd/lxd/device/pci"
 	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
@@ -61,7 +61,7 @@ func (d *nicOVN) UpdatableFields(oldDevice Type) []string {
 
 // getIntegrationBridgeName returns the OVS integration bridge to use.
 func (d *nicOVN) getIntegrationBridgeName() (string, error) {
-	integrationBridge, err := cluster.ConfigGetString(d.state.DB.Cluster, "network.ovn.integration_bridge")
+	integrationBridge, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "network.ovn.integration_bridge")
 	if err != nil {
 		return "", fmt.Errorf("Failed to get OVN integration bridge name: %w", err)
 	}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -61,7 +61,7 @@ func (d *nicOVN) UpdatableFields(oldDevice Type) []string {
 
 // getIntegrationBridgeName returns the OVS integration bridge to use.
 func (d *nicOVN) getIntegrationBridgeName() (string, error) {
-	integrationBridge, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "network.ovn.integration_bridge")
+	integrationBridge, err := clusterConfig.GetString(d.state.DB.Cluster, "network.ovn.integration_bridge")
 	if err != nil {
 		return "", fmt.Errorf("Failed to get OVN integration bridge name: %w", err)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3985,17 +3985,15 @@ func autoSyncImages(ctx context.Context, d *Daemon) error {
 }
 
 func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerprint string) error {
+	s := d.State()
+
 	logger.Info("Syncing image to members started", logger.Ctx{"fingerprint": fingerprint, "project": project})
 	defer logger.Info("Syncing image to members finished", logger.Ctx{"fingerprint": fingerprint, "project": project})
 
 	var desiredSyncNodeCount int64
 
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := clusterConfig.Load(tx)
-		if err != nil {
-			return fmt.Errorf("Failed to load cluster configuration: %w", err)
-		}
-		desiredSyncNodeCount = config.ImagesMinimalReplica()
+		desiredSyncNodeCount = s.GlobalConfig.ImagesMinimalReplica()
 
 		// -1 means that we want to replicate the image on all nodes
 		if desiredSyncNodeCount == -1 {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/filter"
@@ -287,7 +288,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 		if p.Config["images.compression_algorithm"] != "" {
 			compress = p.Config["images.compression_algorithm"]
 		} else {
-			compress, err = cluster.ConfigGetString(d.db.Cluster, "images.compression_algorithm")
+			compress, err = clusterConfig.ConfigGetString(d.db.Cluster, "images.compression_algorithm")
 			if err != nil {
 				return nil, err
 			}
@@ -1884,7 +1885,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 				return nil, fmt.Errorf("Unable to fetch project configuration: %w", err)
 			}
 		} else {
-			interval, err = cluster.ConfigGetInt64(d.db.Cluster, "images.auto_update_interval")
+			interval, err = clusterConfig.ConfigGetInt64(d.db.Cluster, "images.auto_update_interval")
 			if err != nil {
 				return nil, fmt.Errorf("Unable to fetch cluster configuration: %w", err)
 			}
@@ -2228,7 +2229,7 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 			return fmt.Errorf("Unable to fetch project configuration: %w", err)
 		}
 	} else {
-		expiry, err = cluster.ConfigGetInt64(d.db.Cluster, "images.remote_cache_expiry")
+		expiry, err = clusterConfig.ConfigGetInt64(d.db.Cluster, "images.remote_cache_expiry")
 		if err != nil {
 			return fmt.Errorf("Unable to fetch cluster configuration: %w", err)
 		}
@@ -3990,7 +3991,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	var desiredSyncNodeCount int64
 
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := cluster.ConfigLoad(tx)
+		config, err := clusterConfig.ConfigLoad(tx)
 		if err != nil {
 			return fmt.Errorf("Failed to load cluster configuration: %w", err)
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -288,7 +288,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 		if p.Config["images.compression_algorithm"] != "" {
 			compress = p.Config["images.compression_algorithm"]
 		} else {
-			compress, err = clusterConfig.ConfigGetString(d.db.Cluster, "images.compression_algorithm")
+			compress, err = clusterConfig.GetString(d.db.Cluster, "images.compression_algorithm")
 			if err != nil {
 				return nil, err
 			}
@@ -1885,7 +1885,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 				return nil, fmt.Errorf("Unable to fetch project configuration: %w", err)
 			}
 		} else {
-			interval, err = clusterConfig.ConfigGetInt64(d.db.Cluster, "images.auto_update_interval")
+			interval, err = clusterConfig.GetInt64(d.db.Cluster, "images.auto_update_interval")
 			if err != nil {
 				return nil, fmt.Errorf("Unable to fetch cluster configuration: %w", err)
 			}
@@ -2229,7 +2229,7 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 			return fmt.Errorf("Unable to fetch project configuration: %w", err)
 		}
 	} else {
-		expiry, err = clusterConfig.ConfigGetInt64(d.db.Cluster, "images.remote_cache_expiry")
+		expiry, err = clusterConfig.GetInt64(d.db.Cluster, "images.remote_cache_expiry")
 		if err != nil {
 			return fmt.Errorf("Unable to fetch cluster configuration: %w", err)
 		}
@@ -3991,7 +3991,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	var desiredSyncNodeCount int64
 
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := clusterConfig.ConfigLoad(tx)
+		config, err := clusterConfig.Load(tx)
 		if err != nil {
 			return fmt.Errorf("Failed to load cluster configuration: %w", err)
 		}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -678,7 +678,7 @@ func (d *common) startupSnapshot(inst instance.Instance) error {
 // Internal MAAS handling.
 func (d *common) maasUpdate(inst instance.Instance, oldDevices map[string]map[string]string) error {
 	// Check if MAAS is configured
-	maasURL, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
+	maasURL, err := clusterConfig.GetString(d.state.DB.Cluster, "maas.api.url")
 	if err != nil {
 		return err
 	}
@@ -777,7 +777,7 @@ func (d *common) maasInterfaces(inst instance.Instance, devices map[string]map[s
 }
 
 func (d *common) maasRename(inst instance.Instance, newName string) error {
-	maasURL, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
+	maasURL, err := clusterConfig.GetString(d.state.DB.Cluster, "maas.api.url")
 	if err != nil {
 		return err
 	}
@@ -812,7 +812,7 @@ func (d *common) maasRename(inst instance.Instance, newName string) error {
 }
 
 func (d *common) maasDelete(inst instance.Instance) error {
-	maasURL, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
+	maasURL, err := clusterConfig.GetString(d.state.DB.Cluster, "maas.api.url")
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pborman/uuid"
 
 	"github.com/lxc/lxd/lxd/backup"
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
@@ -678,7 +678,7 @@ func (d *common) startupSnapshot(inst instance.Instance) error {
 // Internal MAAS handling.
 func (d *common) maasUpdate(inst instance.Instance, oldDevices map[string]map[string]string) error {
 	// Check if MAAS is configured
-	maasURL, err := cluster.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
+	maasURL, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
 	if err != nil {
 		return err
 	}
@@ -777,7 +777,7 @@ func (d *common) maasInterfaces(inst instance.Instance, devices map[string]map[s
 }
 
 func (d *common) maasRename(inst instance.Instance, newName string) error {
-	maasURL, err := cluster.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
+	maasURL, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
 	if err != nil {
 		return err
 	}
@@ -812,7 +812,7 @@ func (d *common) maasRename(inst instance.Instance, newName string) error {
 }
 
 func (d *common) maasDelete(inst instance.Instance) error {
-	maasURL, err := cluster.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
+	maasURL, err := clusterConfig.ConfigGetString(d.state.DB.Cluster, "maas.api.url")
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7094,12 +7094,6 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 		realDev := ""
 
 		if dev["pool"] != "" {
-			// Storage pool volume.
-			pool, err := storagePools.LoadByName(d.state, dev["pool"])
-			if err != nil {
-				return nil, fmt.Errorf("Failed to get pool: %w", err)
-			}
-
 			// Expected volume name.
 			var volName string
 			var volType storageDrivers.VolumeType
@@ -7111,15 +7105,9 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 				volType = storageDrivers.VolumeTypeContainer
 			}
 
-			// Get the volume.
-			vol := pool.GetVolume(volType, storageDrivers.ContentTypeFS, volName, nil)
-			if !pool.Driver().HasVolume(vol) {
-				continue
-			}
-
 			// Check that we have a mountpoint.
-			mountpoint := vol.MountPath()
-			if mountpoint == "" {
+			mountpoint := storageDrivers.GetVolumeMountPath(dev["pool"], volType, volName)
+			if mountpoint == "" || !shared.PathExists(mountpoint) {
 				continue
 			}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1246,7 +1246,7 @@ func (d *qemu) Start(stateful bool) error {
 	if d.architecture == osarch.ARCH_64BIT_INTEL_X86 {
 		// If using Linux 5.10 or later, use HyperV optimizations.
 		minVer, _ := version.NewDottedVersion("5.10.0")
-		if d.state.KernelVersion.Compare(minVer) >= 0 && shared.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
+		if d.state.OS.KernelVersion.Compare(minVer) >= 0 && shared.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
 			// x86_64 can use hv_time to improve Windows guest performance.
 			cpuExtensions = append(cpuExtensions, "hv_passthrough")
 		}
@@ -3109,7 +3109,7 @@ func (d *qemu) addDriveConfig(bootIndexes map[string]int, driveConf deviceConfig
 	// Use io_uring over native for added performance (if supported by QEMU and kernel is recent enough).
 	// We've seen issues starting VMs when running with io_ring AIO mode on kernels before 5.13.
 	minVer, _ := version.NewDottedVersion("5.13.0")
-	if shared.StringInSlice("io_uring", info.Features) && d.state.KernelVersion.Compare(minVer) >= 0 {
+	if shared.StringInSlice("io_uring", info.Features) && d.state.OS.KernelVersion.Compare(minVer) >= 0 {
 		aioMode = "io_uring"
 	}
 

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -115,7 +115,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		//       running?
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Load cluster configuration.
-			config, err := clusterConfig.ConfigLoad(tx)
+			config, err := clusterConfig.Load(tx)
 			if err != nil {
 				return fmt.Errorf("Failed to load LXD config: %w", err)
 			}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
@@ -114,7 +115,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		//       running?
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Load cluster configuration.
-			config, err := cluster.ConfigLoad(tx)
+			config, err := clusterConfig.ConfigLoad(tx)
 			if err != nil {
 				return fmt.Errorf("Failed to load LXD config: %w", err)
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/archive"
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
@@ -90,7 +91,7 @@ func createFromImage(d *Daemon, r *http.Request, projectName string, req *api.In
 			if p.Config["images.auto_update_cached"] != "" {
 				autoUpdate = shared.IsTrue(p.Config["images.auto_update_cached"])
 			} else {
-				autoUpdate, err = cluster.ConfigGetBool(d.db.Cluster, "images.auto_update_cached")
+				autoUpdate, err = clusterConfig.ConfigGetBool(d.db.Cluster, "images.auto_update_cached")
 				if err != nil {
 					return err
 				}
@@ -955,7 +956,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			if targetProject.Config["images.default_architecture"] != "" {
 				defaultArch = targetProject.Config["images.default_architecture"]
 			} else {
-				config, err := cluster.ConfigLoad(tx)
+				config, err := clusterConfig.ConfigLoad(tx)
 				if err != nil {
 					return err
 				}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -91,7 +91,7 @@ func createFromImage(d *Daemon, r *http.Request, projectName string, req *api.In
 			if p.Config["images.auto_update_cached"] != "" {
 				autoUpdate = shared.IsTrue(p.Config["images.auto_update_cached"])
 			} else {
-				autoUpdate, err = clusterConfig.ConfigGetBool(d.db.Cluster, "images.auto_update_cached")
+				autoUpdate, err = clusterConfig.GetBool(d.db.Cluster, "images.auto_update_cached")
 				if err != nil {
 					return err
 				}
@@ -956,7 +956,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			if targetProject.Config["images.default_architecture"] != "" {
 				defaultArch = targetProject.Config["images.default_architecture"]
 			} else {
-				config, err := clusterConfig.ConfigLoad(tx)
+				config, err := clusterConfig.Load(tx)
 				if err != nil {
 					return err
 				}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -837,6 +837,8 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func instancesPost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	targetProjectName := projectParam(r)
 	logger.Debugf("Responding to instance create")
 
@@ -946,7 +948,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		architectures, err := instance.SuitableArchitectures(d.State(), targetProjectName, req)
+		architectures, err := instance.SuitableArchitectures(s, targetProjectName, req)
 		if err != nil {
 			return response.BadRequest(err)
 		}
@@ -956,12 +958,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			if targetProject.Config["images.default_architecture"] != "" {
 				defaultArch = targetProject.Config["images.default_architecture"]
 			} else {
-				config, err := clusterConfig.Load(tx)
-				if err != nil {
-					return err
-				}
-
-				defaultArch = config.ImagesDefaultArchitecture()
+				defaultArch = s.GlobalConfig.ImagesDefaultArchitecture()
 			}
 
 			defaultArchID := -1

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 )
@@ -170,7 +170,7 @@ type OVNRouterPeering struct {
 
 // NewOVN initialises new OVN client wrapper with the connection set in network.ovn.northbound_connection config.
 func NewOVN(s *state.State) (*OVN, error) {
-	nbConnection, err := cluster.ConfigGetString(s.DB.Cluster, "network.ovn.northbound_connection")
+	nbConnection, err := clusterConfig.ConfigGetString(s.DB.Cluster, "network.ovn.northbound_connection")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get OVN northbound connection string: %w", err)
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -170,7 +170,7 @@ type OVNRouterPeering struct {
 
 // NewOVN initialises new OVN client wrapper with the connection set in network.ovn.northbound_connection config.
 func NewOVN(s *state.State) (*OVN, error) {
-	nbConnection, err := clusterConfig.ConfigGetString(s.DB.Cluster, "network.ovn.northbound_connection")
+	nbConnection, err := clusterConfig.GetString(s.DB.Cluster, "network.ovn.northbound_connection")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get OVN northbound connection string: %w", err)
 	}

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -18,7 +18,6 @@ import (
 	"github.com/lxc/lxd/lxd/maas"
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared"
-	"github.com/lxc/lxd/shared/version"
 )
 
 // State is a gateway to the two main stateful components of LXD, the database
@@ -63,7 +62,4 @@ type State struct {
 
 	// Filesystem monitor
 	DevMonitor fsmonitor.FSMonitor
-
-	// Kernel Version
-	KernelVersion version.DottedVersion
 }

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/lxc/lxd/lxd/bgp"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/dns"
 	"github.com/lxc/lxd/lxd/endpoints"
@@ -62,4 +63,7 @@ type State struct {
 
 	// Filesystem monitor
 	DevMonitor fsmonitor.FSMonitor
+
+	// Global configuration
+	GlobalConfig *clusterConfig.Config
 }

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -66,4 +66,7 @@ type State struct {
 
 	// Global configuration
 	GlobalConfig *clusterConfig.Config
+
+	// Local server name.
+	ServerName string
 }

--- a/lxd/state/testing.go
+++ b/lxd/state/testing.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/firewall"
 	"github.com/lxc/lxd/lxd/sys"
@@ -33,6 +34,7 @@ func NewTestState(t *testing.T) (*State, func()) {
 		OS:                     os,
 		Firewall:               firewall.New(),
 		UpdateCertificateCache: func() {},
+		GlobalConfig:           &clusterConfig.Config{},
 	}
 
 	return state, cleanup

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -14,7 +14,7 @@ import (
 	"github.com/flosch/pongo2"
 	"github.com/gorilla/mux"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
@@ -1197,7 +1197,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			var onlineNodeIDs []int64
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				// Get the offline threshold.
-				config, err := cluster.ConfigLoad(tx)
+				config, err := clusterConfig.ConfigLoad(tx)
 				if err != nil {
 					return fmt.Errorf("Failed to load LXD config: %w", err)
 				}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1197,7 +1197,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			var onlineNodeIDs []int64
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				// Get the offline threshold.
-				config, err := clusterConfig.ConfigLoad(tx)
+				config, err := clusterConfig.Load(tx)
 				if err != nil {
 					return fmt.Errorf("Failed to load LXD config: %w", err)
 				}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -14,7 +14,6 @@ import (
 	"github.com/flosch/pongo2"
 	"github.com/gorilla/mux"
 
-	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
@@ -1127,9 +1126,11 @@ func pruneExpiredCustomVolumeSnapshots(ctx context.Context, d *Daemon, expiredSn
 
 func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
+		s := d.State()
+
 		// Get projects.
 		var projects map[string]*dbCluster.Project
-		err := d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
 			projs, err := dbCluster.GetProjects(ctx, tx.Tx(), dbCluster.ProjectFilter{})
 			if err != nil {
@@ -1157,7 +1158,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		localNodeID := d.db.Cluster.GetNodeID()
 
 		var volumes, remoteVolumes []db.StorageVolumeArgs
-		err = d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			for _, v := range allVolumes {
 				schedule, ok := v.Config["snapshots.schedule"]
 				if !ok || schedule == "" {
@@ -1196,12 +1197,6 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			var nodeCount int
 			var onlineNodeIDs []int64
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				// Get the offline threshold.
-				config, err := clusterConfig.Load(tx)
-				if err != nil {
-					return fmt.Errorf("Failed to load LXD config: %w", err)
-				}
-
 				// Get all the members.
 				nodes, err := tx.GetNodes()
 				if err != nil {
@@ -1212,7 +1207,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 				// Filter to online members.
 				for _, node := range nodes {
-					if node.IsOffline(config.OfflineThreshold()) {
+					if node.IsOffline(s.GlobalConfig.OfflineThreshold()) {
 						continue
 					}
 
@@ -1265,7 +1260,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			return nil
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationVolumeSnapshotCreate, nil, nil, opRun, nil, nil, nil)
+		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, db.OperationVolumeSnapshotCreate, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start create volume snapshot operation", logger.Ctx{"err": err})
 			return

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -99,6 +99,7 @@ type OS struct {
 	// OS info
 	ReleaseInfo   map[string]string
 	KernelVersion version.DottedVersion
+	Uname         *shared.Utsname
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.
@@ -196,12 +197,15 @@ func (s *OS) Init() ([]db.Warning, error) {
 
 	s.ReleaseInfo = osInfo
 
-	uname, _ := shared.Uname()
-	if uname != nil {
-		kernelVersion, err := version.Parse(strings.Split(uname.Release, "-")[0])
-		if err == nil {
-			s.KernelVersion = *kernelVersion
-		}
+	uname, err := shared.Uname()
+	if err != nil {
+		return nil, err
+	}
+	s.Uname = uname
+
+	kernelVersion, err := version.Parse(strings.Split(uname.Release, "-")[0])
+	if err == nil {
+		s.KernelVersion = *kernelVersion
 	}
 
 	return dbWarnings, nil

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/mdlayher/vsock"
@@ -18,6 +19,7 @@ import (
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
+	"github.com/lxc/lxd/shared/version"
 )
 
 // InotifyTargetInfo records the inotify information associated with a given
@@ -95,7 +97,8 @@ type OS struct {
 	VsockID uint32
 
 	// OS info
-	ReleaseInfo map[string]string
+	ReleaseInfo   map[string]string
+	KernelVersion version.DottedVersion
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.
@@ -192,6 +195,14 @@ func (s *OS) Init() ([]db.Warning, error) {
 	}
 
 	s.ReleaseInfo = osInfo
+
+	uname, _ := shared.Uname()
+	if uname != nil {
+		kernelVersion, err := version.Parse(strings.Split(uname.Release, "-")[0])
+		if err == nil {
+			s.KernelVersion = *kernelVersion
+		}
+	}
 
 	return dbWarnings, nil
 }

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/osarch"
 )
 
 // InotifyTargetInfo records the inotify information associated with a given
@@ -92,6 +93,9 @@ type OS struct {
 
 	// VM features
 	VsockID uint32
+
+	// OS info
+	ReleaseInfo map[string]string
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.
@@ -103,6 +107,7 @@ func DefaultOS() *OS {
 	}
 	newOS.InotifyWatch.Fd = -1
 	newOS.InotifyWatch.Targets = make(map[string]*InotifyTargetInfo)
+	newOS.ReleaseInfo = make(map[string]string)
 	return newOS
 }
 
@@ -179,6 +184,14 @@ func (s *OS) Init() ([]db.Warning, error) {
 	}
 
 	s.VsockID = vsockID
+
+	// Fill in the OS release info.
+	osInfo, err := osarch.GetLSBRelease()
+	if err != nil {
+		return nil, err
+	}
+
+	s.ReleaseInfo = osInfo
 
 	return dbWarnings, nil
 }


### PR DESCRIPTION
This branch is meant to significantly reduce the number of needless DB queries that we're currently performing.

This is achieved partly by storing the global config in memory rather than fetching it several times per request as well as ensuring that a simple `GET /1.0` as done with just about every single CLI call doesn't hit the database at all.

Unfortunately this doesn't quite fix the performance issues we found during NorthSec, but it's a good initial step.