### PR TITLE
Operations: Prevent image related background tasks from running concurrently and stepping on each other

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -298,6 +298,8 @@ func pruneExpiredContainerBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 		if err != nil {
 			logger.Error("Failed to expire instance backups", logger.Ctx{"err": err})
 		}
+
+		op.Wait(ctx)
 		logger.Info("Done pruning expired instance backups")
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1524,6 +1524,8 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		if err != nil {
 			logger.Error("Failed to update images", logger.Ctx{"err": err})
 		}
+
+		op.Wait(ctx)
 		logger.Info("Done updating images")
 	}
 
@@ -2071,11 +2073,18 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 			return
 		}
 
+		logger.Debug("Acquiring image task lock")
+		imageTaskMu.Lock()
+		defer imageTaskMu.Unlock()
+		logger.Debug("Acquired image task lock")
+
 		logger.Infof("Pruning expired images")
 		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to expire images", logger.Ctx{"err": err})
 		}
+
+		op.Wait(ctx)
 		logger.Infof("Done pruning expired images")
 	}
 
@@ -2182,6 +2191,8 @@ func pruneLeftoverImages(d *Daemon) {
 		logger.Error("Failed to prune leftover image files", logger.Ctx{"err": err})
 		return
 	}
+
+	op.Wait(d.shutdownCtx)
 	logger.Infof("Done pruning leftover image files")
 }
 
@@ -3944,13 +3955,19 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 			return
 		}
 
-		logger.Infof("Synchronizing images across the cluster")
+		logger.Debug("Acquiring image task lock")
+		imageTaskMu.Lock()
+		defer imageTaskMu.Unlock()
+		logger.Debug("Acquired image task lock")
+
+		logger.Info("Synchronizing images across the cluster")
 		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to synchronize images", logger.Ctx{"err": err})
 			return
 		}
 
+		op.Wait(ctx)
 		logger.Infof("Done synchronizing images across the cluster")
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2087,14 +2087,14 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		defer imageTaskMu.Unlock()
 		logger.Debug("Acquired image task lock")
 
-		logger.Infof("Pruning expired images")
+		logger.Info("Pruning expired images")
 		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to expire images", logger.Ctx{"err": err})
 		}
 
 		op.Wait(ctx)
-		logger.Infof("Done pruning expired images")
+		logger.Info("Done pruning expired images")
 	}
 
 	// Skip the first run, and instead run an initial pruning synchronously
@@ -2199,7 +2199,7 @@ func pruneLeftoverImages(d *Daemon) {
 	defer imageTaskMu.Unlock()
 	logger.Debug("Acquired image task lock")
 
-	logger.Infof("Pruning leftover image files")
+	logger.Info("Pruning leftover image files")
 	err = op.Start()
 	if err != nil {
 		logger.Error("Failed to prune leftover image files", logger.Ctx{"err": err})
@@ -3982,7 +3982,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		op.Wait(ctx)
-		logger.Infof("Done synchronizing images across the cluster")
+		logger.Info("Done synchronizing images across the cluster")
 	}
 
 	return f, task.Hourly()

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -469,6 +469,7 @@ func autoCreateContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to create scheduled container snapshots", logger.Ctx{"err": err})
 		}
 
+		op.Wait(ctx)
 		logger.Info("Done creating scheduled container snapshots")
 	}
 
@@ -588,6 +589,7 @@ func pruneExpiredInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to remove expired instance snapshots", logger.Ctx{"err": err})
 		}
 
+		op.Wait(ctx)
 		logger.Info("Done pruning expired instance snapshots")
 	}
 

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -103,7 +103,7 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		op.Wait(ctx)
-		logger.Infof("Done updating instance types")
+		logger.Info("Done updating instance types")
 	}
 
 	return f, task.Daily()

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -101,6 +101,8 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 		if err != nil {
 			logger.Error("Failed to update instance types", logger.Ctx{"err": err})
 		}
+
+		op.Wait(ctx)
 		logger.Infof("Done updating instance types")
 	}
 

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -32,14 +32,14 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 			return
 		}
 
-		logger.Infof("Expiring log files")
+		logger.Info("Expiring log files")
 		err = op.Start()
 		if err != nil {
 			logger.Error("Failed to expire logs", logger.Ctx{"err": err})
 		}
 
 		op.Wait(ctx)
-		logger.Infof("Done expiring log files")
+		logger.Info("Done expiring log files")
 	}
 
 	return f, task.Daily()

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -37,6 +37,8 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 		if err != nil {
 			logger.Error("Failed to expire logs", logger.Ctx{"err": err})
 		}
+
+		op.Wait(ctx)
 		logger.Infof("Done expiring log files")
 	}
 

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1105,6 +1105,8 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to remove orphaned operations", logger.Ctx{"err": err})
 			return
 		}
+
+		op.Wait(ctx)
 	}
 
 	return f, task.Hourly()

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -503,6 +503,7 @@ func (op *Operation) Render() (string, *api.Operation, error) {
 }
 
 // Wait for the operation to be done.
+// Returns true if operation completed or false if context was cancelled.
 func (op *Operation) Wait(ctx context.Context) (bool, error) {
 	select {
 	case <-op.finished.Done():

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1080,6 +1080,8 @@ func pruneExpireCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) 
 		if err != nil {
 			logger.Error("Failed to expire backups", logger.Ctx{"err": err})
 		}
+
+		op.Wait(ctx)
 		logger.Info("Done pruning expired custom volume snapshots")
 	}
 
@@ -1262,6 +1264,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to create scheduled volume snapshots", logger.Ctx{"err": err})
 		}
 
+		op.Wait(ctx)
 		logger.Info("Done creating scheduled volume snapshots")
 	}
 

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -432,6 +432,8 @@ func pruneResolvedWarningsTask(d *Daemon) (task.Func, task.Schedule) {
 		if err != nil {
 			logger.Error("Failed to prune resolved warnings", logger.Ctx{"err": err})
 		}
+
+		op.Wait(ctx)
 		logger.Info("Done pruning resolved warnings")
 	}
 


### PR DESCRIPTION
Introduces a lock to prevent image related background tasks from running concurrently with each other and potentially stepping on each other's toes by operating on the same image concurrently.

Also ensures other background tasks wait for the invocation to finish before the scheduler can run it again to avoid concurrent invocations of the same task.