### PR TITLE
lxd/storage/drivers/zfs: Fix VM migration

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -876,7 +876,7 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, volumeOnly bool, preFiller *VolumeFiller, op *operations.Operation) error {
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, op)
+		err := d.createVolumeFromMigrationOptimized(fsVol, conn, volTargetArgs, volumeOnly, preFiller, op)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The createVolumeFromMigrationOptimized function calls
CreateVolumeFromMigration for VMs. This is wrong, as the receiver
then expects the migration headers to be sent twice which the sender
doesn't do. It results in the receiver failing to decode the migration
header (JSON) as the received data at that point is actually from
`zfs send`.

This changes createVolumeFromMigrationOptimized to call itself for VM
block filesystems.

Fixes #104435.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
