### PR TITLE
Operations: Fixes race conditions on status propery and improves some function names

### DIFF
--- a/client/operations.go
+++ b/client/operations.go
@@ -214,7 +214,7 @@ func (op *operation) setupListener() error {
 		case <-listener.ctx.Done():
 			op.handlerLock.Lock()
 			if op.listener != nil {
-				op.Err = fmt.Sprintf("%v", listener.err)
+				op.Err = listener.err.Error()
 				close(op.chActive)
 			}
 			op.handlerLock.Unlock()

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -294,7 +294,7 @@ func pruneExpiredContainerBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		logger.Info("Pruning expired instance backups")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to expire instance backups", logger.Ctx{"err": err})
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1520,7 +1520,7 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		logger.Info("Updating images")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to update images", logger.Ctx{"err": err})
 		}
@@ -2072,7 +2072,7 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		logger.Infof("Pruning expired images")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to expire images", logger.Ctx{"err": err})
 		}
@@ -2177,7 +2177,7 @@ func pruneLeftoverImages(d *Daemon) {
 	}
 
 	logger.Infof("Pruning leftover image files")
-	_, err = op.Run()
+	err = op.Start()
 	if err != nil {
 		logger.Error("Failed to prune leftover image files", logger.Ctx{"err": err})
 		return
@@ -3945,7 +3945,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		logger.Infof("Synchronizing images across the cluster")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to synchronize images", logger.Ctx{"err": err})
 			return

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3711,8 +3711,8 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		if opWaitAPI.Status != "success" {
-			return fmt.Errorf(opWaitAPI.Err)
+		if opWaitAPI.StatusCode != api.Success {
+			return fmt.Errorf("Failed operation %q: %q", opWaitAPI.Status, opWaitAPI.Err)
 		}
 
 		d.State().Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(fingerprint, projectName, op.Requestor(), logger.Ctx{"target": req.Target}))

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -462,7 +462,7 @@ func autoCreateContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 		logger.Info("Creating scheduled container snapshots")
 
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to create scheduled container snapshots", logger.Ctx{"err": err})
 		}
@@ -581,7 +581,7 @@ func pruneExpiredInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 		logger.Info("Pruning expired instance snapshots")
 
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to remove expired instance snapshots", logger.Ctx{"err": err})
 		}

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -97,7 +97,7 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		logger.Info("Updating instance types")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to update instance types", logger.Ctx{"err": err})
 		}

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -33,7 +33,7 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 		}
 
 		logger.Infof("Expiring log files")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to expire logs", logger.Ctx{"err": err})
 		}

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -647,7 +647,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 				logger.Debugf("The other side does not support pre-copy")
 			}
 
-			_, err = actionScriptOp.Run()
+			err = actionScriptOp.Start()
 			if err != nil {
 				_ = os.RemoveAll(checkpointDir)
 				return abort(err)

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1089,7 +1089,7 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 			return
 		}
 
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to remove orphaned operations", logger.Ctx{"err": err})
 			return

--- a/lxd/operations/linux.go
+++ b/lxd/operations/linux.go
@@ -52,24 +52,6 @@ func removeDBOperation(op *Operation) error {
 	return err
 }
 
-func getServerName(op *Operation) (string, error) {
-	if op.state == nil {
-		return "", nil
-	}
-
-	var serverName string
-	var err error
-	err = op.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		serverName, err = tx.GetLocalNodeName()
-		return err
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return serverName, nil
-}
-
 func (op *Operation) sendEvent(eventMessage any) {
 	if op.events == nil {
 		return

--- a/lxd/operations/notlinux.go
+++ b/lxd/operations/notlinux.go
@@ -24,14 +24,6 @@ func removeDBOperation(op *Operation) error {
 	return nil
 }
 
-func getServerName(op *Operation) (string, error) {
-	if op.state != nil {
-		return "", fmt.Errorf("registerDBOperation not supported on this platform")
-	}
-
-	return "", nil
-}
-
 func (op *Operation) sendEvent(eventMessage any) {
 	if op.events == nil {
 		return

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -477,11 +477,6 @@ func (op *Operation) Render() (string, *api.Operation, error) {
 	}
 
 	// Local server name
-	var err error
-	serverName, err := getServerName(op)
-	if err != nil {
-		return "", nil, err
-	}
 
 	op.lock.Lock()
 	retOp := &api.Operation{
@@ -495,7 +490,7 @@ func (op *Operation) Render() (string, *api.Operation, error) {
 		Resources:   resources,
 		Metadata:    op.metadata,
 		MayCancel:   op.mayCancel(),
-		Location:    serverName,
+		Location:    op.state.ServerName,
 	}
 
 	if op.err != nil {

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -22,7 +22,7 @@ func OperationResponse(op *Operation) response.Response {
 }
 
 func (r *operationResponse) Render(w http.ResponseWriter) error {
-	_, err := r.op.Run()
+	err := r.op.Start()
 	if err != nil {
 		return err
 	}

--- a/lxd/state/notlinux.go
+++ b/lxd/state/notlinux.go
@@ -12,4 +12,5 @@ import (
 type State struct {
 	Events      *events.Server
 	ShutdownCtx context.Context
+	ServerName  string
 }

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1076,7 +1076,7 @@ func pruneExpireCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) 
 		}
 
 		logger.Info("Pruning expired custom volume snapshots")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to expire backups", logger.Ctx{"err": err})
 		}
@@ -1257,7 +1257,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 		logger.Info("Creating scheduled volume snapshots")
 
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to create scheduled volume snapshots", logger.Ctx{"err": err})
 		}

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -428,7 +428,7 @@ func pruneResolvedWarningsTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		logger.Info("Pruning resolved warnings")
-		_, err = op.Run()
+		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to prune resolved warnings", logger.Ctx{"err": err})
 		}


### PR DESCRIPTION
This PR started because I noticed the image prune and image update tasks were running concurrently and interfering with each other's image delete process when I started LXD for the first time after being away for a week. Whilst this PR doesn't fix that particular issue, it works towards the fix by cleaning up the interface to the `Operation` type to provide clearer state management.

- Renames `Run` to `Start` to avoid implying it returns after the operation has run (and finished).
- Removes unused finished channel returned from `Start` function (should use `Wait` instead).
- Renames `Wait` to `WaitFinal` and updates to accept a context. 
- Fixes races on internal status property.