### PR TITLE
doc: fix version switcher to work for latest

### DIFF
--- a/.sphinx/_extra/versions.json
+++ b/.sphinx/_extra/versions.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "latest",
-        "id": "master"
+        "id": "latest"
     },
     {
         "version": "5.0.x",

--- a/.sphinx/_static/version-switcher.js
+++ b/.sphinx/_static/version-switcher.js
@@ -50,6 +50,9 @@ function getPaths()
 
         path = url.substr(prefix.pathname.length).split("/");
         paths['current'] = path.shift();
+        if (paths['current'] == "master") {
+            paths['current'] = "latest";
+        };
         paths['page'] = path.join("/");
     }
     else {


### PR DESCRIPTION
The version switcher relies on the URL and assumes that the
current version is under "master". We've since added a link
that makes the current version available as "latest" as well.
Therefore, update the script to use "latest" by default and
replace "master" with "latest" if it is used.

This is a bit tricky to test locally, but I *think* it should work.
Basically, it should make the version dropdown show up for 
https://linuxcontainers.org/lxd/docs/latest/ as well, where the
dropdown is currently on an empty string.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>