### PR TITLE
doc: fix indentation for commands

### DIFF
--- a/doc/howto/network_bridge_resolved.md
+++ b/doc/howto/network_bridge_resolved.md
@@ -22,16 +22,16 @@ DNS address
 
   To retrieve the IPv4 address for the bridge, use the following command:
 
-        lxc network get <network_bridge> ipv4.address
+      lxc network get <network_bridge> ipv4.address
 
   To retrieve the IPv6 address for the bridge, use the following command:
 
-        lxc network get <network_bridge> ipv6.address
+      lxc network get <network_bridge> ipv6.address
 
 DNS domain
 : To retrieve the DNS domain name for the bridge, use the following command:
 
-        lxc network get <network_bridge> dns.domain
+      lxc network get <network_bridge> dns.domain
 
   If this option is not set, the default domain name is `lxd`.
 

--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -9,25 +9,25 @@ Complete the following steps to create a standalone OVN network that is connecte
 
 1. Install the OVN tools on the local server:
 
-        sudo apt install ovn-host ovn-central
+       sudo apt install ovn-host ovn-central
 
 1. Configure the OVN integration bridge:
 
-        sudo ovs-vsctl set open_vswitch . \
+       sudo ovs-vsctl set open_vswitch . \
           external_ids:ovn-remote=unix:/var/run/ovn/ovnsb_db.sock \
           external_ids:ovn-encap-type=geneve \
           external_ids:ovn-encap-ip=127.0.0.1
 
 1. Create an OVN network:
 
-        lxc network set <parent_network> ipv4.dhcp.ranges=<IP_range> ipv4.ovn.ranges=<IP_range>
-        lxc network create ovntest --type=ovn network=<parent_network>
+       lxc network set <parent_network> ipv4.dhcp.ranges=<IP_range> ipv4.ovn.ranges=<IP_range>
+       lxc network create ovntest --type=ovn network=<parent_network>
 
 1. Create an instance that uses the `ovntest` network:
 
-        lxc init ubuntu:22.04 c1
-        lxc config device override c1 eth0 network=ovntest
-        lxc start c1
+       lxc init ubuntu:22.04 c1
+       lxc config device override c1 eth0 network=ovntest
+       lxc start c1
 
 1. Run `lxc list` to show the instance information:
 
@@ -55,26 +55,27 @@ See the linked YouTube video for the complete tutorial using four machines.
 
    a. Install the OVN tools:
 
-        sudo apt install ovn-central ovn-host
+       sudo apt install ovn-central ovn-host
 
    b. Mark the OVN services as enabled to ensure that they are started when the machine boots:
 
-        systemctl enable ovn-central
-        systemctl enable ovn-host
+       systemctl enable ovn-central
+       systemctl enable ovn-host
 
    c. Stop OVN for now:
 
-        systemctl stop ovn-central
+       systemctl stop ovn-central
 
    d. Note down the IP address of the machine:
 
-        ip -4 a
+       ip -4 a
 
    e. Open `/etc/default/ovn-central` for editing.
 
    f. Paste in the following configuration (replace `<server_1>`, `<server_2>` and `<server_3>` with the IP addresses of the respective machines, and `<local>` with the IP address of the machine that you are on):
 
-        OVN_CTL_OPTS=" \
+     ```
+     OVN_CTL_OPTS=" \
           --db-nb-addr=<server_1> \
           --db-nb-create-insecure-remote=yes \
           --db-sb-addr=<server_1> \
@@ -83,19 +84,19 @@ See the linked YouTube video for the complete tutorial using four machines.
           --db-sb-cluster-local-addr=<local> \
           --ovn-northd-nb-db=tcp:<server_1>:6641,tcp:<server_2>:6641,tcp:<server_3>:6641 \
           --ovn-northd-sb-db=tcp:<server_1>:6642,tcp:<server_2>:6642,tcp:<server_3>:6642"
-
+     ```
    g. Start OVN:
 
-        systemctl start ovn-central
+       systemctl start ovn-central
 
 1. On the remaining machines, install only `ovn-host` and make sure it is enabled:
 
-        sudo apt install ovn-host
-        systemctl enable ovn-host
+       sudo apt install ovn-host
+       systemctl enable ovn-host
 
 1. On all machines, configure Open vSwitch (replace the variables as described above):
 
-        sudo ovs-vsctl set open_vswitch . \
+       sudo ovs-vsctl set open_vswitch . \
           external_ids:ovn-remote=tcp:<server_1>:6642,tcp:<server_2>:6642,tcp:<server_3>:6642 \
           external_ids:ovn-encap-type=geneve \
           external_ids:ovn-encap-ip=<local>
@@ -105,11 +106,11 @@ See the linked YouTube video for the complete tutorial using four machines.
    Then join the other machines with tokens by running `lxc cluster add <machine_name>` on the first machine and specifying the token when initializing LXD on the other machine.
 1. On the first machine, create and configure the uplink network:
 
-        lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_1>
-        lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_2>
-        lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_3>
-        lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_4>
-        lxc network create UPLINK --type=physical \
+       lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_1>
+       lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_2>
+       lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_3>
+       lxc network create UPLINK --type=physical parent=<uplink_interface> --target=<machine_name_4>
+       lxc network create UPLINK --type=physical \
           ipv4.ovn.ranges=<IP_range> \
           ipv6.ovn.ranges=<IP_range> \
           ipv4.gateway=<gateway> \
@@ -137,20 +138,20 @@ See the linked YouTube video for the complete tutorial using four machines.
 1. Still on the first machine, configure LXD to be able to communicate with the OVN DB cluster.
    To do so, find the value for `ovn-northd-nb-db` in `/etc/default/ovn-central` and provide it to LXD with the following command:
 
-        lxc config set network.ovn.northbound_connection <ovn-northd-nb-db>
+       lxc config set network.ovn.northbound_connection <ovn-northd-nb-db>
 
 1. Finally, create the actual OVN network (on the first machine):
 
-        lxc network create my-ovn --type=ovn
+       lxc network create my-ovn --type=ovn
 
 1. To test the OVN network, create some instances and check the network connectivity:
 
-        lxc launch images:ubuntu/22.04 c1 --network my-ovn
-        lxc launch images:ubuntu/22.04 c2 --network my-ovn
-        lxc launch images:ubuntu/22.04 c3 --network my-ovn
-        lxc launch images:ubuntu/22.04 c4 --network my-ovn
-        lxc list
-        lxc exec c4 bash
-        ping <IP of c1>
-        ping <nameserver>
-        ping6 -n www.linuxcontainers.org
+       lxc launch images:ubuntu/22.04 c1 --network my-ovn
+       lxc launch images:ubuntu/22.04 c2 --network my-ovn
+       lxc launch images:ubuntu/22.04 c3 --network my-ovn
+       lxc launch images:ubuntu/22.04 c4 --network my-ovn
+       lxc list
+       lxc exec c4 bash
+       ping <IP of c1>
+       ping <nameserver>
+       ping6 -n www.linuxcontainers.org

--- a/doc/howto/storage_create_pool.md
+++ b/doc/howto/storage_create_pool.md
@@ -20,113 +20,113 @@ See the following examples for how to create a storage pool using different stor
 
 Create a directory pool named `pool1`:
 
-     lxc storage create pool1 dir
+    lxc storage create pool1 dir
 
 Use the existing directory `/data/lxd` for `pool2`:
 
-     lxc storage create pool2 dir source=/data/lxd
+    lxc storage create pool2 dir source=/data/lxd
 ```
 ```{group-tab} Btrfs
 
 Create a loop-backed pool named `pool1`:
 
-     lxc storage create pool1 btrfs
+    lxc storage create pool1 btrfs
 
 Use the existing Btrfs file system at `/some/path` for `pool2`:
 
-     lxc storage create pool2 btrfs source=/some/path
+    lxc storage create pool2 btrfs source=/some/path
 
 Create a pool named `pool3` on `/dev/sdX`:
 
-     lxc storage create pool3 btrfs source=/dev/sdX
+    lxc storage create pool3 btrfs source=/dev/sdX
 ```
 ```{group-tab} LVM
 
 Create a loop-backed pool named `pool1` (the LVM volume group will also be called `pool1`):
 
-     lxc storage create pool1 lvm
+    lxc storage create pool1 lvm
 
 Use the existing LVM volume group called `my-pool` for `pool2`:
 
-     lxc storage create pool2 lvm source=my-pool
+    lxc storage create pool2 lvm source=my-pool
 
 Use the existing LVM thin pool called `my-pool` in volume group `my-vg` for `pool3`:
 
-     lxc storage create pool3 lvm source=my-vg lvm.thinpool_name=my-pool
+    lxc storage create pool3 lvm source=my-vg lvm.thinpool_name=my-pool
 
 Create a pool named `pool4` on `/dev/sdX` (the LVM volume group will also be called `pool4`):
 
-     lxc storage create pool4 lvm source=/dev/sdX
+    lxc storage create pool4 lvm source=/dev/sdX
 
 Create a pool named `pool5` on `/dev/sdX` with the LVM volume group name `my-pool`:
 
-     lxc storage create pool5 lvm source=/dev/sdX lvm.vg_name=my-pool
+    lxc storage create pool5 lvm source=/dev/sdX lvm.vg_name=my-pool
 ```
 ```{group-tab} ZFS
 
 Create a loop-backed pool named `pool1` (the ZFS zpool will also be called `pool1`):
 
-     lxc storage create pool1 zfs
+    lxc storage create pool1 zfs
 
 Create a loop-backed pool named `pool2` with the ZFS zpool name `my-tank`:
 
-     lxc storage create pool2 zfs zfs.pool_name=my-tank
+    lxc storage create pool2 zfs zfs.pool_name=my-tank
 
 Use the existing ZFS zpool `my-tank` for `pool3`:
 
-     lxc storage create pool3 zfs source=my-tank
+    lxc storage create pool3 zfs source=my-tank
 
 Use the existing ZFS data set `my-tank/slice` for `pool4`:
 
-     lxc storage create pool4 zfs source=my-tank/slice
+    lxc storage create pool4 zfs source=my-tank/slice
 
 Create a pool named `pool5` on `/dev/sdX` (the ZFS zpool will also be called `pool5`):
 
-     lxc storage create pool1 zfs source=/dev/sdX
+    lxc storage create pool1 zfs source=/dev/sdX
 
 Create a pool named `pool6` on `/dev/sdX` with the ZFS zpool name `my-tank`:
 
-     lxc storage create pool6 zfs source=/dev/sdX zfs.pool_name=my-tank
+    lxc storage create pool6 zfs source=/dev/sdX zfs.pool_name=my-tank
 ```
 ```{group-tab} Ceph
 
 Create an OSD storage pool named `pool1` in the default Ceph cluster (named `ceph`):
 
-     lxc storage create pool1 ceph
+    lxc storage create pool1 ceph
 
 Create an OSD storage pool named `pool2` in the Ceph cluster `my-cluster`:
 
-     lxc storage create pool2 ceph ceph.cluster_name=my-cluster
+    lxc storage create pool2 ceph ceph.cluster_name=my-cluster
 
 Create an OSD storage pool named `pool3` with the on-disk name `my-osd` in the default Ceph cluster:
 
-     lxc storage create pool3 ceph ceph.osd.pool_name=my-osd
+    lxc storage create pool3 ceph ceph.osd.pool_name=my-osd
 
 Use the existing OSD storage pool `my-already-existing-osd` for `pool4`:
 
-     lxc storage create pool4 ceph source=my-already-existing-osd
+    lxc storage create pool4 ceph source=my-already-existing-osd
 
 Use the existing OSD erasure-coded pool `ecpool` and the OSD replicated pool `rpl-pool` for `pool5`:
 
-     lxc storage create pool5 ceph source=rpl-pool ceph.osd.data_pool_name=ecpool
+    lxc storage create pool5 ceph source=rpl-pool ceph.osd.data_pool_name=ecpool
 ```
 ```{group-tab} CephFS
 
 Create a storage pool named `pool1` in the default Ceph cluster (named `ceph`):
 
-     lxc storage create pool1 cephfs
+    lxc storage create pool1 cephfs
 
 Create a storage pool named `pool2` in the Ceph cluster `my-cluster`:
 
-     lxc storage create pool2 cephfs cephfs.cluster_name=my-cluster
+    lxc storage create pool2 cephfs cephfs.cluster_name=my-cluster
 
 Use the existing storage pool `my-filesystem` for `pool3`:
 
-     lxc storage create pool3 cephfs source=my-filesystem
+    lxc storage create pool3 cephfs source=my-filesystem
 
 Use the sub-directory `my-directory` from the `my-filesystem` pool for `pool4`:
 
-     lxc storage create pool4 cephfs source=my-filesystem/my-directory
+    lxc storage create pool4 cephfs source=my-filesystem/my-directory
 
 ```
 ````
@@ -142,12 +142,11 @@ Then create the storage pool without specifying the `--target` flag to actually 
 
 For example, the following series of commands sets up a storage pool with the name `my-pool` at different locations and with different sizes on three cluster members:
 
-```bash
-lxc storage create my-pool zfs source=/dev/sdX size=10GB --target=vm01
-lxc storage create my-pool zfs source=/dev/sdX size=15GB --target=vm02
-lxc storage create my-pool zfs source=/dev/sdY size=10GB --target=vm03
-lxc storage create my-pool zfs
-```
+    lxc storage create my-pool zfs source=/dev/sdX size=10GB --target=vm01
+    lxc storage create my-pool zfs source=/dev/sdX size=15GB --target=vm02
+    lxc storage create my-pool zfs source=/dev/sdY size=10GB --target=vm03
+    lxc storage create my-pool zfs
+
 
 ```{note}
 For most storage drivers, the storage pools exist locally on each cluster member.


### PR DESCRIPTION
Fix the indentation for commands so they don't display with
a leading space.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>