### PR TITLE
doc: fix version numbers in the version switcher

### DIFF
--- a/.sphinx/_extra/versions.json
+++ b/.sphinx/_extra/versions.json
@@ -4,11 +4,11 @@
         "id": "master"
     },
     {
-        "version": "5.x",
+        "version": "5.0.x",
         "id": "stable-5.0"
     },
     {
-        "version": "4.x",
+        "version": "4.0.x",
         "id": "stable-4.0"
     }
 ]


### PR DESCRIPTION
Stable is 4.0.x and 5.0.x, not 4.x and 5.x.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>