### PR TITLE
doc: storage: clarify that most docs are about custom volumes

### DIFF
--- a/doc/howto/storage_add_volume.md
+++ b/doc/howto/storage_add_volume.md
@@ -1,5 +1,5 @@
 (storage-add-volume)=
-# How to add a storage volume
+# How to add a custom storage volume
 
 When you create an instance, LXD automatically creates a storage volume that is used as the root disk for the instance.
 
@@ -9,20 +9,20 @@ Custom storage volumes with content type `filesystem` can also be shared between
 
 See {ref}`storage-volumes` for detailed information.
 
-## Create a storage volume
+## Create a custom storage volume
 
-Use the following command to create a storage volume in a storage pool:
+Use the following command to create a custom storage volume in a storage pool:
 
     lxc storage volume create <pool_name> <volume_name> [configuration_options...]
 
 See the {ref}`storage-drivers` documentation for a list of available storage volume configuration options for each driver.
 
-By default, storage volumes use the `filesystem` {ref}`content type <storage-content-types>`.
-To create a storage volume with the content type `block`, add the `--type` flag:
+By default, custom storage volumes use the `filesystem` {ref}`content type <storage-content-types>`.
+To create a custom storage volume with the content type `block`, add the `--type` flag:
 
     lxc storage volume create <pool_name> <volume_name> --type=block [configuration_options...]
 
-To add a storage volume on a cluster member, add the `--target` flag:
+To add a custom storage volume on a cluster member, add the `--target` flag:
 
     lxc storage volume create <pool_name> <volume_name> --target=<cluster_member> [configuration_options...]
 
@@ -32,24 +32,24 @@ This behavior is different for Ceph-based storage pools (`ceph` and `cephfs`), w
 ```
 
 (storage-attach-volume)=
-## Attach a storage volume to an instance
+## Attach a custom storage volume to an instance
 
-After creating a storage volume, you can add it to one or more instances as a {ref}`disk device <instance_device_type_disk>`.
+After creating a custom storage volume, you can add it to one or more instances as a {ref}`disk device <instance_device_type_disk>`.
 
 The following restrictions apply:
 
-- Storage volumes of {ref}`content type <storage-content-types>` `block` cannot be attached to containers, but only to virtual machines.
+- Custom storage volumes of {ref}`content type <storage-content-types>` `block` cannot be attached to containers, but only to virtual machines.
 - To avoid data corruption, storage volumes of {ref}`content type <storage-content-types>` `block` should never be attached to more than one virtual machine at a time.
 
-For storage volumes with the content type `filesystem`, use the following command, where `<location>` is the path for accessing the storage volume inside the instance (for example, `/data`):
+For custom storage volumes with the content type `filesystem`, use the following command, where `<location>` is the path for accessing the storage volume inside the instance (for example, `/data`):
 
     lxc storage volume attach <pool_name> <filesystem_volume_name> <instance_name> <location>
 
-Storage volumes with the content type `block` do not take a location:
+Custom storage volumes with the content type `block` do not take a location:
 
     lxc storage volume attach <pool_name> <block_volume_name> <instance_name>
 
-By default, the storage volume is added to the instance with the volume name as the {ref}`device <devices>` name.
+By default, the custom storage volume is added to the instance with the volume name as the {ref}`device <devices>` name.
 If you want to use a different device name, you can add it to the command:
 
     lxc storage volume attach <pool_name> <filesystem_volume_name> <instance_name> <device_name> <location>

--- a/doc/howto/storage_backup.md
+++ b/doc/howto/storage_backup.md
@@ -1,6 +1,6 @@
-# How to back up storage volumes
+# How to back up custom storage volumes
 
-There are different ways of backing up your storage volumes:
+There are different ways of backing up your custom storage volumes:
 
 - {ref}`storage-backup-snapshots`
 - {ref}`storage-backup-export`
@@ -14,8 +14,8 @@ They can also be used to restore a volume into a different storage pool.
 If you have a separate, network-connected LXD server available, regularly copying a volume to this other server gives high reliability as well, and this method can also be used to back up snapshots of the volume.
 
 ```{note}
-Storage volumes might be attached to an instance, but they are not part of the instance.
-Therefore, the content of a storage volume is not stored when you back up your instance.
+Custom storage volumes might be attached to an instance, but they are not part of the instance.
+Therefore, the content of a custom storage volume is not stored when you back up your instance.
 You must back up the data of your storage volume separately.
 ```
 
@@ -30,9 +30,9 @@ For these drivers, creating snapshots is both quick and space-efficient.
 For the `dir` driver, snapshot functionality is available but not very efficient.
 For the `lvm` driver, snapshot creation is quick, but restoring snapshots is efficient only when using thin-pool mode.
 
-### Create a snapshot
+### Create a snapshot of a custom storage volume
 
-Use the following command to create a snapshot for a storage volume:
+Use the following command to create a snapshot for a custom storage volume:
 
     lxc storage volume snapshot <pool_name> <volume_name> [<snapshot_name>]
 
@@ -47,7 +47,7 @@ Use the following command to display the snapshots for a storage volume:
 
     lxc storage volume info <pool_name> <volume_name>
 
-You can view or modify snapshots in a similar way to storage volumes, by referring to the snapshot with `<volume_name>/<snapshot_name>`.
+You can view or modify snapshots in a similar way to custom storage volumes, by referring to the snapshot with `<volume_name>/<snapshot_name>`.
 
 To show information about a snapshot, use the following command:
 
@@ -61,9 +61,9 @@ To delete a snapshot, use the following command:
 
     lxc storage volume delete <pool_name> <volume_name>/<snapshot_name>
 
-### Schedule snapshots
+### Schedule snapshots of a custom storage volume
 
-You can configure a storage volume to automatically create snapshots at specific times.
+You can configure a custom storage volume to automatically create snapshots at specific times.
 To do so, set the `snapshots.schedule` configuration option for the storage volume (see {ref}`storage-configure-volumes`).
 
 For example, to configure daily snapshots, use the following command:
@@ -77,16 +77,16 @@ To configure taking a snapshot every day at 6 am, use the following command:
 When scheduling regular snapshots, consider setting an automatic expiry (`snapshots.expiry`) and a naming pattern for snapshots (`snapshots.pattern`).
 See the {ref}`storage-drivers` documentation for more information about those configuration options.
 
-### Restore a snapshot
+### Restore a snapshot of a custom storage volume
 
-You can restore a storage volume to the state of any of its snapshots.
+You can restore a custom storage volume to the state of any of its snapshots.
 
 To do so, you must first stop all instances that use the storage volume.
 Then use the following command:
 
     lxc storage volume restore <pool_name> <volume_name> <snapshot_name>
 
-You can also restore a snapshot into a new storage volume, either in the same storage pool or in a different one (even a remote storage pool).
+You can also restore a snapshot into a new custom storage volume, either in the same storage pool or in a different one (even a remote storage pool).
 To do so, use the following command:
 
     lxc storage volume copy <source_pool_name>/<source_volume_name>/<source_snapshot_name> <target_pool_name>/<target_volume_name>
@@ -94,12 +94,12 @@ To do so, use the following command:
 (storage-backup-export)=
 ## Use export files for backup
 
-You can export the full content of your storage volume to a standalone file that can be stored at any location.
+You can export the full content of your custom storage volume to a standalone file that can be stored at any location.
 For highest reliability, store the backup file on a different file system to ensure that it does not get lost or corrupted.
 
-### Export a volume
+### Export a custom storage volume
 
-Use the following command to export a storage volume to a compressed file (for example, `/path/to/my-backup.tgz`):
+Use the following command to export a custom storage volume to a compressed file (for example, `/path/to/my-backup.tgz`):
 
     lxc storage volume export <pool_name> <volume_name> [<file_path>]
 
@@ -126,9 +126,9 @@ You can add any of the following flags to the command:
 : By default, the export file contains all snapshots of the storage volume.
   Add this flag to export the volume without its snapshots.
 
-### Restore a volume from an export file
+### Restore a custom storage volume from an export file
 
-You can import an export file (for example, `/path/to/my-backup.tgz`) as a new storage volume.
+You can import an export file (for example, `/path/to/my-backup.tgz`) as a new custom storage volume.
 To do so, use the following command:
 
     lxc storage volume import <pool_name> <file_path> [<volume_name>]

--- a/doc/howto/storage_configure.md
+++ b/doc/howto/storage_configure.md
@@ -30,6 +30,10 @@ For example, to set the snapshot expiry time to one month, use the following com
 
     lxc storage volume set my-pool my-volume snapshorts.expiry 1M
 
+To configure an instance storage volume, specify the volume name including the {ref}`storage volume type <storage-volume-types>`, for example:
+
+    lxc storage volume set my-pool container/my-container-volume user.XXX value
+
 You can also edit the storage volume configuration by using the following command:
 
     lxc storage volume edit <pool_name> <volume_name>

--- a/doc/howto/storage_configure.md
+++ b/doc/howto/storage_configure.md
@@ -28,7 +28,7 @@ Use the following command to set configuration options for a storage volume:
 
 For example, to set the snapshot expiry time to one month, use the following command:
 
-    lxc storage volume set my-pool my-volume snapshorts.expiry 1M
+    lxc storage volume set my-pool my-volume snapshots.expiry 1M
 
 To configure an instance storage volume, specify the volume name including the {ref}`storage volume type <storage-volume-types>`, for example:
 

--- a/doc/howto/storage_list.md
+++ b/doc/howto/storage_list.md
@@ -22,6 +22,15 @@ To list all available storage volumes in a storage pool, use the following comma
 
 The resulting table contains the {ref}`storage volume type <storage-volume-types>` and the {ref}`content type <storage-content-types>` for each storage volume in the pool.
 
-To show detailed information about a specific volume, use the following command:
+```{note}
+Custom storage volumes might use the same name as instance volumes (for example, you might have a container named `c1` with a container storage volume named `c1` and a custom storage volume named `c1`).
+Therefore, to distinguish between instance storage volumes and custom storage volumes, all instance storage volumes must be referred to as `<volume_type>/<volume_name>` (for example, `container/c1` or `virtual-machine/vm`) in commands.
+```
+
+To show detailed information about a specific custom volume, use the following command:
 
     lxc storage volume show <pool_name> <volume_name>
+
+To show detailed information about a specific instance volume, use the following command:
+
+    lxc storage volume show <pool_name> <volume_type>/<volume_name>


### PR DESCRIPTION
You cannot do the same things with an instance volume as you
can with custom volumes.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>