### PR TITLE
Generator: Fix config table error handling.

### DIFF
--- a/lxd/db/cluster/config.mapper.go
+++ b/lxd/db/cluster/config.mapper.go
@@ -60,7 +60,7 @@ func GetConfig(ctx context.Context, tx *sql.Tx, parent string) (map[int]map[stri
 	// Select.
 	err = query.SelectObjects(sqlStmt, dest, args...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"config\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"%s_config\" table: %w", parent, err)
 	}
 
 	resultMap := map[int]map[string]string{}
@@ -121,10 +121,9 @@ func UpdateConfig(ctx context.Context, tx *sql.Tx, parent string, referenceID in
 		}
 
 		err = CreateConfig(ctx, tx, parent, object)
-	}
-
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/lxd/db/cluster/devices.mapper.go
+++ b/lxd/db/cluster/devices.mapper.go
@@ -60,7 +60,7 @@ func GetDevices(ctx context.Context, tx *sql.Tx, parent string) (map[int][]Devic
 	// Select.
 	err = query.SelectObjects(sqlStmt, dest, args...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"devices\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"%s_devices\" table: %w", parent, err)
 	}
 
 	config, err := GetConfig(ctx, tx, parent+"_device")

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -303,6 +303,7 @@ func GetInstanceDevices(ctx context.Context, tx *sql.Tx, instanceID int) (map[st
 			return nil, fmt.Errorf("Found duplicate Device with name %q", ref.Name)
 		}
 	}
+
 	return devices, nil
 }
 

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -197,6 +197,7 @@ func GetProfileDevices(ctx context.Context, tx *sql.Tx, profileID int) (map[stri
 			return nil, fmt.Errorf("Found duplicate Device with name %q", ref.Name)
 		}
 	}
+
 	return devices, nil
 }
 

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -136,6 +136,7 @@ func GetInstanceSnapshotDevices(ctx context.Context, tx *sql.Tx, instanceSnapsho
 			return nil, fmt.Errorf("Found duplicate Device with name %q", ref.Name)
 		}
 	}
+
 	return devices, nil
 }
 


### PR DESCRIPTION
While investigating the issue over [here](https://discuss.linuxcontainers.org/t/database-error-sql-transaction-has-already-been-committed-or-rolled-back/14464), I noticed the `GetConfig` error messages weren't informative of which `<parent>_config` table is actually having problems. Then I noticed that in `UpdateConfig`, the error from `CreateConfig` was only checked once for the whole config, instead of per call.

So this adds the actual table name to the error message for `GetConfig`, and properly checks the error from `CreateConfig`. 

Additionally adds some new-lines via `buf.N()` to make the code look a bit more readable/consistent.