### PR TITLE
Fixes structcheck, typecheck, unused, varcheck lint errors

### DIFF
--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -141,8 +141,6 @@ func (c *cmdClusterGroupAssign) Run(cmd *cobra.Command, args []string) error {
 type cmdClusterGroupCreate struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
-
-	flagFormat string
 }
 
 func (c *cmdClusterGroupCreate) Command() *cobra.Command {
@@ -197,8 +195,6 @@ func (c *cmdClusterGroupCreate) Run(cmd *cobra.Command, args []string) error {
 type cmdClusterGroupDelete struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
-
-	flagFormat string
 }
 
 func (c *cmdClusterGroupDelete) Command() *cobra.Command {
@@ -250,8 +246,6 @@ func (c *cmdClusterGroupDelete) Run(cmd *cobra.Command, args []string) error {
 type cmdClusterGroupEdit struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
-
-	flagFormat string
 }
 
 func (c *cmdClusterGroupEdit) Command() *cobra.Command {
@@ -506,8 +500,6 @@ func (c *cmdClusterGroupRemove) Run(cmd *cobra.Command, args []string) error {
 type cmdClusterGroupRename struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
-
-	flagFormat string
 }
 
 func (c *cmdClusterGroupRename) Command() *cobra.Command {

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -19,8 +19,7 @@ import (
 )
 
 type cmdNetworkPeer struct {
-	global     *cmdGlobal
-	flagTarget string
+	global *cmdGlobal
 }
 
 func (c *cmdNetworkPeer) Command() *cobra.Command {

--- a/lxd-user/main_daemon.go
+++ b/lxd-user/main_daemon.go
@@ -19,9 +19,7 @@ var mu sync.RWMutex
 var connections uint64
 var transactions uint64
 
-type cmdDaemon struct {
-	global *cmdGlobal
-}
+type cmdDaemon struct{}
 
 func (c *cmdDaemon) Command() *cobra.Command {
 	cmd := &cobra.Command{}

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -81,7 +81,6 @@ func TestCluster_RenameNode(t *testing.T) {
 type clusterFixture struct {
 	t       *testing.T
 	clients map[*Daemon]lxd.InstanceServer
-	daemons []*Daemon
 }
 
 // Enable networking in the given daemon. The password is optional and can be

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -129,9 +129,6 @@ type Daemon struct {
 	// Keep track of skews.
 	timeSkew bool
 
-	// Kernel version.
-	kernelVersion version.DottedVersion
-
 	// Configuration.
 	globalConfig   *clusterConfig.Config
 	globalConfigMu sync.Mutex

--- a/lxd/events/common.go
+++ b/lxd/events/common.go
@@ -27,7 +27,6 @@ type listenerCommon struct {
 	done         *cancel.Canceller
 	id           string
 	lock         sync.Mutex
-	pongsPending uint
 	recvFunc     EventHandler
 }
 

--- a/lxd/response/swagger.go
+++ b/lxd/response/swagger.go
@@ -1,6 +1,6 @@
 // Package response contains helpers for rendering LXD HTTP responses.
 //
-//nolint:deadcode
+//nolint:deadcode,unused
 package response
 
 import (

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -437,34 +437,6 @@ func (d *btrfs) getSubvolumesMetaData(vol Volume) ([]BTRFSSubVolume, error) {
 	return subVols, nil
 }
 
-func (d *btrfs) getSubvolumeUUID(vol Volume) (string, error) {
-	stdout := strings.Builder{}
-
-	poolMountPath := GetPoolMountPath(vol.pool)
-
-	// List all subvolumes in the given filesystem with their UUIDs.
-	err := shared.RunCommandWithFds(nil, &stdout, "btrfs", "subvolume", "list", "-u", poolMountPath)
-	if err != nil {
-		return "", err
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(stdout.String()))
-
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-
-		if len(fields) != 11 {
-			continue
-		}
-
-		if vol.MountPath() == filepath.Join(poolMountPath, fields[10]) {
-			return fields[8], nil
-		}
-	}
-
-	return "", nil
-}
-
 func (d *btrfs) getSubVolumeReceivedUUID(vol Volume) (string, error) {
 	stdout := strings.Builder{}
 

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -28,7 +28,7 @@ test_static_analysis() {
 
     # golangci-lint
     if command -v golangci-lint >/dev/null 2>&1; then
-      golangci-lint run --disable-all -E deadcode -E errcheck -E gosimple -E govet -E ineffassign -E staticcheck
+      golangci-lint run
     else
       echo "golangci-lint not found, some go linters will not run"
     fi


### PR DESCRIPTION
Fixes lint errors for the remaining default linters used by `golangci-lint` in preparation for #10392.