### PR TITLE
lxd/instance/lxc: Don't fail on missing apparmor

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -951,10 +951,8 @@ func (d *lxc) initLXC(config bool) error {
 		}
 	} else {
 		// Make sure that LXC won't try to apply an apparmor profile.
-		err := lxcSetConfigItem(cc, "lxc.apparmor.profile", "unconfined")
-		if err != nil {
-			return err
-		}
+		// This may fail on liblxc compiled without apparmor, so ignore errors.
+		_ = lxcSetConfigItem(cc, "lxc.apparmor.profile", "unconfined")
 	}
 
 	// Setup Seccomp if necessary


### PR DESCRIPTION
Reported from https://discuss.linuxcontainers.org/t/failed-to-set-lxc-config-lxc-apparmor-profile-unconfined/14468

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>