### PR TITLE
Fix sysinfo boottime

### DIFF
--- a/lxd/cgroup/abstraction.go
+++ b/lxd/cgroup/abstraction.go
@@ -507,6 +507,10 @@ func (cg *CGroup) GetMemorySwapLimit() (int64, error) {
 			return -1, err
 		}
 
+		if val == "max" {
+			return shared.GetMeminfo("SwapTotal")
+		}
+
 		n, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return 0, fmt.Errorf("Failed parsing %q: %w", val, err)

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -290,6 +290,10 @@ func intArrayToString(arr any) string {
 }
 
 func DeviceTotalMemory() (int64, error) {
+	return GetMeminfo("MemTotal")
+}
+
+func GetMeminfo(field string) (int64, error) {
 	// Open /proc/meminfo
 	f, err := os.Open("/proc/meminfo")
 	if err != nil {
@@ -303,7 +307,7 @@ func DeviceTotalMemory() (int64, error) {
 		line := scan.Text()
 
 		// We only care about MemTotal
-		if !strings.HasPrefix(line, "MemTotal:") {
+		if !strings.HasPrefix(line, field+":") {
 			continue
 		}
 
@@ -320,7 +324,7 @@ func DeviceTotalMemory() (int64, error) {
 		return valueBytes, nil
 	}
 
-	return -1, fmt.Errorf("Couldn't find MemTotal")
+	return -1, fmt.Errorf("Couldn't find %s", field)
 }
 
 // OpenPtyInDevpts creates a new PTS pair, configures them and returns them.


### PR DESCRIPTION
This aligns the boot time info in sysinfo with the logic we're using to generate /proc/uptime inside of LXCFS.
To do this without too much overhead, I'm also extending the sys package to give us the host system boot time through the OS struct.

Finally, when testing this logic on a cgroup2 system with swap accounting enabled, I noticed that our swap logic in cgroup2 would fail when the limit would be returned as `max`. So I re-shuffled our meminfo parsing logic a tiny bit and now have the cgroup2 parser return the host total swap when the swap limit is reported as `max` by the kernel.