### PR TITLE
Instance: Don't wait for update operation to complete when removing disk from running container

### DIFF
--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -179,6 +179,11 @@ func Get(projectName string, instanceName string) *InstanceOperation {
 
 // Action returns operation's action.
 func (op *InstanceOperation) Action() Action {
+	// This function can be called on a nil struct.
+	if op == nil {
+		return ""
+	}
+
 	return op.action
 }
 


### PR DESCRIPTION
Fixes #10636

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>