### PR TITLE
Generator: Handle Devices as a collection

### DIFF
--- a/lxd/db/cluster/certificate_projects.interface.mapper.go
+++ b/lxd/db/cluster/certificate_projects.interface.mapper.go
@@ -17,9 +17,9 @@ type CertificateProjectGenerated interface {
 	// generator: certificate_project DeleteMany
 	DeleteCertificateProjects(ctx context.Context, tx *sql.Tx, certificateID int) error
 
-	// CreateCertificateProject adds a new certificate_project to the database.
+	// CreateCertificateProjects adds a new certificate_project to the database.
 	// generator: certificate_project Create
-	CreateCertificateProject(ctx context.Context, tx *sql.Tx, object CertificateProject) (int64, error)
+	CreateCertificateProjects(ctx context.Context, tx *sql.Tx, objects []CertificateProject) error
 
 	// UpdateCertificateProjects updates the certificate_project matching the given key parameters.
 	// generator: certificate_project Update

--- a/lxd/db/cluster/devices.interface.mapper.go
+++ b/lxd/db/cluster/devices.interface.mapper.go
@@ -13,9 +13,9 @@ type DeviceGenerated interface {
 	// generator: device GetMany
 	GetDevices(ctx context.Context, tx *sql.Tx, parent string) (map[int][]Device, error)
 
-	// CreateDevice adds a new device to the database.
+	// CreateDevices adds a new device to the database.
 	// generator: device Create
-	CreateDevice(ctx context.Context, tx *sql.Tx, parent string, object Device) error
+	CreateDevices(ctx context.Context, tx *sql.Tx, parent string, objects map[string]Device) error
 
 	// UpdateDevices updates the device matching the given key parameters.
 	// generator: device Update

--- a/lxd/db/cluster/profiles.interface.mapper.go
+++ b/lxd/db/cluster/profiles.interface.mapper.go
@@ -33,13 +33,13 @@ type ProfileGenerated interface {
 	// generator: profile GetOne
 	GetProfile(ctx context.Context, tx *sql.Tx, project string, name string) (*Profile, error)
 
-	// CreateProfileConfig adds a new profile Config to the database.
+	// CreateProfileConfig adds new profile Config to the database.
 	// generator: profile Create
 	CreateProfileConfig(ctx context.Context, tx *sql.Tx, profileID int64, config map[string]string) error
 
-	// CreateProfileDevice adds a new profile Device to the database.
+	// CreateProfileDevices adds new profile Devices to the database.
 	// generator: profile Create
-	CreateProfileDevice(ctx context.Context, tx *sql.Tx, profileID int64, device Device) error
+	CreateProfileDevices(ctx context.Context, tx *sql.Tx, profileID int64, devices map[string]Device) error
 
 	// CreateProfile adds a new profile to the database.
 	// generator: profile Create

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -270,11 +270,15 @@ func CreateProfile(ctx context.Context, tx *sql.Tx, object Profile) (int64, erro
 	return id, nil
 }
 
-// CreateProfileDevice adds a new profile Device to the database.
+// CreateProfileDevices adds new profile Devices to the database.
 // generator: profile Create
-func CreateProfileDevice(ctx context.Context, tx *sql.Tx, profileID int64, device Device) error {
-	device.ReferenceID = int(profileID)
-	err := CreateDevice(ctx, tx, "profile", device)
+func CreateProfileDevices(ctx context.Context, tx *sql.Tx, profileID int64, devices map[string]Device) error {
+	for key, device := range devices {
+		device.ReferenceID = int(profileID)
+		devices[key] = device
+	}
+
+	err := CreateDevices(ctx, tx, "profile", devices)
 	if err != nil {
 		return fmt.Errorf("Insert Device failed for Profile: %w", err)
 	}
@@ -282,7 +286,7 @@ func CreateProfileDevice(ctx context.Context, tx *sql.Tx, profileID int64, devic
 	return nil
 }
 
-// CreateProfileConfig adds a new profile Config to the database.
+// CreateProfileConfig adds new profile Config to the database.
 // generator: profile Create
 func CreateProfileConfig(ctx context.Context, tx *sql.Tx, profileID int64, config map[string]string) error {
 	referenceID := int(profileID)

--- a/lxd/db/cluster/projects.interface.mapper.go
+++ b/lxd/db/cluster/projects.interface.mapper.go
@@ -25,7 +25,7 @@ type ProjectGenerated interface {
 	// generator: project Exists
 	ProjectExists(ctx context.Context, tx *sql.Tx, name string) (bool, error)
 
-	// CreateProjectConfig adds a new project Config to the database.
+	// CreateProjectConfig adds new project Config to the database.
 	// generator: project Create
 	CreateProjectConfig(ctx context.Context, tx *sql.Tx, projectID int64, config map[string]string) error
 

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -192,7 +192,7 @@ func CreateProject(ctx context.Context, tx *sql.Tx, object Project) (int64, erro
 	return id, nil
 }
 
-// CreateProjectConfig adds a new project Config to the database.
+// CreateProjectConfig adds new project Config to the database.
 // generator: project Create
 func CreateProjectConfig(ctx context.Context, tx *sql.Tx, projectID int64, config map[string]string) error {
 	referenceID := int(projectID)

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -199,7 +199,7 @@ func TestInstanceList(t *testing.T) {
 			return err
 		}
 
-		err = cluster.CreateProfileDevice(ctx, tx.Tx(), id, profileDevices["root"])
+		err = cluster.CreateProfileDevices(ctx, tx.Tx(), id, profileDevices)
 		if err != nil {
 			return err
 		}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -302,12 +302,9 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		for _, device := range devices {
-			err = dbCluster.CreateProfileDevice(ctx, tx.Tx(), id, device)
-			if err != nil {
-				return err
-			}
-
+		err = dbCluster.CreateProfileDevices(ctx, tx.Tx(), id, devices)
+		if err != nil {
+			return err
 		}
 
 		return err


### PR DESCRIPTION
To keep this in line with how we handle `Config` fields for entities (Instances, Profiles, etc), this updates the generator to expect a `map[string]cluster.Device` for generated database CRUD functions. 