### PR TITLE
DB: Optimise query pattern for InstanceList

### DIFF
--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -15,6 +15,7 @@ import (
 type cmdGlobal struct {
 	flagHelp        bool
 	flagParallel    int
+	flagProject     string
 	flagReportFile  string
 	flagReportLabel string
 	flagVersion     bool
@@ -31,7 +32,7 @@ func (c *cmdGlobal) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c.srv = srv
+	c.srv = srv.UseProject(c.flagProject)
 
 	// Print the initial header
 	err = benchmark.PrintServerInfo(srv)
@@ -112,6 +113,7 @@ func main() {
 	app.PersistentFlags().IntVarP(&globalCmd.flagParallel, "parallel", "P", -1, "Number of threads to use"+"``")
 	app.PersistentFlags().StringVar(&globalCmd.flagReportFile, "report-file", "", "Path to the CSV report file"+"``")
 	app.PersistentFlags().StringVar(&globalCmd.flagReportLabel, "report-label", "", "Label for the new entry in the report [default=ACTION]"+"``")
+	app.PersistentFlags().StringVar(&globalCmd.flagProject, "project", "default", "Project to use")
 
 	// Version handling
 	app.SetVersionTemplate("{{.Version}}\n")

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -59,7 +59,7 @@ func (p *Project) ToAPI(ctx context.Context, tx *sql.Tx) (*api.Project, error) {
 	var err error
 	apiProject.Config, err = GetProjectConfig(ctx, tx, p.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed loading project config: %w", err)
 	}
 
 	return apiProject, nil

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -306,61 +306,256 @@ var ErrInstanceListStop = fmt.Errorf("search stopped")
 // InstanceList loads all instances across all projects and for each instance runs the instanceFunc passing in the
 // instance and it's project and profiles. Accepts optional filter argument to specify a subset of instances.
 func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func(inst InstanceArgs, project api.Project, profiles []api.Profile) error) error {
-	var instances []InstanceArgs
-	projectsByName := map[string]api.Project{}
+	projectsByName := make(map[string]*api.Project)
+	profilesByID := make(map[int]*api.Profile)
+	var instances map[int]InstanceArgs
+	instanceApplyProfileIDs := make(map[int64][]int)
 
 	if filter == nil {
 		filter = &cluster.InstanceFilter{}
 	}
 
-	// Retrieve required info from the database in single transaction for performance.
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		dbInstances, err := cluster.GetInstances(ctx, tx.tx, *filter)
-		if err != nil {
-			return fmt.Errorf("Failed loading instances: %w", err)
+	// instanceConfig function loads config for all specified instanceIDs in a single query and then updates
+	// the entries in the instances map.
+	instanceConfig := func(tx *ClusterTx, instanceIDs []int) error {
+		q := `
+		SELECT
+			instance_id,
+			key,
+			value
+		FROM instances_config
+		WHERE instance_id IN
+		` + query.Params(len(instanceIDs))
+
+		args := make([]any, 0, len(instanceIDs))
+		for _, instanceID := range instanceIDs {
+			args = append(args, instanceID)
 		}
 
-		instances = make([]InstanceArgs, 0, len(dbInstances))
-		for _, instance := range dbInstances {
-			// Get expanded instance information.
-			instanceArgs, err := InstanceToArgs(ctx, tx.tx, &instance)
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
+			var instanceID int
+			var key, value string
+
+			err := scan(&instanceID, &key, &value)
 			if err != nil {
 				return err
 			}
 
-			// Add an empty api.Project so we know this is an instance project.
-			_, ok := projectsByName[instance.Project]
-			if !ok {
-				projectsByName[instance.Project] = api.Project{}
+			_, found := instances[instanceID]
+			if !found {
+				return fmt.Errorf("Failed loading instance config, referenced instance %d not loaded", instanceID)
 			}
 
-			instances = append(instances, *instanceArgs)
+			if instances[instanceID].Config == nil {
+				inst := instances[instanceID]
+				inst.Config = make(map[string]string)
+				instances[instanceID] = inst
+			}
+
+			_, found = instances[instanceID].Config[key]
+			if found {
+				return fmt.Errorf("Duplicate config row found for key %q for instance ID %d", key, instanceID)
+			}
+
+			instances[instanceID].Config[key] = value
+
+			return nil
+		}, args...)
+	}
+
+	// instanceDevices loads the device config for all instanceIDs specified in a single query and then updates
+	// the entries in the instances map.
+	instanceDevices := func(tx *ClusterTx, instanceIDs []int) error {
+		q := `
+		SELECT
+			instances_devices.instance_id AS instance_id,
+			instances_devices.name AS device_name,
+			instances_devices.type AS device_type,
+			instances_devices_config.key,
+			instances_devices_config.value
+		FROM instances_devices_config
+		JOIN instances_devices ON instances_devices.id = instances_devices_config.instance_device_id
+		WHERE instances_devices.instance_id IN
+		` + query.Params(len(instanceIDs))
+
+		args := make([]any, 0, len(instanceIDs))
+		for _, instanceID := range instanceIDs {
+			args = append(args, instanceID)
 		}
 
+		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
+			var instanceID int
+			var deviceType cluster.DeviceType
+			var deviceName, key, value string
+
+			err := scan(&instanceID, &deviceName, &deviceType, &key, &value)
+			if err != nil {
+				return err
+			}
+
+			_, found := instances[instanceID]
+			if !found {
+				return fmt.Errorf("Failed loading instance device, referenced instance %d not loaded", instanceID)
+			}
+
+			if instances[instanceID].Devices == nil {
+				inst := instances[instanceID]
+				inst.Devices = make(deviceConfig.Devices)
+				instances[instanceID] = inst
+			}
+
+			_, found = instances[instanceID].Devices[deviceName]
+			if !found {
+				instances[instanceID].Devices[deviceName] = deviceConfig.Device{
+					"type": deviceType.String(),
+				}
+			}
+
+			_, found = instances[instanceID].Devices[deviceName][key]
+			if found {
+				return fmt.Errorf("Duplicate device row found for device %q key %q for instance ID %d", deviceName, key, instanceID)
+			}
+
+			instances[instanceID].Devices[deviceName][key] = value
+
+			return nil
+		}, args...)
+	}
+
+	// instanceProfiles loads the profile IDs to apply to an instance (in the application order) for all
+	// instanceIDs in a single query and then updates the instanceApplyProfileIDs and profilesByID maps.
+	instanceProfiles := func(tx *ClusterTx, instanceIDs []int) error {
+		instanceProjectProfilesSQL := `
+		SELECT
+			instances_profiles.instance_id AS instance_id,
+			instances_profiles.profile_id AS profile_id
+		FROM instances_profiles
+		WHERE instances_profiles.instance_id IN
+		` + query.Params(len(instanceIDs)) +
+			`ORDER BY instances_profiles.instance_id, instances_profiles.apply_order`
+
+		args := make([]any, 0, len(instanceIDs))
+		for _, instanceID := range instanceIDs {
+			args = append(args, instanceID)
+		}
+
+		return tx.QueryScan(instanceProjectProfilesSQL, func(scan func(dest ...any) error) error {
+			var instanceID int64
+			var profileID int
+
+			err := scan(&instanceID, &profileID)
+			if err != nil {
+				return err
+			}
+
+			instanceApplyProfileIDs[instanceID] = append(instanceApplyProfileIDs[instanceID], profileID)
+
+			// Record that this profile is referenced by at least one instance in the list.
+			_, ok := profilesByID[profileID]
+			if !ok {
+				profilesByID[profileID] = nil
+			}
+
+			return nil
+		}, args...)
+	}
+
+	// Retrieve required info from the database in single transaction for performance.
+	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+		// Get all projects.
 		projects, err := cluster.GetProjects(ctx, tx.tx, cluster.ProjectFilter{})
 		if err != nil {
 			return fmt.Errorf("Failed loading projects: %w", err)
 		}
 
-		// Index of all projects by name and record which projects have the profiles feature.
+		// Get all profiles.
+		profiles, err := cluster.GetProfiles(ctx, tx.Tx(), cluster.ProfileFilter{})
+		if err != nil {
+			return fmt.Errorf("Failed loading profiles: %w", err)
+		}
+
+		// Get all instances using supplied filter.
+		dbInstances, err := cluster.GetInstances(ctx, tx.tx, *filter)
+		if err != nil {
+			return fmt.Errorf("Failed loading instances: %w", err)
+		}
+
+		// Convert instances to partial InstanceArgs slice (Config, Devices and Profiles not populated).
+		instances = make(map[int]InstanceArgs, len(dbInstances))
+		instanceIDs := make([]int, 0, len(dbInstances))
+		for _, instance := range dbInstances {
+			args := InstanceArgs{
+				ID:           instance.ID,
+				Project:      instance.Project,
+				Name:         instance.Name,
+				Node:         instance.Node,
+				Type:         instance.Type,
+				Snapshot:     instance.Snapshot,
+				Architecture: instance.Architecture,
+				Ephemeral:    instance.Ephemeral,
+				CreationDate: instance.CreationDate,
+				Stateful:     instance.Stateful,
+				LastUsedDate: instance.LastUseDate.Time,
+				Description:  instance.Description,
+				ExpiryDate:   instance.ExpiryDate.Time,
+			}
+
+			// Record that this project is referenced by at least one instance in the list.
+			_, ok := projectsByName[instance.Project]
+			if !ok {
+				projectsByName[instance.Project] = nil
+			}
+
+			instances[instance.ID] = args
+			instanceIDs = append(instanceIDs, instance.ID)
+		}
+
+		// Populate instance config.
+		err = instanceConfig(tx, instanceIDs)
+		if err != nil {
+			return fmt.Errorf("Failed loading instance config: %w", err)
+		}
+
+		// Populate instance devices.
+		err = instanceDevices(tx, instanceIDs)
+		if err != nil {
+			return fmt.Errorf("Failed loading instance devices: %w", err)
+		}
+
+		// Get profiles applied to instances (in order they are applied).
+		err = instanceProfiles(tx, instanceIDs)
+		if err != nil {
+			return fmt.Errorf("Failed getting instance profiles: %w", err)
+		}
+
+		// Populate projectsByName map entry for referenced projects.
+		// This way we only call ToAPI() on the projects actually referenced by the instances in
+		// the list, which can reduce the number of queries run.
 		for _, project := range projects {
-			// Skip any projects not associated with an instance in this filtered list.
-			instanceProject, ok := projectsByName[project.Name]
+			_, ok := projectsByName[project.Name]
 			if !ok {
 				continue
 			}
 
-			// Don't call ToAPI more than once per project.
-			if instanceProject.Name != "" {
-				continue
-			}
-
-			apiProject, err := project.ToAPI(ctx, tx.tx)
+			projectsByName[project.Name], err = project.ToAPI(ctx, tx.tx)
 			if err != nil {
 				return err
 			}
+		}
 
-			projectsByName[project.Name] = *apiProject
+		// Populate profilesByID map entry for referenced profiles.
+		// This way we only call ToAPI() on the profiles actually referenced by the instances in
+		// the list, which can reduce the number of queries run.
+		for _, profile := range profiles {
+			_, ok := profilesByID[profile.ID]
+			if !ok {
+				continue
+			}
+
+			profilesByID[profile.ID], err = profile.ToAPI(ctx, tx.tx)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -372,7 +567,23 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func
 	// Call the instanceFunc provided for each instance after the transaction has ended, as we don't know if
 	// the instanceFunc will be slow or may need to make additional DB queries.
 	for _, instance := range instances {
-		err = instanceFunc(instance, projectsByName[instance.Project], instance.Profiles)
+		// Populate instance profiles list before calling instanceFunc.
+		instance.Profiles = make([]api.Profile, 0, len(instance.Profiles))
+		for _, applyProfileID := range instanceApplyProfileIDs[int64(instance.ID)] {
+			profile := profilesByID[applyProfileID]
+			if profile == nil {
+				return fmt.Errorf("Instance %d references profile %d that isn't loaded", instance.ID, applyProfileID)
+			}
+
+			instance.Profiles = append(instance.Profiles, *profile)
+		}
+
+		project := projectsByName[instance.Project]
+		if project == nil {
+			return fmt.Errorf("Instance references %d project %q that isn't loaded", instance.ID, instance.Project)
+		}
+
+		err = instanceFunc(instance, *project, instance.Profiles)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -305,7 +305,7 @@ var ErrInstanceListStop = fmt.Errorf("search stopped")
 
 // InstanceList loads all instances across all projects and for each instance runs the instanceFunc passing in the
 // instance and it's project and profiles. Accepts optional filter argument to specify a subset of instances.
-func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func(inst InstanceArgs, project api.Project, profiles []api.Profile) error) error {
+func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func(inst InstanceArgs, project api.Project) error) error {
 	projectsByName := make(map[string]*api.Project)
 	profilesByID := make(map[int]*api.Profile)
 	var instances map[int]InstanceArgs
@@ -583,7 +583,7 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func
 			return fmt.Errorf("Instance references %d project %q that isn't loaded", instance.ID, instance.Project)
 		}
 
-		err = instanceFunc(instance, *project, instance.Profiles)
+		err = instanceFunc(instance, *project)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -278,11 +278,11 @@ func TestInstanceList(t *testing.T) {
 
 	assert.Len(t, instances, 1)
 
-	assert.Equal(t, instances[0].Config, map[string]string{"a": "1", "c": "3"})
-	assert.Equal(t, instances[0].Devices.CloneNative(), map[string]map[string]string{
+	assert.Equal(t, map[string]string{"a": "1", "c": "3"}, instances[0].Config)
+	assert.Equal(t, map[string]map[string]string{
 		"root": {"type": "disk", "b": "2"},
 		"eth0": {"type": "nic", "d": "4"},
-	})
+	}, instances[0].Devices.CloneNative())
 }
 
 func TestCreateInstance(t *testing.T) {

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -265,8 +265,13 @@ func TestInstanceList(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	opts := db.InstanceListOpts{
+		Devices: true,
+		Config:  true,
+	}
+
 	var instances []db.InstanceArgs
-	err = c.InstanceList(nil, func(dbInst db.InstanceArgs, p api.Project) error {
+	err = c.InstanceList(nil, opts, func(dbInst db.InstanceArgs, p api.Project) error {
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
 

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -266,9 +266,9 @@ func TestInstanceList(t *testing.T) {
 	require.NoError(t, err)
 
 	var instances []db.InstanceArgs
-	err = c.InstanceList(nil, func(dbInst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
-		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, profiles)
-		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, profiles)
+	err = c.InstanceList(nil, func(dbInst db.InstanceArgs, p api.Project) error {
+		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
+		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
 
 		instances = append(instances, dbInst)
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1473,8 +1473,8 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 
 		if shared.IsFalseOrEmpty(poolVolumePut.Config["security.shifted"]) {
 			volumeUsedBy := []instance.Instance{}
-			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.InstanceArgs, project api.Project, profiles []api.Profile, usedByDevices []string) error {
-				inst, err := instance.Load(d.state, dbInst, profiles)
+			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+				inst, err := instance.Load(d.state, dbInst, dbInst.Profiles)
 				if err != nil {
 					return err
 				}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -372,7 +372,12 @@ func (d *nicBridged) checkAddressConflict() error {
 		ourNICMAC, _ = net.ParseMAC(d.volatileGet()["hwaddr"])
 	}
 
-	return d.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
+	opts := db.InstanceListOpts{
+		Devices: true,
+		Config:  true,
+	}
+
+	return d.state.DB.Cluster.InstanceList(&filter, opts, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		if instNetworkProject != project.Default {

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -372,7 +372,7 @@ func (d *nicBridged) checkAddressConflict() error {
 		ourNICMAC, _ = net.ParseMAC(d.volatileGet()["hwaddr"])
 	}
 
-	return d.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	return d.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		if instNetworkProject != project.Default {
@@ -381,7 +381,7 @@ func (d *nicBridged) checkAddressConflict() error {
 
 		// Iterate through each of the instance's devices, looking for NICs that are linked to
 		// the same network, on the same cluster member as this NIC and have matching static IPs.
-		for devName, devConfig := range db.ExpandInstanceDevices(inst.Devices.Clone(), profiles) {
+		for devName, devConfig := range db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles) {
 			if devConfig["type"] != "nic" {
 				continue
 			}

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -203,8 +203,12 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 		}
 	}
 
+	opts := db.InstanceListOpts{
+		Devices: true,
+	}
+
 	// Find instances using the ACLs. Most expensive to do.
-	err = s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -204,7 +204,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 	}
 
 	// Find instances using the ACLs. Most expensive to do.
-	err = s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	err = s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -213,7 +213,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 			return nil
 		}
 
-		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), profiles)
+		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 
 		// Iterate through each of the instance's devices, looking for NICs that are using any of the ACLs.
 		for devName, devConfig := range devices {

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2452,7 +2452,11 @@ func (n *bridge) bridgeNetworkExternalSubnets(bridgeProjectNetworks map[string][
 func (n *bridge) bridgedNICExternalRoutes(bridgeProjectNetworks map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	opts := db.InstanceListOpts{
+		Devices: true,
+	}
+
+	err := n.state.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -2681,7 +2685,12 @@ func (n *bridge) ForwardCreate(forward api.NetworkForwardsPost, clientType reque
 					Node: &localNode,
 				}
 
-				err = n.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
+				opts := db.InstanceListOpts{
+					Devices: true,
+					Config:  true,
+				}
+
+				err = n.state.DB.Cluster.InstanceList(&filter, opts, func(inst db.InstanceArgs, p api.Project) error {
 					// Get the instance's effective network project name.
 					instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2452,7 +2452,7 @@ func (n *bridge) bridgeNetworkExternalSubnets(bridgeProjectNetworks map[string][
 func (n *bridge) bridgedNICExternalRoutes(bridgeProjectNetworks map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -2460,7 +2460,7 @@ func (n *bridge) bridgedNICExternalRoutes(bridgeProjectNetworks map[string][]*ap
 			return nil // Managed bridge networks can only exist in default project.
 		}
 
-		devices := db.ExpandInstanceDevices(inst.Devices, profiles)
+		devices := db.ExpandInstanceDevices(inst.Devices, inst.Profiles)
 
 		// Iterate through each of the instance's devices, looking for bridged NICs that are linked to
 		// networks specified.
@@ -2681,7 +2681,7 @@ func (n *bridge) ForwardCreate(forward api.NetworkForwardsPost, clientType reque
 					Node: &localNode,
 				}
 
-				err = n.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+				err = n.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
 					// Get the instance's effective network project name.
 					instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -2689,7 +2689,7 @@ func (n *bridge) ForwardCreate(forward api.NetworkForwardsPost, clientType reque
 						return nil // Managed bridge networks can only exist in default project.
 					}
 
-					devices := db.ExpandInstanceDevices(inst.Devices.Clone(), profiles)
+					devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 
 					// Iterate through each of the instance's devices, looking for bridged NICs
 					// that are linked to this network.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3813,10 +3813,10 @@ func (n *ovn) ovnNetworkExternalSubnets(ovnProjectNetworksWithOurUplink map[stri
 func (n *ovn) ovnNICExternalRoutes(ovnProjectNetworksWithOurUplink map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
-		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), profiles)
+		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 
 		// Iterate through each of the instance's devices, looking for OVN NICs that are linked to networks
 		// that use our uplink.
@@ -3931,7 +3931,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
 			// This will restore the l2proxy DNAT_AND_SNAT rules.
-			err = n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+			err = n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 				// Get the instance's effective network project name.
 				instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -3941,7 +3941,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 					return nil
 				}
 
-				devices := db.ExpandInstanceDevices(inst.Devices.Clone(), profiles)
+				devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 
 				// Iterate through each of the instance's devices, looking for NICs that are linked
 				// this network.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3813,7 +3813,11 @@ func (n *ovn) ovnNetworkExternalSubnets(ovnProjectNetworksWithOurUplink map[stri
 func (n *ovn) ovnNICExternalRoutes(ovnProjectNetworksWithOurUplink map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	opts := db.InstanceListOpts{
+		Devices: true,
+	}
+
+	err := n.state.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
@@ -3929,9 +3933,14 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 				return fmt.Errorf("Failed getting active ports: %w", err)
 			}
 
+			opts := db.InstanceListOpts{
+				Devices: true,
+				Config:  true,
+			}
+
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
 			// This will restore the l2proxy DNAT_AND_SNAT rules.
-			err = n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+			err = n.state.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
 				// Get the instance's effective network project name.
 				instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -74,7 +74,11 @@ func MACDevName(mac net.HardwareAddr) string {
 
 // usedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 func usedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error) error {
-	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	opts := db.InstanceListOpts{
+		Devices: true,
+	}
+
+	return s.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -74,7 +74,7 @@ func MACDevName(mac net.HardwareAddr) string {
 
 // usedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 func usedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error) error {
-	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -84,7 +84,7 @@ func usedByInstanceDevices(s *state.State, networkProjectName string, networkNam
 		}
 
 		// Look for NIC devices using this network.
-		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), profiles)
+		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 		for devName, devConfig := range devices {
 			if isInUseByDevice(networkName, devConfig) {
 				err := usageFunc(inst, devName, devConfig)

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -65,8 +65,13 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 
 	reservedDevices := map[string]struct{}{}
 
+	opts := db.InstanceListOpts{
+		Devices: true,
+		Config:  true,
+	}
+
 	// Check if any instances are using the VF device.
-	err = s.DB.Cluster.InstanceList(&filter, func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(&filter, opts, func(dbInst db.InstanceArgs, p api.Project) error {
 		// Expand configs so we take into account profile devices.
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -66,10 +66,10 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	reservedDevices := map[string]struct{}{}
 
 	// Check if any instances are using the VF device.
-	err = s.DB.Cluster.InstanceList(&filter, func(dbInst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	err = s.DB.Cluster.InstanceList(&filter, func(dbInst db.InstanceArgs, p api.Project) error {
 		// Expand configs so we take into account profile devices.
-		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, profiles)
-		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, profiles)
+		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
+		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
 
 		for name, dev := range dbInst.Devices {
 			// If device references a parent host interface name, mark that as reserved.

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -401,7 +401,11 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	opts := db.InstanceListOpts{
+		Config: true,
+	}
+
+	return d.State().DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -401,7 +401,7 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	return d.State().DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3980,8 +3980,8 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		// Check for config changing that is not allowed when running instances are using it.
 		if changedConfig["security.shifted"] != "" {
-			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, profiles []api.Profile, usedByDevices []string) error {
-				inst, err := instance.Load(b.state, dbInst, profiles)
+			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+				inst, err := instance.Load(b.state, dbInst, dbInst.Profiles)
 				if err != nil {
 					return err
 				}
@@ -4508,8 +4508,8 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 	}
 
 	// Check that the volume isn't in use by running instances.
-	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, profiles []api.Profile, usedByDevices []string) error {
-		inst, err := instance.Load(b.state, dbInst, profiles)
+	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+		inst, err := instance.Load(b.state, dbInst, dbInst.Profiles)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -48,7 +48,7 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 		Node: &localNode,
 	}
 
-	err = b.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
+	err = b.state.DB.Cluster.InstanceList(&filter, db.InstanceListOpts{}, func(inst db.InstanceArgs, p api.Project) error {
 		// Check we can convert the instance to the volume type needed.
 		volType, err := InstanceTypeToVolumeType(inst.Type)
 		if err != nil {

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -48,7 +48,7 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 		Node: &localNode,
 	}
 
-	err = b.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile) error {
+	err = b.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
 		// Check we can convert the instance to the volume type needed.
 		volType, err := InstanceTypeToVolumeType(inst.Type)
 		if err != nil {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -705,7 +705,11 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 		return err
 	}
 
-	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	opts := db.InstanceListOpts{
+		Devices: true,
+	}
+
+	return s.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
 		// If the volume has a specific cluster member which is different than the instance then skip as
 		// instance cannot be using this volume.
 		if vol.Location != "" && inst.Node != vol.Location {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1078,8 +1078,8 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if a running instance is using it.
-	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.InstanceArgs, project api.Project, profiles []api.Profile, usedByDevices []string) error {
-		inst, err := instance.Load(d.State(), dbInst, profiles)
+	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+		inst, err := instance.Load(d.State(), dbInst, dbInst.Profiles)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -23,8 +23,8 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 	s := d.State()
 
 	// Update all instances that are using the volume with a local (non-expanded) device.
-	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, profiles []api.Profile, usedByDevices []string) error {
-		inst, err := instance.Load(s, dbInst, profiles)
+	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+		inst, err := instance.Load(s, dbInst, dbInst.Profiles)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 
 	// Pass false to expandDevices, as we only want to see instances directly using a volume, rather than their
 	// profiles using a volume.
-	err = storagePools.VolumeUsedByInstanceDevices(s, poolName, projectName, vol, false, func(inst db.InstanceArgs, p api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(s, poolName, projectName, vol, false, func(inst db.InstanceArgs, p api.Project, usedByDevices []string) error {
 		if inst.Project == project.Default {
 			volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/instances/%s", version.APIVersion, inst.Name))
 		} else {


### PR DESCRIPTION
This PR fixes the instance list speed regression introduced by https://github.com/lxc/lxd/commit/fe37c21bae5ab70f65a7e6639de5c759588fb339 and goes further to optimise the query pattern than was in LXD 5.2.

The main problem was that the `InstanceToArgs` function loads the profile(s) (and its config and devices) for every instance, even if multiple instances use the same profile(s). Additionally the `GetDevices()` and `GetConfig()` prepare a statement on every call, which is inefficient.

This PR updates `InstanceList()` to use its own optimised queries.

On LXD 5.2 (before that commit), my test box could create 128 `images:ubuntu/jammy` containers on ZFS (with pre-warmed image volume) in: **1m27.566s, 1m28.397s, 1m28.810s**

On LXD 5.3 (after that commit), the results are as follows: **2m2.597s, 2m2.060s, 2m3.763s**

On LXD edge channel with this PR, the results are as follows: **1m24.483s, 1m26.036s, 1m27.209s**

Using `lxd.benchmark init --count 128 images:ubuntu/jammy`

Edge with PR:  Batch processing completed in **32.712s**
LXD 5.3:           Batch processing completed in **66.488s**
LXD 5.2:           Batch processing completed in **36.039s**