### PR TITLE
lxd/dns: Add support for SOA (and accept IXFR)

### DIFF
--- a/lxd/dns/handler.go
+++ b/lxd/dns/handler.go
@@ -39,8 +39,8 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		return
 	}
 
-	// Check that it's AXFR.
-	if r.Question[0].Qtype != dns.TypeAXFR {
+	// Check that it's a supported request type.
+	if r.Question[0].Qtype != dns.TypeAXFR && r.Question[0].Qtype != dns.TypeIXFR && r.Question[0].Qtype != dns.TypeSOA {
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeNotImplemented)
 		err := w.WriteMsg(m)
@@ -69,7 +69,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	m.Authoritative = true
 
 	// Load the zone.
-	zone, err := d.server.zoneRetriever(name)
+	zone, err := d.server.zoneRetriever(name, r.Question[0].Qtype != dns.TypeSOA)
 	if err != nil {
 		// On failure, return NXDOMAIN.
 		m := new(dns.Msg)

--- a/lxd/dns/server.go
+++ b/lxd/dns/server.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ZoneRetriever is a function which fetches a DNS zone.
-type ZoneRetriever func(name string) (*Zone, error)
+type ZoneRetriever func(name string, full bool) (*Zone, error)
 
 // Server represents a DNS server instance.
 type Server struct {

--- a/lxd/network/zone/interface.go
+++ b/lxd/network/zone/interface.go
@@ -20,6 +20,7 @@ type NetworkZone interface {
 	Etag() []any
 	UsedBy() ([]string, error)
 	Content() (*strings.Builder, error)
+	SOA() (*strings.Builder, error)
 
 	// Records.
 	AddRecord(req api.NetworkZoneRecordsPost) error


### PR DESCRIPTION
This change adds support for quickly returning a valid SOA request.
This is used by modern named/bind9 prior to any AXFR/IXFR attempt.

Additionally, also accept IXFR requests and just return AXFR data.
This is apparently much better handled than just rejecting IXFR requests.