### PR TITLE
Test: Add tests for passing unix character devices as disks into a container

### DIFF
--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -135,8 +135,11 @@ test_container_devices_disk_cephfs() {
 }
 
 test_container_devices_disk_socket() {
-  lxc config device add foo unix-socket disk source="${LXD_DIR}/unix.socket" path=/root/lxd.sock
   lxc start foo
+  lxc config device add foo unix-socket disk source="${LXD_DIR}/unix.socket" path=/root/lxd.sock
   [ "$(lxc exec foo -- stat /root/lxd.sock -c '%F')" = "socket" ] || false
+  lxc restart -f foo
+  [ "$(lxc exec foo -- stat /root/lxd.sock -c '%F')" = "socket" ] || false
+  lxc config device remove foo unix-socket
   lxc stop foo -f
 }

--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -9,6 +9,7 @@ test_container_devices_disk() {
   test_container_devices_disk_ceph
   test_container_devices_disk_cephfs
   test_container_devices_disk_socket
+  test_container_devices_disk_char
 
   lxc delete -f foo
 }
@@ -141,5 +142,15 @@ test_container_devices_disk_socket() {
   lxc restart -f foo
   [ "$(lxc exec foo -- stat /root/lxd.sock -c '%F')" = "socket" ] || false
   lxc config device remove foo unix-socket
+  lxc stop foo -f
+}
+
+test_container_devices_disk_char() {
+  lxc start foo
+  lxc config device add foo char disk source=/dev/zero path=/root/zero
+  [ "$(lxc exec foo -- stat /root/zero -c '%F')" = "character special file" ] || false
+  lxc restart -f foo
+  [ "$(lxc exec foo -- stat /root/zero -c '%F')" = "character special file" ] || false
+  lxc config device remove foo char
   lxc stop foo -f
 }


### PR DESCRIPTION
LXD 5.3 had an issue passing some host paths as `disk` devices into containers that were working in LXD 5.2 and earlier.
These devices could be hot-plugged into a running container, but could not be present on container start otherwise it would fail to start with an error like this in the `lxc info --show-log <instance>` output similar to:

```
ERROR conf - …/src/src/lxc/conf.c:mount_entry:2459 - Operation not permitted - Failed to mount “/var/snap/lxd/common/lxd/devices/web/disk.X0.tmp-.X11–unix-X0” on “/var/snap/lxd/common/lxc//tmp/.X11-unix/X0”
```

This caused quite a bit of disruption:

- https://github.com/lxc/lxc/issues/4160
- https://github.com/lxc/lxc/issues/4162
- https://discuss.linuxcontainers.org/t/cant-mount-external-xfs-device-mountpoint-in-container/14510
- https://discuss.linuxcontainers.org/t/cannot-start-lxc-containers-with-gui-profile/14497
- https://discuss.linuxcontainers.org/t/need-help-containers-failed-to-start-after-snap-refresh-to-5-3/14480
- https://discuss.linuxcontainers.org/t/mounted-samba-from-host-fails-with-error/14526
- https://discuss.linuxcontainers.org/t/cant-start-container-after-debian-11-3/14521

I was able to reproduce this issue by passing in a unix character device from the host's `/dev` path (such as `/dev/zero`) into the container as a `disk` device when running LXD `5.3-924be6a`.

The issue turned out to be a regression in liblxc since switching to meson build system, which was fixed in:

https://github.com/lxc/lxc/commit/8ee615c27d4e646b13a767ffc59823262b38427d

By restoring detection of statvfs support during liblxc build.

This was confirmed working in LXD snap `latest/candidate` `5.3-91e042b`.

This PR adds an explicit check for that scenario to hopefully catch any similar regressions in the future.

However due to our Jenkins per-pull-request test system using the liblxc edge PPA (https://launchpad.net/~ubuntu-lxc/+archive/ubuntu/lxc-git-master) even with this PR (and possibly an existing check in our test suite) it would not have detected the issue in LXD 5.3 as the liblxc edge ppa was not yet updated to use the meson build system at the time LXD 5.3 was released, and so the liblxc bundled in the LXD 5.3 snap was newer than what was being used in the test suite. This has now been updated to use meson and is now up to date for Jammy, although the jenkins builds are currently on Focal and are not yet updated.
