### PR TITLE
Events: Remove frequent `Failed closing listener connection` error

### DIFF
--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -67,9 +67,6 @@ func (e *listenerCommon) Close() {
 
 	logger.Debug("Event listener server handler stopped", logger.Ctx{"listener": e.ID(), "local": e.LocalAddr(), "remote": e.RemoteAddr()})
 
-	err := e.EventListenerConnection.Close()
-	if err != nil {
-		logger.Error("Failed closing listener connection", logger.Ctx{"listener": e.ID(), "err": err})
-	}
+	_ = e.EventListenerConnection.Close()
 	e.ctxCancel()
 }

--- a/lxd/events/devlxdEvents.go
+++ b/lxd/events/devlxdEvents.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/cancel"
 )
 
 // DevLXDServer represents an instance of an devlxd event server.
@@ -34,14 +35,11 @@ func NewDevLXDServer(debug bool, verbose bool) *DevLXDServer {
 
 // AddListener creates and returns a new event listener.
 func (s *DevLXDServer) AddListener(instanceID int, connection EventListenerConnection, messageTypes []string) (*DevLXDListener, error) {
-	ctx, ctxCancel := context.WithCancel(context.Background())
-
 	listener := &DevLXDListener{
 		listenerCommon: listenerCommon{
 			EventListenerConnection: connection,
 			messageTypes:            messageTypes,
-			ctx:                     ctx,
-			ctxCancel:               ctxCancel,
+			done:                    cancel.New(context.Background()),
 			id:                      uuid.New(),
 		},
 		instanceID: instanceID,

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/cancel"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -69,14 +70,11 @@ func (s *Server) AddListener(projectName string, allProjects bool, connection Ev
 		return nil, fmt.Errorf("Cannot specify project name when listening for events on all projects")
 	}
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
-
 	listener := &Listener{
 		listenerCommon: listenerCommon{
 			EventListenerConnection: connection,
 			messageTypes:            messageTypes,
-			ctx:                     ctx,
-			ctxCancel:               ctxCancel,
+			done:                    cancel.New(context.Background()),
 			id:                      uuid.New(),
 			recvFunc:                recvFunc,
 		},


### PR DESCRIPTION
This is happening since https://github.com/lxc/lxd/pull/10428 and was generating lots of noise in the logs.

Noticed whilst working on https://github.com/lxc/lxd/pull/10471