### PR TITLE
Instance: Revert InstanceList selective config loading optimisation

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -303,15 +303,9 @@ SELECT instances.name, nodes.id, nodes.address, nodes.heartbeat, projects.name
 // ErrInstanceListStop used as return value from InstanceList's instanceFunc when prematurely stopping the search.
 var ErrInstanceListStop = fmt.Errorf("search stopped")
 
-// InstanceListOpts indicate the options required for instance list.
-type InstanceListOpts struct {
-	Config  bool // Include instance config.
-	Devices bool // Include instance devices.
-}
-
 // InstanceList loads all instances across all projects and for each instance runs the instanceFunc passing in the
 // instance and it's project and profiles. Accepts optional filter argument to specify a subset of instances.
-func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, opts InstanceListOpts, instanceFunc func(inst InstanceArgs, project api.Project) error) error {
+func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func(inst InstanceArgs, project api.Project) error) error {
 	projectsByName := make(map[string]*api.Project)
 	profilesByID := make(map[int]*api.Profile)
 	var instances map[int]InstanceArgs
@@ -527,20 +521,16 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, opts InstanceList
 			}
 		}
 
-		if opts.Config {
-			// Populate instance config.
-			err = instanceConfig(tx, instanceIDs)
-			if err != nil {
-				return fmt.Errorf("Failed loading instance config: %w", err)
-			}
+		// Populate instance config.
+		err = instanceConfig(tx, instanceIDs)
+		if err != nil {
+			return fmt.Errorf("Failed loading instance config: %w", err)
 		}
 
-		if opts.Devices {
-			// Populate instance devices.
-			err = instanceDevices(tx, instanceIDs)
-			if err != nil {
-				return fmt.Errorf("Failed loading instance devices: %w", err)
-			}
+		// Populate instance devices.
+		err = instanceDevices(tx, instanceIDs)
+		if err != nil {
+			return fmt.Errorf("Failed loading instance devices: %w", err)
 		}
 
 		// Get all profiles.

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -265,13 +265,8 @@ func TestInstanceList(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	opts := db.InstanceListOpts{
-		Devices: true,
-		Config:  true,
-	}
-
 	var instances []db.InstanceArgs
-	err = c.InstanceList(nil, opts, func(dbInst db.InstanceArgs, p api.Project) error {
+	err = c.InstanceList(nil, func(dbInst db.InstanceArgs, p api.Project) error {
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -372,12 +372,7 @@ func (d *nicBridged) checkAddressConflict() error {
 		ourNICMAC, _ = net.ParseMAC(d.volatileGet()["hwaddr"])
 	}
 
-	opts := db.InstanceListOpts{
-		Devices: true,
-		Config:  true,
-	}
-
-	return d.state.DB.Cluster.InstanceList(&filter, opts, func(inst db.InstanceArgs, p api.Project) error {
+	return d.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		if instNetworkProject != project.Default {

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -203,12 +203,8 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 		}
 	}
 
-	opts := db.InstanceListOpts{
-		Devices: true,
-	}
-
 	// Find instances using the ACLs. Most expensive to do.
-	err = s.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2452,11 +2452,7 @@ func (n *bridge) bridgeNetworkExternalSubnets(bridgeProjectNetworks map[string][
 func (n *bridge) bridgedNICExternalRoutes(bridgeProjectNetworks map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	opts := db.InstanceListOpts{
-		Devices: true,
-	}
-
-	err := n.state.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
+	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -2685,12 +2681,7 @@ func (n *bridge) ForwardCreate(forward api.NetworkForwardsPost, clientType reque
 					Node: &localNode,
 				}
 
-				opts := db.InstanceListOpts{
-					Devices: true,
-					Config:  true,
-				}
-
-				err = n.state.DB.Cluster.InstanceList(&filter, opts, func(inst db.InstanceArgs, p api.Project) error {
+				err = n.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
 					// Get the instance's effective network project name.
 					instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3873,11 +3873,7 @@ func (n *ovn) ovnNetworkExternalSubnets(ovnProjectNetworksWithOurUplink map[stri
 func (n *ovn) ovnNICExternalRoutes(ovnProjectNetworksWithOurUplink map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	opts := db.InstanceListOpts{
-		Devices: true,
-	}
-
-	err := n.state.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
+	err := n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
@@ -3993,14 +3989,9 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 				return fmt.Errorf("Failed getting active ports: %w", err)
 			}
 
-			opts := db.InstanceListOpts{
-				Devices: true,
-				Config:  true,
-			}
-
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
 			// This will restore the l2proxy DNAT_AND_SNAT rules.
-			err = n.state.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
+			err = n.state.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 				// Get the instance's effective network project name.
 				instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -74,11 +74,7 @@ func MACDevName(mac net.HardwareAddr) string {
 
 // usedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 func usedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error) error {
-	opts := db.InstanceListOpts{
-		Devices: true,
-	}
-
-	return s.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
+	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -65,13 +65,8 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 
 	reservedDevices := map[string]struct{}{}
 
-	opts := db.InstanceListOpts{
-		Devices: true,
-		Config:  true,
-	}
-
 	// Check if any instances are using the VF device.
-	err = s.DB.Cluster.InstanceList(&filter, opts, func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(&filter, func(dbInst db.InstanceArgs, p api.Project) error {
 		// Expand configs so we take into account profile devices.
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -401,11 +401,7 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	opts := db.InstanceListOpts{
-		Config: true,
-	}
-
-	return d.State().DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
+	return d.State().DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -48,7 +48,7 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 		Node: &localNode,
 	}
 
-	err = b.state.DB.Cluster.InstanceList(&filter, db.InstanceListOpts{}, func(inst db.InstanceArgs, p api.Project) error {
+	err = b.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
 		// Check we can convert the instance to the volume type needed.
 		volType, err := InstanceTypeToVolumeType(inst.Type)
 		if err != nil {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -705,11 +705,7 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 		return err
 	}
 
-	opts := db.InstanceListOpts{
-		Devices: true,
-	}
-
-	return s.DB.Cluster.InstanceList(nil, opts, func(inst db.InstanceArgs, p api.Project) error {
+	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
 		// If the volume has a specific cluster member which is different than the instance then skip as
 		// instance cannot be using this volume.
 		if vol.Location != "" && inst.Node != vol.Location {


### PR DESCRIPTION
This allowed the introduction of a hard to debug OVN bug because of the way that Go doesn't panic when reading from a nil map.
The particular optimisation wasn't much used, and its potential to introduce subtle bugs in the future means I don't think its worth keeping in its current form.