### PR TITLE
Enables gosimple linter and fixes lint errors

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -105,9 +105,5 @@ func (e *EventListener) Wait() error {
 
 // IsActive returns true if this listener is still connected, false otherwise.
 func (e *EventListener) IsActive() bool {
-	if e.ctx.Err() == nil {
-		return true
-	}
-
-	return false
+	return e.ctx.Err() == nil
 }

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -87,11 +87,7 @@ func (r *ProtocolLXD) GetInstanceNamesAllProjects(instanceType api.InstanceType)
 
 	names := map[string][]string{}
 	for _, instance := range instances {
-		if _, ok := names[instance.Project]; ok {
-			names[instance.Project] = append(names[instance.Project], instance.Name)
-		} else {
-			names[instance.Project] = []string{instance.Name}
-		}
+		names[instance.Project] = append(names[instance.Project], instance.Name)
 	}
 	return names, nil
 }

--- a/lxc/config/config.go
+++ b/lxc/config/config.go
@@ -64,7 +64,7 @@ func (c *Config) CookiesPath(remote string) string {
 
 // ServerCertPath returns the path for the remote's server certificate
 func (c *Config) ServerCertPath(remote string) string {
-	if c.Remotes[remote].Global == true {
+	if c.Remotes[remote].Global {
 		return c.GlobalConfigPath("servercerts", fmt.Sprintf("%s.crt", remote))
 	}
 	return c.ConfigPath("servercerts", fmt.Sprintf("%s.crt", remote))

--- a/lxc/config/file.go
+++ b/lxc/config/file.go
@@ -98,7 +98,7 @@ func (c *Config) SaveConfig(path string) error {
 
 	// Remove the global remotes
 	for k, v := range c.Remotes {
-		if v.Global == true {
+		if v.Global {
 			delete(conf.Remotes, k)
 		}
 	}

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -189,7 +189,7 @@ func (c *Config) GetImageServer(name string) (lxd.ImageServer, error) {
 }
 
 func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
-	remote, _ := c.Remotes[name]
+	remote := c.Remotes[name]
 	args := lxd.ConnectionArgs{
 		UserAgent: c.UserAgent,
 		AuthType:  remote.AuthType,

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -189,7 +189,7 @@ func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
 	// Revert project for `sourceServer` which may have been overwritten
 	// by `--project` flag in `GetImageServer` method
 	remote := conf.Remotes[remoteName]
-	if remote.Protocol != "simplestream" && remote.Public == false {
+	if remote.Protocol != "simplestream" && !remote.Public {
 		d, ok := sourceServer.(lxd.InstanceServer)
 		if ok {
 			sourceServer = d.UseProject(remote.Project)

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -447,7 +447,7 @@ func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if c.global.flagProject != "" && c.flagAllProjects == true {
+	if c.global.flagProject != "" && c.flagAllProjects {
 		return fmt.Errorf(i18n.G("Can't specify --project with --all-projects"))
 	}
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -222,7 +222,7 @@ func (c *cmdRemoteAdd) RunToken(server string, token string, rawToken *api.Certi
 
 		// Handle project.
 		remote := conf.Remotes[server]
-		project, err := c.findProject(d.(lxd.InstanceServer), c.flagProject)
+		project, err := c.findProject(d, c.flagProject)
 		if err != nil {
 			return fmt.Errorf(i18n.G("Failed to find project: %w"), err)
 		}

--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -204,6 +204,4 @@ func reconfigureNetworkInterfaces() {
 			logger.Error("Unable to reconfigure network interface", logger.Ctx{"interface": iface.Name, "err": err})
 		}
 	}
-
-	return
 }

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -294,7 +294,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		ServerClustered:        clustered,
 		ServerEventMode:        string(cluster.ServerEventMode()),
 		ServerName:             serverName,
-		Firewall:               fmt.Sprintf("%s", d.firewall),
+		Firewall:               d.firewall.String(),
 	}
 
 	env.KernelFeatures = map[string]string{

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -688,10 +688,8 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Handle optional service integration on cluster join
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			var err error
-
 			// Add the new node to the default cluster group.
-			err = tx.AddNodeToClusterGroup("default", req.ServerName)
+			err := tx.AddNodeToClusterGroup("default", req.ServerName)
 			if err != nil {
 				return fmt.Errorf("Failed to add new member to the default cluster group: %w", err)
 			}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -141,7 +141,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	tarWriter := instancewriter.NewInstanceTarWriter(tarPipeWriter, idmap)
 
 	// Setup tar writer go routine, with optional compression.
-	tarWriterRes := make(chan error, 0)
+	tarWriterRes := make(chan error)
 	var compressErr error
 
 	backupProgressWriter := &ioprogress.ProgressWriter{
@@ -310,7 +310,7 @@ func pruneExpiredContainerBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to expire instance backups", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done pruning expired instance backups")
 	}
 
@@ -432,7 +432,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	tarWriter := instancewriter.NewInstanceTarWriter(tarPipeWriter, nil)
 
 	// Setup tar writer go routine, with optional compression.
-	tarWriterRes := make(chan error, 0)
+	tarWriterRes := make(chan error)
 	var compressErr error
 
 	go func(resCh chan<- error) {

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -106,8 +106,6 @@ func (lc *eventListenerClient) SetEventMode(eventMode EventMode, eventHubPushCh 
 		lc.hubPushCancel()
 		lc.hubPushCancel = nil
 	}
-
-	return
 }
 
 var eventMode EventMode = EventModeFullMesh

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -58,7 +58,7 @@ func NewGateway(shutdownCtx context.Context, db *db.Node, networkCert *shared.Ce
 		options:     o,
 		ctx:         ctx,
 		cancel:      cancel,
-		upgradeCh:   make(chan struct{}, 0),
+		upgradeCh:   make(chan struct{}),
 		acceptCh:    make(chan net.Conn),
 		store:       &dqliteNodeStore{},
 	}
@@ -733,7 +733,7 @@ func (g *Gateway) NetworkUpdateCert(cert *shared.CertInfo) {
 // the first (and leader) node of a new LXD cluster.
 func (g *Gateway) init(bootstrap bool) error {
 	logger.Debugf("Initializing database gateway")
-	g.stopCh = make(chan struct{}, 0)
+	g.stopCh = make(chan struct{})
 
 	info, err := loadInfo(g.db, g.networkCert)
 	if err != nil {
@@ -1114,8 +1114,8 @@ func dqliteProxy(name string, stopCh chan struct{}, remote net.Conn, local net.C
 		}
 	}
 
-	remoteToLocal := make(chan error, 0)
-	localToRemote := make(chan error, 0)
+	remoteToLocal := make(chan error)
+	localToRemote := make(chan error)
 
 	// Start copying data back and forth until either the client or the
 	// server get closed or hit an error.

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -136,8 +136,6 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 			return nil
 		})
 	}
-
-	return
 }
 
 // Send sends heartbeat requests to the nodes supplied and updates heartbeat state.
@@ -492,7 +490,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		g.HeartbeatNodeHook(hbState, true, unavailableMembers)
 	}
 
-	duration := time.Now().Sub(startTime)
+	duration := time.Since(startTime)
 	if duration > heartbeatInterval {
 		logger.Warn("Heartbeat round duration greater than heartbeat interval", logger.Ctx{"duration": duration, "interval": heartbeatInterval})
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -427,7 +427,6 @@ func writeMacaroonsRequiredResponse(b *identchecker.Bakery, r *http.Request, w h
 		})
 	herr.(*httpbakery.Error).Info.CookieNameSuffix = "auth"
 	httpbakery.WriteError(ctx, w, herr)
-	return
 }
 
 // State creates a new State instance linked to our internal db and os.
@@ -2078,8 +2077,6 @@ func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLead
 
 		logger.Info("Partial heartbeat received", logger.Ctx{"local": localAddress})
 	}
-
-	return
 }
 
 // nodeRefreshTask is run when a full state heartbeat is sent (on the leader) or received (by a non-leader member).

--- a/lxd/db/backups.go
+++ b/lxd/db/backups.go
@@ -171,7 +171,7 @@ func (c *Cluster) CreateInstanceBackup(args InstanceBackup) error {
 			optimizedStorageInt = 1
 		}
 
-		str := fmt.Sprintf("INSERT INTO instances_backups (instance_id, name, creation_date, expiry_date, container_only, optimized_storage) VALUES (?, ?, ?, ?, ?, ?)")
+		str := "INSERT INTO instances_backups (instance_id, name, creation_date, expiry_date, container_only, optimized_storage) VALUES (?, ?, ?, ?, ?, ?)"
 		stmt, err := tx.tx.Prepare(str)
 		if err != nil {
 			return err
@@ -214,7 +214,7 @@ func (c *Cluster) DeleteInstanceBackup(name string) error {
 // to the new one.
 func (c *Cluster) RenameInstanceBackup(oldName, newName string) error {
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		str := fmt.Sprintf("UPDATE instances_backups SET name = ? WHERE name = ?")
+		str := "UPDATE instances_backups SET name = ? WHERE name = ?"
 		stmt, err := tx.tx.Prepare(str)
 		if err != nil {
 			return err
@@ -364,7 +364,7 @@ func (c *Cluster) CreateStoragePoolVolumeBackup(args StoragePoolVolumeBackup) er
 			optimizedStorageInt = 1
 		}
 
-		str := fmt.Sprintf("INSERT INTO storage_volumes_backups (storage_volume_id, name, creation_date, expiry_date, volume_only, optimized_storage) VALUES (?, ?, ?, ?, ?, ?)")
+		str := "INSERT INTO storage_volumes_backups (storage_volume_id, name, creation_date, expiry_date, volume_only, optimized_storage) VALUES (?, ?, ?, ?, ?, ?)"
 		stmt, err := tx.tx.Prepare(str)
 		if err != nil {
 			return err
@@ -483,7 +483,7 @@ WHERE backups.id=?
 // to the new one.
 func (c *Cluster) RenameVolumeBackup(oldName, newName string) error {
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		str := fmt.Sprintf("UPDATE storage_volumes_backups SET name = ? WHERE name = ?")
+		str := "UPDATE storage_volumes_backups SET name = ? WHERE name = ?"
 		stmt, err := tx.tx.Prepare(str)
 		if err != nil {
 			return err

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -3129,7 +3129,7 @@ DELETE FROM storage_volumes_config WHERE storage_volume_id NOT IN (SELECT id FRO
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	stmts = fmt.Sprintf(`
+	stmts = `
 CREATE TABLE projects (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name TEXT NOT NULL,
@@ -3440,7 +3440,7 @@ CREATE INDEX containers_project_id_and_node_id_and_name_idx ON containers (proje
 CREATE INDEX images_project_id_idx ON images (project_id);
 CREATE INDEX images_aliases_project_id_idx ON images_aliases (project_id);
 CREATE INDEX profiles_project_id_idx ON profiles (project_id);
-`)
+`
 	_, err = tx.ExecContext(ctx, stmts)
 	if err != nil {
 		return fmt.Errorf("Failed to add project_id column: %w", err)
@@ -3462,7 +3462,7 @@ CREATE VIEW projects_used_by_ref (name, value) AS
 	}
 
 	// Create a view to easily query all profiles used by a certain container
-	stmt = fmt.Sprintf(`
+	stmt = `
 CREATE VIEW containers_profiles_ref (project, node, name, value) AS
    SELECT projects.name, nodes.name, containers.name, profiles.name
      FROM containers_profiles
@@ -3471,28 +3471,28 @@ CREATE VIEW containers_profiles_ref (project, node, name, value) AS
        JOIN projects ON projects.id=containers.project_id
        JOIN nodes ON nodes.id=containers.node_id
      ORDER BY containers_profiles.apply_order
-`)
+`
 	_, err = tx.Exec(stmt)
 	if err != nil {
 		return fmt.Errorf("Failed to containers_profiles_ref view: %w", err)
 	}
 
 	// Create a view to easily query the config of a certain container.
-	stmt = fmt.Sprintf(`
+	stmt = `
 CREATE VIEW containers_config_ref (project, node, name, key, value) AS
    SELECT projects.name, nodes.name, containers.name, containers_config.key, containers_config.value
      FROM containers_config
        JOIN containers ON containers.id=containers_config.container_id
        JOIN projects ON projects.id=containers.project_id
        JOIN nodes ON nodes.id=containers.node_id
-`)
+`
 	_, err = tx.Exec(stmt)
 	if err != nil {
 		return fmt.Errorf("Failed to containers_config_ref view: %w", err)
 	}
 
 	// Create a view to easily query the devices of a certain container.
-	stmt = fmt.Sprintf(`
+	stmt = `
 CREATE VIEW containers_devices_ref (project, node, name, device, type, key, value) AS
    SELECT projects.name, nodes.name, containers.name,
           containers_devices.name, containers_devices.type,
@@ -3502,27 +3502,27 @@ CREATE VIEW containers_devices_ref (project, node, name, device, type, key, valu
      JOIN containers ON containers.id=containers_devices.container_id
      JOIN projects ON projects.id=containers.project_id
      JOIN nodes ON nodes.id=containers.node_id
-`)
+`
 	_, err = tx.Exec(stmt)
 	if err != nil {
 		return fmt.Errorf("Failed to containers_devices_ref view: %w", err)
 	}
 
 	// Create a view to easily query the config of a certain profile.
-	stmt = fmt.Sprintf(`
+	stmt = `
 CREATE VIEW profiles_config_ref (project, name, key, value) AS
    SELECT projects.name, profiles.name, profiles_config.key, profiles_config.value
      FROM profiles_config
      JOIN profiles ON profiles.id=profiles_config.profile_id
      JOIN projects ON projects.id=profiles.project_id
-`)
+`
 	_, err = tx.Exec(stmt)
 	if err != nil {
 		return fmt.Errorf("Failed to profiles_config_ref view: %w", err)
 	}
 
 	// Create a view to easily query the devices of a certain profile.
-	stmt = fmt.Sprintf(`
+	stmt = `
 CREATE VIEW profiles_devices_ref (project, name, device, type, key, value) AS
    SELECT projects.name, profiles.name,
           profiles_devices.name, profiles_devices.type,
@@ -3531,7 +3531,7 @@ CREATE VIEW profiles_devices_ref (project, name, device, type, key, value) AS
      LEFT OUTER JOIN profiles_devices_config ON profiles_devices_config.profile_device_id=profiles_devices.id
      JOIN profiles ON profiles.id=profiles_devices.profile_id
      JOIN projects ON projects.id=profiles.project_id
-`)
+`
 	_, err = tx.Exec(stmt)
 	if err != nil {
 		return fmt.Errorf("Failed to profiles_devices_ref view: %w", err)

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -190,9 +190,7 @@ func (m *Mapping) FieldArgs(fields []*Field, extra ...string) string {
 		args = append(args, arg)
 	}
 
-	for _, arg := range extra {
-		args = append(args, arg)
-	}
+	args = append(args, extra...)
 
 	return strings.Join(args, ", ")
 }

--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -270,7 +270,7 @@ func (s *Stmt) create(buf *file.Buffer, replace bool) error {
 				otherTable := entityTable(otherRef)
 				params[i] += fmt.Sprintf(" JOIN %s ON %s.id = %s.%s_id", otherTable, otherTable, table, otherRef)
 			}
-			params[i] += fmt.Sprintf(" WHERE")
+			params[i] += " WHERE"
 			for _, other := range via[ref] {
 				join := other.Config.Get("join")
 				if join == "" {
@@ -447,7 +447,7 @@ func whereClause(fields []*Field) string {
 				otherTable := entityTable(otherRef)
 				subSelect += fmt.Sprintf(" JOIN %s ON %s.id = %s.%s_id", otherTable, otherTable, refTable, otherRef)
 			}
-			subSelect += fmt.Sprintf(" WHERE")
+			subSelect += " WHERE"
 			for _, other := range via[ref] {
 				otherRef := lex.Snake(other.Name)
 				otherTable := entityTable(otherRef)

--- a/lxd/db/generate/lex/case.go
+++ b/lxd/db/generate/lex/case.go
@@ -71,5 +71,5 @@ func Snake(name string) string {
 	if lastUpper != 0 {
 		ret.WriteRune(unicode.ToLower(lastUpper))
 	}
-	return string(ret.Bytes())
+	return ret.String()
 }

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -199,7 +199,7 @@ SELECT fingerprint
   JOIN projects ON projects.id = images.project_id
  WHERE projects.name = ?
 `
-	if public == true {
+	if public {
 		q += " AND public=1"
 	}
 

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -523,7 +523,7 @@ func (c *ClusterTx) CreateInstanceConfig(id int, config map[string]string) error
 
 // UpdateInstanceConfig inserts/updates/deletes the provided keys
 func (c *ClusterTx) UpdateInstanceConfig(id int, values map[string]string) error {
-	insertSQL := fmt.Sprintf("INSERT OR REPLACE INTO instances_config (instance_id, key, value) VALUES")
+	insertSQL := "INSERT OR REPLACE INTO instances_config (instance_id, key, value) VALUES"
 	deleteSQL := "DELETE FROM instances_config WHERE key IN %s AND instance_id=?"
 	return c.configUpdate(id, values, insertSQL, deleteSQL)
 }
@@ -587,7 +587,7 @@ func (c *ClusterTx) DeleteInstanceConfigKey(id int64, key string) error {
 // UpdateInstancePowerState sets the the power state of the container with the given ID.
 func (c *ClusterTx) UpdateInstancePowerState(id int, state string) error {
 	// Set the new value
-	str := fmt.Sprintf("INSERT OR REPLACE INTO instances_config (instance_id, key, value) VALUES (?, 'volatile.last_state.power', ?)")
+	str := "INSERT OR REPLACE INTO instances_config (instance_id, key, value) VALUES (?, 'volatile.last_state.power', ?)"
 	stmt, err := c.tx.Prepare(str)
 	if err != nil {
 		return err
@@ -878,7 +878,7 @@ func CreateInstanceConfig(tx *sql.Tx, id int, config map[string]string) error {
 // the instance with the given ID.
 func UpdateInstance(tx *sql.Tx, id int, description string, architecture int, ephemeral bool,
 	expiryDate time.Time) error {
-	str := fmt.Sprintf("UPDATE instances SET description=?, architecture=?, ephemeral=?, expiry_date=? WHERE id=?")
+	str := "UPDATE instances SET description=?, architecture=?, ephemeral=?, expiry_date=? WHERE id=?"
 	stmt, err := tx.Prepare(str)
 	if err != nil {
 		return err

--- a/lxd/db/network_peers.go
+++ b/lxd/db/network_peers.go
@@ -372,9 +372,7 @@ func (c *Cluster) GetNetworkPeerNames(networkID int64) (map[int64]string, error)
 
 // UpdateNetworkPeer updates an existing Network Peer.
 func (c *Cluster) UpdateNetworkPeer(networkID int64, peerID int64, info *api.NetworkPeerPut) error {
-	var err error
-
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		// Update existing Network peer record.
 		res, err := tx.tx.Exec(`
 		UPDATE networks_peers

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -227,9 +227,8 @@ func networkZoneConfig(tx *ClusterTx, id int64, zone *api.NetworkZone) error {
 // CreateNetworkZone creates a new Network zone.
 func (c *Cluster) CreateNetworkZone(projectName string, info *api.NetworkZonesPost) (int64, error) {
 	var id int64
-	var err error
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		// Insert a new Network zone record.
 		result, err := tx.tx.Exec(`
 			INSERT INTO networks_zones (project_id, name, description)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -507,9 +507,7 @@ func (c *Cluster) networks(project string, where string, args ...any) ([]string,
 
 	if where != "" {
 		q += fmt.Sprintf(" AND %s", where)
-		for _, arg := range args {
-			inargs = append(inargs, arg)
-		}
+		inargs = append(inargs, args...)
 	}
 
 	var name string
@@ -851,7 +849,7 @@ func updateNetworkDescription(tx *sql.Tx, id int64, description string) error {
 }
 
 func networkConfigAdd(tx *sql.Tx, networkID, nodeID int64, config map[string]string) error {
-	str := fmt.Sprintf("INSERT INTO networks_config (network_id, node_id, key, value) VALUES(?, ?, ?, ?)")
+	str := "INSERT INTO networks_config (network_id, node_id, key, value) VALUES(?, ?, ?, ?)"
 	stmt, err := tx.Prepare(str)
 	if err != nil {
 		return err

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -201,7 +201,7 @@ func (n NodeInfo) ToAPI(cluster *Cluster, node *Node, leader string) (*api.Clust
 	}
 
 	if n.IsOffline(offlineThreshold) {
-		result.Message = fmt.Sprintf("No heartbeat for %s (%s)", time.Now().Sub(n.Heartbeat), n.Heartbeat)
+		result.Message = fmt.Sprintf("No heartbeat for %s (%s)", time.Since(n.Heartbeat), n.Heartbeat)
 	}
 
 	return &result, nil
@@ -523,10 +523,10 @@ JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id`
 
 	if pending {
 		// Include only pending nodes
-		sql += fmt.Sprintf("WHERE state=? ")
+		sql += "WHERE state=? "
 	} else {
 		// Include created and evacuated nodes
-		sql += fmt.Sprintf("WHERE state!=? ")
+		sql += "WHERE state!=? "
 	}
 
 	args = append([]any{ClusterMemberStatePending}, args...)
@@ -1147,7 +1147,7 @@ func (c *ClusterTx) GetNodeWithLeastInstances(archs []int, defaultArch int, grou
 		}
 
 		count := created + pending
-		if containers == -1 || count < containers || (isDefaultArch == true && isDefaultArchChosen == false) {
+		if containers == -1 || count < containers || (isDefaultArch && !isDefaultArchChosen) {
 			containers = count
 			name = node.Name
 			if isDefaultArch {

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -27,12 +27,12 @@ func (c *Cluster) GetProfileNames(project string) ([]string, error) {
 		return nil, err
 	}
 
-	q := fmt.Sprintf(`
+	q := `
 SELECT profiles.name
  FROM profiles
  JOIN projects ON projects.id = profiles.project_id
 WHERE projects.name = ?
-`)
+`
 	inargs := []any{project}
 	var name string
 	outfmt := []any{name}

--- a/lxd/db/schema/schema.go
+++ b/lxd/db/schema/schema.go
@@ -60,7 +60,7 @@ func NewFromMap(versionsToUpdates map[int]Update) *Schema {
 	}
 
 	// Sort the versions,
-	sort.Sort(sort.IntSlice(versions))
+	sort.Ints(versions)
 
 	// Build the updates slice.
 	updates := []Update{}

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -5,7 +5,6 @@ package db
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/lxc/lxd/lxd/db/cluster"
@@ -21,7 +20,7 @@ func (c *ClusterTx) UpdateInstanceSnapshotConfig(id int, values map[string]strin
 // UpdateInstanceSnapshot updates the description and expiry date of the
 // instance snapshot with the given ID.
 func (c *ClusterTx) UpdateInstanceSnapshot(id int, description string, expiryDate time.Time) error {
-	str := fmt.Sprintf("UPDATE instances_snapshots SET description=?, expiry_date=? WHERE id=?")
+	str := "UPDATE instances_snapshots SET description=?, expiry_date=? WHERE id=?"
 	stmt, err := c.tx.Prepare(str)
 	if err != nil {
 		return err

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -609,9 +609,7 @@ func (c *Cluster) storagePools(where string, args ...any) ([]string, error) {
 
 	if where != "" {
 		stmt += fmt.Sprintf(" WHERE %s", where)
-		for _, arg := range args {
-			inargs = append(inargs, arg)
-		}
+		inargs = append(inargs, args...)
 	}
 
 	result, err := queryScan(c, stmt, inargs, outargs)

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -208,7 +208,7 @@ func (c *Cluster) GetExpiredStorageVolumeSnapshots() ([]StorageVolumeArgs, error
 
 // Updates the expiry date of a storage volume snapshot.
 func storageVolumeSnapshotExpiryDateUpdate(tx *sql.Tx, volumeID int64, expiryDate time.Time) error {
-	stmt := fmt.Sprintf("UPDATE storage_volumes_snapshots SET expiry_date=? WHERE id=?")
+	stmt := "UPDATE storage_volumes_snapshots SET expiry_date=? WHERE id=?"
 	_, err := tx.Exec(stmt, expiryDate, volumeID)
 	return err
 }

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -172,7 +172,7 @@ func (c *Cluster) UpsertWarning(nodeName string, projectName string, entityTypeC
 
 // UpdateWarningStatus updates the status of the warning with the given UUID.
 func (c *ClusterTx) UpdateWarningStatus(UUID string, status WarningStatus) error {
-	str := fmt.Sprintf("UPDATE warnings SET status=?, updated_date=? WHERE uuid=?")
+	str := "UPDATE warnings SET status=?, updated_date=? WHERE uuid=?"
 	stmt, err := c.tx.Prepare(str)
 	if err != nil {
 		return err
@@ -189,7 +189,7 @@ func (c *ClusterTx) UpdateWarningStatus(UUID string, status WarningStatus) error
 
 // UpdateWarningState updates the warning message and status with the given ID.
 func (c *ClusterTx) UpdateWarningState(UUID string, message string, status WarningStatus) error {
-	str := fmt.Sprintf("UPDATE warnings SET last_message=?, last_seen_date=?, updated_date=?, status = ?, count=count+1 WHERE uuid=?")
+	str := "UPDATE warnings SET last_message=?, last_seen_date=?, updated_date=?, status = ?, count=count+1 WHERE uuid=?"
 	stmt, err := c.tx.Prepare(str)
 	if err != nil {
 		return err

--- a/lxd/device/device_common.go
+++ b/lxd/device/device_common.go
@@ -68,11 +68,7 @@ func (d *deviceCommon) Register() error {
 // Returns true if instance type is container, as majority of devices can be started/stopped when
 // instance is running. If instance type is VM then returns false as this is not currently supported.
 func (d *deviceCommon) CanHotPlug() bool {
-	if d.inst.Type() == instancetype.Container {
-		return true
-	}
-
-	return false
+	return d.inst.Type() == instancetype.Container
 }
 
 // CanMigrate returns whether the device can be migrated to any other cluster member.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -140,7 +140,7 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 	}
 
 	// Remount bind mounts in readonly mode if requested
-	if readonly == true && flags&unix.MS_BIND == unix.MS_BIND {
+	if readonly && flags&unix.MS_BIND == unix.MS_BIND {
 		flags = unix.MS_RDONLY | unix.MS_BIND | unix.MS_REMOUNT
 		err = unix.Mount("", dstPath, fsName, uintptr(flags), "")
 		if err != nil {
@@ -183,7 +183,7 @@ func diskCephRbdMap(clusterName string, userName string, poolName string, volume
 		"--cluster", clusterName,
 		"--pool", poolName,
 		"map",
-		fmt.Sprintf("%s", volumeName))
+		volumeName)
 	if err != nil {
 		return "", err
 	}
@@ -198,7 +198,7 @@ func diskCephRbdMap(clusterName string, userName string, poolName string, volume
 }
 
 func diskCephRbdUnmap(deviceName string) error {
-	unmapImageName := fmt.Sprintf("%s", deviceName)
+	unmapImageName := deviceName
 	busyCount := 0
 again:
 	_, err := shared.RunCommand(

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -58,7 +58,7 @@ func NetworkGetDevMAC(devName string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s", content)), nil
+	return strings.TrimSpace(string(content)), nil
 }
 
 // NetworkSetDevMAC sets the MAC setting for a named network device if different from current.
@@ -921,7 +921,7 @@ func isIPAvailable(ctx context.Context, address net.IP, parentInterface string) 
 
 	// Handle IPv4 address.
 	if address.To4() != nil {
-		timeout := deadline.Sub(time.Now())
+		timeout := time.Until(deadline)
 		arping.SetTimeout(timeout)
 		_, _, err := arping.PingOverIfaceByName(address, parentInterface)
 		if err != nil {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1915,9 +1915,7 @@ func (d *disk) getParentBlocks(path string) ([]string, error) {
 						return nil, err
 					}
 
-					for _, dev := range subDevices {
-						devices = append(devices, dev)
-					}
+					devices = append(devices, subDevices...)
 				}
 			} else {
 				continue

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -360,7 +360,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 					devNICMAC, _ = net.ParseMAC(inst.Config[fmt.Sprintf("volatile.%s.hwaddr", devName)])
 				}
 
-				if ourNICMAC != nil && devNICMAC != nil && bytes.Compare(ourNICMAC, devNICMAC) == 0 {
+				if ourNICMAC != nil && devNICMAC != nil && bytes.Equal(ourNICMAC, devNICMAC) {
 					return fmt.Errorf("MAC address %q already defined on another NIC", devNICMAC.String())
 				}
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -181,7 +181,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	// Apply network level config options to device config before validation.
-	d.config["mtu"] = fmt.Sprintf("%s", netConfig["bridge.mtu"])
+	d.config["mtu"] = netConfig["bridge.mtu"]
 
 	rules := nicValidationRules(requiredFields, optionalFields, instConf)
 

--- a/lxd/device/unix_hotplug.go
+++ b/lxd/device/unix_hotplug.go
@@ -35,11 +35,7 @@ type unixHotplug struct {
 // isRequired indicates whether the device config requires this device to start OK.
 func (d *unixHotplug) isRequired() bool {
 	// Defaults to not required.
-	if shared.IsTrue(d.config["required"]) {
-		return true
-	}
-
-	return false
+	return shared.IsTrue(d.config["required"])
 }
 
 // validateConfig checks the supplied config for correctness.

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -37,11 +37,7 @@ type usb struct {
 // isRequired indicates whether the device config requires this device to start OK.
 func (d *usb) isRequired() bool {
 	// Defaults to not required.
-	if shared.IsTrue(d.config["required"]) {
-		return true
-	}
-
-	return false
+	return shared.IsTrue(d.config["required"])
 }
 
 // validateConfig checks the supplied config for correctness.

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -91,7 +91,7 @@ func deviceNetlinkListener() (chan []string, chan []string, chan device.USBEvent
 	}
 
 	chCPU := make(chan []string, 1)
-	chNetwork := make(chan []string, 0)
+	chNetwork := make(chan []string)
 	chUSB := make(chan device.USBEvent)
 	chUnix := make(chan device.UnixHotplugEvent)
 
@@ -522,8 +522,6 @@ func deviceNetworkPriority(s *state.State, netif string) {
 
 		_ = cg.SetNetIfPrio(fmt.Sprintf("%s %d", netif, networkInt))
 	}
-
-	return
 }
 
 func deviceEventListener(s *state.State) {

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -382,7 +382,7 @@ func findContainerForPid(pid int32, s *state.State) (instance.Container, error) 
 		re := regexp.MustCompile(`^PPid:\s+([0-9]+)`)
 		for _, line := range strings.Split(string(status), "\n") {
 			m := re.FindStringSubmatch(line)
-			if m != nil && len(m) > 1 {
+			if len(m) > 1 {
 				result, err := strconv.Atoi(m[1])
 				if err != nil {
 					return nil, err

--- a/lxd/dns/handler.go
+++ b/lxd/dns/handler.go
@@ -125,8 +125,6 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	if err != nil {
 		logger.Error("Unable to write message", logger.Ctx{"err": err})
 	}
-
-	return
 }
 
 func (d *dnsHandler) isAllowed(zone api.NetworkZone, ip string, tsig *dns.TSIG, tsigStatus bool) bool {

--- a/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
+++ b/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
@@ -189,7 +189,7 @@ func (t *Transaction) getDHCPFreeIPv4(usedIPs map[[4]byte]dnsmasq.DHCPAllocation
 	// Lets see if there is already an allocation for our device and that it sits within subnet.
 	// If there are custom DHCP ranges defined, check also that the IP falls within one of the ranges.
 	for _, DHCP := range usedIPs {
-		if (deviceStaticFileName == DHCP.StaticFileName || bytes.Compare(mac, DHCP.MAC) == 0) && DHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
+		if (deviceStaticFileName == DHCP.StaticFileName || bytes.Equal(mac, DHCP.MAC)) && DHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
 			return DHCP.IP, nil
 		}
 	}
@@ -376,9 +376,9 @@ func AllocateTask(opts *Options, f func(*Transaction) error) error {
 	}
 
 	// If MAC or either IPv4 or IPv6 assigned is different than what is in dnsmasq config, rebuild config.
-	macChanged := bytes.Compare(opts.HostMAC, t.currentDHCPMAC) != 0
-	ipv4Changed := (t.allocatedIPv4 != nil && bytes.Compare(t.currentDHCPv4.IP, t.allocatedIPv4.To4()) != 0)
-	ipv6Changed := (t.allocatedIPv6 != nil && bytes.Compare(t.currentDHCPv6.IP, t.allocatedIPv6.To16()) != 0)
+	macChanged := !bytes.Equal(opts.HostMAC, t.currentDHCPMAC)
+	ipv4Changed := (t.allocatedIPv4 != nil && !bytes.Equal(t.currentDHCPv4.IP, t.allocatedIPv4.To4()))
+	ipv6Changed := (t.allocatedIPv6 != nil && !bytes.Equal(t.currentDHCPv6.IP, t.allocatedIPv6.To16()))
 
 	if macChanged || ipv4Changed || ipv6Changed {
 		var IPv4Str, IPv6Str string

--- a/lxd/events/connections.go
+++ b/lxd/events/connections.go
@@ -191,16 +191,11 @@ func (e *streamListenerConnection) Reader(ctx context.Context, recvFunc EventHan
 		}
 	}()
 
-	for {
-		if ctx.Err() != nil {
-			return
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		}
+	if ctx.Err() != nil {
+		return
 	}
+
+	<-ctx.Done()
 }
 
 func (e *streamListenerConnection) WriteJSON(event any) error {

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -737,7 +737,7 @@ func (d Nftables) aclRuleCriteriaToRules(networkName string, ipVersion uint, rul
 			return "", true, nil // Rule is not appropriate for ipVersion.
 		}
 
-		if partial && isPartialRule == false {
+		if partial && !isPartialRule {
 			isPartialRule = true
 		}
 
@@ -754,7 +754,7 @@ func (d Nftables) aclRuleCriteriaToRules(networkName string, ipVersion uint, rul
 			return "", partial, nil // Rule is not appropriate for ipVersion.
 		}
 
-		if partial && isPartialRule == false {
+		if partial && !isPartialRule {
 			isPartialRule = true
 		}
 
@@ -906,7 +906,7 @@ func (d Nftables) aclRulePortToACLMatch(direction string, portCriteria ...string
 		if len(criterionParts) > 1 {
 			fieldParts = append(fieldParts, fmt.Sprintf("%s-%s", criterionParts[0], criterionParts[1]))
 		} else {
-			fieldParts = append(fieldParts, fmt.Sprintf("%s", criterionParts[0]))
+			fieldParts = append(fieldParts, criterionParts[0])
 		}
 	}
 

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -739,7 +739,7 @@ func (d Xtables) aclRulePortToACLMatch(direction string, portCriteria ...string)
 		if len(criterionParts) > 1 {
 			fieldParts = append(fieldParts, fmt.Sprintf("%s:%s", criterionParts[0], criterionParts[1]))
 		} else {
-			fieldParts = append(fieldParts, fmt.Sprintf("%s", criterionParts[0]))
+			fieldParts = append(fieldParts, criterionParts[0])
 		}
 	}
 

--- a/lxd/fsmonitor/drivers/driver_fanotify.go
+++ b/lxd/fsmonitor/drivers/driver_fanotify.go
@@ -59,14 +59,9 @@ func (d *fanotify) load(ctx context.Context) error {
 	}
 
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				_ = unix.Close(d.fd)
-				fanotifyLoaded = false
-				return
-			}
-		}
+		<-ctx.Done()
+		_ = unix.Close(d.fd)
+		fanotifyLoaded = false
 	}()
 
 	go d.getEvents(fd)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1535,7 +1535,7 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to update images", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done updating images")
 	}
 
@@ -2094,7 +2094,7 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to expire images", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done pruning expired images")
 	}
 
@@ -2207,7 +2207,7 @@ func pruneLeftoverImages(d *Daemon) {
 		return
 	}
 
-	op.Wait(d.shutdownCtx)
+	_, _ = op.Wait(d.shutdownCtx)
 	logger.Infof("Done pruning leftover image files")
 }
 
@@ -3982,7 +3982,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 			return
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done synchronizing images across the cluster")
 	}
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -498,7 +498,7 @@ func autoCreateContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to create scheduled container snapshots", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done creating scheduled container snapshots")
 	}
 
@@ -618,7 +618,7 @@ func pruneExpiredInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to remove expired instance snapshots", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done pruning expired instance snapshots")
 	}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3475,7 +3475,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 	}
 
 	// If the container wasn't running but was stateful, should we restore it as running?
-	if stateful == true {
+	if stateful {
 		if !shared.PathExists(d.StatePath()) {
 			err = fmt.Errorf("Stateful snapshot restore requested by snapshot is stateless")
 			op.Done(err)
@@ -5503,7 +5503,6 @@ func (d *lxc) stopForkfile() {
 
 	d.logger.Debug("Stopping forkfile", logger.Ctx{"pid": pid})
 	_ = unix.Kill(int(pid), unix.SIGINT)
-	return
 }
 
 // Console attaches to the instance console.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1566,11 +1566,7 @@ func (d *qemu) Start(stateful bool) error {
 }
 
 func (d *qemu) architectureSupportsUEFI() bool {
-	if shared.IntInSlice(d.architecture, []int{osarch.ARCH_64BIT_INTEL_X86, osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN}) {
-		return true
-	}
-
-	return false
+	return shared.IntInSlice(d.architecture, []int{osarch.ARCH_64BIT_INTEL_X86, osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN})
 }
 
 func (d *qemu) setupNvram() error {

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -86,8 +86,8 @@ func Create(projectName string, instanceName string, action Action, createReusua
 	op.instanceName = instanceName
 	op.action = action
 	op.reusable = createReusuable
-	op.chanDone = make(chan error, 0)
-	op.chanReset = make(chan time.Duration, 0)
+	op.chanDone = make(chan error)
+	op.chanReset = make(chan time.Duration)
 
 	instanceOperations[opKey] = op
 	logger.Debug("Instance operation lock created", logger.Ctx{"project": op.projectName, "instance": op.instanceName, "action": op.action, "reusable": op.reusable})

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -102,7 +102,7 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to update instance types", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done updating instance types")
 	}
 

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -299,8 +299,6 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 			break
 		}
 	}
-
-	return
 }
 
 type instanceStopList []instance.Instance

--- a/lxd/ip/filter.go
+++ b/lxd/ip/filter.go
@@ -32,7 +32,7 @@ func (a *ActionPolice) AddAction() []string {
 		result = append(result, "mtu", a.Mtu)
 	}
 
-	if a.Drop == true {
+	if a.Drop {
 		result = append(result, "drop")
 	}
 	return result

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -310,19 +310,19 @@ func (l *Link) Delete() error {
 func (l *Link) BridgeVLANAdd(vid string, pvid bool, untagged bool, self bool, master bool) error {
 	cmd := []string{"vlan", "add", "dev", l.Name, "vid", vid}
 
-	if pvid == true {
+	if pvid {
 		cmd = append(cmd, "pvid")
 	}
 
-	if untagged == true {
+	if untagged {
 		cmd = append(cmd, "untagged")
 	}
 
-	if self == true {
+	if self {
 		cmd = append(cmd, "self")
 	}
 
-	if master == true {
+	if master {
 		cmd = append(cmd, "master")
 	}
 
@@ -337,11 +337,11 @@ func (l *Link) BridgeVLANAdd(vid string, pvid bool, untagged bool, self bool, ma
 func (l *Link) BridgeVLANDelete(vid string, self bool, master bool) error {
 	cmd := []string{"vlan", "del", "dev", l.Name, "vid", vid}
 
-	if self == true {
+	if self {
 		cmd = append(cmd, "self")
 	}
 
-	if master == true {
+	if master {
 		cmd = append(cmd, "master")
 	}
 
@@ -355,7 +355,7 @@ func (l *Link) BridgeVLANDelete(vid string, self bool, master bool) error {
 // BridgeLinkSetIsolated sets bridge 'isolated' attribute on a port
 func (l *Link) BridgeLinkSetIsolated(isolated bool) error {
 	isolatedState := "on"
-	if isolated == false {
+	if !isolated {
 		isolatedState = "off"
 	}
 
@@ -369,7 +369,7 @@ func (l *Link) BridgeLinkSetIsolated(isolated bool) error {
 // BridgeLinkSetHairpin sets bridge 'hairpin' attribute on a port
 func (l *Link) BridgeLinkSetHairpin(hairpin bool) error {
 	hairpinState := "on"
-	if hairpin == false {
+	if !hairpin {
 		hairpinState = "off"
 	}
 

--- a/lxd/ip/neigh.go
+++ b/lxd/ip/neigh.go
@@ -73,7 +73,7 @@ func (n *Neigh) Show() ([]Neigh, error) {
 
 		// Check neighbour matches desired MAC address if specified.
 		if n.MAC != nil {
-			if bytes.Compare(n.MAC, mac) != 0 {
+			if !bytes.Equal(n.MAC, mac) {
 				continue
 			}
 		}

--- a/lxd/ip/qdisc.go
+++ b/lxd/ip/qdisc.go
@@ -18,11 +18,11 @@ func (qdisc *Qdisc) mainCmd() []string {
 		cmd = append(cmd, "handle", qdisc.Handle)
 	}
 
-	if qdisc.Root == true {
+	if qdisc.Root {
 		cmd = append(cmd, "root")
 	}
 
-	if qdisc.Ingress == true {
+	if qdisc.Ingress {
 		cmd = append(cmd, "ingress")
 	}
 	return cmd
@@ -41,11 +41,11 @@ func (qdisc *Qdisc) Add() error {
 // Delete deletes qdisc from node
 func (qdisc *Qdisc) Delete() error {
 	cmd := []string{"qdisc", "del", "dev", qdisc.Dev}
-	if qdisc.Root == true {
+	if qdisc.Root {
 		cmd = append(cmd, "root")
 	}
 
-	if qdisc.Ingress == true {
+	if qdisc.Ingress {
 		cmd = append(cmd, "ingress")
 	}
 

--- a/lxd/lifecycle/cluster_member.go
+++ b/lxd/lifecycle/cluster_member.go
@@ -21,7 +21,7 @@ const (
 // Event creates the lifecycle event for an action on a cluster member.
 func (a ClusterMemberAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("cluster-member-%s", a)
-	u := fmt.Sprintf("/1.0/cluster/members")
+	u := "/1.0/cluster/members"
 	if name != "" {
 		u = fmt.Sprintf("%s/%s", u, url.PathEscape(name))
 	}

--- a/lxd/lifecycle/config.go
+++ b/lxd/lifecycle/config.go
@@ -17,7 +17,7 @@ const (
 // Event creates the lifecycle event for an action on the server configuration
 func (a ConfigAction) Event(requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
 	eventType := fmt.Sprintf("config-%s", a)
-	u := fmt.Sprintf("/1.0")
+	u := "/1.0"
 
 	return api.EventLifecycle{
 		Action:    eventType,

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -38,7 +38,7 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 			logger.Error("Failed to expire logs", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done expiring log files")
 	}
 

--- a/lxd/maas/controller.go
+++ b/lxd/maas/controller.go
@@ -203,7 +203,7 @@ func (c *Controller) CreateContainer(inst Instance, interfaces []ContainerInterf
 	// Wipe the container entry if anything fails
 	success := false
 	defer func() {
-		if success == true {
+		if success {
 			return
 		}
 

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -647,11 +647,7 @@ func canUseShiftfs() bool {
 	}
 
 	err = unix.Mount(shared.VarPath(), shared.VarPath(), "shiftfs", 0, "mark")
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 // We're only using this during daemon startup to give an indication whether

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -91,13 +91,10 @@ func (c ClusterMember) ToRaftNode() (*db.RaftNode, error) {
 	switch c.Role {
 	case "voter":
 		role = db.RaftVoter
-		break
 	case "stand-by":
 		role = db.RaftStandBy
-		break
 	case "spare":
 		role = db.RaftSpare
-		break
 	default:
 		return nil, fmt.Errorf("unknown raft role: %q", c.Role)
 	}

--- a/lxd/main_forkproxy.go
+++ b/lxd/main_forkproxy.go
@@ -365,7 +365,7 @@ func listenerInstance(epFd C.int, lAddr *deviceConfig.ProxyAddress, cAddr *devic
 
 	if proxy && cAddr.ConnType == "tcp" {
 		if lAddr.ConnType == "unix" {
-			_, _ = dstConn.Write([]byte(fmt.Sprintf("PROXY UNKNOWN\r\n")))
+			_, _ = dstConn.Write([]byte("PROXY UNKNOWN\r\n"))
 		} else {
 			cHost, cPort, err := net.SplitHostPort(srcConn.RemoteAddr().String())
 			if err != nil {
@@ -904,13 +904,11 @@ func unixRelayer(src *net.UnixConn, dst *net.UnixConn, ch chan error) {
 		}
 
 		// Close those fds we received
-		if fds != nil {
-			for _, fd := range fds {
-				err := unix.Close(fd)
-				if err != nil {
-					ch <- err
-					return
-				}
+		for _, fd := range fds {
+			err := unix.Close(fd)
+			if err != nil {
+				ch <- err
+				return
 			}
 		}
 	}
@@ -1005,14 +1003,14 @@ func getListenerFile(protocol string, addr string) (*os.File, error) {
 		return nil, fmt.Errorf("Failed to listen on %s: %w", addr, err)
 	}
 
-	file := &os.File{}
-	switch listener.(type) {
+	var file *os.File
+	switch l := listener.(type) {
 	case *net.TCPListener:
-		tcpListener := listener.(*net.TCPListener)
-		file, err = tcpListener.File()
+		file, err = l.File()
 	case *net.UnixListener:
-		unixListener := listener.(*net.UnixListener)
-		file, err = unixListener.File()
+		file, err = l.File()
+	default:
+		return nil, fmt.Errorf("Could not get listener file: invalid listener type")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get file from listener: %w", err)

--- a/lxd/main_recover.go
+++ b/lxd/main_recover.go
@@ -229,7 +229,9 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 	fmt.Print("Starting recovery...\n")
 
 	// Send /internal/recover/import request to LXD.
-	reqImport := internalRecoverImportPost{
+	// Don't lint next line with gosimple. It says we should convert reqValidate directly to an internalRecoverImportPost
+	// because their types are identical. This is less clear and will not work if either type changes in the future.
+	reqImport := internalRecoverImportPost{ //nolint:gosimple
 		Pools: reqValidate.Pools,
 	}
 

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -1045,7 +1045,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 		offerHeader.SnapshotNames = snapshotNames
 	}
 
-	if offerHeader.GetPredump() == true {
+	if offerHeader.GetPredump() {
 		// If the other side wants pre-dump and if this side supports it, let's use it.
 		respHeader.Predump = proto.Bool(true)
 	} else {

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -205,7 +205,7 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 				}
 			}
 
-			if offer.Refresh != nil && *offer.Refresh == true {
+			if offer.Refresh != nil && *offer.Refresh {
 				// Optimized refresh with zfs only works if ZfsFeatureMigrationHeader is available.
 				if ourType.FSType == MigrationFSType_ZFS && !shared.StringInSlice(ZFSFeatureMigrationHeader, commonFeatures) {
 					continue

--- a/lxd/migration/utils.go
+++ b/lxd/migration/utils.go
@@ -22,19 +22,19 @@ func (m *MigrationHeader) GetRsyncFeaturesSlice() []string {
 		return features
 	}
 	if m.RsyncFeatures != nil {
-		if m.RsyncFeatures.Xattrs != nil && *m.RsyncFeatures.Xattrs == true {
+		if m.RsyncFeatures.Xattrs != nil && *m.RsyncFeatures.Xattrs {
 			features = append(features, "xattrs")
 		}
 
-		if m.RsyncFeatures.Delete != nil && *m.RsyncFeatures.Delete == true {
+		if m.RsyncFeatures.Delete != nil && *m.RsyncFeatures.Delete {
 			features = append(features, "delete")
 		}
 
-		if m.RsyncFeatures.Compress != nil && *m.RsyncFeatures.Compress == true {
+		if m.RsyncFeatures.Compress != nil && *m.RsyncFeatures.Compress {
 			features = append(features, "compress")
 		}
 
-		if m.RsyncFeatures.Bidirectional != nil && *m.RsyncFeatures.Bidirectional == true {
+		if m.RsyncFeatures.Bidirectional != nil && *m.RsyncFeatures.Bidirectional {
 			features = append(features, "bidirectional")
 		}
 	}
@@ -50,11 +50,11 @@ func (m *MigrationHeader) GetZfsFeaturesSlice() []string {
 	}
 
 	if m.ZfsFeatures != nil {
-		if m.ZfsFeatures.Compress != nil && *m.ZfsFeatures.Compress == true {
+		if m.ZfsFeatures.Compress != nil && *m.ZfsFeatures.Compress {
 			features = append(features, "compress")
 		}
 
-		if m.ZfsFeatures.MigrationHeader != nil && *m.ZfsFeatures.MigrationHeader == true {
+		if m.ZfsFeatures.MigrationHeader != nil && *m.ZfsFeatures.MigrationHeader {
 			features = append(features, ZFSFeatureMigrationHeader)
 		}
 	}
@@ -70,15 +70,15 @@ func (m *MigrationHeader) GetBtrfsFeaturesSlice() []string {
 	}
 
 	if m.BtrfsFeatures != nil {
-		if m.BtrfsFeatures.MigrationHeader != nil && *m.BtrfsFeatures.MigrationHeader == true {
+		if m.BtrfsFeatures.MigrationHeader != nil && *m.BtrfsFeatures.MigrationHeader {
 			features = append(features, BTRFSFeatureMigrationHeader)
 		}
 
-		if m.BtrfsFeatures.HeaderSubvolumes != nil && *m.BtrfsFeatures.HeaderSubvolumes == true {
+		if m.BtrfsFeatures.HeaderSubvolumes != nil && *m.BtrfsFeatures.HeaderSubvolumes {
 			features = append(features, BTRFSFeatureSubvolumes)
 		}
 
-		if m.BtrfsFeatures.HeaderSubvolumeUuids != nil && *m.BtrfsFeatures.HeaderSubvolumeUuids == true {
+		if m.BtrfsFeatures.HeaderSubvolumeUuids != nil && *m.BtrfsFeatures.HeaderSubvolumeUuids {
 			features = append(features, BTRFSFeatureSubvolumeUUIDs)
 		}
 	}

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -478,7 +478,7 @@ func ovnRuleCriteriaToOVNACLRule(direction string, rule *api.NetworkACLRule, por
 
 	// Add protocol filters.
 	if shared.StringInSlice(rule.Protocol, []string{"tcp", "udp"}) {
-		matchParts = append(matchParts, fmt.Sprintf("%s", rule.Protocol))
+		matchParts = append(matchParts, rule.Protocol)
 
 		if rule.SourcePort != "" {
 			matchParts = append(matchParts, ovnRulePortToOVNACLMatch(rule.Protocol, "src", shared.SplitNTrimSpace(rule.SourcePort, ",", -1, false)...))
@@ -488,7 +488,7 @@ func ovnRuleCriteriaToOVNACLRule(direction string, rule *api.NetworkACLRule, por
 			matchParts = append(matchParts, ovnRulePortToOVNACLMatch(rule.Protocol, "dst", shared.SplitNTrimSpace(rule.DestinationPort, ",", -1, false)...))
 		}
 	} else if shared.StringInSlice(rule.Protocol, []string{"icmp4", "icmp6"}) {
-		matchParts = append(matchParts, fmt.Sprintf("%s", rule.Protocol))
+		matchParts = append(matchParts, rule.Protocol)
 
 		if rule.ICMPType != "" {
 			matchParts = append(matchParts, fmt.Sprintf("%s.type == %s", rule.Protocol, rule.ICMPType))

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -487,10 +487,10 @@ func (n *ovn) Validate(config map[string]string) error {
 
 			// Skip overlap checks if external subnet's protocol has anycast mode enabled on uplink.
 			if externalSubnet.IP.To4() == nil {
-				if ipv6UplinkAnycast == true {
+				if ipv6UplinkAnycast {
 					continue
 				}
-			} else if ipv4UplinkAnycast == true {
+			} else if ipv4UplinkAnycast {
 				continue
 			}
 
@@ -519,10 +519,10 @@ func (n *ovn) Validate(config map[string]string) error {
 
 			// Skip overlap checks if external subnet's protocol has anycast mode enabled on uplink.
 			if externalSNATSubnet.IP.To4() == nil {
-				if ipv6UplinkAnycast == true {
+				if ipv6UplinkAnycast {
 					continue
 				}
-			} else if ipv4UplinkAnycast == true {
+			} else if ipv4UplinkAnycast {
 				continue
 			}
 
@@ -2290,8 +2290,7 @@ func (n *ovn) logicalRouterPolicySetup(client *openvswitch.OVN, excludePeers ...
 	// Add rules to drop inbound traffic arriving on external uplink port from peer connection addresses.
 	// This prevents source address spoofing of peer connection routes from the external network, which in
 	// turn allows us to use the peer connection's address set for referencing traffic from the peer in ACL.
-	var err error
-	err = n.forPeers(func(targetOVNNet *ovn) error {
+	err := n.forPeers(func(targetOVNNet *ovn) error {
 		if shared.Int64InSlice(targetOVNNet.ID(), excludePeers) {
 			return nil // Don't setup rules for this peer network connection.
 		}
@@ -2391,7 +2390,7 @@ func (n *ovn) addChassisGroupEntry() error {
 	}
 
 	// Sort the nodes based on ID for stable priority generation.
-	sort.Sort(sort.IntSlice(nodeIDs))
+	sort.Ints(nodeIDs)
 
 	// Generate a random priority from the seed for each node until we find a match for our node ID.
 	// In this way the chassis priority for this node will be set to a per-node stable random value.
@@ -3104,10 +3103,10 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 
 		// Skip overlap checks if the external route's protocol has anycast mode enabled on the uplink.
 		if portExternalRoute.IP.To4() == nil {
-			if ipv6UplinkAnycast == true {
+			if ipv6UplinkAnycast {
 				continue
 			}
-		} else if ipv4UplinkAnycast == true {
+		} else if ipv4UplinkAnycast {
 			continue
 		}
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -424,7 +424,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 
 	// Update the host files.
 	for _, network := range networks {
-		entries, _ := entries[network]
+		entries := entries[network]
 
 		// Skip networks we don't manage (or don't have DHCP enabled).
 		if !shared.PathExists(shared.VarPath("networks", network, "dnsmasq.pid")) {
@@ -663,12 +663,7 @@ func pingIP(ip net.IP) bool {
 	}
 
 	_, err := shared.RunCommand(cmd, "-n", "-q", ip.String(), "-c", "1", "-W", "1")
-	if err != nil {
-		// Remote didn't answer.
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 func pingSubnet(subnet *net.IPNet) bool {
@@ -837,7 +832,7 @@ func GetMACSlice(hwaddr string) []string {
 
 	if !strings.Contains(hwaddr, ":") {
 		if s, err := strconv.ParseUint(hwaddr, 10, 64); err == nil {
-			hwaddr = fmt.Sprintln(fmt.Sprintf("%x", s))
+			hwaddr = fmt.Sprintf("%x\n", s)
 			var tuple string
 			for i, r := range hwaddr {
 				tuple = tuple + string(r)
@@ -1116,11 +1111,7 @@ func SubnetContainsIP(outerSubnet *net.IPNet, ip net.IP) bool {
 
 	ipSubnet.IP = ip
 
-	if SubnetContains(outerSubnet, ipSubnet) {
-		return true
-	}
-
-	return false
+	return SubnetContains(outerSubnet, ipSubnet)
 }
 
 // SubnetIterate iterates through each IP in a subnet calling a function for each IP.

--- a/lxd/network/network_utils_bridge.go
+++ b/lxd/network/network_utils_bridge.go
@@ -17,7 +17,7 @@ func BridgeVLANFilteringStatus(interfaceName string) (string, error) {
 		return "", fmt.Errorf("Failed getting bridge VLAN status for %q: %w", interfaceName, err)
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s", content)), nil
+	return strings.TrimSpace(string(content)), nil
 }
 
 // BridgeVLANFilterSetStatus sets the status of VLAN filtering on a bridge interface.
@@ -37,7 +37,7 @@ func BridgeVLANDefaultPVID(interfaceName string) (string, error) {
 		return "", fmt.Errorf("Failed getting bridge VLAN default PVID for %q: %w", interfaceName, err)
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s", content)), nil
+	return strings.TrimSpace(string(content)), nil
 }
 
 // BridgeVLANSetDefaultPVID sets the VLAN default port VLAN ID (PVID).

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -240,7 +240,7 @@ func sriovGetFreeVFInterface(reservedDevices map[string]struct{}, parentDev stri
 
 			// Skip VFs if they do not relate to the same device and port as the parent PF.
 			// Some card vendors change the device ID for each port.
-			if bytes.Compare(pfDevPort, vfDevPort) != 0 || bytes.Compare(pfDevID, vfDevID) != 0 {
+			if !bytes.Equal(pfDevPort, vfDevPort) || !bytes.Equal(pfDevID, vfDevID) {
 				continue
 			}
 

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1693,8 +1693,8 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 			)
 		} else {
 			args = append(args,
-				fmt.Sprintf("%s", ipToString(r.ListenAddress)),
-				fmt.Sprintf("%s", ipToString(r.TargetAddress)),
+				ipToString(r.ListenAddress),
+				ipToString(r.TargetAddress),
 			)
 		}
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1108,7 +1108,7 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 			return
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 	}
 
 	return f, task.Hourly()

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -816,15 +816,12 @@ func isContainerLowLevelOptionForbidden(key string) bool {
 
 // Return true if a low-level VM option is forbidden.
 func isVMLowLevelOptionForbidden(key string) bool {
-	if shared.StringInSlice(key, []string{
+	return shared.StringInSlice(key, []string{
 		"boot.host_shutdown_timeout",
 		"limits.memory.hugepages",
 		"raw.idmap",
 		"raw.qemu",
-	}) {
-		return true
-	}
-	return false
+	})
 }
 
 // AllowInstanceUpdate returns an error if any project-specific limit or

--- a/lxd/resources/utils.go
+++ b/lxd/resources/utils.go
@@ -69,11 +69,7 @@ func int64InSlice(key int64, list []int64) bool {
 
 func sysfsExists(path string) bool {
 	_, err := os.Lstat(path)
-	if err == nil {
-		return true
-	}
-
-	return false
+	return err == nil
 }
 
 func sysfsNumaNode(path string) (uint64, error) {

--- a/lxd/revert/revert_test.go
+++ b/lxd/revert/revert_test.go
@@ -13,7 +13,7 @@ func ExampleReverter_fail() {
 	revert.Add(func() { fmt.Println("1st step") })
 	revert.Add(func() { fmt.Println("2nd step") })
 
-	return // Revert functions are run in reverse order on return.
+	// Revert functions are run in reverse order on return.
 	// Output: 2nd step
 	// 1st step
 }
@@ -26,6 +26,5 @@ func ExampleReverter_success() {
 	revert.Add(func() { fmt.Println("2nd step") })
 
 	revert.Success() // Revert functions added are not run on return.
-	return
 	// Output:
 }

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -132,7 +132,7 @@ func sendSetup(name string, path string, bwlimit string, execPath string, featur
 		args = append(args, "--bwlimit", bwlimit)
 	}
 
-	if features != nil && len(features) > 0 {
+	if len(features) > 0 {
 		args = append(args, rsyncFeatureArgs(features)...)
 	}
 
@@ -270,7 +270,7 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 		"--sparse",
 	}
 
-	if features != nil && len(features) > 0 {
+	if len(features) > 0 {
 		args = append(args, rsyncFeatureArgs(features)...)
 	}
 

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -1119,7 +1119,7 @@ func TaskIDs(pid int) (int64, int64, int64, int64, error) {
 
 		if !UIDFound {
 			m := reUID.FindStringSubmatch(line)
-			if m != nil && len(m) > 2 {
+			if len(m) > 2 {
 				// effective uid
 				result, err := strconv.ParseInt(m[2], 10, 64)
 				if err != nil {
@@ -1130,7 +1130,7 @@ func TaskIDs(pid int) (int64, int64, int64, int64, error) {
 				UIDFound = true
 			}
 
-			if m != nil && len(m) > 4 {
+			if len(m) > 4 {
 				// fsuid
 				result, err := strconv.ParseInt(m[4], 10, 64)
 				if err != nil {
@@ -1145,7 +1145,7 @@ func TaskIDs(pid int) (int64, int64, int64, int64, error) {
 
 		if !GIDFound {
 			m := reGID.FindStringSubmatch(line)
-			if m != nil && len(m) > 2 {
+			if len(m) > 2 {
 				// effective gid
 				result, err := strconv.ParseInt(m[2], 10, 64)
 				if err != nil {
@@ -1156,7 +1156,7 @@ func TaskIDs(pid int) (int64, int64, int64, int64, error) {
 				GIDFound = true
 			}
 
-			if m != nil && len(m) > 4 {
+			if len(m) > 4 {
 				// fsgid
 				result, err := strconv.ParseInt(m[4], 10, 64)
 				if err != nil {
@@ -1190,7 +1190,7 @@ func FindTGID(procFd int) (int, error) {
 	reTGID := regexp.MustCompile(`^Tgid:\s+([0-9]+)`)
 	for _, line := range strings.Split(string(status), "\n") {
 		m := reTGID.FindStringSubmatch(line)
-		if m != nil && len(m) > 1 {
+		if len(m) > 1 {
 			result, err := strconv.ParseUint(m[1], 10, 32)
 			if err != nil {
 				return -1, err
@@ -1535,7 +1535,7 @@ func (s *Server) HandleSetxattrSyscall(c Instance, siov *Iovec) int {
 		fmt.Sprintf("%d", args.flags),
 		fmt.Sprintf("%d", whiteout),
 		fmt.Sprintf("%d", args.size),
-		fmt.Sprintf("%s", args.value))
+		string(args.value))
 	if err != nil {
 		errno, err := strconv.Atoi(stderr)
 		if err != nil || errno == C.ENOANO {
@@ -1749,7 +1749,7 @@ func (s *Server) HandleSysinfoSyscall(c Instance, siov *Iovec) int {
 
 	age := float64(tickValue / 100)
 	if age > 0 {
-		instMetrics.Uptime = int64(time.Now().Sub(s.s.OS.BootTime).Seconds() - age)
+		instMetrics.Uptime = int64(time.Since(s.s.OS.BootTime).Seconds() - age)
 	}
 
 	// Get instance process count.
@@ -1911,7 +1911,7 @@ func mountFlagsToOpts(flags C.ulong) string {
 		}
 
 		if opts == "" {
-			opts = fmt.Sprintf("%s", optOrArg)
+			opts = optOrArg
 		} else {
 			opts = fmt.Sprintf("%s,%s", opts, optOrArg)
 		}
@@ -2153,9 +2153,9 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 			fmt.Sprintf("%d", args.gid),
 			fmt.Sprintf("%d", args.fsuid),
 			fmt.Sprintf("%d", args.fsgid),
-			fmt.Sprintf("%s", fuseSource),
-			fmt.Sprintf("%s", args.target),
-			fmt.Sprintf("%s", fuseOpts))
+			fuseSource,
+			args.target,
+			fuseOpts)
 	} else {
 		_, _, err = shared.RunCommandSplit(
 			nil,
@@ -2166,9 +2166,9 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 			fmt.Sprintf("%d", args.pid),
 			fmt.Sprintf("%d", pidFdNr),
 			fmt.Sprintf("%d", 0),
-			fmt.Sprintf("%s", args.source),
-			fmt.Sprintf("%s", args.target),
-			fmt.Sprintf("%s", args.fstype),
+			args.source,
+			args.target,
+			args.fstype,
 			fmt.Sprintf("%d", args.flags),
 			string(args.idmapType),
 			fmt.Sprintf("%d", args.uid),
@@ -2179,7 +2179,7 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 			fmt.Sprintf("%d", args.nsgid),
 			fmt.Sprintf("%d", args.nsfsuid),
 			fmt.Sprintf("%d", args.nsfsgid),
-			fmt.Sprintf("%s", args.data))
+			args.data)
 	}
 	if err != nil {
 		ctx["syscall_continue"] = "true"
@@ -2208,7 +2208,7 @@ func (s *Server) HandleBpfSyscall(c Instance, siov *Iovec) int {
 
 	if shared.IsFalseOrEmpty(c.ExpandedConfig()["security.syscalls.intercept.bpf.devices"]) {
 		ctx["syscall_continue"] = "true"
-		ctx["syscall_handler_reason"] = fmt.Sprintf("No bpf policy specified")
+		ctx["syscall_handler_reason"] = "No bpf policy specified"
 		C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))
 		return 0
 	}
@@ -2216,7 +2216,7 @@ func (s *Server) HandleBpfSyscall(c Instance, siov *Iovec) int {
 	tgid, err := FindTGID(siov.procFd)
 	if err != nil || tgid == -1 {
 		ctx["syscall_continue"] = "true"
-		ctx["syscall_handler_reason"] = fmt.Sprintf("Could not find thread group leader ID")
+		ctx["syscall_handler_reason"] = "Could not find thread group leader ID"
 		C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))
 		return 0
 	}
@@ -2367,9 +2367,7 @@ func MountSyscallFilter(config map[string]string) []string {
 
 	fsAllowed := strings.Split(config["security.syscalls.intercept.mount.allowed"], ",")
 	if len(fsAllowed) > 0 && fsAllowed[0] != "" {
-		for _, allowedfs := range fsAllowed {
-			fs = append(fs, allowedfs)
-		}
+		fs = append(fs, fsAllowed...)
 	}
 
 	return fs

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -230,6 +230,4 @@ func storagePoolDriversCacheUpdate(s *state.State) {
 	storagePoolUsedDriversCacheVal.Store(usedDrivers)
 	storagePoolSupportedDriversCacheVal.Store(supportedDrivers)
 	storagePoolDriversCacheLock.Unlock()
-
-	return
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -761,12 +761,10 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 		return nil, nil, fmt.Errorf("Error updating backup file: %w", err)
 	}
 
-	var postHook func(instance.Instance) error
-
 	// Create a post hook function that will use the instance (that will be created) to setup a new volume
 	// containing the instance's root disk device's config so that the driver's post hook function can access
 	// that config to perform any post instance creation setup.
-	postHook = func(inst instance.Instance) error {
+	postHook := func(inst instance.Instance) error {
 		l.Debug("CreateInstanceFromBackup post hook started")
 		defer l.Debug("CreateInstanceFromBackup post hook finished")
 
@@ -1272,7 +1270,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			if err != nil {
 				return err
 			}
-			revert.Add(func() { VolumeDBDelete(b, projectName, newSnapshotName, vol.Type()) })
+			revert.Add(func() { _ = VolumeDBDelete(b, projectName, newSnapshotName, vol.Type()) })
 
 			// Generate source snapshot volumes list.
 			srcSnapVolumeName := drivers.GetSnapshotVolumeName(srcVolName, srcSnap.Name)

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -147,7 +147,7 @@ func (d *btrfs) snapshotSubvolume(path string, dest string, recursion bool) erro
 		if err != nil {
 			return err
 		}
-		sort.Sort(sort.StringSlice(subSubVols))
+		sort.Strings(subSubVols)
 
 		for _, subSubVol := range subSubVols {
 			subSubVolSnapPath := filepath.Join(dest, subSubVol)
@@ -388,7 +388,7 @@ func (d *btrfs) getSubvolumesMetaData(vol Volume) ([]BTRFSSubVolume, error) {
 	if err != nil {
 		return nil, err
 	}
-	sort.Sort(sort.StringSlice(subVolPaths))
+	sort.Strings(subVolPaths)
 
 	// Add any subvolumes under the root subvolume with relative path to root.
 	for _, subVolPath := range subVolPaths {

--- a/lxd/storage/drivers/driver_cephfs_utils.go
+++ b/lxd/storage/drivers/driver_cephfs_utils.go
@@ -9,11 +9,7 @@ import (
 // fsExists checks that the Ceph FS instance indeed exists.
 func (d *cephfs) fsExists(clusterName string, userName string, fsName string) bool {
 	_, err := shared.RunCommand("ceph", "--name", fmt.Sprintf("client.%s", userName), "--cluster", clusterName, "fs", "get", fsName)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 // getConfig parses the Ceph configuration file and returns the list of monitors and secret key.

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -439,11 +439,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 
 // genericVFSHasVolume is a generic HasVolume implementation for VFS-only drivers.
 func genericVFSHasVolume(vol Volume) bool {
-	if shared.PathExists(vol.MountPath()) {
-		return true
-	}
-
-	return false
+	return shared.PathExists(vol.MountPath())
 }
 
 // genericVFSGetVolumeDiskPath is a generic GetVolumeDiskPath implementation for VFS-only drivers.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -721,7 +721,7 @@ func shiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet, shift bool) error 
 	var err error
 	roSubvols := []string{}
 	subvols, _ := BTRFSSubVolumesGet(path)
-	sort.Sort(sort.StringSlice(subvols))
+	sort.Strings(subvols)
 	for _, subvol := range subvols {
 		subvol = filepath.Join(path, subvol)
 

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -221,9 +221,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	for _, volume := range custVolumes {
-		volumes = append(volumes, volume)
-	}
+	volumes = append(volumes, custVolumes...)
 
 	// We exclude volumes of type image, since those are special: they are stored using the storage_volumes
 	// table, but are effectively a cache which is not tied to projects, so we always link the to the default

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1082,7 +1082,7 @@ func pruneExpireCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) 
 			logger.Error("Failed to expire backups", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done pruning expired custom volume snapshots")
 	}
 
@@ -1265,7 +1265,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to create scheduled volume snapshots", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done creating scheduled volume snapshots")
 	}
 

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -182,7 +182,7 @@ func CheckTrustState(cert x509.Certificate, trustedCerts map[string]x509.Certifi
 
 	// Check whether client certificate is in trust store.
 	for fingerprint, v := range trustedCerts {
-		if bytes.Compare(cert.Raw, v.Raw) == 0 {
+		if bytes.Equal(cert.Raw, v.Raw) {
 			logger.Debug("Matched trusted cert", logger.Ctx{"fingerprint": fingerprint, "subject": v.Subject})
 			return true, fingerprint
 		}

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -30,9 +30,9 @@ func GetArchitectures() ([]int, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, personality := range personalities {
-		architectures = append(architectures, personality)
-	}
+
+	architectures = append(architectures, personalities...)
+
 	return architectures, nil
 }
 

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -434,7 +434,7 @@ func pruneResolvedWarningsTask(d *Daemon) (task.Func, task.Schedule) {
 			logger.Error("Failed to prune resolved warnings", logger.Ctx{"err": err})
 		}
 
-		op.Wait(ctx)
+		_, _ = op.Wait(ctx)
 		logger.Info("Done pruning resolved warnings")
 	}
 

--- a/shared/idmap/idmapset_linux.go
+++ b/shared/idmap/idmapset_linux.go
@@ -331,11 +331,11 @@ func (m IdmapSet) Swap(i, j int) {
 
 func (m IdmapSet) Less(i, j int) bool {
 	if m.Idmap[i].Isuid != m.Idmap[j].Isuid {
-		return m.Idmap[i].Isuid == true
+		return m.Idmap[i].Isuid
 	}
 
 	if m.Idmap[i].Isgid != m.Idmap[j].Isgid {
-		return m.Idmap[i].Isgid == true
+		return m.Idmap[i].Isgid
 	}
 
 	return m.Idmap[i].Nsid < m.Idmap[j].Nsid

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -138,7 +138,7 @@ func TestReaderToChannel(t *testing.T) {
 		if len(data) > 0 {
 			for i := 0; i < len(data); i++ {
 				if buf[offset+i] != data[i] {
-					t.Error(fmt.Sprintf("byte %d didn't match", offset+i))
+					t.Errorf("byte %d didn't match", offset+i)
 					return
 				}
 			}

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -28,7 +28,7 @@ test_static_analysis() {
 
     # golangci-lint
     if command -v golangci-lint >/dev/null 2>&1; then
-      golangci-lint run --disable-all -E deadcode -E errcheck
+      golangci-lint run --disable-all -E deadcode -E errcheck -E gosimple
     else
       echo "golangci-lint not found, some go linters will not run"
     fi

--- a/test/syscall/sysinfo/sysinfo.go
+++ b/test/syscall/sysinfo/sysinfo.go
@@ -17,5 +17,4 @@ func main() {
 	}
 
 	fmt.Printf("%+v\n", s)
-	return
 }


### PR DESCRIPTION
As part of #10392 we are incrementally adding (and conforming to) the [golangci-lint](https://golangci-lint.run/usage/linters/) default linters. 

This PR adds enables `gosimple` in `static-analysis.sh` and fixes the lint errors it produces.