### PR TITLE
lxd/db/generate/lex: Use cases.Title instead of deprecated strings.Title

### DIFF
--- a/lxd/db/generate/lex/case.go
+++ b/lxd/db/generate/lex/case.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Capital capitalizes the given string ("foo" -> "Foo").
 func Capital(s string) string {
-	return strings.Title(s) //nolint:staticcheck
+	return cases.Title(language.English, cases.NoLower).String(s)
 }
 
 // Minuscule turns the first character to lower case ("Foo" -> "foo") or the whole word if it is all uppercase ("UUID" -> "uuid").


### PR DESCRIPTION
Using the cases.NoLower option preserves behaviour to that of
strings.Title.

See https://github.com/lxc/lxd/pull/10598#issuecomment-1167941855