### PR TITLE
lxd/network/openvswitch: Use %s so that delimiting quotes are not escaped.

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -433,8 +433,8 @@ func (o *OVN) LogicalRouterPortAdd(routerName OVNRouter, portName OVNRouterPort,
 			}
 
 			_, err := o.nbctl("set", "Logical_Router_Port", string(portName),
-				fmt.Sprintf("networks=%q", strings.Join(ips, `","`)),
-				fmt.Sprintf("mac=%q", mac.String()),
+				fmt.Sprintf(`networks="%s"`, strings.Join(ips, `","`)),
+				fmt.Sprintf(`mac="%s"`, mac.String()),
 				fmt.Sprintf("options:gateway_mtu=%d", gatewayMTU),
 			)
 			if err != nil {


### PR DESCRIPTION
Closes #10605 