### PR TITLE
Instance: Move most of device lifecycle logic into common driver

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1176,7 +1176,7 @@ func (d *common) devicesAdd(inst instance.Instance, instanceRunning bool) (rever
 				continue
 			}
 
-			return nil, fmt.Errorf("Failed to load device to add %q: %w", entry.Name, err)
+			return nil, fmt.Errorf("Failed add validation for device %q: %w", entry.Name, err)
 		}
 
 		err = d.deviceAdd(dev, instanceRunning)
@@ -1209,7 +1209,7 @@ func (d *common) devicesRegister(inst instance.Instance) {
 		}
 
 		if err != nil {
-			d.logger.Error("Failed to load device to register", logger.Ctx{"err": err, "device": entry.Name})
+			d.logger.Error("Failed register validation for device", logger.Ctx{"err": err, "device": entry.Name})
 			continue
 		}
 
@@ -1245,7 +1245,7 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 			// removal, as in the scenario that a new version of LXD has additional validation
 			// restrictions than older versions we still need to allow previously valid devices
 			// to be removed.
-			d.logger.Error("Device remove validation failed", logger.Ctx{"device": entry.Name, "err": err})
+			d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
 		}
 
 		// If a device was returned from deviceLoad even if validation fails, then try to stop and remove.
@@ -1281,12 +1281,12 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 			}
 
 			if userRequested {
-				return fmt.Errorf("Failed to load device to add %q: %w", entry.Name, err)
+				return fmt.Errorf("Failed add validation for device %q: %w", entry.Name, err)
 			}
 
 			// If update is non-user requested (i.e from a snapshot restore), there's nothing we can
 			// do to fix the config and we don't want to prevent the snapshot restore so log and allow.
-			d.logger.Error("Failed to load device to add, skipping as non-user requested", logger.Ctx{"device": entry.Name, "err": err})
+			d.logger.Error("Failed add validation for device, skipping as non-user requested", logger.Ctx{"device": entry.Name, "err": err})
 
 			continue
 		}
@@ -1322,7 +1322,7 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 	for _, entry := range updateDevices.Sorted() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed update validation for device %q: %w", entry.Name, err)
 		}
 
 		err = dev.Update(oldExpandedDevices, instanceRunning)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -350,6 +350,16 @@ func (d *common) TemplatesPath() string {
 	return filepath.Join(d.Path(), "templates")
 }
 
+// StoragePool returns the storage pool name.
+func (d *common) StoragePool() (string, error) {
+	pool, err := d.getStoragePool()
+	if err != nil {
+		return "", err
+	}
+
+	return pool.Name(), nil
+}
+
 //
 // SECTION: internal functions
 //
@@ -1097,14 +1107,4 @@ func (d *common) getStoragePool() (storagePools.Pool, error) {
 	d.storagePool = pool
 
 	return d.storagePool, nil
-}
-
-// StoragePool returns the storage pool name.
-func (d *common) StoragePool() (string, error) {
-	pool, err := d.getStoragePool()
-	if err != nil {
-		return "", err
-	}
-
-	return pool.Name(), nil
 }

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1345,24 +1345,20 @@ func (d *common) devicesRemove(inst instance.Instance) {
 	for _, entry := range d.expandedDevices.Reversed() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
-			// If deviceLoad fails with unsupported device type then skip removal.
-			if errors.Is(err, device.ErrUnsupportedDevType) {
-				continue
-			}
-
-			// If deviceLoad fails for any other reason then just log the error and proceed
-			// with removal, as in the scenario that a new version of LXD has additional
-			// validation restrictions than older versions we still need to allow previously
-			// valid devices to be remove.
+			// Just log an error, but still allow the device to be removed if usable device returned.
 			d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
 		}
 
-		// If a device was returned from deviceLoad even if validation fails, then try and remove.
+		// If a usable device was returned from deviceLoad try to remove anyway, even if validation fails.
+		// This allows for the scenario where a new version of LXD has additional validation restrictions
+		// than older versions and we still need to allow previously valid devices to be stopped even if
+		// they are no longer considered valid.
 		if dev != nil {
 			err = d.deviceRemove(dev, false)
 			if err != nil {
 				d.logger.Error("Failed to remove device", logger.Ctx{"device": dev.Name(), "err": err})
 			}
 		}
+
 	}
 }

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1205,10 +1205,6 @@ func (d *common) devicesAdd(inst instance.Instance, instanceRunning bool) (rever
 func (d *common) devicesRegister(inst instance.Instance) {
 	for _, entry := range d.ExpandedDevices().Sorted() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
-		if errors.Is(err, device.ErrUnsupportedDevType) {
-			continue
-		}
-
 		if err != nil {
 			d.logger.Error("Failed register validation for device", logger.Ctx{"err": err, "device": entry.Name})
 			continue

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1142,3 +1142,15 @@ func (d *common) deviceAdd(dev device.Device, instanceRunning bool) error {
 
 	return dev.Add()
 }
+
+// deviceRemove loads a new device and calls its Remove() function.
+func (d *common) deviceRemove(dev device.Device, instanceRunning bool) error {
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
+	l.Debug("Removing device")
+
+	if instanceRunning && !dev.CanHotPlug() {
+		return fmt.Errorf("Device cannot be removed when instance is running")
+	}
+
+	return dev.Remove()
+}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1130,3 +1130,15 @@ func (d *common) deviceLoad(inst instance.Instance, deviceName string, rawConfig
 	// Return device even if error occurs as caller may still use device.
 	return dev, err
 }
+
+// deviceAdd loads a new device and calls its Add() function.
+func (d *common) deviceAdd(dev device.Device, instanceRunning bool) error {
+	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
+	l.Debug("Adding device")
+
+	if instanceRunning && !dev.CanHotPlug() {
+		return fmt.Errorf("Device cannot be added when instance is running")
+	}
+
+	return dev.Add()
+}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1136,7 +1136,12 @@ func (d *common) deviceLoad(inst instance.Instance, deviceName string, rawConfig
 
 	dev, err := device.New(inst, d.state, deviceName, configCopy, d.deviceVolatileGetFunc(deviceName), d.deviceVolatileSetFunc(deviceName))
 
-	// Return device even if error occurs as caller may still use device.
+	// If validation fails with unsupported device type then don't return the device for use.
+	if errors.Is(err, device.ErrUnsupportedDevType) {
+		return nil, err
+	}
+
+	// Return device even if error occurs as caller may still attempt to use device for stop and remove.
 	return dev, err
 }
 

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1233,15 +1233,7 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 	for _, entry := range removeDevices.Reversed() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
-			// If deviceLoad fails with unsupported device type then skip stopping.
-			if errors.Is(err, device.ErrUnsupportedDevType) {
-				continue
-			}
-
-			// If deviceLoad fails for any other reason then just log the error and proceed with
-			// removal, as in the scenario that a new version of LXD has additional validation
-			// restrictions than older versions we still need to allow previously valid devices
-			// to be removed.
+			// Just log an error, but still allow the device to be removed if usable device returned.
 			d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
 		}
 
@@ -1273,10 +1265,6 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 	for _, entry := range addDevices.Sorted() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
-			if errors.Is(err, device.ErrUnsupportedDevType) {
-				continue // No point in trying to add or start device below.
-			}
-
 			if userRequested {
 				return fmt.Errorf("Failed add validation for device %q: %w", entry.Name, err)
 			}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1164,8 +1164,8 @@ func (d *common) deviceRemove(dev device.Device, instanceRunning bool) error {
 	return dev.Remove()
 }
 
-// updateDevices applies device changes to an instance.
-func (d *common) updateDevices(inst instance.Instance, removeDevices deviceConfig.Devices, addDevices deviceConfig.Devices, updateDevices deviceConfig.Devices, oldExpandedDevices deviceConfig.Devices, instanceRunning bool, userRequested bool) error {
+// devicesUpdate applies device changes to an instance.
+func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfig.Devices, addDevices deviceConfig.Devices, updateDevices deviceConfig.Devices, oldExpandedDevices deviceConfig.Devices, instanceRunning bool, userRequested bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1334,3 +1334,30 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 	revert.Success()
 	return nil
 }
+
+// devicesRemove runs device removal function for each device.
+func (d *common) devicesRemove(inst instance.Instance) {
+	for _, entry := range d.expandedDevices.Reversed() {
+		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
+		if err != nil {
+			// If deviceLoad fails with unsupported device type then skip removal.
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue
+			}
+
+			// If deviceLoad fails for any other reason then just log the error and proceed
+			// with removal, as in the scenario that a new version of LXD has additional
+			// validation restrictions than older versions we still need to allow previously
+			// valid devices to be remove.
+			d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
+		}
+
+		// If a device was returned from deviceLoad even if validation fails, then try and remove.
+		if dev != nil {
+			err = d.deviceRemove(dev, false)
+			if err != nil {
+				d.logger.Error("Failed to remove device", logger.Ctx{"device": dev.Name(), "err": err})
+			}
+		}
+	}
+}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1177,10 +1177,6 @@ func (d *common) devicesAdd(inst instance.Instance, instanceRunning bool) (rever
 	for _, entry := range d.expandedDevices.Sorted() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
-			if errors.Is(err, device.ErrUnsupportedDevType) {
-				continue
-			}
-
 			return nil, fmt.Errorf("Failed add validation for device %q: %w", entry.Name, err)
 		}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1320,24 +1320,7 @@ func (d *lxc) devlxdEventSend(eventType string, eventMessage map[string]any) err
 
 // RegisterDevices calls the Register() function on all of the instance's devices.
 func (d *lxc) RegisterDevices() {
-	for _, entry := range d.ExpandedDevices().Sorted() {
-		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
-		if errors.Is(err, device.ErrUnsupportedDevType) {
-			continue
-		}
-
-		if err != nil {
-			d.logger.Error("Failed to load device to register", logger.Ctx{"err": err, "device": entry.Name})
-			continue
-		}
-
-		// Check whether device wants to register for any events.
-		err = dev.Register()
-		if err != nil {
-			d.logger.Error("Failed to register device", logger.Ctx{"err": err, "device": entry.Name})
-			continue
-		}
-	}
+	d.devicesRegister(d)
 }
 
 // deviceStart loads a new device and calls its Start() function.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1936,7 +1936,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	for i, entry := range sortedDevices {
 		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed to load device to start %q: %w", dev.Name(), err)
+			return "", nil, fmt.Errorf("Failed start validation for device %q: %w", dev.Name(), err)
 		}
 
 		// Run pre-start of check all devices before starting any device to avoid expensive revert.
@@ -2989,7 +2989,7 @@ func (d *lxc) cleanupDevices(instanceRunning bool, stopHookNetnsPath string) {
 			// If deviceLoad fails for any other reason then just log the error and proceed with stop,
 			// as in the scenario that a new version of LXD has additional validation restrictions than
 			// older versions we still need to allow previously valid devices to be stopped.
-			d.logger.Error("Device stop validation failed", logger.Ctx{"device": dd.Name, "err": err})
+			d.logger.Error("Failed stop validation for device", logger.Ctx{"device": dd.Name, "err": err})
 		}
 
 		// If a device was returned from deviceLoad even if validation fails, then try and stop.
@@ -3644,7 +3644,7 @@ func (d *lxc) Delete(force bool) error {
 				// with removal, as in the scenario that a new version of LXD has additional
 				// validation restrictions than older versions we still need to allow previously
 				// valid devices to be remove.
-				d.logger.Error("Device remove validation failed", logger.Ctx{"device": entry.Name, "err": err})
+				d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
 			}
 
 			// If a device was returned from deviceLoad even if validation fails, then try and remove.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4228,7 +4228,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	isRunning := d.IsRunning()
 
 	// Use the device interface to apply update changes.
-	err = d.updateDevices(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
+	err = d.devicesUpdate(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3631,30 +3631,8 @@ func (d *lxc) Delete(force bool) error {
 			return err
 		}
 
-		// Remove devices from container.
-		for _, entry := range d.expandedDevices.Reversed() {
-			dev, err := d.deviceLoad(d, entry.Name, entry.Config)
-			if err != nil {
-				// If deviceLoad fails with unsupported device type then skip removal.
-				if errors.Is(err, device.ErrUnsupportedDevType) {
-					continue
-				}
-
-				// If deviceLoad fails for any other reason then just log the error and proceed
-				// with removal, as in the scenario that a new version of LXD has additional
-				// validation restrictions than older versions we still need to allow previously
-				// valid devices to be remove.
-				d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
-			}
-
-			// If a device was returned from deviceLoad even if validation fails, then try and remove.
-			if dev != nil {
-				err = d.deviceRemove(dev, false)
-				if err != nil {
-					d.logger.Error("Failed to remove device", logger.Ctx{"device": dev.Name(), "err": err})
-				}
-			}
-		}
+		// Run device removal function for each device.
+		d.devicesRemove(d)
 
 		// Clean things up.
 		d.cleanup()

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1514,21 +1514,6 @@ func (d *lxc) deviceAttachNIC(configCopy map[string]string, netIF []deviceConfig
 	return nil
 }
 
-// deviceUpdate loads a new device and calls its Update() function.
-func (d *lxc) deviceUpdate(deviceName string, rawConfig deviceConfig.Device, oldDevices deviceConfig.Devices, instanceRunning bool) error {
-	dev, err := d.deviceLoad(d, deviceName, rawConfig)
-	if err != nil {
-		return err
-	}
-
-	err = dev.Update(oldDevices, instanceRunning)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // deviceStop loads a new device and calls its Stop() function.
 // Accepts a stopHookNetnsPath argument which is required when run from the onStopNS hook before the
 // container's network namespace is unmounted (which is required for NIC device cleanup).
@@ -4243,7 +4228,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	isRunning := d.IsRunning()
 
 	// Use the device interface to apply update changes.
-	err = d.updateDevices(removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
+	err = d.updateDevices(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
 	if err != nil {
 		return err
 	}
@@ -4705,108 +4690,6 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 	}
 
-	return nil
-}
-
-func (d *lxc) updateDevices(removeDevices deviceConfig.Devices, addDevices deviceConfig.Devices, updateDevices deviceConfig.Devices, oldExpandedDevices deviceConfig.Devices, instanceRunning bool, userRequested bool) error {
-	revert := revert.New()
-	defer revert.Fail()
-
-	// Remove devices in reverse order to how they were added.
-	for _, dd := range removeDevices.Reversed() {
-		dev, err := d.deviceLoad(d, dd.Name, dd.Config)
-		if err != nil {
-			// If deviceLoad fails with unsupported device type then skip stopping.
-			if errors.Is(err, device.ErrUnsupportedDevType) {
-				continue
-			}
-
-			// If deviceLoad fails for any other reason then just log the error and proceed with
-			// removal, as in the scenario that a new version of LXD has additional validation
-			// restrictions than older versions we still need to allow previously valid devices
-			// to be removed.
-			d.logger.Error("Device remove validation failed", logger.Ctx{"devName": dd.Name, "err": err})
-		}
-
-		// If a device was returned from deviceLoad even if validation fails, then try to stop and remove.
-		if dev != nil {
-			if instanceRunning {
-				err = d.deviceStop(dev, instanceRunning, "")
-				if err != nil {
-					return fmt.Errorf("Failed to stop device %q: %w", dev.Name(), err)
-				}
-			}
-
-			err = d.deviceRemove(dev, instanceRunning)
-			if err != nil && err != device.ErrUnsupportedDevType {
-				return fmt.Errorf("Failed to remove device %q: %w", dev.Name(), err)
-			}
-		}
-
-		// Check whether we are about to add the same device back with updated config and
-		// if not, or if the device type has changed, then remove all volatile keys for
-		// this device (as its an actual removal or a device type change).
-		err = d.deviceVolatileReset(dd.Name, dd.Config, addDevices[dd.Name])
-		if err != nil {
-			return fmt.Errorf("Failed to reset volatile data for device %q: %w", dd.Name, err)
-		}
-	}
-
-	// Add devices in sorted order, this ensures that device mounts are added in path order.
-	for _, dd := range addDevices.Sorted() {
-		dev, err := d.deviceLoad(d, dd.Name, dd.Config)
-		if err != nil {
-			if errors.Is(err, device.ErrUnsupportedDevType) {
-				continue // No point in trying to add or start device below.
-			}
-
-			if userRequested {
-				return fmt.Errorf("Failed to load device to add %q: %w", dev.Name(), err)
-			}
-
-			// If update is non-user requested (i.e from a snapshot restore), there's nothing we can
-			// do to fix the config and we don't want to prevent the snapshot restore so log and allow.
-			d.logger.Error("Failed to load device to add, skipping as non-user requested", logger.Ctx{"device": dev.Name(), "err": err})
-
-			continue
-		}
-
-		err = d.deviceAdd(dev, instanceRunning)
-		if err != nil {
-			if userRequested {
-				return fmt.Errorf("Failed to add device %q: %w", dev.Name(), err)
-			}
-
-			// If update is non-user requested (i.e from a snapshot restore), there's nothing we can
-			// do to fix the config and we don't want to prevent the snapshot restore so log and allow.
-			d.logger.Error("Failed to add device, skipping as non-user requested", logger.Ctx{"device": dev.Name(), "err": err})
-		}
-
-		revert.Add(func() { _ = d.deviceRemove(dev, instanceRunning) })
-
-		if instanceRunning {
-			err = dev.PreStartCheck()
-			if err != nil {
-				return fmt.Errorf("Failed pre-start check for device %q: %w", dev.Name(), err)
-			}
-
-			_, err := d.deviceStart(dev, instanceRunning)
-			if err != nil && err != device.ErrUnsupportedDevType {
-				return fmt.Errorf("Failed to start device %q: %w", dev.Name(), err)
-			}
-
-			revert.Add(func() { _ = d.deviceStop(dev, instanceRunning, "") })
-		}
-	}
-
-	for _, dev := range updateDevices.Sorted() {
-		err := d.deviceUpdate(dev.Name, dev.Config, oldExpandedDevices, instanceRunning)
-		if err != nil && err != device.ErrUnsupportedDevType {
-			return fmt.Errorf("Failed to update device %q: %w", dev.Name, err)
-		}
-	}
-
-	revert.Success()
 	return nil
 }
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1359,18 +1359,6 @@ func (d *lxc) RegisterDevices() {
 	}
 }
 
-// deviceAdd loads a new device and calls its Add() function.
-func (d *lxc) deviceAdd(dev device.Device, instanceRunning bool) error {
-	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
-	l.Debug("Adding device")
-
-	if instanceRunning && !dev.CanHotPlug() {
-		return fmt.Errorf("Device cannot be added when instance is running")
-	}
-
-	return dev.Add()
-}
-
 // deviceStart loads a new device and calls its Start() function.
 func (d *lxc) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfig.RunConfig, error) {
 	configCopy := dev.Config()

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -296,31 +296,12 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 
 	if !d.IsSnapshot() {
 		// Add devices to container.
-		for _, entry := range d.expandedDevices.Sorted() {
-			dev, err := d.deviceLoad(d, entry.Name, entry.Config)
-			if err != nil {
-				if errors.Is(err, device.ErrUnsupportedDevType) {
-					continue
-				}
-
-				return nil, nil, fmt.Errorf("Failed to load device to add %q: %w", entry.Name, err)
-			}
-
-			err = d.deviceAdd(dev, false)
-			if err != nil {
-				return nil, nil, fmt.Errorf("Failed to add device %q: %w", dev.Name(), err)
-			}
-
-			revert.Add(func() { _ = d.deviceRemove(dev, false) })
-		}
-
-		// Update MAAS (must run after the MAC addresses have been generated).
-		err = d.maasUpdate(d, nil)
+		cleanup, err := d.devicesAdd(d, false)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		revert.Add(func() { _ = d.maasDelete(d) })
+		revert.Add(cleanup)
 	}
 
 	d.logger.Info("Created container", logger.Ctx{"ephemeral": d.ephemeral})

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1710,18 +1710,6 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 	return nil
 }
 
-// deviceRemove loads a new device and calls its Remove() function.
-func (d *lxc) deviceRemove(dev device.Device, instanceRunning bool) error {
-	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
-	l.Debug("Removing device")
-
-	if instanceRunning && !dev.CanHotPlug() {
-		return fmt.Errorf("Device cannot be removed when instance is running")
-	}
-
-	return dev.Remove()
-}
-
 // DeviceEventHandler actions the results of a RunConfig after an event has occurred on a device.
 func (d *lxc) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 	// Device events can only be processed when the container is running.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4901,29 +4901,7 @@ func (d *qemu) Delete(force bool) error {
 		}
 
 		// Run device removal function for each device.
-		for _, entry := range d.expandedDevices.Reversed() {
-			dev, err := d.deviceLoad(d, entry.Name, entry.Config)
-			if err != nil {
-				// If deviceLoad fails with unsupported device type then skip removal.
-				if errors.Is(err, device.ErrUnsupportedDevType) {
-					continue
-				}
-
-				// If deviceLoad fails for any other reason then just log the error and proceed
-				// with removal, as in the scenario that a new version of LXD has additional
-				// validation restrictions than older versions we still need to allow previously
-				// valid devices to be remove.
-				d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
-			}
-
-			// If a device was returned from deviceLoad even if validation fails, then try and remove.
-			if dev != nil {
-				err = d.deviceRemove(dev, false)
-				if err != nil {
-					d.logger.Error("Failed to remove device", logger.Ctx{"device": dev.Name(), "err": err})
-				}
-			}
-		}
+		d.devicesRemove(d)
 
 		// Clean things up.
 		d.cleanup()

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4469,7 +4469,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	isRunning := d.IsRunning()
 
 	// Use the device interface to apply update changes.
-	err = d.updateDevices(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
+	err = d.devicesUpdate(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1149,7 +1149,7 @@ func (d *qemu) Start(stateful bool) error {
 		}
 
 		revert.Add(func() {
-			err := d.deviceStop(dev, false)
+			err := d.deviceStop(dev, false, "")
 			if err != nil {
 				d.logger.Error("Failed to cleanup device", logger.Ctx{"device": dev.Name(), "err": err})
 			}
@@ -1895,7 +1895,7 @@ func (d *qemu) deviceAttachNIC(deviceName string, configCopy map[string]string, 
 }
 
 // deviceStop loads a new device and calls its Stop() function.
-func (d *qemu) deviceStop(dev device.Device, instanceRunning bool) error {
+func (d *qemu) deviceStop(dev device.Device, instanceRunning bool, _ string) error {
 	configCopy := dev.Config()
 	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
 	l.Debug("Stopping device")
@@ -4765,7 +4765,7 @@ func (d *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices devi
 		// If a device was returned from deviceLoad even if validation fails, then try and stop and remove.
 		if dev != nil {
 			if instanceRunning {
-				err = d.deviceStop(dev, instanceRunning)
+				err = d.deviceStop(dev, instanceRunning, "")
 				if err != nil {
 					return fmt.Errorf("Failed to stop device %q: %w", dev.Name(), err)
 				}
@@ -4829,7 +4829,7 @@ func (d *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices devi
 				return fmt.Errorf("Failed to start device %q: %w", dev.Name(), err)
 			}
 
-			revert.Add(func() { _ = d.deviceStop(dev, instanceRunning) })
+			revert.Add(func() { _ = d.deviceStop(dev, instanceRunning, "") })
 		}
 	}
 
@@ -4966,7 +4966,7 @@ func (d *qemu) cleanupDevices() {
 
 		// If a device was returned from deviceLoad even if validation fails, then try and stop.
 		if dev != nil {
-			err = d.deviceStop(dev, false)
+			err = d.deviceStop(dev, false, "")
 			if err != nil {
 				d.logger.Error("Failed to stop device", logger.Ctx{"device": dev.Name(), "err": err})
 			}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1648,24 +1648,7 @@ func (d *qemu) qemuArchConfig(arch int) (string, string, error) {
 
 // RegisterDevices calls the Register() function on all of the instance's devices.
 func (d *qemu) RegisterDevices() {
-	for _, entry := range d.ExpandedDevices().Sorted() {
-		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
-		if err == device.ErrUnsupportedDevType {
-			continue
-		}
-
-		if err != nil {
-			d.logger.Error("Failed to load device to register", logger.Ctx{"err": err, "instance": d.Name(), "device": entry.Name})
-			continue
-		}
-
-		// Check whether device wants to register for any events.
-		err = dev.Register()
-		if err != nil {
-			d.logger.Error("Failed to register device", logger.Ctx{"err": err, "instance": d.Name(), "device": entry.Name})
-			continue
-		}
-	}
+	d.devicesRegister(d)
 }
 
 // SaveConfigFile is not used by VMs because the Qemu config file is generated at start up and is not needed

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1105,7 +1105,7 @@ func (d *qemu) Start(stateful bool) error {
 		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
 		if err != nil {
 			op.Done(err)
-			return fmt.Errorf("Failed to load device to start %q: %w", dev.Name(), err)
+			return fmt.Errorf("Failed start validation for device %q: %w", dev.Name(), err)
 		}
 
 		// Run pre-start of check all devices before starting any device to avoid expensive revert.
@@ -4807,7 +4807,7 @@ func (d *qemu) cleanupDevices() {
 			// If deviceLoad fails for any other reason then just log the error and proceed with stop,
 			// as in the scenario that a new version of LXD has additional validation restrictions than
 			// older versions we still need to allow previously valid devices to be stopped.
-			d.logger.Error("Device stop validation failed", logger.Ctx{"device": dd.Name, "err": err})
+			d.logger.Error("Failed stop validation for device", logger.Ctx{"device": dd.Name, "err": err})
 		}
 
 		// If a device was returned from deviceLoad even if validation fails, then try and stop.
@@ -4913,7 +4913,7 @@ func (d *qemu) Delete(force bool) error {
 				// with removal, as in the scenario that a new version of LXD has additional
 				// validation restrictions than older versions we still need to allow previously
 				// valid devices to be remove.
-				d.logger.Error("Device remove validation failed", logger.Ctx{"device": entry.Name, "err": err})
+				d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
 			}
 
 			// If a device was returned from deviceLoad even if validation fails, then try and remove.
@@ -6272,7 +6272,7 @@ func (d *qemu) getNetworkState() (map[string]api.InstanceStateNetwork, error) {
 
 		dev, err := d.deviceLoad(d, k, m)
 		if err != nil {
-			d.logger.Warn("Could not load device", logger.Ctx{"device": k, "err": err})
+			d.logger.Warn("Failed state validation for device", logger.Ctx{"device": k, "err": err})
 			continue
 		}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5117,17 +5117,6 @@ func (d *qemu) Delete(force bool) error {
 	return nil
 }
 
-func (d *qemu) deviceRemove(dev device.Device, instanceRunning bool) error {
-	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
-	l.Debug("Removing device")
-
-	if instanceRunning && !dev.CanHotPlug() {
-		return fmt.Errorf("Device cannot be removed when instance is running")
-	}
-
-	return dev.Remove()
-}
-
 // Export publishes the instance.
 func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time.Time) (api.ImageMetadata, error) {
 	ctxMap := logger.Ctx{

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5117,17 +5117,6 @@ func (d *qemu) Delete(force bool) error {
 	return nil
 }
 
-func (d *qemu) deviceAdd(dev device.Device, instanceRunning bool) error {
-	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
-	l.Debug("Adding device")
-
-	if instanceRunning && !dev.CanHotPlug() {
-		return fmt.Errorf("Device cannot be added when instance is running")
-	}
-
-	return dev.Add()
-}
-
 func (d *qemu) deviceRemove(dev device.Device, instanceRunning bool) error {
 	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": dev.Config()["type"]})
 	l.Debug("Removing device")


### PR DESCRIPTION
Before adding more complexity to the instance device lifecycle logic related to https://github.com/lxc/lxd/issues/10114 I thought I would first move the duplicated logic into the common driver so that the future changes can be done in one place (or at least fewer places).