### PR TITLE
Storage: Restore missing instance volume snapshot DB records

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -68,6 +68,7 @@ var patches = []patch{
 	{name: "clustering_server_cert_trust", stage: patchPreDaemonStorage, run: patchClusteringServerCertTrust},
 	{name: "warnings_remove_empty_node", stage: patchPostDaemonStorage, run: patchRemoveWarningsWithEmptyNode},
 	{name: "dnsmasq_entries_include_device_name", stage: patchPostDaemonStorage, run: patchDnsmasqEntriesIncludeDeviceName},
+	{name: "storage_missing_snapshot_records", stage: patchPostDaemonStorage, run: patchGenericStorage},
 }
 
 type patch struct {

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -77,7 +77,7 @@ type patch struct {
 }
 
 func (p *patch) apply(d *Daemon) error {
-	logger.Infof("Applying patch %q", p.name)
+	logger.Info("Applying patch", logger.Ctx{"name": p.name})
 
 	err := p.run(p.name, d)
 	if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -463,6 +463,8 @@ func (b *lxdBackend) Unmount() (bool, error) {
 
 // ApplyPatch runs the requested patch at both backend and driver level.
 func (b *lxdBackend) ApplyPatch(name string) error {
+	b.logger.Info("Applying patch", logger.Ctx{"name": name})
+
 	// Run early backend patches.
 	patch, ok := lxdEarlyPatches[name]
 	if ok {

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -1,7 +1,128 @@
 package storage
 
-var lxdEarlyPatches = map[string]func(b *lxdBackend) error{}
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/storage/drivers"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
+)
+
+var lxdEarlyPatches = map[string]func(b *lxdBackend) error{
+	"storage_missing_snapshot_records": patchMissingSnapshotRecords,
+}
 
 var lxdLatePatches = map[string]func(b *lxdBackend) error{}
 
 // Patches start here.
+
+// patchMissingSnapshotRecords creates any missing storage volume records for instance volume snapshots.
+// This is needed because it seems that in 2019 some instance snapshots did not have their associated volume DB
+// records created. This later caused problems when we started validating that the instance snapshot DB record
+// count matched the volume snapshot DB record count.
+func patchMissingSnapshotRecords(b *lxdBackend) error {
+	var err error
+	var localNode string
+
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		localNode, err = tx.GetLocalNodeName()
+		if err != nil {
+			return fmt.Errorf("Failed to get local member name: %w", err)
+		}
+
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// Get instances on this local server (as the DB helper functions return volumes on local server), also
+	// avoids running the same queries on every cluster member for instances on shared storage.
+	filter := db.InstanceFilter{
+		Node: &localNode,
+	}
+
+	err = b.state.DB.Cluster.InstanceList(&filter, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+		// Check we can convert the instance to the volume type needed.
+		volType, err := InstanceTypeToVolumeType(inst.Type)
+		if err != nil {
+			return err
+		}
+
+		contentType := drivers.ContentTypeFS
+		if inst.Type == instancetype.VM {
+			contentType = drivers.ContentTypeBlock
+		}
+
+		// Get all the instance snapshot DB records.
+		var instPoolName string
+		var snapshots []db.Instance
+		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			instPoolName, err = tx.GetInstancePool(p.Name, inst.Name)
+			if err != nil {
+				if api.StatusErrorCheck(err, http.StatusNotFound) {
+					// If the instance cannot be associated to a pool its got bigger problems
+					// outside the scope of this patch. Will skip due to empty instPoolName.
+					return nil
+				}
+
+				return fmt.Errorf("Failed finding pool for instance %q in project %q: %w", inst.Name, p.Name, err)
+			}
+
+			snapshots, err = tx.GetInstanceSnapshotsWithName(p.Name, inst.Name)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		if instPoolName != b.Name() {
+			return nil // This instance isn't hosted on this storage pool, skip.
+		}
+
+		dbVol, err := VolumeDBGet(b, p.Name, inst.Name, volType)
+		if err != nil {
+			return fmt.Errorf("Failed loading storage volume record %q: %w", inst.Name, err)
+		}
+
+		// Get all the instance volume snapshot DB records.
+		dbVolSnaps, err := VolumeDBSnapshotsGet(b, p.Name, inst.Name, volType)
+		if err != nil {
+			return fmt.Errorf("Failed loading storage volume snapshot records %q: %w", inst.Name, err)
+		}
+
+		for i := range snapshots {
+			foundVolumeSnapshot := false
+			for _, dbVolSnap := range dbVolSnaps {
+				if dbVolSnap.Name == snapshots[i].Name {
+					foundVolumeSnapshot = true
+					break
+				}
+			}
+
+			if !foundVolumeSnapshot {
+				b.logger.Info("Creating missing volume snapshot record", logger.Ctx{"project": snapshots[i].Project, "instance": snapshots[i].Name})
+				err = VolumeDBCreate(b, snapshots[i].Project, snapshots[i].Name, "Auto repaired", volType, true, dbVol.Config, time.Time{}, contentType, false)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -31,7 +31,8 @@ type btrfs struct {
 func (d *btrfs) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_lvm_skipactivation": nil,
+		"storage_lvm_skipactivation":       nil,
+		"storage_missing_snapshot_records": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -29,7 +29,8 @@ type ceph struct {
 func (d *ceph) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_lvm_skipactivation": nil,
+		"storage_lvm_skipactivation":       nil,
+		"storage_missing_snapshot_records": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -27,7 +27,8 @@ type cephfs struct {
 func (d *cephfs) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_lvm_skipactivation": nil,
+		"storage_lvm_skipactivation":       nil,
+		"storage_missing_snapshot_records": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -20,7 +20,8 @@ type dir struct {
 func (d *dir) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_lvm_skipactivation": nil,
+		"storage_lvm_skipactivation":       nil,
+		"storage_missing_snapshot_records": nil,
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -33,7 +33,8 @@ type lvm struct {
 func (d *lvm) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_lvm_skipactivation": d.patchStorageSkipActivation,
+		"storage_lvm_skipactivation":       d.patchStorageSkipActivation,
+		"storage_missing_snapshot_records": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -41,7 +41,8 @@ type zfs struct {
 func (d *zfs) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_lvm_skipactivation": nil,
+		"storage_lvm_skipactivation":       nil,
+		"storage_missing_snapshot_records": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/pool_load.go
+++ b/lxd/storage/pool_load.go
@@ -251,14 +251,12 @@ func Patch(s *state.State, patchName string) error {
 	for _, poolName := range pools {
 		pool, err := LoadByName(s, poolName)
 		if err != nil {
-			if err == drivers.ErrUnknownDriver {
-				continue
-			}
+			return fmt.Errorf("Failed loading storage pool %q: %w", poolName, err)
+		}
 
-			err = pool.ApplyPatch(patchName)
-			if err != nil {
-				return fmt.Errorf("Failed applying patch to pool %q: %w", poolName, err)
-			}
+		err = pool.ApplyPatch(patchName)
+		if err != nil {
+			return fmt.Errorf("Failed applying patch to pool %q: %w", poolName, err)
 		}
 	}
 

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -195,7 +195,7 @@ func VolumeDBGet(pool Pool, projectName string, volumeName string, volumeType dr
 	_, vol, err := p.state.DB.Cluster.GetLocalStoragePoolVolume(projectName, volumeName, volDBType, pool.ID())
 	if err != nil {
 		if response.IsNotFoundError(err) {
-			return vol, fmt.Errorf("Storage volume %q of type %q does not exist on pool %q: %w", fmt.Sprintf("%s_%s", projectName, volumeName), volumeType, pool.Name(), err)
+			return vol, fmt.Errorf("Storage volume %q in project %q of type %q does not exist on pool %q: %w", volumeName, projectName, volumeType, pool.Name(), err)
 		}
 
 		return nil, err

--- a/test/main.sh
+++ b/test/main.sh
@@ -248,6 +248,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_snap_restore "snapshot restores"
     run_test test_snap_expiry "snapshot expiry"
     run_test test_snap_schedule "snapshot scheduling"
+    run_test test_snap_volume_db_recovery "snapshot volume database record recovery"
     run_test test_config_profiles "profiles and configuration"
     run_test test_config_edit "container configuration edit"
     run_test test_config_edit_container_snapshot_pool_config "container and snapshot volume configuration edit"


### PR DESCRIPTION
Fixes https://github.com/lxc/lxd/issues/10501

This patch detects missing instance volume snapshot DB records and recreates them using the parent volume's config.

Tested using:

```
lxc init images:ubuntu/jammy c1
lxc snapshot c1
lxc snapshot c1
lxd sql global 'delete from storage_volumes_snapshots where id IN(n,n)' # Using volume snapshot record IDs
lxc start c1
Error: Instance snapshot record count doesn't match instance snapshot volume record count
lxd shutdown
# start lxd
lxc storage volume ls <pool>
+----------------------+------------------------------------------------------------------+---------------+--------------+---------+
|         TYPE         |                               NAME                               |  DESCRIPTION  | CONTENT-TYPE | USED BY |
+----------------------+------------------------------------------------------------------+---------------+--------------+---------+
| container            | c1                                                               |               | filesystem   | 1       |
+----------------------+------------------------------------------------------------------+---------------+--------------+---------+
| container (snapshot) | c1/snap0                                                         | Auto repaired | filesystem   | 1       |
+----------------------+------------------------------------------------------------------+---------------+--------------+---------+
| container (snapshot) | c1/snap1                                                         | Auto repaired | filesystem   | 1       |
+----------------------+------------------------------------------------------------------+---------------+--------------+---------+
lxc start c1 # Starts OK
lxc restore c1 snap0 # Restores OK
```

This PR also fixes an issue that was preventing storage patches from being run.