### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3,6 +3,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   doc:
     name: Documentation (Sphinx)

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -2,8 +2,13 @@ name: Commits
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   dco-check:
+    permissions:
+      pull-requests: read  # for tim-actions/get-pr-commits to get list of commits from the PR
     name: Signed-off-by (DCO)
     runs-on: ubuntu-20.04
     steps:
@@ -19,6 +24,8 @@ jobs:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 
   target-branch:
+    permissions:
+      contents: none
     name: Branch target
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -2,8 +2,14 @@ name: Triaging
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   label:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     name: PR labels
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
