### PR TITLE
Fix migration between LXD 4.0 and LXD 5.0

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -910,6 +910,10 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 		return err
 	}
 
+	// The source/sender will never set Refresh. However, to determine the correct migration type
+	// Refresh needs to be set.
+	offerHeader.Refresh = &c.refresh
+
 	// Extract the source's migration type and then match it against our pool's
 	// supported types and features. If a match is found the combined features list
 	// will be sent back to requester.

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -285,6 +285,10 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		return err
 	}
 
+	// The source/sender will never set Refresh. However, to determine the correct migration type
+	// Refresh needs to be set.
+	offerHeader.Refresh = &c.refresh
+
 	// Extract the source's migration type and then match it against our pool's
 	// supported types and features. If a match is found the combined features list
 	// will be sent back to requester.

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -205,7 +205,7 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 				}
 			}
 
-			if offer.Refresh != nil && *offer.Refresh {
+			if offer.GetRefresh() {
 				// Optimized refresh with zfs only works if ZfsFeatureMigrationHeader is available.
 				if ourType.FSType == MigrationFSType_ZFS && !shared.StringInSlice(ZFSFeatureMigrationHeader, commonFeatures) {
 					continue


### PR DESCRIPTION
- lxd: Add refresh arg to MatchTypes
- lxd/migration: Handle optimized refresh for older versions
