### PR TITLE
LXD: Move away from accepting revert.Reverter as an argument and instead return revert.Hook for cleanup

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -868,8 +868,8 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 
 // clusterInitMember initialises storage pools and networks on this member. We pass two LXD client instances, one
 // connected to ourselves (the joining member) and one connected to the target cluster member to join.
-// Returns a revert function that can be used to undo the setup if a subsequent step fails.
-func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberConfig []api.ClusterMemberConfigKey) (func(), error) {
+// Returns a revert fail function that can be used to undo this function if a subsequent step fails.
+func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberConfig []api.ClusterMemberConfigKey) (revert.Hook, error) {
 	data := initDataNode{}
 
 	// Fetch all pools currently defined in the cluster.

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -491,10 +491,11 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 		return nil, fmt.Errorf("Invalid instance type")
 	}
 
-	inst, instOp, err := instance.CreateInternal(s, *dbInst, false, revert)
+	inst, instOp, cleanup, err := instance.CreateInternal(s, *dbInst, false)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
+	revert.Add(cleanup)
 	defer instOp.Done(err)
 
 	return inst, err
@@ -527,7 +528,7 @@ func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Poo
 		return err
 	}
 
-	_, snapInstOp, err := instance.CreateInternal(s, db.InstanceArgs{
+	_, snapInstOp, cleanup, err := instance.CreateInternal(s, db.InstanceArgs{
 		Project:      projectName,
 		Architecture: arch,
 		BaseImage:    snap.Config["volatile.base_image"],
@@ -541,10 +542,11 @@ func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Poo
 		Name:         poolVol.Container.Name + shared.SnapshotDelimiter + snap.Name,
 		Profiles:     snap.Profiles,
 		Stateful:     snap.Stateful,
-	}, false, revert)
+	}, false)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance snapshot record %q: %w", snap.Name, err)
 	}
+	revert.Add(cleanup)
 	defer snapInstOp.Done(err)
 
 	return nil

--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -55,7 +55,7 @@ type RunConfig struct {
 	USBDevice        []USBDeviceItem  // USB device configuration settings.
 	TPMDevice        []RunConfigItem  // TPM device configuration settings.
 	PCIDevice        []RunConfigItem  // PCI device configuration settings.
-	Revert           *revert.Reverter // Revert setup of device on post-setup error.
+	Revert           revert.Hook      // Revert setup of device on post-setup error.
 }
 
 // NICConfigDir shared constant used to indicate where NIC config is stored.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -501,9 +501,9 @@ func DiskVMVirtiofsdStart(execPath string, inst instance.Instance, socketPath st
 		return nil, nil, fmt.Errorf("Failed to save virtiofsd state: %w", err)
 	}
 
-	revertExternal := revert.Clone()
+	cleanup := revert.Clone().Fail
 	revert.Success()
-	return revertExternal.Fail, listener, err
+	return cleanup, listener, err
 }
 
 // DiskVMVirtiofsdStop stops an existing virtiofsd process and cleans up.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -298,9 +298,9 @@ func diskAddRootUserNSEntry(idmaps []idmap.IdmapEntry, hostRootID int64) []idmap
 
 // DiskVMVirtfsProxyStart starts a new virtfs-proxy-helper process.
 // If the idmaps slice is supplied then the proxy process is run inside a user namespace using the supplied maps.
-// Returns a revert fail function that can be used to undo this function if a subsequent step fails,
-// and a file handle to the proxy process.
-func DiskVMVirtfsProxyStart(execPath string, pidPath string, sharePath string, idmaps []idmap.IdmapEntry) (revert.Hook, *os.File, error) {
+// Returns a file handle to the proxy process and a revert fail function that can be used to undo this function if
+// a subsequent step fails,
+func DiskVMVirtfsProxyStart(execPath string, pidPath string, sharePath string, idmaps []idmap.IdmapEntry) (*os.File, revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -384,9 +384,9 @@ func DiskVMVirtfsProxyStart(execPath string, pidPath string, sharePath string, i
 		return nil, nil, fmt.Errorf("Failed to save virtfs-proxy-helper state: %w", err)
 	}
 
-	revertExternal := revert.Clone()
+	cleanup := revert.Clone().Fail
 	revert.Success()
-	return revertExternal.Fail, cDialUnixFile, err
+	return cDialUnixFile, cleanup, err
 }
 
 // DiskVMVirtfsProxyStop stops the virtfs-proxy-helper process.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -298,8 +298,9 @@ func diskAddRootUserNSEntry(idmaps []idmap.IdmapEntry, hostRootID int64) []idmap
 
 // DiskVMVirtfsProxyStart starts a new virtfs-proxy-helper process.
 // If the idmaps slice is supplied then the proxy process is run inside a user namespace using the supplied maps.
-// Returns a revert function, and a file handle to the proxy process.
-func DiskVMVirtfsProxyStart(execPath string, pidPath string, sharePath string, idmaps []idmap.IdmapEntry) (func(), *os.File, error) {
+// Returns a revert fail function that can be used to undo this function if a subsequent step fails,
+// and a file handle to the proxy process.
+func DiskVMVirtfsProxyStart(execPath string, pidPath string, sharePath string, idmaps []idmap.IdmapEntry) (revert.Hook, *os.File, error) {
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1206,9 +1206,9 @@ func (d *disk) mountPoolVolume() (func(), string, error) {
 		}
 	}
 
-	revertExternal := revert.Clone() // Clone before calling revert.Success() so we can return the Fail func.
+	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
 	revert.Success()
-	return revertExternal.Fail, srcPath, err
+	return cleanup, srcPath, err
 }
 
 // createDevice creates a disk device mount on host.
@@ -1340,9 +1340,9 @@ func (d *disk) createDevice(srcPath string) (func(), string, bool, error) {
 	}
 	revert.Add(func() { _ = DiskMountClear(devPath) })
 
-	revertExternal := revert.Clone() // Clone before calling revert.Success() so we can return the Fail func.
+	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
 	revert.Success()
-	return revertExternal.Fail, devPath, isFile, err
+	return cleanup, devPath, isFile, err
 }
 
 // localSourceOpen opens a local disk source path and returns a file handle to it.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -656,9 +656,7 @@ func (d *disk) detectVMPoolMountOpts() []string {
 
 // startVM starts the disk device for a virtual machine instance.
 func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
-	runConf := deviceConfig.RunConfig{
-		Revert: revert.New(),
-	}
+	runConf := deviceConfig.RunConfig{}
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -694,7 +692,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 
 		revert.Add(func() { _ = f.Close() })
 		runConf.PostHooks = append(runConf.PostHooks, f.Close)
-		runConf.Revert.Add(func() { _ = f.Close() }) // Close file on VM start failure.
+		runConf.Revert = func() { _ = f.Close() } // Close file on VM start failure.
 
 		// Encode the file descriptor and original isoPath into the DevPath field.
 		runConf.Mounts = []deviceConfig.MountEntryItem{
@@ -868,7 +866,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				}
 				revert.Add(func() { _ = f.Close() })
 				runConf.PostHooks = append(runConf.PostHooks, f.Close)
-				runConf.Revert.Add(func() { _ = f.Close() }) // Close file on VM start failure.
+				runConf.Revert = func() { _ = f.Close() } // Close file on VM start failure.
 
 				// Encode the file descriptor and original srcPath into the DevPath field.
 				mount.DevPath = fmt.Sprintf("%s:%d:%s", DiskFileDescriptorMountPrefix, f.Fd(), mount.DevPath)

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -844,11 +844,11 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				// Start virtfs-proxy-helper for 9p share (this will rewrite mount.DevPath with
 				// socket FD number so must come after starting virtiofsd).
 				err = func() error {
-					revertFunc, sockFile, err := DiskVMVirtfsProxyStart(d.state.OS.ExecPath, d.vmVirtfsProxyHelperPaths(), mount.DevPath, rawIDMaps)
+					sockFile, cleanup, err := DiskVMVirtfsProxyStart(d.state.OS.ExecPath, d.vmVirtfsProxyHelperPaths(), mount.DevPath, rawIDMaps)
 					if err != nil {
 						return err
 					}
-					revert.Add(revertFunc)
+					revert.Add(cleanup)
 
 					// Request the unix socket is closed after QEMU has connected on startup.
 					runConf.PostHooks = append(runConf.PostHooks, sockFile.Close)

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -928,6 +928,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 }
 
 // setupHostFilters applies any host side network filters.
+// Returns a revert fail function that can be used to undo this function if a subsequent step fails.
 func (d *nicBridged) setupHostFilters(oldConfig deviceConfig.Device) (revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -957,9 +957,9 @@ func (d *nicBridged) setupHostFilters(oldConfig deviceConfig.Device) (revert.Hoo
 		revert.Add(func() { d.removeFilters(d.config) })
 	}
 
-	revertExternal := revert.Clone()
+	cleanup := revert.Clone().Fail
 	revert.Success()
-	return revertExternal.Fail, nil
+	return cleanup, nil
 }
 
 // removeFilters removes any network level filters defined for the instance.

--- a/lxd/init.go
+++ b/lxd/init.go
@@ -402,9 +402,9 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 		}
 	}
 
-	revertExternal := revert.Clone() // Clone before calling revert.Success() so we can return the Fail func.
+	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
 	revert.Success()
-	return revertExternal.Fail, nil
+	return cleanup, nil
 }
 
 // Helper to initialize LXD clustering.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -550,10 +550,11 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 	}
 
 	// Create the snapshot.
-	snap, snapInstOp, err := instance.CreateInternal(d.state, args, true, revert)
+	snap, snapInstOp, cleanup, err := instance.CreateInternal(d.state, args, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance snapshot record %q: %w", name, err)
 	}
+	revert.Add(cleanup)
 	defer snapInstOp.Done(err)
 
 	pool, err := storagePools.LoadByInstance(d.state, snap)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2067,7 +2067,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		}
 
 		if runConf.Revert != nil {
-			revert.Add(runConf.Revert.Fail)
+			revert.Add(runConf.Revert)
 		}
 
 		// Process rootfs setup.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1160,7 +1160,7 @@ func (d *qemu) Start(stateful bool) error {
 		}
 
 		if runConf.Revert != nil {
-			revert.Add(runConf.Revert.Fail)
+			revert.Add(runConf.Revert)
 		}
 
 		// Add post-start hooks

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -167,9 +167,11 @@ func qemuInstantiate(s *state.State, args db.InstanceArgs, expandedDevices devic
 }
 
 // qemuCreate creates a new storage volume record and returns an initialised Instance.
-// Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
-// revert's Fail() or Success() function as needed.
-func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
+// Returns a revert fail function that can be used to undo this function if a subsequent step fails.
+func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.Hook, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
 	// Create the instance struct.
 	d := &qemu{
 		common: common{
@@ -219,39 +221,39 @@ func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (
 	// Load the config.
 	err = d.init()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to expand config: %w", err)
+		return nil, nil, fmt.Errorf("Failed to expand config: %w", err)
 	}
 
 	// Validate expanded config (allows mixed instance types for profiles).
 	err = instance.ValidConfig(s.OS, d.expandedConfig, true, instancetype.Any)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid config: %w", err)
+		return nil, nil, fmt.Errorf("Invalid config: %w", err)
 	}
 
 	err = instance.ValidDevices(s, d.Project(), d.Type(), d.expandedDevices, true)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid devices: %w", err)
+		return nil, nil, fmt.Errorf("Invalid devices: %w", err)
 	}
 
 	// Retrieve the instance's storage pool.
 	_, rootDiskDevice, err := d.getRootDiskDevice()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if rootDiskDevice["pool"] == "" {
-		return nil, fmt.Errorf("The instances's root device is missing the pool property")
+		return nil, nil, fmt.Errorf("The instances's root device is missing the pool property")
 	}
 
 	// Initialize the storage pool.
 	d.storagePool, err = storagePools.LoadByName(d.state, rootDiskDevice["pool"])
 	if err != nil {
-		return nil, fmt.Errorf("Failed loading storage pool: %w", err)
+		return nil, nil, fmt.Errorf("Failed loading storage pool: %w", err)
 	}
 
 	volType, err := storagePools.InstanceTypeToVolumeType(d.Type())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	storagePoolSupported := false
@@ -263,7 +265,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (
 	}
 
 	if !storagePoolSupported {
-		return nil, fmt.Errorf("Storage pool does not support instance type")
+		return nil, nil, fmt.Errorf("Storage pool does not support instance type")
 	}
 
 	if !d.IsSnapshot() {
@@ -275,12 +277,12 @@ func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (
 					continue
 				}
 
-				return nil, fmt.Errorf("Failed to load device to add %q: %w", entry.Name, err)
+				return nil, nil, fmt.Errorf("Failed to load device to add %q: %w", entry.Name, err)
 			}
 
 			err = d.deviceAdd(dev, false)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to add device %q: %w", dev.Name(), err)
+				return nil, nil, fmt.Errorf("Failed to add device %q: %w", dev.Name(), err)
 			}
 
 			revert.Add(func() { _ = d.deviceRemove(dev, false) })
@@ -289,7 +291,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (
 		// Update MAAS (must run after the MAC addresses have been generated).
 		err = d.maasUpdate(d, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		revert.Add(func() { _ = d.maasDelete(d) })
@@ -303,7 +305,9 @@ func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, nil))
 	}
 
-	return d, nil
+	cleanup := revert.Clone().Fail
+	revert.Success()
+	return d, cleanup, err
 }
 
 // qemu is the QEMU virtual machine driver.

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -109,14 +109,14 @@ func validDevices(state *state.State, projectName string, instanceType instancet
 	return nil
 }
 
-func create(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
+func create(s *state.State, args db.InstanceArgs) (instance.Instance, revert.Hook, error) {
 	if args.Type == instancetype.Container {
-		return lxcCreate(s, args, revert)
+		return lxcCreate(s, args)
 	} else if args.Type == instancetype.VM {
-		return qemuCreate(s, args, revert)
+		return qemuCreate(s, args)
 	}
 
-	return nil, fmt.Errorf("Instance type invalid")
+	return nil, nil, fmt.Errorf("Instance type invalid")
 }
 
 // DriverStatuses returns a map of DriverStatus structs for all instance type drivers.

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -45,9 +45,8 @@ var ValidDevices func(state *state.State, projectName string, instanceType insta
 var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error)
 
 // Create is linked from instance/drivers.create to allow difference instance types to be created.
-// Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
-// revert's Fail() or Success() function as needed.
-var Create func(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (Instance, error)
+// Returns a revert fail function that can be used to undo this function if a subsequent step fails.
+var Create func(s *state.State, args db.InstanceArgs) (Instance, revert.Hook, error)
 
 // CompareSnapshots returns a list of snapshots to sync to the target and a list of
 // snapshots to remove from the target. A snapshot will be marked as "to sync" if it either doesn't

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -872,12 +872,16 @@ func ValidName(instanceName string, isSnapshot bool) error {
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to
 // call the revert's Fail() or Success() function as needed.
 // Returns the created instance, along with a "create" operation lock that needs to be marked as Done once the
-// instance is fully completed.
-func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, revert *revert.Reverter) (Instance, *operationlock.InstanceOperation, error) {
+// instance is fully completed, and a revert fail function that can be used to undo this function if a subsequent
+// step fails.
+func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Instance, *operationlock.InstanceOperation, revert.Hook, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
 	// Check instance type requested is supported by this machine.
 	err := s.InstanceTypes[args.Type]
 	if err != nil {
-		return nil, nil, fmt.Errorf("Instance type %q is not supported on this server: %w", args.Type, err)
+		return nil, nil, nil, fmt.Errorf("Instance type %q is not supported on this server: %w", args.Type, err)
 	}
 
 	// Set default values.
@@ -911,7 +915,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 
 	err = ValidName(args.Name, args.Snapshot)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if !args.Snapshot {
@@ -932,7 +936,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 	// Validate instance config.
 	err = ValidConfig(s.OS, args.Config, false, args.Type)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Leave validating devices to Create function call below.
@@ -940,27 +944,27 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 	// Validate architecture.
 	_, err = osarch.ArchitectureName(args.Architecture)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if !shared.IntInSlice(args.Architecture, s.OS.Architectures) {
-		return nil, nil, fmt.Errorf("Requested architecture isn't supported by this host")
+		return nil, nil, nil, fmt.Errorf("Requested architecture isn't supported by this host")
 	}
 
 	// Validate profiles.
 	profiles, err := s.DB.Cluster.GetProfileNames(args.Project)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	checkedProfiles := []string{}
 	for _, profile := range args.Profiles {
 		if !shared.StringInSlice(profile, profiles) {
-			return nil, nil, fmt.Errorf("Requested profile %q doesn't exist", profile)
+			return nil, nil, nil, fmt.Errorf("Requested profile %q doesn't exist", profile)
 		}
 
 		if shared.StringInSlice(profile, checkedProfiles) {
-			return nil, nil, fmt.Errorf("Duplicate profile found in request")
+			return nil, nil, nil, fmt.Errorf("Duplicate profile found in request")
 		}
 
 		checkedProfiles = append(checkedProfiles, profile)
@@ -977,7 +981,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 	// Prevent concurrent create requests for same instance.
 	op, err := operationlock.Create(args.Project, args.Name, operationlock.ActionCreate, false, false)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	revert.Add(func() { op.Done(err) })
 
@@ -1074,27 +1078,30 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 				thing = "Snapshot"
 			}
 
-			return nil, nil, fmt.Errorf("%s %q already exists", thing, args.Name)
+			return nil, nil, nil, fmt.Errorf("%s %q already exists", thing, args.Name)
 		}
 
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	revert.Add(func() { _ = s.DB.Cluster.DeleteInstance(dbInst.Project, dbInst.Name) })
 
 	args = db.InstanceToArgs(&dbInst)
-	inst, err := Create(s, args, revert)
+	inst, cleanup, err := Create(s, args)
 	if err != nil {
 		logger.Error("Failed initialising instance", logger.Ctx{"project": args.Project, "instance": args.Name, "type": args.Type, "err": err})
-		return nil, nil, fmt.Errorf("Failed initialising instance: %w", err)
+		return nil, nil, nil, fmt.Errorf("Failed initialising instance: %w", err)
 	}
+	revert.Add(cleanup)
 
 	// Wipe any existing log for this instance name.
 	if clearLogDir {
 		_ = os.RemoveAll(inst.LogPath())
 	}
 
-	return inst, op, nil
+	cleanup = revert.Clone().Fail
+	revert.Success()
+	return inst, op, cleanup, err
 }
 
 // NextSnapshotName finds the next snapshot for an instance.

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lxc/lxd/lxd/db/cluster"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
-	instanceDrivers "github.com/lxc/lxd/lxd/instance/drivers"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -169,15 +168,18 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	c2.IsRunning()
 	suite.Req.Nil(err)
 
-	// This causes the mock storage pool to be loaded internally, allowing it to match the created container.
-	err = c2.UpdateBackupFile()
+	apiC1, etagC1, err := c.RenderFull()
 	suite.Req.Nil(err)
 
-	instanceDrivers.PrepareEqualTest(c, c2)
+	apiC2, etagC2, err := c2.RenderFull()
+	suite.Req.Nil(err)
+
+	suite.Equal(etagC1, etagC2)
 	suite.Exactly(
-		c,
-		c2,
-		"The loaded container isn't excactly the same as the created one.")
+		apiC1,
+		apiC2,
+		"The loaded container isn't excactly the same as the created one.",
+	)
 }
 
 func (suite *containerTestSuite) TestContainer_Path_Regular() {

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -14,7 +14,6 @@ import (
 	instanceDrivers "github.com/lxc/lxd/lxd/instance/drivers"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
-	"github.com/lxc/lxd/lxd/revert"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -32,7 +31,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -84,7 +83,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -116,7 +115,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 	_, err := suite.d.State().DB.Cluster.CreateNetwork(project.Default, "unknownbr0", "", db.NetworkTypeBridge, nil)
 	suite.Req.Nil(err)
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -151,7 +150,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.Nil(err)
 
 	// Create the container
-	c, op, err := instance.CreateInternal(state, args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -189,7 +188,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -206,7 +205,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -222,7 +221,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
@@ -245,7 +244,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
 	err = c.Update(db.InstanceArgs{
@@ -297,7 +296,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
@@ -311,7 +310,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -321,24 +320,24 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
-	c1, op, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c1, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-1",
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, revert.New())
+	}, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
 
-	c2, op, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c2, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-2",
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, revert.New())
+	}, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c2.Delete(true) }()
@@ -364,24 +363,24 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
-	c1, op, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c1, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-1",
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
 		},
-	}, true, revert.New())
+	}, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
 
-	c2, op, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c2, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-2",
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, revert.New())
+	}, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c2.Delete(true) }()
@@ -407,14 +406,14 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
-	c1, op, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+	c1, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 		Type: instancetype.Container,
 		Name: "isol-1",
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
 			"raw.idmap":               "both 1000 1000",
 		},
-	}, true, revert.New())
+	}, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
@@ -447,13 +446,13 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 	maps := []*idmap.IdmapSet{}
 
 	for i := 0; i < 7; i++ {
-		c, op, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
+		c, op, _, err := instance.CreateInternal(suite.d.State(), db.InstanceArgs{
 			Type: instancetype.Container,
 			Name: fmt.Sprintf("isol-%d", i),
 			Config: map[string]string{
 				"security.idmap.isolated": "true",
 			},
-		}, true, revert.New())
+		}, true)
 
 		/* we should fail if there are no ids left */
 		if i != 6 {

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -952,10 +952,11 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 				}
 
 				// Create the snapshot instance.
-				_, snapInstOp, err := instance.CreateInternal(state, snapArgs, true, revert)
+				_, snapInstOp, cleanup, err := instance.CreateInternal(state, snapArgs, true)
 				if err != nil {
 					return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 				}
+				revert.Add(cleanup)
 				defer snapInstOp.Done(err)
 			}
 		}

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -649,11 +649,11 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 		// apply those rules to each network affected by the ACL, so pass the full list of OVN networks
 		// affected by this ACL (either because the ACL is assigned directly or because it is assigned to
 		// an OVN NIC in an instance or profile).
-		r, err := OVNEnsureACLs(d.state, d.logger, client, d.projectName, aclNameIDs, aclOVNNets, []string{d.info.Name}, true)
+		cleanup, err := OVNEnsureACLs(d.state, d.logger, client, d.projectName, aclNameIDs, aclOVNNets, []string{d.info.Name}, true)
 		if err != nil {
 			return fmt.Errorf("Failed ensuring ACL is configured in OVN: %w", err)
 		}
-		revert.Add(r.Fail)
+		revert.Add(cleanup)
 
 		// Run unused port group cleanup in case any formerly referenced ACL in this ACL's rules means that
 		// an ACL port group is now considered unused.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2243,11 +2243,11 @@ func (n *ovn) setup(update bool) error {
 			n.Name(): {Name: n.Name(), Type: n.Type(), ID: n.ID(), Config: n.Config()},
 		}
 
-		r, err := acl.OVNEnsureACLs(n.state, n.logger, client, n.Project(), aclNameIDs, aclNets, securityACLS, false)
+		cleanup, err := acl.OVNEnsureACLs(n.state, n.logger, client, n.Project(), aclNameIDs, aclNets, securityACLS, false)
 		if err != nil {
 			return fmt.Errorf("Failed ensuring security ACLs are configured in OVN for network: %w", err)
 		}
-		revert.Add(r.Fail)
+		revert.Add(cleanup)
 	}
 
 	revert.Success()
@@ -3489,11 +3489,11 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 				n.Name(): {Name: n.Name(), Type: n.Type(), ID: n.ID(), Config: n.Config()},
 			}
 
-			r, err := acl.OVNEnsureACLs(n.state, n.logger, client, n.Project(), aclNameIDs, aclNets, nicACLNames, false)
+			cleanup, err := acl.OVNEnsureACLs(n.state, n.logger, client, n.Project(), aclNameIDs, aclNets, nicACLNames, false)
 			if err != nil {
 				return "", fmt.Errorf("Failed ensuring security ACLs are configured in OVN for instance: %w", err)
 			}
-			revert.Add(r.Fail)
+			revert.Add(cleanup)
 
 			for _, aclName := range nicACLNames {
 				aclID, found := aclNameIDs[aclName]

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
-	"github.com/lxc/lxd/lxd/revert"
 )
 
 func (suite *containerTestSuite) TestSnapshotScheduling() {
@@ -18,7 +17,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 		Name:      "hal9000",
 	}
 
-	c, op, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
 	suite.Req.Nil(err)
 	suite.Equal(true, snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1188,7 +1188,7 @@ func (d *btrfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 	d.logger.Debug("Created read-only backup snapshot", logger.Ctx{"sourcePath": sourcePath, "path": mountPath})
 
 	cleanup := revert.Clone().Fail
-	defer revert.Success()
+	revert.Success()
 	return mountPath, cleanup, nil
 }
 

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -20,8 +20,8 @@ func (d *dir) withoutGetVolID() Driver {
 }
 
 // setupInitialQuota enables quota on a new volume and sets with an initial quota from config.
-// Returns a revert function that can be used to remove the quota if there is a subsequent error.
-func (d *dir) setupInitialQuota(vol Volume) (func(), error) {
+// Returns a revert fail function that can be used to undo this function if a subsequent step fails.
+func (d *dir) setupInitialQuota(vol Volume) (revert.Hook, error) {
 	if vol.IsVMBlock() {
 		return nil, nil
 	}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -2097,7 +2097,7 @@ func (d *zfs) readonlySnapshot(vol Volume) (string, *revert.Reverter, error) {
 		d.logger.Debug("Unmounted ZFS snapshot dataset", logger.Ctx{"dev": srcSnapshot, "path": tmpDir})
 	})
 
-	defer revert.Success()
+	revert.Success()
 	return tmpDir, revert.Clone(), nil
 }
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -479,10 +479,9 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		}
 	}
 
-	revertExternal := revert.Clone() // Clone before calling revert.Success() so we can return the Fail func.
-
+	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
 	revert.Success()
-	return postHook, revertExternal.Fail, nil
+	return postHook, cleanup, nil
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -868,7 +868,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 		return nil, nil, err
 	}
 
-	revertExternal := revert.Clone() // Clone before calling revert.Success() so we can return the Fail func.
+	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
 	revert.Success()
 
 	var postHook VolumePostHook
@@ -892,7 +892,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 		}
 	}
 
-	return postHook, revertExternal.Fail, nil
+	return postHook, cleanup, nil
 }
 
 // genericVFSCopyVolume copies a volume and its snapshots using a non-optimized method.

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -275,7 +275,7 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol Volume, conn io.ReadW
 
 // genericVFSCreateVolumeFromMigration receives a volume and its snapshots over a non-optimized method.
 // initVolume is run against the main volume (not the snapshots) and is often used for quota initialization.
-func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (func(), error), vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (revert.Hook, error), vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	// Check migration transport type matches volume type.
 	if vol.contentType == ContentTypeBlock {
 		if volTargetArgs.MigrationType.FSType != migration.MigrationFSType_BLOCK_AND_RSYNC {
@@ -897,7 +897,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 
 // genericVFSCopyVolume copies a volume and its snapshots using a non-optimized method.
 // initVolume is run against the main volume (not the snapshots) and is often used for quota initialization.
-func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (func(), error), vol Volume, srcVol Volume, srcSnapshots []Volume, refresh bool, allowInconsistent bool, op *operations.Operation) error {
+func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, error), vol Volume, srcVol Volume, srcSnapshots []Volume, refresh bool, allowInconsistent bool, op *operations.Operation) error {
 	if vol.contentType != srcVol.contentType {
 		return fmt.Errorf("Content type of source and target must be the same")
 	}


### PR DESCRIPTION
By returning a `revert.Hook` rather than accepting a `*revert.Revert` argument it is clearer who is responsible for the eventual cleanup when an error occurs (the called function itself if an error occurs internally or the caller of the functions if an error after the function has finished) and it aligns better with the wider use of `defer` or `revert.Fail()` patterns in the code base.

Its also clearer to return a `revert.Hook` which indicates the function is for revert cleanup, rather than returning a `func()` which is unclear that the returned function is for.

Also in places where we were returning a `*revert.Reverter`, we now return a `revert.Hook` for consistency.

Also fixes a couple of places where the call to `revert.Success()` was incorrectly deferred.