### PR TITLE
Adds staticcheck and fixes lint errors

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -409,8 +409,7 @@ func (r *ProtocolLXD) rawWebsocket(url string) (*websocket.Conn, error) {
 
 	// Setup a new websocket dialer based on it
 	dialer := websocket.Dialer{
-		//lint:ignore SA1019 DialContext doesn't exist in Go 1.13
-		NetDial:          httpTransport.Dial,
+		NetDialContext:   httpTransport.DialContext,
 		TLSClientConfig:  httpTransport.TLSClientConfig,
 		Proxy:            httpTransport.Proxy,
 		HandshakeTimeout: time.Second * 5,

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -2,6 +2,7 @@ package lxd
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1370,9 +1371,9 @@ func (r *ProtocolLXD) rawSFTPConn(apiURL *url.URL) (net.Conn, error) {
 	var err error
 
 	if httpTransport.TLSClientConfig != nil {
-		conn, err = httpTransport.DialTLS("tcp", apiURL.Host)
+		conn, err = httpTransport.DialTLSContext(context.Background(), "tcp", apiURL.Host)
 	} else {
-		conn, err = httpTransport.Dial("tcp", apiURL.Host)
+		conn, err = httpTransport.DialContext(context.Background(), "tcp", apiURL.Host)
 	}
 	if err != nil {
 		return nil, err

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1414,7 +1414,7 @@ func (r *ProtocolLXD) rawSFTPConn(apiURL *url.URL) (net.Conn, error) {
 // GetInstanceFileSFTPConn returns a connection to the instance's SFTP endpoint.
 func (r *ProtocolLXD) GetInstanceFileSFTPConn(instanceName string) (net.Conn, error) {
 	apiURL := api.NewURL()
-	apiURL.URL = *&r.httpBaseURL // Preload the URL with the client base URL.
+	apiURL.URL = r.httpBaseURL // Preload the URL with the client base URL.
 	apiURL.Path("1.0", "instances", instanceName, "sftp")
 	r.setURLQueryAttributes(&apiURL.URL)
 

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -1,6 +1,7 @@
 package lxd
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -91,7 +92,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 			return -1, err
 		}
 
-		size, err := shared.DownloadFileHash(nil, r.http, r.httpUserAgent, req.ProgressHandler, req.Canceler, filename, url, hash, sha256.New(), target)
+		size, err := shared.DownloadFileHash(context.TODO(), r.http, r.httpUserAgent, req.ProgressHandler, req.Canceler, filename, url, hash, sha256.New(), target)
 		if err != nil {
 			// Handle cancelation
 			if err.Error() == "net/http: request canceled" {
@@ -104,7 +105,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 				return -1, err
 			}
 
-			size, err = shared.DownloadFileHash(nil, r.http, r.httpUserAgent, req.ProgressHandler, req.Canceler, filename, url, hash, sha256.New(), target)
+			size, err = shared.DownloadFileHash(context.TODO(), r.http, r.httpUserAgent, req.ProgressHandler, req.Canceler, filename, url, hash, sha256.New(), target)
 			if err != nil {
 				return -1, err
 			}

--- a/lxc-to-lxd/main_migrate.go
+++ b/lxc-to-lxd/main_migrate.go
@@ -191,7 +191,7 @@ func convertContainer(d lxd.ContainerServer, container *liblxc.Container, storag
 
 	// Make sure we don't have a conflict
 	fmt.Println("Checking for existing containers")
-	containers, err := d.GetContainerNames()
+	containers, err := d.GetInstanceNames(api.InstanceTypeContainer)
 	if err != nil {
 		return err
 	}

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -293,7 +293,10 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 		}
 
 		pemKey, _ := pem.Decode(content)
-		if x509.IsEncryptedPEMBlock(pemKey) {
+		// Golang has deprecated all methods relating to PEM encryption due to a vulnerability.
+		// However, the weakness does not make PEM unsafe for our purposes as it pertains to password protection on the
+		// key file (client.key is only readable to the user in any case), so we'll ignore deprecation.
+		if x509.IsEncryptedPEMBlock(pemKey) { //nolint:staticcheck
 			if c.PromptPassword == nil {
 				return nil, fmt.Errorf("Private key is password protected and no helper was configured")
 			}
@@ -303,7 +306,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 				return nil, err
 			}
 
-			derKey, err := x509.DecryptPEMBlock(pemKey, []byte(password))
+			derKey, err := x509.DecryptPEMBlock(pemKey, []byte(password)) //nolint:staticcheck
 			if err != nil {
 				return nil, err
 			}

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -155,7 +155,6 @@ func (c *cmdRemoteAdd) RunToken(server string, token string, rawToken *api.Certi
 
 	var certificate *x509.Certificate
 	var err error
-	var d lxd.InstanceServer
 
 	if !conf.HasClientCertificate() {
 		fmt.Fprintf(os.Stderr, i18n.G("Generating a client certificate. This may take a minute...")+"\n")
@@ -170,7 +169,7 @@ func (c *cmdRemoteAdd) RunToken(server string, token string, rawToken *api.Certi
 
 		conf.Remotes[server] = config.Remote{Addr: addr, Protocol: c.flagProtocol, AuthType: c.flagAuthType, Domain: c.flagDomain}
 
-		d, err = conf.GetInstanceServer(server)
+		_, err = conf.GetInstanceServer(server)
 		if err != nil {
 			certificate, err = shared.GetRemoteCertificate(addr, c.global.conf.UserAgent)
 			if err != nil {
@@ -206,7 +205,7 @@ func (c *cmdRemoteAdd) RunToken(server string, token string, rawToken *api.Certi
 			}
 		}
 
-		d, err = conf.GetInstanceServer(server)
+		d, err := conf.GetInstanceServer(server)
 		if err != nil {
 			continue
 		}

--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -50,7 +50,7 @@ func (l *networkListener) Accept() (net.Conn, error) {
 			break
 		}
 
-		if err.(net.Error).Temporary() {
+		if err.(net.Error).Timeout() {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -558,8 +558,9 @@ func NotifyHeartbeat(state *state.State, gateway *Gateway) {
 		heartbeatCancel()
 
 		// Wait for heartbeat to finish and then release.
+		// Ignore staticcheck "SA2001: empty critical section" because we want to wait for the lock.
 		gateway.HeartbeatLock.Lock()
-		gateway.HeartbeatLock.Unlock()
+		gateway.HeartbeatLock.Unlock() //nolint:staticcheck
 	}
 
 	hbState := NewAPIHearbeat(state.DB.Cluster)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -633,7 +633,6 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 
 		// Actually process the request
 		var resp response.Response
-		resp = response.NotImplemented(nil)
 
 		// Return Unavailable Error (503) if daemon is shutting down.
 		// There are some exceptions:

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -309,7 +309,7 @@ func parseField(f *ast.Field, kind string) (*Field, error) {
 	name := f.Names[0]
 
 	if !name.IsExported() {
-		//return nil, fmt.Errorf("Unexported field name %q", name.Name)
+		return nil, fmt.Errorf("Unexported field name %q", name.Name)
 	}
 
 	// Ignore fields that are marked with a tag of `db:"ingore"`

--- a/lxd/db/generate/lex/case.go
+++ b/lxd/db/generate/lex/case.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Capital capitalizes the given string ("foo" -> "Foo")
 func Capital(s string) string {
-	return strings.Title(s)
+	return cases.Title(language.English).String(s)
 }
 
 // Minuscule turns the first character to lower case ("Foo" -> "foo") or the whole word if it is all uppercase ("UUID" -> "uuid")

--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -122,7 +122,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 		if mdevUUID == "" || !shared.PathExists(fmt.Sprintf("/sys/bus/pci/devices/%s/%s", pciAddress, mdevUUID)) {
 			mdevUUID = uuid.New()
 
-			err = ioutil.WriteFile(filepath.Join(fmt.Sprintf("/sys/bus/pci/devices/%s/mdev_supported_types/%s/create", pciAddress, d.config["mdev"])), []byte(mdevUUID), 200)
+			err = ioutil.WriteFile(filepath.Join(fmt.Sprintf("/sys/bus/pci/devices/%s/mdev_supported_types/%s/create", pciAddress, d.config["mdev"])), []byte(mdevUUID), 0200)
 			if err != nil {
 				if os.IsNotExist(err) {
 					return nil, fmt.Errorf("The requested profile %q does not exist", d.config["mdev"])

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -23,7 +23,7 @@ type DevLxdDialer struct {
 	Path string
 }
 
-func (d DevLxdDialer) DevLxdDial(network, path string) (net.Conn, error) {
+func (d DevLxdDialer) DevLxdDial(ctx context.Context, network, path string) (net.Conn, error) {
 	addr, err := net.ResolveUnixAddr("unix", d.Path)
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func TestHttpRequest(t *testing.T) {
 	}
 	defer func() { _ = d.Stop(context.Background(), unix.SIGQUIT) }()
 
-	c := http.Client{Transport: &http.Transport{Dial: DevLxdDialer{Path: fmt.Sprintf("%s/devlxd/sock", testDir)}.DevLxdDial}}
+	c := http.Client{Transport: &http.Transport{DialContext: DevLxdDialer{Path: fmt.Sprintf("%s/devlxd/sock", testDir)}.DevLxdDial}}
 
 	raw, err := c.Get("http://1.0")
 	if err != nil {

--- a/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
+++ b/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
@@ -377,8 +377,8 @@ func AllocateTask(opts *Options, f func(*Transaction) error) error {
 
 	// If MAC or either IPv4 or IPv6 assigned is different than what is in dnsmasq config, rebuild config.
 	macChanged := !bytes.Equal(opts.HostMAC, t.currentDHCPMAC)
-	ipv4Changed := (t.allocatedIPv4 != nil && !bytes.Equal(t.currentDHCPv4.IP, t.allocatedIPv4.To4()))
-	ipv6Changed := (t.allocatedIPv6 != nil && !bytes.Equal(t.currentDHCPv6.IP, t.allocatedIPv6.To16()))
+	ipv4Changed := t.allocatedIPv4 != nil && !t.currentDHCPv4.IP.Equal(t.allocatedIPv4.To4())
+	ipv6Changed := t.allocatedIPv6 != nil && !t.currentDHCPv6.IP.Equal(t.allocatedIPv6.To16())
 
 	if macChanged || ipv4Changed || ipv6Changed {
 		var IPv4Str, IPv6Str string

--- a/lxd/endpoints/endpoints_test.go
+++ b/lxd/endpoints/endpoints_test.go
@@ -1,6 +1,7 @@
 package endpoints_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -56,10 +57,10 @@ func newEndpoints(t *testing.T) (*endpoints.Endpoints, *endpoints.Config, func()
 
 // Perform an HTTP GET "/" over the unix socket at the given path.
 func httpGetOverUnixSocket(path string) error {
-	dial := func(network, addr string) (net.Conn, error) {
+	dial := func(_ context.Context, network, addr string) (net.Conn, error) {
 		return net.Dial("unix", path)
 	}
-	client := &http.Client{Transport: &http.Transport{Dial: dial}}
+	client := &http.Client{Transport: &http.Transport{DialContext: dial}}
 	_, err := client.Get("http://unix.socket/")
 	return err
 }

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -1180,13 +1180,13 @@ func (d Xtables) matchEbtablesRule(activeRule []string, matchRule []string, dele
 		matchIPMaskStr := strings.SplitN(match, "/", 2)
 		if len(matchIPMaskStr) == 2 && matchIPMaskStr[0] == strings.Split(active, "/")[0] {
 			// If the active subnet is a CIDR string we have a match if the masks are identical.
-			activeIP, activeIPNet, err := net.ParseCIDR(active)
+			_, activeIPNet, err := net.ParseCIDR(active)
 			if err == nil {
 				return subnetMask(activeIPNet) == matchIPMaskStr[1]
 			}
 
 			// If the active subnet is a single IP then we have a match if the generated mask is a full mask.
-			activeIP = net.ParseIP(active)
+			activeIP := net.ParseIP(active)
 			if activeIP != nil {
 				if activeIP.To4() != nil {
 					return matchIPMaskStr[1] == "255.255.255.255"

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -318,7 +318,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 					"path": "/",
 					"pool": instRootDiskDevice["pool"],
 				}
-			} else {
+			} else { //nolint:staticcheck // (keep the empty branch for the comment)
 				// Snapshot has multiple root disk devices, we can't automatically fix this so
 				// leave alone so we don't prevent copy.
 			}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -259,7 +259,6 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 		return nil, err
 	}
 
-	snapList := []*instance.Instance{}
 	var snapshots []instance.Instance
 
 	if !opts.instanceOnly {
@@ -342,14 +341,12 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			}
 
 			// Create the snapshots.
-			snapInst, snapInstOp, cleanup, err := instance.CreateInternal(s, snapInstArgs, true)
+			_, snapInstOp, cleanup, err := instance.CreateInternal(s, snapInstArgs, true)
 			if err != nil {
 				return nil, fmt.Errorf("Failed creating instance snapshot record %q: %w", newSnapName, err)
 			}
 			revert.Add(cleanup)
 			defer snapInstOp.Done(err)
-
-			snapList = append(snapList, &snapInst)
 		}
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5245,7 +5245,7 @@ func (d *qemu) FileSFTPConn() (net.Conn, error) {
 	req.Header["Upgrade"] = []string{"sftp"}
 	req.Header["Connection"] = []string{"Upgrade"}
 
-	conn, err := httpTransport.Dial("tcp", "8443")
+	conn, err := httpTransport.DialContext(context.Background(), "tcp", "8443")
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -763,7 +763,7 @@ func qemuUSB(opts *qemuUSBOpts) []cfgSection {
 				{key: "name", value: "usbredir"},
 			},
 		}, {
-			name: fmt.Sprintf(fmt.Sprintf(`device "qemu_spice-usb%d"`, i)),
+			name: fmt.Sprintf(`device "qemu_spice-usb%d"`, i),
 			entries: []cfgEntry{
 				{key: "driver", value: "usb-redir"},
 				{key: "chardev", value: chardev},

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -420,7 +420,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		URL: req.Source.Operation,
 		Dialer: websocket.Dialer{
 			TLSClientConfig:  config,
-			NetDial:          shared.RFC3493Dialer,
+			NetDialContext:   shared.RFC3493Dialer,
 			HandshakeTimeout: time.Second * 5,
 		},
 		Instance:     inst,

--- a/lxd/main_recover.go
+++ b/lxd/main_recover.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
@@ -195,7 +197,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 		if len(res.UnknownVolumes) > 0 {
 			fmt.Print("The following unknown volumes have been found:\n")
 			for _, unknownVol := range res.UnknownVolumes {
-				fmt.Printf(" - %s %q on pool %q in project %q (includes %d snapshots)\n", strings.Title(unknownVol.Type), unknownVol.Name, unknownVol.Pool, unknownVol.Project, unknownVol.SnapshotCount)
+				fmt.Printf(" - %s %q on pool %q in project %q (includes %d snapshots)\n", cases.Title(language.English).String(unknownVol.Type), unknownVol.Name, unknownVol.Pool, unknownVol.Project, unknownVol.SnapshotCount)
 			}
 		}
 

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -240,7 +240,7 @@ func (s *migrationSourceWs) ConnectTarget(certificate string, operation string, 
 
 	dialer := websocket.Dialer{
 		TLSClientConfig:  config,
-		NetDial:          shared.RFC3493Dialer,
+		NetDialContext:   shared.RFC3493Dialer,
 		HandshakeTimeout: time.Second * 5,
 	}
 

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -385,7 +385,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 	// or not it's doing a refresh as the migration sink/receiver will know
 	// this, and adjust the migration types accordingly.
 	poolMigrationTypes = pool.MigrationTypes(storagePools.InstanceContentType(s.instance), false)
-	if len(poolMigrationTypes) < 0 {
+	if len(poolMigrationTypes) == 0 {
 		return abort(fmt.Errorf("No source migration types available"))
 	}
 

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -69,7 +69,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 	// or not it's doing a refresh as the migration sink/receiver will know
 	// this, and adjust the migration types accordingly.
 	poolMigrationTypes = pool.MigrationTypes(storageDrivers.ContentType(srcConfig.Volume.ContentType), false)
-	if len(poolMigrationTypes) < 0 {
+	if len(poolMigrationTypes) == 0 {
 		return fmt.Errorf("No source migration types available")
 	}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4365,7 +4365,8 @@ func (n *ovn) PeerCreate(peer api.NetworkPeersPost) error {
 	// Check if there is an existing peer using the same name, or whether there is already a peering (in any
 	// state) to the target network.
 	peers, err := n.state.DB.Cluster.GetNetworkPeers(n.ID())
-	if err == nil {
+	if err != nil {
+		return err
 	}
 
 	for _, existingPeer := range peers {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -433,9 +433,9 @@ func (o *OVN) LogicalRouterPortAdd(routerName OVNRouter, portName OVNRouterPort,
 			}
 
 			_, err := o.nbctl("set", "Logical_Router_Port", string(portName),
-				fmt.Sprintf(`networks="%s"`, strings.Join(ips, `","`)),
-				fmt.Sprintf(`mac="%s"`, fmt.Sprintf(mac.String())),
-				fmt.Sprintf(`options:gateway_mtu=%d`, gatewayMTU),
+				fmt.Sprintf("networks=%q", strings.Join(ips, `","`)),
+				fmt.Sprintf("mac=%q", mac.String()),
+				fmt.Sprintf("options:gateway_mtu=%d", gatewayMTU),
 			)
 			if err != nil {
 				return err

--- a/lxd/resources/cpu.go
+++ b/lxd/resources/cpu.go
@@ -250,9 +250,9 @@ func GetCPU() (*api.ResourcesCPU, error) {
 		}
 
 		// Grab socket data if needed
-		resSocket, ok := cpuSockets[cpuSocket]
+		_, ok := cpuSockets[cpuSocket]
 		if !ok {
-			resSocket = &api.ResourcesCPUSocket{}
+			resSocket := &api.ResourcesCPUSocket{}
 
 			// Socket number
 			resSocket.Socket = uint64(cpuSocket)

--- a/lxd/storage/drivers/utils_ceph.go
+++ b/lxd/storage/drivers/utils_ceph.go
@@ -110,7 +110,7 @@ func CephMonitors(cluster string) ([]string, error) {
 					server = strings.Split(server, "/")[0]
 
 					// Handle end of nested blocks.
-					server = strings.Replace(server, "]]", "]", 0)
+					server = strings.ReplaceAll(server, "]]", "]")
 					if !strings.HasPrefix(server, "[") {
 						server = strings.TrimSuffix(server, "]")
 					}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -849,7 +849,7 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 		URL: req.Source.Operation,
 		Dialer: websocket.Dialer{
 			TLSClientConfig:  config,
-			NetDial:          shared.RFC3493Dialer,
+			NetDialContext:   shared.RFC3493Dialer,
 			HandshakeTimeout: time.Second * 5,
 		},
 		Secrets:    req.Source.Websockets,

--- a/lxd/sys/apparmor.go
+++ b/lxd/sys/apparmor.go
@@ -81,13 +81,20 @@ func (s *OS) initAppArmor() []db.Warning {
 }
 
 func haveMacAdmin() bool {
-	c, err := capability.NewPid(0)
+	c, err := capability.NewPid2(0)
 	if err != nil {
 		return false
 	}
+
+	err = c.Load()
+	if err != nil {
+		return false
+	}
+
 	if c.Get(capability.EFFECTIVE, capability.CAP_MAC_ADMIN) {
 		return true
 	}
+
 	return false
 }
 

--- a/lxd/util/config.go
+++ b/lxd/util/config.go
@@ -32,8 +32,8 @@ func CompareConfigs(config1, config2 map[string]string, exclude []string) error 
 			for i := range delta {
 				if delta[i] == key {
 					present = true
+					break
 				}
-				break
 			}
 			if !present {
 				delta = append(delta, key)

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -118,7 +118,7 @@ func HTTPClient(certificate string, proxy proxyFunc) (*http.Client, error) {
 
 	tr := &http.Transport{
 		TLSClientConfig:       tlsConfig,
-		Dial:                  shared.RFC3493Dialer,
+		DialContext:           shared.RFC3493Dialer,
 		Proxy:                 proxy,
 		DisableKeepAlives:     true,
 		ExpectContinueTimeout: time.Second * 30,

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -418,7 +418,7 @@ func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, 
 
 	tr := &http.Transport{
 		TLSClientConfig:       tlsConfig,
-		Dial:                  RFC3493Dialer,
+		DialContext:           RFC3493Dialer,
 		Proxy:                 ProxyFromEnvironment,
 		ExpectContinueTimeout: time.Second * 30,
 		ResponseHeaderTimeout: time.Second * 3600,

--- a/shared/cert_test.go
+++ b/shared/cert_test.go
@@ -46,6 +46,7 @@ func TestKeyPairAndCA(t *testing.T) {
 	block, _ := pem.Decode(info.PublicKey())
 	if block == nil {
 		t.Errorf("expected PublicKey to be decodable")
+		return
 	}
 	_, err = x509.ParseCertificate(block.Bytes)
 	if err != nil {

--- a/shared/cmd/ask.go
+++ b/shared/cmd/ask.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/lxc/lxd/shared"
 )
@@ -109,15 +109,15 @@ func AskString(question string, defaultAnswer string, validate func(string) erro
 // AskPassword asks the user to enter a password.
 func AskPassword(question string) string {
 	for {
-		fmt.Printf(question)
+		fmt.Print(question)
 
-		pwd, _ := terminal.ReadPassword(0)
+		pwd, _ := term.ReadPassword(0)
 		fmt.Println("")
 		inFirst := string(pwd)
 		inFirst = strings.TrimSuffix(inFirst, "\n")
 
 		fmt.Printf("Again: ")
-		pwd, _ = terminal.ReadPassword(0)
+		pwd, _ = term.ReadPassword(0)
 		fmt.Println("")
 		inSecond := string(pwd)
 		inSecond = strings.TrimSuffix(inSecond, "\n")
@@ -136,8 +136,8 @@ func AskPassword(question string) string {
 // It's the same as AskPassword, but it won't ask to enter it again.
 func AskPasswordOnce(question string) string {
 	for {
-		fmt.Printf(question)
-		pwd, _ := terminal.ReadPassword(0)
+		fmt.Print(question)
+		pwd, _ := term.ReadPassword(0)
 		fmt.Println("")
 
 		// refuse empty password
@@ -152,7 +152,7 @@ func AskPasswordOnce(question string) string {
 
 // Ask a question on the output stream and read the answer from the input stream
 func askQuestion(question, defaultAnswer string) (string, error) {
-	fmt.Printf(question)
+	fmt.Print(question)
 
 	return readAnswer(defaultAnswer)
 }

--- a/shared/ioprogress/tracker.go
+++ b/shared/ioprogress/tracker.go
@@ -61,7 +61,7 @@ func (pt *ProgressTracker) update(n int) {
 	var progressInt int64
 	if pt.Length > 0 {
 		pt.percentage = percentage
-		progressInt = int64(1 - (int(percentage) % 1) + int(percentage))
+		progressInt = int64(1 + int(percentage))
 		if progressInt > 100 {
 			progressInt = 100
 		}

--- a/shared/network.go
+++ b/shared/network.go
@@ -376,39 +376,37 @@ type WebsocketIO struct {
 }
 
 func (w *WebsocketIO) Read(p []byte) (n int, err error) {
-	for {
-		// First read from this message
-		if w.reader == nil {
-			var mt int
+	// First read from this message
+	if w.reader == nil {
+		var mt int
 
-			mt, w.reader, err = w.Conn.NextReader()
-			if err != nil {
-				return 0, err
-			}
-
-			if mt == websocket.CloseMessage {
-				return 0, io.EOF
-			}
-
-			if mt == websocket.TextMessage {
-				return 0, io.EOF
-			}
-		}
-
-		// Perform the read itself
-		n, err := w.reader.Read(p)
-		if err == io.EOF {
-			// At the end of the message, reset reader
-			w.reader = nil
-			return n, nil
-		}
-
+		mt, w.reader, err = w.Conn.NextReader()
 		if err != nil {
 			return 0, err
 		}
 
+		if mt == websocket.CloseMessage {
+			return 0, io.EOF
+		}
+
+		if mt == websocket.TextMessage {
+			return 0, io.EOF
+		}
+	}
+
+	// Perform the read itself
+	n, err = w.reader.Read(p)
+	if err == io.EOF {
+		// At the end of the message, reset reader
+		w.reader = nil
 		return n, nil
 	}
+
+	if err != nil {
+		return 0, err
+	}
+
+	return n, nil
 }
 
 func (w *WebsocketIO) Write(p []byte) (n int, err error) {

--- a/shared/network.go
+++ b/shared/network.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -24,7 +25,7 @@ const connectErrorPrefix = "Unable to connect to"
 
 // RFC3493Dialer connects to the specified server and returns the connection.
 // If the connection cannot be established then an error with the connectErrorPrefix is returned.
-func RFC3493Dialer(network string, address string) (net.Conn, error) {
+func RFC3493Dialer(context context.Context, network string, address string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -582,7 +582,7 @@ func IsNetworkPort(value string) error {
 		return fmt.Errorf("Invalid port number %q", value)
 	}
 
-	if port < 0 || port > 65535 {
+	if port > 65535 {
 		return fmt.Errorf("Out of port number range (0-65535) %q", value)
 	}
 

--- a/shared/version/useragent.go
+++ b/shared/version/useragent.go
@@ -5,6 +5,9 @@ import (
 	"runtime"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/lxc/lxd/shared/osarch"
 )
 
@@ -23,8 +26,7 @@ func getUserAgent() string {
 	if err != nil {
 		panic(err)
 	}
-
-	osTokens := []string{strings.Title(runtime.GOOS), arch}
+	osTokens := []string{cases.Title(language.English).String(arch)}
 	osTokens = append(osTokens, getPlatformVersionStrings()...)
 
 	// Initial version string

--- a/test/deps/devlxd-client.go
+++ b/test/deps/devlxd-client.go
@@ -24,7 +24,7 @@ type devLxdDialer struct {
 	Path string
 }
 
-func (d devLxdDialer) devLxdDial(network, path string) (net.Conn, error) {
+func (d devLxdDialer) devLxdDial(ctx context.Context, network, path string) (net.Conn, error) {
 	addr, err := net.ResolveUnixAddr("unix", d.Path)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (d devLxdDialer) devLxdDial(network, path string) (net.Conn, error) {
 }
 
 var devLxdTransport = &http.Transport{
-	Dial: devLxdDialer{"/dev/lxd/sock"}.devLxdDial,
+	DialContext: devLxdDialer{"/dev/lxd/sock"}.devLxdDial,
 }
 
 func devlxdMonitorStream() {
@@ -77,7 +77,7 @@ func devlxdMonitorStream() {
 
 func devlxdMonitorWebsocket(c http.Client) {
 	dialer := websocket.Dialer{
-		NetDial:          devLxdTransport.Dial,
+		NetDialContext:   devLxdTransport.DialContext,
 		HandshakeTimeout: time.Second * 5,
 	}
 

--- a/test/macaroon-identity/auth.go
+++ b/test/macaroon-identity/auth.go
@@ -66,8 +66,7 @@ func (s *authService) thirdPartyChecker(ctx context.Context, req *http.Request, 
 		return nil, err
 	}
 
-	tokenString := string(token.Value)
-	username, ok := s.userTokens[tokenString]
+	username, ok := s.userTokens[string(token.Value)]
 	if token.Kind != "form" || !ok {
 		return nil, fmt.Errorf("invalid token %#v", token)
 	}

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -28,7 +28,7 @@ test_static_analysis() {
 
     # golangci-lint
     if command -v golangci-lint >/dev/null 2>&1; then
-      golangci-lint run --disable-all -E deadcode -E errcheck -E gosimple
+      golangci-lint run --disable-all -E deadcode -E errcheck -E gosimple -E govet -E ineffassign -E staticcheck
     else
       echo "golangci-lint not found, some go linters will not run"
     fi


### PR DESCRIPTION
Continuing with #10392, this PR includes staticcheck in the static analysis script and fixes all associated lint errors.

Additionally, `govet` and `ineffassign` are added to the static analysis script (there were no lint errors for these).