### PR TITLE
doc: storage: I/O limits

### DIFF
--- a/doc/howto/storage_add_volume.md
+++ b/doc/howto/storage_add_volume.md
@@ -53,3 +53,22 @@ If you want to use a different device name, you can add it to the command:
 
     lxc storage volume attach <pool_name> <filesystem_volume_name> <instance_name> <device_name> <location>
     lxc storage volume attach <pool_name> <block_volume_name> <instance_name> <device_name>
+
+## Configure I/O limits
+
+I/O limits in IOp/s or MB/s can be set on storage devices when attached to an
+instance (see [Instances](/instances.md)).
+
+Those are applied through the Linux `blkio` cgroup controller which makes it possible
+to restrict I/O at the disk level (but nothing finer grained than that).
+
+Because those apply to a whole physical disk rather than a partition or path, the following restrictions apply:
+
+ - Limits will not apply to filesystems that are backed by virtual devices (e.g. device mapper).
+ - If a filesystem is backed by multiple block devices, each device will get the same limit.
+ - If the instance is passed two disk devices that are each backed by the same disk,
+   the limits of the two devices will be averaged.
+
+It's also worth noting that all I/O limits only apply to actual block device access,
+so you will need to consider the filesystem's own overhead when setting limits.
+This also means that access to cached data will not be affected by the limit.

--- a/doc/howto/storage_add_volume.md
+++ b/doc/howto/storage_add_volume.md
@@ -55,21 +55,23 @@ If you want to use a different device name, you can add it to the command:
     lxc storage volume attach <pool_name> <filesystem_volume_name> <instance_name> <device_name> <location>
     lxc storage volume attach <pool_name> <block_volume_name> <instance_name> <device_name>
 
+(storage-configure-IO)=
 ## Configure I/O limits
 
-I/O limits in IOp/s or MB/s can be set on storage devices when attached to an
-instance (see [Instances](/instances.md)).
+When you attach a storage volume to an instance as a {ref}`disk device <instance_device_type_disk>`, you can configure I/O limits for it.
+To do so, set the `limits.read`, `limits.write` or `limits.max` properties to the corresponding limits (in IOp/s or MB/s).
+See the {ref}`instance_device_type_disk` reference for more information.
 
-Those are applied through the Linux `blkio` cgroup controller which makes it possible
-to restrict I/O at the disk level (but nothing finer grained than that).
+The limits are applied through the Linux `blkio` cgroup controller, which makes it possible to restrict I/O at the disk level (but nothing finer grained than that).
 
-Because those apply to a whole physical disk rather than a partition or path, the following restrictions apply:
+```{note}
+Because the limits apply to a whole physical disk rather than a partition or path, the following restrictions apply:
 
- - Limits will not apply to filesystems that are backed by virtual devices (e.g. device mapper).
- - If a filesystem is backed by multiple block devices, each device will get the same limit.
- - If the instance is passed two disk devices that are each backed by the same disk,
-   the limits of the two devices will be averaged.
+- Limits will not apply to filesystems that are backed by virtual devices (for example, device mapper).
+- If a filesystem is backed by multiple block devices, each device will get the same limit.
+- If two disk devices that are backed by the same disk are attached to the same instance, the limits of the two devices will be averaged.
+```
 
-It's also worth noting that all I/O limits only apply to actual block device access,
-so you will need to consider the filesystem's own overhead when setting limits.
-This also means that access to cached data will not be affected by the limit.
+All I/O limits only apply to actual block device access.
+Therefore, consider the filesystem's own overhead when setting limits.
+Access to cached data is not affected by the limit.

--- a/doc/howto/storage_add_volume.md
+++ b/doc/howto/storage_add_volume.md
@@ -31,9 +31,10 @@ For most storage drivers, custom storage volumes are not replicated across the c
 This behavior is different for Ceph-based storage pools (`ceph` and `cephfs`), where volumes are available from any cluster member.
 ```
 
+(storage-attach-volume)=
 ## Attach a storage volume to an instance
 
-After creating a storage volume, you can add it to one or more instances as a {ref}`disk device <instance_device_type_nic>`.
+After creating a storage volume, you can add it to one or more instances as a {ref}`disk device <instance_device_type_disk>`.
 
 The following restrictions apply:
 

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -754,6 +754,7 @@ To create a `sriov` `infiniband` device use:
 lxc config device add <instance> <device-name> infiniband nictype=sriov parent=<sriov-enabled-device>
 ```
 
+(instance_device_type_disk)=
 #### Type: disk
 
 Supported instance types: container, VM
@@ -761,6 +762,8 @@ Supported instance types: container, VM
 Disk entries are essentially mountpoints inside the instance. They can
 either be a bind-mount of an existing file or directory on the host, or
 if the source is a block device, a regular mount.
+
+They can also be created by {ref}`attaching a storage volume to an instance <storage-attach-volume>`.
 
 LXD supports the following additional source types:
 
@@ -787,8 +790,8 @@ The following properties exist:
 
 Key                 | Type      | Default   | Required  | Description
 :--                 | :--       | :--       | :--       | :--
-limits.read         | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in iops (must be suffixed with "iops")
-limits.write        | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in iops (must be suffixed with "iops")
+limits.read         | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in iops (must be suffixed with "iops") - see also {ref}`storage-configure-IO`
+limits.write        | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in iops (must be suffixed with "iops") - see also {ref}`storage-configure-IO`
 limits.max          | string    | -         | no        | Same as modifying both limits.read and limits.write
 path                | string    | -         | yes       | Path inside the instance where the disk will be mounted (only for containers).
 source              | string    | -         | yes       | Path on the host, either to a file/directory or to a block device

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -61,12 +61,12 @@ limits.cpu                                      | string    | -                 
 limits.cpu.allowance                            | string    | 100%              | yes           | container                 | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
 limits.cpu.priority                             | integer   | 10 (maximum)      | yes           | container                 | CPU scheduling priority compared to other instances sharing the same CPUs (overcommit) (integer between 0 and 10)
 limits.disk.priority                            | integer   | 5 (medium)        | yes           | -                         | When under load, how much priority to give to the instance's I/O requests (integer between 0 and 10)
-limits.hugepages.64KB                           | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see below) to limit number of 64 KB hugepages (Available hugepage sizes are architecture dependent.)
-limits.hugepages.1MB                            | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see below) to limit number of 1 MB hugepages (Available hugepage sizes are architecture dependent.)
-limits.hugepages.2MB                            | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see below) to limit number of 2 MB hugepages (Available hugepage sizes are architecture dependent.)
-limits.hugepages.1GB                            | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see below) to limit number of 1 GB hugepages (Available hugepage sizes are architecture dependent.)
+limits.hugepages.64KB                           | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see {ref}`instances-limit-units`) to limit number of 64 KB hugepages (Available hugepage sizes are architecture dependent.)
+limits.hugepages.1MB                            | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see {ref}`instances-limit-units`) to limit number of 1 MB hugepages (Available hugepage sizes are architecture dependent.)
+limits.hugepages.2MB                            | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see {ref}`instances-limit-units`) to limit number of 2 MB hugepages (Available hugepage sizes are architecture dependent.)
+limits.hugepages.1GB                            | string    | -                 | yes           | container                 | Fixed value in bytes (various suffixes supported, see {ref}`instances-limit-units`) to limit number of 1 GB hugepages (Available hugepage sizes are architecture dependent.)
 limits.kernel.\*                                | string    | -                 | no            | container                 | This limits kernel resources per instance (e.g. number of open files)
-limits.memory                                   | string    | -                 | yes           | -                         | Percentage of the host's memory or fixed value in bytes (various suffixes supported, see below) (defaults to 1GiB for VMs)
+limits.memory                                   | string    | -                 | yes           | -                         | Percentage of the host's memory or fixed value in bytes (various suffixes supported, see {ref}`instances-limit-units`) (defaults to 1GiB for VMs)
 limits.memory.enforce                           | string    | hard              | yes           | container                 | If hard, instance can't exceed its memory limit. If soft, the instance can exceed its memory limit when extra host memory is available
 limits.memory.hugepages                         | boolean   | false             | no            | virtual-machine           | Controls whether to back the instance using hugepages rather than regular system memory
 limits.memory.swap                              | boolean   | true              | yes           | container                 | Controls whether to encourage/discourage swapping less used pages for this instance
@@ -364,8 +364,8 @@ name                     | string  | kernel assigned   | no       | no      | Th
 mtu                      | integer | parent MTU        | no       | yes     | The MTU of the new interface
 hwaddr                   | string  | randomly assigned | no       | no      | The MAC address of the new interface
 host\_name               | string  | randomly assigned | no       | no      | The name of the interface inside the host
-limits.ingress           | string  | -                 | no       | no      | I/O limit in bit/s for incoming traffic (various suffixes supported, see below)
-limits.egress            | string  | -                 | no       | no      | I/O limit in bit/s for outgoing traffic (various suffixes supported, see below)
+limits.ingress           | string  | -                 | no       | no      | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
+limits.egress            | string  | -                 | no       | no      | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
 limits.max               | string  | -                 | no       | no      | Same as modifying both limits.ingress and limits.egress
 ipv4.address             | string  | -                 | no       | no      | An IPv4 address to assign to the instance through DHCP (Can be `none` to restrict all IPv4 traffic when security.ipv4\_filtering is set)
 ipv6.address             | string  | -                 | no       | no      | An IPv6 address to assign to the instance through DHCP (Can be `none` to restrict all IPv6 traffic when security.ipv6\_filtering is set)
@@ -578,8 +578,8 @@ name                    | string  | kernel assigned   | no       | The name of t
 mtu                     | integer | kernel assigned   | no       | The MTU of the new interface
 hwaddr                  | string  | randomly assigned | no       | The MAC address of the new interface
 host\_name              | string  | randomly assigned | no       | The name of the interface inside the host
-limits.ingress          | string  | -                 | no       | I/O limit in bit/s for incoming traffic (various suffixes supported, see below)
-limits.egress           | string  | -                 | no       | I/O limit in bit/s for outgoing traffic (various suffixes supported, see below)
+limits.ingress          | string  | -                 | no       | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
+limits.egress           | string  | -                 | no       | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
 limits.max              | string  | -                 | no       | Same as modifying both limits.ingress and limits.egress
 ipv4.routes             | string  | -                 | no       | Comma delimited list of IPv4 static routes to add on host to NIC
 ipv6.routes             | string  | -                 | no       | Comma delimited list of IPv6 static routes to add on host to NIC
@@ -648,8 +648,8 @@ name                    | string  | kernel assigned   | no       | The name of t
 host\_name              | string  | randomly assigned | no       | The name of the interface inside the host
 mtu                     | integer | parent MTU        | no       | The MTU of the new interface
 hwaddr                  | string  | randomly assigned | no       | The MAC address of the new interface
-limits.ingress          | string  | -                 | no       | I/O limit in bit/s for incoming traffic (various suffixes supported, see below)
-limits.egress           | string  | -                 | no       | I/O limit in bit/s for outgoing traffic (various suffixes supported, see below)
+limits.ingress          | string  | -                 | no       | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
+limits.egress           | string  | -                 | no       | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
 limits.max              | string  | -                 | no       | Same as modifying both limits.ingress and limits.egress
 ipv4.address            | string  | -                 | no       | Comma delimited list of IPv4 static addresses to add to the instance
 ipv4.routes             | string  | -                 | no       | Comma delimited list of IPv4 static routes to add on host to NIC (without L2 ARP/NDP proxy)
@@ -787,14 +787,14 @@ The following properties exist:
 
 Key                 | Type      | Default   | Required  | Description
 :--                 | :--       | :--       | :--       | :--
-limits.read         | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see below) or in iops (must be suffixed with "iops")
-limits.write        | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see below) or in iops (must be suffixed with "iops")
+limits.read         | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in iops (must be suffixed with "iops")
+limits.write        | string    | -         | no        | I/O limit in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in iops (must be suffixed with "iops")
 limits.max          | string    | -         | no        | Same as modifying both limits.read and limits.write
 path                | string    | -         | yes       | Path inside the instance where the disk will be mounted (only for containers).
 source              | string    | -         | yes       | Path on the host, either to a file/directory or to a block device
 required            | boolean   | true      | no        | Controls whether to fail if the source doesn't exist
 readonly            | boolean   | false     | no        | Controls whether to make the mount read-only
-size                | string    | -         | no        | Disk size in bytes (various suffixes supported, see below). This is only supported for the rootfs (/)
+size                | string    | -         | no        | Disk size in bytes (various suffixes supported, see {ref}`instances-limit-units`). This is only supported for the rootfs (/)
 size.state          | string    | -         | no        | Same as size above but applies to the filesystem volume used for saving runtime state in virtual machines.
 recursive           | boolean   | false     | no        | Whether or not to recursively mount the source path
 pool                | string    | -         | no        | The storage pool the disk device belongs to. This is only applicable for storage volumes managed by LXD
@@ -1062,7 +1062,7 @@ Key                 | Type      | Default   | Required  | Description
 :--                 | :--       | :--       | :--       | :--
 address             | string    | -         | yes       | PCI address of the device.
 
-
+(instances-limit-units)=
 ### Units for storage and network limits
 Any value representing bytes or bits can make use of a number of useful
 suffixes to make it easier to understand what a particular limit is.

--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -73,21 +73,3 @@ LXD will fallback to using rsync to transfer the individual files instead.
 When rsync has to be used LXD allows to specify an upper limit on the amount of
 socket I/O by setting the `rsync.bwlimit` storage pool property to a non-zero
 value.
-
-## I/O limits
-I/O limits in IOp/s or MB/s can be set on storage devices when attached to an
-instance (see [Instances](/instances.md)).
-
-Those are applied through the Linux `blkio` cgroup controller which makes it possible
-to restrict I/O at the disk level (but nothing finer grained than that).
-
-Because those apply to a whole physical disk rather than a partition or path, the following restrictions apply:
-
- - Limits will not apply to filesystems that are backed by virtual devices (e.g. device mapper).
- - If a filesystem is backed by multiple block devices, each device will get the same limit.
- - If the instance is passed two disk devices that are each backed by the same disk,
-   the limits of the two devices will be averaged.
-
-It's also worth noting that all I/O limits only apply to actual block device access,
-so you will need to consider the filesystem's own overhead when setting limits.
-This also means that access to cached data will not be affected by the limit.


### PR DESCRIPTION
Clean up the section about configuring I/O limits, move it to the how-to, and link to it from the instances page.