### PR TITLE
Device: Allow copying and snapshot restoring instance snapshots that results in device confict

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -355,6 +355,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 // checkAddressConflict checks for conflicting IP/MAC addresses on another NIC connected to same network on the
 // same cluster member. Can only validate this when the instance is supplied (and not doing profile validation).
+// Returns api.StatusError with status code set to http.StatusConflict if conflicting address found.
 func (d *nicBridged) checkAddressConflict() error {
 	node := d.inst.Location()
 	filter := cluster.InstanceFilter{
@@ -425,7 +426,7 @@ func (d *nicBridged) checkAddressConflict() error {
 			}
 
 			if ourNICMAC != nil && devNICMAC != nil && bytes.Equal(ourNICMAC, devNICMAC) {
-				return fmt.Errorf("MAC address %q already defined on another NIC", devNICMAC.String())
+				return api.StatusErrorf(http.StatusConflict, "MAC address %q already defined on another NIC", devNICMAC.String())
 			}
 
 			// Check NIC's static IPs don't match this NIC's static IPs.
@@ -438,7 +439,7 @@ func (d *nicBridged) checkAddressConflict() error {
 				devNICIP := net.ParseIP(devConfig[key])
 
 				if ourNICIPs[key] != nil && devNICIP != nil && ourNICIPs[key].Equal(devNICIP) {
-					return fmt.Errorf("IP address %q already defined on another NIC", devNICIP.String())
+					return api.StatusErrorf(http.StatusConflict, "IP address %q already defined on another NIC", devNICIP.String())
 				}
 			}
 		}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -289,98 +289,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 	// Check there isn't another NIC with any of the same addresses specified on the same cluster member.
 	// Can only validate this when the instance is supplied (and not doing profile validation).
 	if d.inst != nil {
-		node := d.inst.Location()
-		filter := cluster.InstanceFilter{
-			Node: &node, // Managed bridge networks have a per-server DHCP daemon.
-		}
-
-		ourNICIPs := make(map[string]net.IP, 2)
-		ourNICIPs["ipv4.address"] = net.ParseIP(d.config["ipv4.address"])
-		ourNICIPs["ipv6.address"] = net.ParseIP(d.config["ipv6.address"])
-
-		ourNICMAC, _ := net.ParseMAC(d.config["hwaddr"])
-		if ourNICMAC == nil {
-			v := d.volatileGet()
-			ourNICMAC, _ = net.ParseMAC(v["hwaddr"])
-		}
-
-		err := d.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
-			// Get the instance's effective network project name.
-			instNetworkProject := project.NetworkProjectFromRecord(&p)
-
-			if instNetworkProject != project.Default {
-				return nil // Managed bridge networks can only exist in default project.
-			}
-
-			devices := db.ExpandInstanceDevices(inst.Devices.Clone(), profiles)
-			// Iterate through each of the instance's devices, looking for NICs that are linked to
-			// the same network, on the same cluster member as this NIC and have matching static IPs.
-			for devName, devConfig := range devices {
-				if devConfig["type"] != "nic" {
-					continue
-				}
-
-				// Skip NICs that specify a NIC type that is not the same as our own.
-				if !shared.StringInSlice(devConfig["nictype"], []string{"", "bridged"}) {
-					continue
-				}
-
-				// Skip our own device. This avoids triggering duplicate device errors during
-				// updates or when making temporary copies of our instance during migrations.
-				if instance.IsSameLogicalInstance(d.inst, &inst) && d.Name() == devName {
-					continue
-				}
-
-				// Skip NICs not connected to our NIC's managed network.
-				// If our NIC is connected to a managed network (either via network or parent keys)
-				// but the other NIC doesn't reference the same network name via either its network
-				// or parent keys then we can say it is connected to a different network, so the
-				// duplicate checks can be skipped.
-				if d.network != nil && !network.NICUsesNetwork(devConfig, &api.Network{Name: d.network.Name()}) {
-					continue
-				}
-
-				// Skip NICs that are connected to a managed network or different unmanaged parent
-				// when we are not connected to a managed network.
-				if d.network == nil && (devConfig["network"] != "" || d.config["parent"] != devConfig["parent"]) {
-					continue
-				}
-
-				// Skip NICs connected to other VLANs (not perfect though as one NIC could
-				// explicitly specify the default untagged VLAN and these would be connected to
-				// same L2 even though the values are different, and there is a different default
-				// value for native and openvswith parent bridges).
-				if d.config["vlan"] != devConfig["vlan"] {
-					continue
-				}
-
-				// Check NIC's MAC address doesn't match this NIC's MAC address.
-				devNICMAC, _ := net.ParseMAC(devConfig["hwaddr"])
-				if devNICMAC == nil {
-					devNICMAC, _ = net.ParseMAC(inst.Config[fmt.Sprintf("volatile.%s.hwaddr", devName)])
-				}
-
-				if ourNICMAC != nil && devNICMAC != nil && bytes.Equal(ourNICMAC, devNICMAC) {
-					return fmt.Errorf("MAC address %q already defined on another NIC", devNICMAC.String())
-				}
-
-				// Check NIC's static IPs don't match this NIC's static IPs.
-				for _, key := range []string{"ipv4.address", "ipv6.address"} {
-					if d.config[key] == "" {
-						continue // No static IP specified on this NIC.
-					}
-
-					// Parse IPs to avoid being tripped up by presentation differences.
-					devNICIP := net.ParseIP(devConfig[key])
-
-					if ourNICIPs[key] != nil && devNICIP != nil && ourNICIPs[key].Equal(devNICIP) {
-						return fmt.Errorf("IP address %q already defined on another NIC", devNICIP.String())
-					}
-				}
-			}
-
-			return nil
-		})
+		err := d.checkAddressConflict()
 		if err != nil {
 			return err
 		}
@@ -442,6 +351,100 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	return nil
+}
+
+// checkAddressConflict checks for conflicting IP/MAC addresses on another NIC connected to same network on the
+// same cluster member. Can only validate this when the instance is supplied (and not doing profile validation).
+func (d *nicBridged) checkAddressConflict() error {
+	node := d.inst.Location()
+	filter := cluster.InstanceFilter{
+		Node: &node, // Managed bridge networks have a per-server DHCP daemon.
+	}
+
+	ourNICIPs := make(map[string]net.IP, 2)
+	ourNICIPs["ipv4.address"] = net.ParseIP(d.config["ipv4.address"])
+	ourNICIPs["ipv6.address"] = net.ParseIP(d.config["ipv6.address"])
+
+	ourNICMAC, _ := net.ParseMAC(d.config["hwaddr"])
+	if ourNICMAC == nil {
+		ourNICMAC, _ = net.ParseMAC(d.volatileGet()["hwaddr"])
+	}
+
+	return d.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+		// Get the instance's effective network project name.
+		instNetworkProject := project.NetworkProjectFromRecord(&p)
+		if instNetworkProject != project.Default {
+			return nil // Managed bridge networks can only exist in default project.
+		}
+
+		// Iterate through each of the instance's devices, looking for NICs that are linked to
+		// the same network, on the same cluster member as this NIC and have matching static IPs.
+		for devName, devConfig := range db.ExpandInstanceDevices(inst.Devices.Clone(), profiles) {
+			if devConfig["type"] != "nic" {
+				continue
+			}
+
+			// Skip NICs that specify a NIC type that is not the same as our own.
+			if !shared.StringInSlice(devConfig["nictype"], []string{"", "bridged"}) {
+				continue
+			}
+
+			// Skip our own device. This avoids triggering duplicate device errors during
+			// updates or when making temporary copies of our instance during migrations.
+			if instance.IsSameLogicalInstance(d.inst, &inst) && d.Name() == devName {
+				continue
+			}
+
+			// Skip NICs not connected to our NIC's managed network.
+			// If our NIC is connected to a managed network (either via network or parent keys)
+			// but the other NIC doesn't reference the same network name via either its network
+			// or parent keys then we can say it is connected to a different network, so the
+			// duplicate checks can be skipped.
+			if d.network != nil && !network.NICUsesNetwork(devConfig, &api.Network{Name: d.network.Name()}) {
+				continue
+			}
+
+			// Skip NICs that are connected to a managed network or different unmanaged parent
+			// when we are not connected to a managed network.
+			if d.network == nil && (devConfig["network"] != "" || d.config["parent"] != devConfig["parent"]) {
+				continue
+			}
+
+			// Skip NICs connected to other VLANs (not perfect though as one NIC could
+			// explicitly specify the default untagged VLAN and these would be connected to
+			// same L2 even though the values are different, and there is a different default
+			// value for native and openvswith parent bridges).
+			if d.config["vlan"] != devConfig["vlan"] {
+				continue
+			}
+
+			// Check NIC's MAC address doesn't match this NIC's MAC address.
+			devNICMAC, _ := net.ParseMAC(devConfig["hwaddr"])
+			if devNICMAC == nil {
+				devNICMAC, _ = net.ParseMAC(inst.Config[fmt.Sprintf("volatile.%s.hwaddr", devName)])
+			}
+
+			if ourNICMAC != nil && devNICMAC != nil && bytes.Equal(ourNICMAC, devNICMAC) {
+				return fmt.Errorf("MAC address %q already defined on another NIC", devNICMAC.String())
+			}
+
+			// Check NIC's static IPs don't match this NIC's static IPs.
+			for _, key := range []string{"ipv4.address", "ipv6.address"} {
+				if d.config[key] == "" {
+					continue // No static IP specified on this NIC.
+				}
+
+				// Parse IPs to avoid being tripped up by presentation differences.
+				devNICIP := net.ParseIP(devConfig[key])
+
+				if ourNICIPs[key] != nil && devNICIP != nil && ourNICIPs[key].Equal(devNICIP) {
+					return fmt.Errorf("IP address %q already defined on another NIC", devNICIP.String())
+				}
+			}
+		}
+
+		return nil
+	})
 }
 
 // validateEnvironment checks the runtime environment for correctness.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1936,7 +1936,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	for i, entry := range sortedDevices {
 		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed start validation for device %q: %w", dev.Name(), err)
+			return "", nil, fmt.Errorf("Failed start validation for device %q: %w", entry.Name, err)
 		}
 
 		// Run pre-start of check all devices before starting any device to avoid expensive revert.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1105,7 +1105,7 @@ func (d *qemu) Start(stateful bool) error {
 		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
 		if err != nil {
 			op.Done(err)
-			return fmt.Errorf("Failed start validation for device %q: %w", dev.Name(), err)
+			return fmt.Errorf("Failed start validation for device %q: %w", entry.Name, err)
 		}
 
 		// Run pre-start of check all devices before starting any device to avoid expensive revert.


### PR DESCRIPTION
This allows the instance copy (or restored instance snapshot) operation to complete if there are device conflicts (such as NIC address conflicts with another instance's NIC), so they can be manually fixed before the instances can be started.

Builds on the work of @Viktor-Yakovchuk in https://github.com/lxc/lxd/pull/10363

The key difference between the original idea to fix this issue and this PR is that we do not remove the device `Add()` step.
Because removing this step would mean that NIC devices would not be able to reserve their static IPs via a static DHCP reservation at add time.

Instead this PR will optimistically try and reserve static IPs as DHCP leases, but if the config is conflicting with an existing instance, then it will skip the reservation.

In the end we didn't need the logic to detect a missing dnsmasq entry at start time, as in order to fix the conflict one must issue a config update, which will trigger a dnsmasq entry rebuild. 

Because for `bridged` NICs each DHCP reservation is in its own per-instance-per-NIC dnsmasq config file, when the conflicting instance NIC is removed, it doesn't interfere with the original instance NIC's dnsmasq config file. So we don't have to worry about accidentally removing the DHCP reservation for the original instance NIC. 
**Note: This may not be the case when we come to implement this for `ovn` NICs!**

Fixes https://github.com/lxc/lxd/issues/10114

Depends on https://github.com/lxc/lxd/pull/10551