### PR TITLE
Instance: Use the negotiated index migration header version on target

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -939,7 +939,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 	// with the new storage layer.
 	myTarget = func(conn *websocket.Conn, op *operations.Operation, args MigrationSinkArgs) error {
 		volTargetArgs := migration.VolumeTargetArgs{
-			IndexHeaderVersion: migration.IndexHeaderVersion,
+			IndexHeaderVersion: respHeader.GetIndexHeaderVersion(),
 			Name:               args.Instance.Name(),
 			MigrationType:      respTypes[0],
 			Refresh:            args.Refresh,    // Indicate to receiver volume should exist.


### PR DESCRIPTION
This was missed in https://github.com/lxc/lxd/commit/3f4fbf60ef249bad5e88d70f9d441f9a5d206dfb to actually use the negotiated version on the target side.

This allows migration between LXD 4.0.x and LXD current.

Otherwise get an error like:

```
lxc copy c1 v2: --refresh 
Error: Failed instance creation: Error transferring instance data: Failed creating instance on target: Failed decoding migration index header: invalid character '\x00' looking for beginning of value
```

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>