### PR TITLE
New `raw.qemu.conf` config option

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1677,3 +1677,6 @@ for overriding the evacuation mode traditionally set through
 ## resources\_pci\_vpd
 Adds a new VPD struct to the PCI resource entries.
 This struct extracts vendor provided data including the full product name and additional key/value configuration pairs.
+
+## qemu\_raw\_conf
+Introdues a `raw.qemu.conf` configuration key to override select sections of the generated qemu.conf.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -87,6 +87,7 @@ raw.apparmor                                    | blob      | -                 
 raw.idmap                                       | blob      | -                 | no            | unprivileged container    | Raw idmap configuration (e.g. "both 1000 1000")
 raw.lxc                                         | blob      | -                 | no            | container                 | Raw LXC configuration to be appended to the generated one
 raw.qemu                                        | blob      | -                 | no            | virtual-machine           | Raw Qemu configuration to be appended to the generated command line
+raw.qemu.conf                                   | blob      | -                 | no            | virtual-machine           | Addition/override to the generated qemu.conf file
 raw.seccomp                                     | blob      | -                 | no            | container                 | Raw Seccomp configuration
 security.devlxd                                 | boolean   | true              | no            | -                         | Controls the presence of /dev/lxd in the instance
 security.devlxd.images                          | boolean   | false             | no            | container                 | Controls the availability of the /1.0/images API over devlxd

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2796,6 +2796,8 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 		return "", nil, fmt.Errorf("Failed writing agent mounts file: %w", err)
 	}
 
+	// process any user-specified overrides
+	cfg = qemuRawCfgOverride(cfg, d.expandedConfig)
 	// Write the config file to disk.
 	sb := qemuStringifyCfg(cfg...)
 	configPath := filepath.Join(d.LogPath(), "qemu.conf")

--- a/lxd/instance/drivers/driver_qemu_config_override.go
+++ b/lxd/instance/drivers/driver_qemu_config_override.go
@@ -1,0 +1,254 @@
+package drivers
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const pattern = `\s*(?m:(?:\[([^\]]+)\](?:\[(\d+)\])?)|(?:([^=]+)[ \t]*=[ \t]*(?:"([^"]*)"|([^\n]*)))$)`
+
+var parser = regexp.MustCompile(pattern)
+
+type rawConfigKey struct {
+	sectionName string
+	index       uint
+	entryKey    string
+}
+
+type configMap map[rawConfigKey]string
+
+func sortedConfigKeys(cfgMap configMap) []rawConfigKey {
+	rv := []rawConfigKey{}
+
+	for k := range cfgMap {
+		rv = append(rv, k)
+	}
+
+	sort.Slice(rv, func(i, j int) bool {
+		return rv[i].sectionName < rv[j].sectionName ||
+			rv[i].index < rv[j].index ||
+			rv[i].entryKey < rv[j].entryKey
+	})
+
+	return rv
+}
+
+func parseConfOverride(confOverride string) configMap {
+	s := confOverride
+	rv := configMap{}
+	currentSectionName := ""
+	var currentIndex uint
+	currentEntryCount := 0
+
+	for {
+		loc := parser.FindStringSubmatchIndex(s)
+		if loc == nil {
+			break
+		}
+
+		if loc[2] > 0 {
+			if currentSectionName != "" && currentEntryCount == 0 {
+				// new section started and previous section ended without entries
+				k := rawConfigKey{
+					sectionName: currentSectionName,
+					index:       currentIndex,
+					entryKey:    "",
+				}
+				rv[k] = ""
+			}
+
+			currentEntryCount = 0
+			currentSectionName = strings.TrimSpace(s[loc[2]:loc[3]])
+			if loc[4] > 0 {
+				i, err := strconv.Atoi(s[loc[4]:loc[5]])
+				if err != nil || i < 0 {
+					panic("failed to parse index")
+				}
+				currentIndex = uint(i)
+			} else {
+				currentIndex = 0
+			}
+		} else {
+			entryKey := strings.TrimSpace(s[loc[6]:loc[7]])
+			var value string
+
+			if loc[8] > 0 {
+				// quoted value
+				value = s[loc[8]:loc[9]]
+			} else {
+				// unquoted value
+				value = strings.TrimSpace(s[loc[10]:loc[11]])
+			}
+
+			k := rawConfigKey{
+				sectionName: currentSectionName,
+				index:       currentIndex,
+				entryKey:    entryKey,
+			}
+
+			rv[k] = value
+			currentEntryCount++
+		}
+
+		s = s[loc[1]:]
+	}
+
+	if currentSectionName != "" && currentEntryCount == 0 {
+		// previous section ended without entries
+		k := rawConfigKey{
+			sectionName: currentSectionName,
+			index:       currentIndex,
+			entryKey:    "",
+		}
+		rv[k] = ""
+	}
+
+	return rv
+}
+
+func updateEntries(entries []cfgEntry, sk rawConfigKey, cfgMap configMap) []cfgEntry {
+	rv := []cfgEntry{}
+
+	for _, entry := range entries {
+
+		newEntry := cfgEntry{
+			key:   entry.key,
+			value: entry.value,
+		}
+
+		ek := rawConfigKey{sk.sectionName, sk.index, entry.key}
+		if val, ok := cfgMap[ek]; ok {
+			// override
+			delete(cfgMap, ek)
+			newEntry.value = val
+		}
+
+		rv = append(rv, newEntry)
+	}
+
+	return rv
+}
+
+func appendEntries(entries []cfgEntry, sk rawConfigKey, cfgMap configMap) []cfgEntry {
+	// sort to have deterministic output in the appended entries
+	sortedKeys := sortedConfigKeys(cfgMap)
+	// processed all modifications for the current section, now
+	// handle new entries
+	for _, rawKey := range sortedKeys {
+		if rawKey.sectionName != sk.sectionName || rawKey.index != sk.index {
+			continue
+		}
+
+		newEntry := cfgEntry{
+			key:   rawKey.entryKey,
+			value: cfgMap[rawKey],
+		}
+
+		entries = append(entries, newEntry)
+		delete(cfgMap, rawKey)
+	}
+
+	return entries
+}
+
+func updateSections(cfg []cfgSection, cfgMap configMap) []cfgSection {
+	newCfg := []cfgSection{}
+	sectionCounts := map[string]uint{}
+
+	for _, section := range cfg {
+		count, ok := sectionCounts[section.name]
+
+		if ok {
+			sectionCounts[section.name] = count + 1
+		} else {
+			sectionCounts[section.name] = 1
+		}
+
+		index := sectionCounts[section.name] - 1
+		sk := rawConfigKey{section.name, index, ""}
+
+		if val, ok := cfgMap[sk]; ok {
+			if val == "" {
+				// deleted section
+				delete(cfgMap, sk)
+				continue
+			}
+		}
+
+		newSection := cfgSection{
+			name:    section.name,
+			comment: section.comment,
+		}
+
+		newSection.entries = updateEntries(section.entries, sk, cfgMap)
+		newSection.entries = appendEntries(newSection.entries, sk, cfgMap)
+
+		newCfg = append(newCfg, newSection)
+	}
+
+	return newCfg
+}
+
+func appendSections(newCfg []cfgSection, cfgMap configMap) []cfgSection {
+	tmp := map[rawConfigKey]cfgSection{}
+	// sort to have deterministic output in the appended entries
+	sortedKeys := sortedConfigKeys(cfgMap)
+
+	for _, k := range sortedKeys {
+		if k.entryKey == "" {
+			// makes no sense to process section deletions (the only case where
+			// entryKey == "") since we are only adding new sections now
+			continue
+		}
+		sectionKey := rawConfigKey{k.sectionName, k.index, ""}
+		section, found := tmp[sectionKey]
+		if !found {
+			section = cfgSection{
+				name: k.sectionName,
+			}
+		}
+		section.entries = append(section.entries, cfgEntry{
+			key:   k.entryKey,
+			value: cfgMap[k],
+		})
+		tmp[sectionKey] = section
+	}
+
+	rawSections := []rawConfigKey{}
+	for rawSection := range tmp {
+		rawSections = append(rawSections, rawSection)
+	}
+
+	// Sort to have deterministic output in the appended sections
+	sort.Slice(rawSections, func(i, j int) bool {
+		return rawSections[i].sectionName < rawSections[j].sectionName ||
+			rawSections[i].index < rawSections[j].index
+	})
+
+	for _, rawSection := range rawSections {
+		newCfg = append(newCfg, tmp[rawSection])
+	}
+
+	return newCfg
+}
+
+func qemuRawCfgOverride(cfg []cfgSection, expandedConfig map[string]string) []cfgSection {
+	confOverride, ok := expandedConfig["raw.qemu.conf"]
+	if !ok {
+		return cfg
+	}
+
+	cfgMap := parseConfOverride(confOverride)
+
+	if len(cfgMap) == 0 {
+		// If no keys are found, we return the cfg unmodified.
+		return cfg
+	}
+
+	newCfg := updateSections(cfg, cfgMap)
+	newCfg = appendSections(newCfg, cfgMap)
+
+	return newCfg
+}

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -1064,6 +1065,505 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}}
 		for _, tc := range testCases {
 			runTest(tc.expected, qemuTPM(&tc.opts))
+		}
+	})
+
+	t.Run("qemu_raw_cfg_override", func(t *testing.T) {
+		cfg := []cfgSection{{
+			name: "global",
+			entries: []cfgEntry{
+				{key: "driver", value: "ICH9-LPC"},
+				{key: "property", value: "disable_s3"},
+				{key: "value", value: "1"},
+			},
+		}, {
+			name: "global",
+			entries: []cfgEntry{
+				{key: "driver", value: "ICH9-LPC"},
+				{key: "property", value: "disable_s4"},
+				{key: "value", value: "1"},
+			},
+		}, {
+			name: "memory",
+			entries: []cfgEntry{
+				{key: "size", value: "1024M"},
+			},
+		}, {
+			name: `device "qemu_gpu"`,
+			entries: []cfgEntry{
+				{key: "driver", value: "virtio-gpu-pci"},
+				{key: "bus", value: "qemu_pci3"},
+				{key: "addr", value: "00.0"},
+			},
+		}, {
+			name: `device "qemu_keyboard"`,
+			entries: []cfgEntry{
+				{key: "driver", value: "virtio-keyboard-pci"},
+				{key: "bus", value: "qemu_pci2"},
+				{key: "addr", value: "00.1"},
+			},
+		}}
+		testCases := []struct {
+			cfg       []cfgSection
+			overrides map[string]string
+			expected  string
+		}{{
+			// unmodified
+			cfg,
+			map[string]string{},
+			`[global]
+			driver = "ICH9-LPC"
+			property = "disable_s3"
+			value = "1"
+
+			[global]
+			driver = "ICH9-LPC"
+			property = "disable_s4"
+			value = "1"
+
+			[memory]
+			size = "1024M"
+
+			[device "qemu_gpu"]
+			driver = "virtio-gpu-pci"
+			bus = "qemu_pci3"
+			addr = "00.0"
+
+			[device "qemu_keyboard"]
+			driver = "virtio-keyboard-pci"
+			bus = "qemu_pci2"
+			addr = "00.1"`,
+		}, {
+			// override some keys
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[memory]
+						size = "4096M"
+
+						[device "qemu_gpu"]
+						driver = "qxl-vga"`,
+			},
+			`[global]
+			driver = "ICH9-LPC"
+			property = "disable_s3"
+			value = "1"
+
+			[global]
+			driver = "ICH9-LPC"
+			property = "disable_s4"
+			value = "1"
+
+			[memory]
+			size = "4096M"
+
+			[device "qemu_gpu"]
+			driver = "qxl-vga"
+			bus = "qemu_pci3"
+			addr = "00.0"
+
+			[device "qemu_keyboard"]
+			driver = "virtio-keyboard-pci"
+			bus = "qemu_pci2"
+			addr = "00.1"`,
+		}, {
+			// delete some keys
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[device "qemu_keyboard"]
+						driver = ""
+
+						[device "qemu_gpu"]
+						addr = ""`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s4"
+				value = "1"
+
+				[memory]
+				size = "1024M"
+
+				[device "qemu_gpu"]
+				driver = "virtio-gpu-pci"
+				bus = "qemu_pci3"
+
+				[device "qemu_keyboard"]
+				bus = "qemu_pci2"
+				addr = "00.1"`,
+		}, {
+			// add some keys to existing sections
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[memory]
+						somekey = "somevalue"
+						somekey2 =             "somevalue2"
+						somekey3 =   "somevalue3"
+						somekey4="somevalue4"
+
+						[device "qemu_keyboard"]
+						multifunction="off"
+
+						[device "qemu_gpu"]
+						multifunction=      "on"`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s4"
+				value = "1"
+
+				[memory]
+				size = "1024M"
+				somekey = "somevalue"
+				somekey2 = "somevalue2"
+				somekey3 = "somevalue3"
+				somekey4 = "somevalue4"
+
+				[device "qemu_gpu"]
+				driver = "virtio-gpu-pci"
+				bus = "qemu_pci3"
+				addr = "00.0"
+				multifunction = "on"
+
+				[device "qemu_keyboard"]
+				driver = "virtio-keyboard-pci"
+				bus = "qemu_pci2"
+				addr = "00.1"
+				multifunction = "off"`,
+		}, {
+			// edit/add/remove
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[memory]
+						size = "2048M"
+						[device "qemu_gpu"]
+						multifunction = "on"
+						[device "qemu_keyboard"]
+						addr = ""
+						bus = ""`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s4"
+				value = "1"
+
+				[memory]
+				size = "2048M"
+
+				[device "qemu_gpu"]
+				driver = "virtio-gpu-pci"
+				bus = "qemu_pci3"
+				addr = "00.0"
+				multifunction = "on"
+
+				[device "qemu_keyboard"]
+				driver = "virtio-keyboard-pci"`,
+		}, {
+			// delete sections
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[memory]
+						[device "qemu_keyboard"]
+						[global][1]`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[device "qemu_gpu"]
+				driver = "virtio-gpu-pci"
+				bus = "qemu_pci3"
+				addr = "00.0"`,
+		}, {
+			// add sections
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[object1]
+						key1     = "value1"
+						key2     = "value2"
+
+						[object "2"]
+						key3  = "value3"
+						[object "3"]
+						key4  = "value4"
+
+						[object "2"]
+						key5  = "value5"
+
+						[object1]
+						key6     = "value6"`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s4"
+				value = "1"
+
+				[memory]
+				size = "1024M"
+
+				[device "qemu_gpu"]
+				driver = "virtio-gpu-pci"
+				bus = "qemu_pci3"
+				addr = "00.0"
+
+				[device "qemu_keyboard"]
+				driver = "virtio-keyboard-pci"
+				bus = "qemu_pci2"
+				addr = "00.1"
+
+				[object "2"]
+				key3 = "value3"
+				key5 = "value5"
+
+				[object "3"]
+				key4 = "value4"
+
+				[object1]
+				key1 = "value1"
+				key2 = "value2"
+				key6 = "value6"`,
+		}, {
+			// add/remove sections
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[device "qemu_gpu"]
+						[object "2"]
+						key3  = "value3"
+						[object "3"]
+						key4  = "value4"
+						[object "2"]
+						key5  = "value5"`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s4"
+				value = "1"
+
+				[memory]
+				size = "1024M"
+
+				[device "qemu_keyboard"]
+				driver = "virtio-keyboard-pci"
+				bus = "qemu_pci2"
+				addr = "00.1"
+
+				[object "2"]
+				key3 = "value3"
+				key5 = "value5"
+
+				[object "3"]
+				key4 = "value4"`,
+		}, {
+			// edit keys of repeated sections
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[global][1]
+						property ="disable_s1"
+						[global]
+						property ="disable_s5"
+						[global][1]
+						value = ""
+						[global][0]
+						somekey ="somevalue"
+						[global][1]
+						anotherkey = "anothervalue"`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s5"
+				value = "1"
+				somekey = "somevalue"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s1"
+				anotherkey = "anothervalue"
+
+				[memory]
+				size = "1024M"
+
+				[device "qemu_gpu"]
+				driver = "virtio-gpu-pci"
+				bus = "qemu_pci3"
+				addr = "00.0"
+
+				[device "qemu_keyboard"]
+				driver = "virtio-keyboard-pci"
+				bus = "qemu_pci2"
+				addr = "00.1"`,
+		}, {
+			// create multiple sections with same name
+			cfg,
+			// note that for appending new sections, all that matters is that
+			// the index is higher than the existing indexes
+			map[string]string{
+				"raw.qemu.conf": `
+						[global][2]
+						property =  "new section"
+						[global][2]
+						value =     "new value"
+						[object][3]
+						k1 =        "v1"
+						[object][3]
+						k2 =        "v2"
+						[object][4]
+						k3 =        "v1"
+						[object][4]
+						k2 =        "v2"
+						[object][11]
+						k11 =  "v11"`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s4"
+				value = "1"
+
+				[memory]
+				size = "1024M"
+
+				[device "qemu_gpu"]
+				driver = "virtio-gpu-pci"
+				bus = "qemu_pci3"
+				addr = "00.0"
+
+				[device "qemu_keyboard"]
+				driver = "virtio-keyboard-pci"
+				bus = "qemu_pci2"
+				addr = "00.1"
+
+				[global]
+				property = "new section"
+				value = "new value"
+
+				[object]
+				k1 = "v1"
+				k2 = "v2"
+
+				[object]
+				k2 = "v2"
+				k3 = "v1"
+
+				[object]
+				k11 = "v11"`,
+		}, {
+			// mix all operations
+			cfg,
+			map[string]string{
+				"raw.qemu.conf": `
+						[memory]
+						size = "8192M"
+						[device "qemu_keyboard"]
+						multifunction=on
+						bus =
+						[device "qemu_gpu"]
+						[object "3"]
+						key4 = " value4 "
+						[object "2"]
+						key3 =   value3  
+						[object "3"]
+						key5 = "value5"`,
+			},
+			`[global]
+				driver = "ICH9-LPC"
+				property = "disable_s3"
+				value = "1"
+
+				[global]
+				driver = "ICH9-LPC"
+				property = "disable_s4"
+				value = "1"
+
+				[memory]
+				size = "8192M"
+
+				[device "qemu_keyboard"]
+				driver = "virtio-keyboard-pci"
+				addr = "00.1"
+				multifunction = "on"
+
+				[object "2"]
+				key3 = "value3"
+
+				[object "3"]
+				key4 = " value4 "
+				key5 = "value5"`,
+		}}
+		for _, tc := range testCases {
+			runTest(tc.expected, qemuRawCfgOverride(tc.cfg, tc.overrides))
+		}
+	})
+
+	t.Run("parse_conf_override", func(t *testing.T) {
+		input := `
+		[global]
+		key1 = "val1"
+		key3 = "val3"
+
+		[global][0]
+		key2 = "val2"
+
+		[global][1]
+		key1 = "val3"
+
+		[global][4]
+		key2 = "val4"
+
+		[global] 
+
+		[global][4]
+		[global][5]
+		`
+		expected := configMap{
+			{"global", 0, "key1"}: "val1",
+			{"global", 0, "key3"}: "val3",
+			{"global", 0, "key2"}: "val2",
+			{"global", 1, "key1"}: "val3",
+			{"global", 4, "key2"}: "val4",
+			{"global", 0, ""}:     "",
+			{"global", 4, ""}:     "",
+			{"global", 5, ""}:     "",
+		}
+		actual := parseConfOverride(input)
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected: %v. Got: %v", expected, actual)
 		}
 	})
 }

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -101,7 +101,7 @@ _have lxc && {
       migration.incremental.memory.goal nvidia.runtime \
       nvidia.driver.capabilities nvidia.require.cuda nvidia.require.driver \
       migration.incremental.memory.iterations raw.apparmor raw.idmap raw.qemu \
-      raw.lxc raw.seccomp security.idmap.base security.idmap.isolated \
+      raw.qemu.conf raw.lxc raw.seccomp security.idmap.base security.idmap.isolated \
       security.idmap.size security.devlxd security.devlxd.images \
       security.nesting security.privileged security.protection.delete \
       security.protection.shift security.secureboot \

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -275,7 +275,8 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	"migration.stateful": validate.Optional(validate.IsBool),
 
 	// Caller is responsible for full validation of any raw.* value.
-	"raw.qemu": validate.IsAny,
+	"raw.qemu":      validate.IsAny,
+	"raw.qemu.conf": validate.IsAny,
 
 	"security.agent.metrics": validate.Optional(validate.IsBool),
 	"security.secureboot":    validate.Optional(validate.IsBool),

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -334,6 +334,7 @@ var APIExtensions = []string{
 	"container_syscall_intercept_sysinfo",
 	"clustering_evacuation_mode",
 	"resources_pci_vpd",
+	"qemu_raw_conf",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This is my new attempt to implement a method for customizing the generated `qemu.conf` for VM instances. In my first PR (#9321) my goal was to modify the templates explicitly for every new config key/section that the user would have access to (that PR only the GPU driver could be modified).

The new approach is much more flexible while being less obtrusive (only one line is added to call the new function which handles overriding), and is made possible by the recent refactoring in how `qemu.conf` is generated. The goal here is to implement a mini DSL that allows users to have granular control over the generated `qemu.conf` for a VM instance using lxd config keys.

The new `qemuRawCfgOverride` function takes a `[]cfgSection` slice plus an expandedConfig map, and returns a new `[]cfgSection` slice representing the "edited" config.

To override a configuration entry, the user specifies the new value using a `raw.qemu.config.SECTION.ENTRY` lxd config key, where `SECTION` is the name of the `qemu.conf` config section, and `ENTRY` is the config key under `SECTION`. For example:

    raw.qemu.config.global.value: 0

will set:

    [global]
    value = "0"

If the value would already have been set in the generated config, then it will be overriden. Since `qemu.conf` allows multiple config sections with the exact same name, the lxd config can specify which section should be updated by using a bracket syntax like this:

    raw.qemu.config.global[1].value: 1

In the above example, the second `[global]` section would be changed (the bracket indexes start at 0). When the user doesn't specify an index, it is assumed to be "0", so the first example is equivalent to:

    raw.qemu.config.global[0].value: 0

Note that `qemu.conf` section names can have spaces and double quotes, so it required to specify the section exactly as it appears inside the brackets.  For example, to change the gpu driver, one could use:

    raw.qemu.config.device "qemu_gpu".driver: qxl-vga

Besides adding and editing entries/sections, the user can also delete by setting an empty string as the value. For example, to remove the `multifunction = "on"` entry from `[device "qemu_balloon"]`, one can use:

    raw.qemu.config.device "qemu_balloon".multifunction: ""

It is also possible to delete whole sections by specifying an empty string as the value without specifying the entry name. So, to delete the `device "qemu_balloon"` section, this could be used:

    raw.qemu.config.device "qemu_balloon": ""

One last thing to note is that section indexes (the bracket number after section name) are also used when appending new sections, but they don't have to follow a strict sequence. So if one specifies:

    raw.qemu.config.global[11].value: "10"
    raw.qemu.config.global[2].value: "1"

Then two new `[global]` sections will be appended to the end of the `qemu.conf` (assuming only 2 existed before), with the second one having the value "10".

The new code is fully covered with tests.


Closes #9766