### PR TITLE
workflows/static-analysis: Download but do not update dependencies.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           make deps
 
-      - name: Update gomod
+      - name: Download go dependencies
         run: |
-          make update
+          go mod download
 
       - name: Run static analysis
         run: |


### PR DESCRIPTION
We should not update the go mod as part of the static analysis workflow because updated dependencies are not committed to the codebase and could cause the static analysis to fail.

Closes #10630.