### PR TITLE
lxd/profiles/utils: Add missing profiles slice check

### DIFF
--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -1066,6 +1066,10 @@ func (c *Cluster) CreateImage(project, fp string, fname string, sz int64, public
 				return err
 			}
 
+			if len(dbProfiles) != 1 {
+				return fmt.Errorf("Failed to find default profile in project %q", project)
+			}
+
 			_, err = tx.tx.Exec("INSERT INTO images_profiles(image_id, profile_id) VALUES(?, ?)", id, dbProfiles[0].ID)
 			if err != nil {
 				return err

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -113,6 +113,10 @@ func doProfileUpdate(d *Daemon, projectName string, name string, id int64, profi
 			return err
 		}
 
+		if len(newProfiles) != 1 {
+			return fmt.Errorf("Failed to find profile %q in project %q", name, projectName)
+		}
+
 		apiProfile, err := newProfiles[0].ToAPI(ctx, tx.Tx())
 		if err != nil {
 			return err


### PR DESCRIPTION
GetProfilesIfEnabled can return an empty slice with no error, so it's
not safe to check the first index without checking if the slice is
empty.

Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>