### PR TITLE
Optimize snapshot expiry

### DIFF
--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -108,6 +108,61 @@ func (c *ClusterTx) UpdateInstanceSnapshot(id int, description string, expiryDat
 	return nil
 }
 
+// GetLocalExpiredInstanceSnapshots returns a list of expired snapshots.
+func (c *ClusterTx) GetLocalExpiredInstanceSnapshots() ([]InstanceSnapshot, error) {
+	q := `
+	SELECT
+		instances_snapshots.id,
+		instances_snapshots.expiry_date
+	FROM instances_snapshots
+	JOIN instances ON instances.id=instances_snapshots.instance_id
+	WHERE instances.node_id=? AND instances_snapshots.expiry_date != '0001-01-01T00:00:00Z'
+	`
+
+	snapshotIDs := []int{}
+	err := c.QueryScan(q, func(scan func(dest ...any) error) error {
+		var id int
+		var expiry sql.NullTime
+
+		// Read the row.
+		err := scan(&id, &expiry)
+		if err != nil {
+			return err
+		}
+
+		// Skip if not expired.
+		if !expiry.Valid || expiry.Time.Unix() <= 0 {
+			return nil
+		}
+
+		if time.Now().Unix()-expiry.Time.Unix() < 0 {
+			return nil
+		}
+
+		// Add the snapshot.
+		snapshotIDs = append(snapshotIDs, id)
+
+		return nil
+	}, c.nodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch all the expired snapshot details.
+	snapshots := make([]InstanceSnapshot, len(snapshotIDs))
+
+	for i, id := range snapshotIDs {
+		snap, err := c.GetInstanceSnapshots(InstanceSnapshotFilter{ID: &id})
+		if err != nil {
+			return nil, err
+		}
+
+		snapshots[i] = snap[0]
+	}
+
+	return snapshots, nil
+}
+
 // GetInstanceSnapshotID returns the ID of the snapshot with the given name.
 func (c *Cluster) GetInstanceSnapshotID(project, instance, name string) (int, error) {
 	var id int64

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -17,6 +17,7 @@ import (
 //go:generate mapper reset -i -b "//go:build linux && cgo && !agent"
 //
 //go:generate mapper stmt -d cluster -p db -e instance_snapshot objects
+//go:generate mapper stmt -d cluster -p db -e instance_snapshot objects-by-ID
 //go:generate mapper stmt -d cluster -p db -e instance_snapshot objects-by-Project-and-Instance
 //go:generate mapper stmt -d cluster -p db -e instance_snapshot objects-by-Project-and-Instance-and-Name
 //go:generate mapper stmt -d cluster -p db -e instance_snapshot id
@@ -48,6 +49,7 @@ type InstanceSnapshot struct {
 
 // InstanceSnapshotFilter specifies potential query parameter fields.
 type InstanceSnapshotFilter struct {
+	ID       *int
 	Project  *string
 	Instance *string
 	Name     *string

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -166,7 +166,7 @@ func (c *Cluster) GetExpiredStorageVolumeSnapshots() ([]StorageVolumeArgs, error
 	JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id = storage_volumes.id
 	JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
 	JOIN projects ON storage_volumes.project_id = projects.id
-	WHERE storage_volumes.type = ?`
+	WHERE storage_volumes.type = ? AND storage_volumes_snapshots.expiry_date != '0001-01-01T00:00:00Z'`
 
 	var snapshots []StorageVolumeArgs
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1084,8 +1084,6 @@ func pruneExpireCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) 
 		logger.Info("Done pruning expired custom volume snapshots")
 	}
 
-	f(context.Background())
-
 	first := true
 	schedule := func() (time.Duration, error) {
 		interval := time.Minute


### PR DESCRIPTION
This reworks the database aspect of snapshot expiry checking to reduce the minutely check down to a single DB query.