### PR TITLE
lxd-generate: Revert to deprecated strings.Title.

### DIFF
--- a/lxd/db/generate/lex/case.go
+++ b/lxd/db/generate/lex/case.go
@@ -4,14 +4,11 @@ import (
 	"bytes"
 	"strings"
 	"unicode"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 // Capital capitalizes the given string ("foo" -> "Foo")
 func Capital(s string) string {
-	return cases.Title(language.English).String(s)
+	return strings.Title(s) //nolint:staticcheck
 }
 
 // Minuscule turns the first character to lower case ("Foo" -> "foo") or the whole word if it is all uppercase ("UUID" -> "uuid")


### PR DESCRIPTION
Usage of `cases.Title(language.English).String(str)` is subtely different
from `strings.Title`. For example, `strings.Title("UUID")` returns `"UUID"`,
whereas `cases.Title(language.English).String("UUID")` returns `"Uuid"`.
This is breaking the generated database code.

Signed-off-by: Mark Laing <mark.laing@canonical.com>