### PR TITLE
Instance: Stop and remove device after non-user requested update validation fails

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -545,6 +545,19 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
 
+	// Rebuild dnsmasq config if parent is a managed bridge network using dnsmasq and static lease file is
+	// missing.
+	bridgeNet, ok := d.network.(bridgeNetwork)
+	if ok && d.network.IsManaged() && bridgeNet.UsesDNSMasq() {
+		deviceStaticFileName := dnsmasq.DHCPStaticAllocationPath(d.network.Name(), dnsmasq.StaticAllocationFileName(d.inst.Project(), d.inst.Name(), d.Name()))
+		if !shared.PathExists(deviceStaticFileName) {
+			err = d.rebuildDnsmasqEntry()
+			if err != nil {
+				return nil, fmt.Errorf("Failed creating DHCP static allocation: %w", err)
+			}
+		}
+	}
+
 	// Apply host-side routes to bridge interface.
 	routes := []string{}
 	routes = append(routes, shared.SplitNTrimSpace(d.config["ipv4.routes"], ",", -1, true)...)

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -474,6 +474,8 @@ func (d *nicBridged) UpdatableFields(oldDevice Type) []string {
 
 // Add is run when a device is added to a non-snapshot instance whether or not the instance is running.
 func (d *nicBridged) Add() error {
+	networkVethFillFromVolatile(d.config, d.volatileGet())
+
 	// Rebuild dnsmasq entry if needed and reload.
 	err := d.rebuildDnsmasqEntry()
 	if err != nil {

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -116,13 +116,18 @@ func GetVersion() (*version.DottedVersion, error) {
 	return version.Parse(lines[2])
 }
 
+// DHCPStaticAllocationPath returns the path to the DHCP static allocation file.
+func DHCPStaticAllocationPath(network string, deviceStaticFileName string) string {
+	return shared.VarPath("networks", network, "dnsmasq.hosts", deviceStaticFileName)
+}
+
 // DHCPStaticAllocation retrieves the dnsmasq statically allocated MAC and IPs for an instance device static file.
 // Returns MAC, IPv4 and IPv6 DHCPAllocation structs respectively.
 func DHCPStaticAllocation(network string, deviceStaticFileName string) (net.HardwareAddr, DHCPAllocation, DHCPAllocation, error) {
 	var IPv4, IPv6 DHCPAllocation
 	var mac net.HardwareAddr
 
-	file, err := os.Open(shared.VarPath("networks", network, "dnsmasq.hosts", deviceStaticFileName))
+	file, err := os.Open(DHCPStaticAllocationPath(network, deviceStaticFileName))
 	if err != nil {
 		return nil, IPv4, IPv6, err
 	}

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -605,7 +605,6 @@ test_container_devices_nic_bridged() {
 
   # Test container with conflicting addresses can be restored from backup.
   lxc import foo.tar.gz
-  rm foo.tar.gz
   ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false
   ! lxc start foo || false
   lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.232'
@@ -621,8 +620,16 @@ test_container_devices_nic_bridged() {
   # Check MAC conflict detection:
   ! lxc config device set "${ctName}" eth0 hwaddr="0a:92:a7:0d:b7:c9" || false
 
+  # Test container with conflicting addresses rebuilds DHCP lease if original conflicting instance is removed.
   lxc delete -f foo
   ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false
+  lxc import foo.tar.gz
+  rm foo.tar.gz
+  ! lxc start foo || false
+  lxc delete "${ctName}" -f
+  lxc start foo
+  grep -F "192.0.2.232" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0"
+  lxc delete -f foo
 
   # Check we haven't left any NICS lying around.
   endNicCount=$(find /sys/class/net | wc -l)
@@ -632,7 +639,6 @@ test_container_devices_nic_bridged() {
   fi
 
   # Cleanup.
-  lxc delete "${ctName}" -f
   lxc profile delete "${ctName}"
   lxc network delete "${brName}"
 }

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -581,7 +581,7 @@ test_container_devices_nic_bridged() {
 
   # Test container snapshot with conflicting addresses can be restored.
   lxc restore foo snap0 # Test restore, IPs conflict on config device update (due to only IPs changing).
-  grep -F "192.0.2.233" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" # Check lease file not changed (due to only IPs changing).
+  ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false # Check lease file removed (due to non-user requested update failing).
   lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.232'
   ! lxc start foo || false
   lxc config device set foo eth0 \
@@ -592,7 +592,7 @@ test_container_devices_nic_bridged() {
   lxc stop -f foo
 
   lxc restore foo snap0 # Test restore, IPs conflict on config device remove/add (due to MAC change).
-  ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false # Check IP file removed (due to MAC change).
+  ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false # Check lease file removed (due to MAC change).
   lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.232'
   ! lxc start foo || false
   lxc config device set foo eth0 \


### PR DESCRIPTION
This ensures that if we are applying invalid device config to the database that we don't leave the existing device on the system out-of-sync with the config in the database. 

Once the device has had its config fixed its system state will be re-applied when next started.

Also fixes scenario where an instance can be started but is missing its static DHCP lease file.
This can happen if the instance device was conflicting with another instance NIC device when it was created, and then subsequently the original instance device was removed meaning the new NIC no longer conflicts, so can be started without further config modification, in which case the static DHCP lease file would previously never had a chance to be created, and DHCP would not have worked correctly.

Follows on from https://github.com/lxc/lxd/pull/10546
