### PR TITLE
Don't double TLS connections between LXD and agent

### DIFF
--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -179,7 +179,7 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 
 	// Start the server.
 	go func() {
-		err := servers["http"].ServeTLS(networkTLSListener(l, tlsConfig), "agent.crt", "agent.key")
+		err := servers["http"].Serve(networkTLSListener(l, tlsConfig))
 		if err != nil {
 			errChan <- err
 		}

--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/ip"
@@ -40,21 +39,8 @@ func networkTLSListener(inner net.Listener, config *tls.Config) *networkListener
 // Accept waits for and returns the next incoming TLS connection then use the
 // current TLS configuration to handle it.
 func (l *networkListener) Accept() (net.Conn, error) {
-	var c net.Conn
-	var err error
-
-	// Accept() is non-blocking in go < 1.12 hence the loop and error check.
-	for {
-		c, err = l.Listener.Accept()
-		if err == nil {
-			break
-		}
-
-		if err.(net.Error).Timeout() {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-
+	c, err := l.Listener.Accept()
+	if err != nil {
 		return nil, err
 	}
 

--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -2,7 +2,6 @@ package vsock
 
 import (
 	"context"
-	"crypto/tls"
 	"net"
 	"net/http"
 	"strings"
@@ -66,16 +65,7 @@ func HTTPClient(vsockID int, tlsClientCert string, tlsClientKey string, tlsServe
 				return nil, err
 			}
 
-			tlsConn := tls.Client(conn, tlsConfig)
-
-			// Validate the connection.
-			err = tlsConn.Handshake()
-			if err != nil {
-				_ = conn.Close()
-				return nil, err
-			}
-
-			return tlsConn, nil
+			return conn, nil
 		},
 		DisableKeepAlives:     true,
 		ExpectContinueTimeout: time.Second * 30,


### PR DESCRIPTION
For some reason our TLS over vsock logic was incredibly broken and we were effectively doing TLS over TLS.
Not only is that a big waste of CPU time, it's also causing some issues when we need to extract client certificates as is the case in #10610.

Unfortunately I couldn't find a way to gracefully fix this, so as soon as a system will receive this fix, the guests will need a reboot to receive a new agent with the corrected logic.