### PR TITLE
lxd/resources: Handle invalid VPD lengths

### DIFF
--- a/lxd/resources/pci_vpd.go
+++ b/lxd/resources/pci_vpd.go
@@ -115,6 +115,11 @@ func parsePCIVPD(buf []byte) api.ResourcesPCIVPD {
 			}
 
 		default:
+			// Check that we aren't past the buffer (invalid length).
+			if len(buf) < length {
+				break
+			}
+
 			// For other tags, just skip the value.
 			buf = buf[length:]
 		}


### PR DESCRIPTION
Closes #10627

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>