### PR TITLE
doc: storage: clarification about sharing of storage volumes

### DIFF
--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -116,10 +116,11 @@ Each storage volume uses one of the following content types:
 : This content type is used for containers and container images.
   It is the default content type for custom storage volumes.
 
-  Custom storage volumes of content type `filesystem` can be attached to both containers and virtual machines.
+  Custom storage volumes of content type `filesystem` can be attached to both containers and virtual machines, and they can be shared between instances.
 
 `block`
 : This content type is used for virtual machines and virtual machine images.
   You can create a custom storage volume of type `block` by using the `--type=block` flag.
 
   Custom storage volumes of content type `block` can only be attached to virtual machines.
+  They should not be shared between instances, because simultaneous access can lead to data corruption.

--- a/doc/howto/storage_add_volume.md
+++ b/doc/howto/storage_add_volume.md
@@ -1,11 +1,11 @@
 (storage-add-volume)=
 # How to add a storage volume
 
-When you launch an instance, LXD automatically creates a storage volume that is used as the root disk for the instance.
+When you create an instance, LXD automatically creates a storage volume that is used as the root disk for the instance.
 
 You can add custom storage volumes to your instances.
 Such custom storage volumes are independent of the instance, which means that they can be backed up separately and are retained until you delete them.
-You can also share custom storage volumes between different instances.
+Custom storage volumes with content type `filesystem` can also be shared between different instances.
 
 See {ref}`storage-volumes` for detailed information.
 


### PR DESCRIPTION
Only filesystem storage volumes can be shared.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>