### PR TITLE
lxd-agent exec bug

### DIFF
--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -1,6 +1,7 @@
 package vsock
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -35,7 +36,7 @@ func HTTPClient(vsockID int, tlsClientCert string, tlsClientKey string, tlsServe
 	client.Transport = &http.Transport{
 		TLSClientConfig: tlsConfig,
 		// Setup a VM socket dialer.
-		Dial: func(network, addr string) (net.Conn, error) {
+		DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
 			var conn net.Conn
 			var err error
 


### PR DESCRIPTION
The problem was that the vsock HTTP client was using Dial instead of DialContext in it's `http.Transport`. I think `staticcheck` checks for deprecated function calls, but not for assignments to deprecated fields. I've searched the codebase for any other assignment to `transport.Dial` but can't find any so there shouldn't be any more issues :crossed_fingers: .

Closes #10596. 