### PR TITLE
Instance: Allow 5 minutes for the root disk unmount process

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2987,7 +2987,8 @@ func (d *lxc) onStop(args map[string]string) error {
 		}
 
 		// Stop the storage for this container
-		_ = op.Reset()
+		waitTimeout := operationlock.TimeoutShutdown
+		_ = op.ResetTimeout(waitTimeout)
 		err = d.unmount()
 		if err != nil {
 			err = fmt.Errorf("Failed unmounting instance: %w", err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -554,7 +554,7 @@ func (d *qemu) pidWait(timeout time.Duration, op *operationlock.InstanceOperatio
 		}
 
 		if op != nil {
-			_ = op.Reset() // Reset timeout to 30s.
+			_ = op.Reset() // Reset timeout to default.
 		}
 
 		time.Sleep(time.Millisecond * time.Duration(250))
@@ -588,8 +588,7 @@ func (d *qemu) onStop(target string) error {
 		d.logger.Error("VM process failed to stop", logger.Ctx{"timeout": waitTimeout})
 	}
 
-	// Reset timeout to 30s.
-	_ = op.Reset()
+	_ = op.Reset() // Reset timeout to default.
 
 	// Record power state.
 	err = d.VolatileSet(map[string]string{"volatile.last_state.power": "STOPPED"})
@@ -626,8 +625,7 @@ func (d *qemu) onStop(target string) error {
 
 	// Reboot the instance.
 	if target == "reboot" {
-		// Reset timeout to 30s.
-		_ = op.Reset()
+		_ = op.Reset() // Reset timeout to default.
 
 		err = d.Start(false)
 		if err != nil {
@@ -637,8 +635,7 @@ func (d *qemu) onStop(target string) error {
 
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestarted.Event(d, nil))
 	} else if d.ephemeral {
-		// Reset timeout to 30s.
-		_ = op.Reset()
+		_ = op.Reset() // Reset timeout to default.
 
 		// Destroy ephemeral virtual machines.
 		err = d.Delete(true)
@@ -1420,8 +1417,7 @@ func (d *qemu) Start(stateful bool) error {
 		return err
 	}
 
-	// Reset timeout to 30s.
-	_ = op.Reset()
+	_ = op.Reset() // Reset timeout to default.
 
 	err = p.StartWithFiles(fdFiles)
 	if err != nil {
@@ -1518,8 +1514,7 @@ func (d *qemu) Start(stateful bool) error {
 	// the process from a guest initiated reset using the event handler returned from getMonitorEventHandler().
 	_ = monitor.Reset()
 
-	// Reset timeout to 30s.
-	_ = op.Reset()
+	_ = op.Reset() // Reset timeout to default.
 
 	// Restore the state.
 	if stateful {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1739,9 +1739,9 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 					return false, fmt.Errorf("Failed locating zvol for deactivation: %w", err)
 				}
 
-				// We cannot wait longer than the operationlock.TimeoutSeconds to avoid continuing
+				// We cannot wait longer than the operationlock.TimeoutShutdown to avoid continuing
 				// the unmount process beyond the ongoing request.
-				waitDuration := time.Duration(operationlock.TimeoutSeconds * time.Second)
+				waitDuration := operationlock.TimeoutShutdown
 				waitUntil := time.Now().Add(waitDuration)
 				i := 0
 				for {


### PR DESCRIPTION
And increase ZFS volume deactivation retry timeout (allowed by the increased timeout for the unmount operation) to allow the host more time to flush the data back to the storage layer.

Fixes #10483