### PR TITLE
doc: storage: Clarify driver names

### DIFF
--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -1,5 +1,5 @@
 (storage-btrfs)=
-# Btrfs
+# Btrfs - `btrfs`
 
  - Uses a subvolume per instance, image and snapshot, creating Btrfs snapshots when creating a new object.
  - Btrfs can be used as a storage backend inside a container (nesting), so long as the parent container is itself on Btrfs. (But see notes about Btrfs quota via qgroups.)

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -1,5 +1,5 @@
 (storage-ceph)=
-# Ceph
+# Ceph - `ceph`
 
 - Uses RBD images for images, then snapshots and clones to create instances
   and snapshots.

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -1,5 +1,5 @@
 (storage-cephfs)=
-# CephFS
+# CephFS - `cephfs`
 
  - Can only be used for custom storage volumes
  - Supports snapshots if enabled on the server side

--- a/doc/reference/storage_dir.md
+++ b/doc/reference/storage_dir.md
@@ -1,5 +1,5 @@
 (storage-dir)=
-# dir
+# Directory - `dir`
 
  - While this backend is fully functional, it's also much slower than
    all the others due to it having to unpack images or do instant copies of

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -1,5 +1,5 @@
 (storage-lvm)=
-# LVM
+# LVM - `lvm`
 
  - Uses LVs for images, then LV snapshots for instances and instance snapshots.
  - The filesystem used for the LVs is ext4 (can be configured to use xfs instead).

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -3,7 +3,7 @@ discourse: 1333
 ---
 
 (storage-zfs)=
-# ZFS
+# ZFS - `zfs`
 
  - When LXD creates a ZFS pool, compression is enabled by default.
  - Uses ZFS filesystems for images, then snapshots and clones to create instances and snapshots.


### PR DESCRIPTION
As a quick fix, give both the name and the driver "ID" to specify
when creating the driver in the title.
We can clarify more when cleaning up the driver documentation.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>