### PR TITLE
Upgrades shellcheck to version 0.8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ jobs:
           sudo apt-get install -y acl attr autoconf automake dnsmasq-base git libacl1-dev libcap-dev liblxc1 liblxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables curl gettext jq sqlite3 socat bind9-dnsutils
           python3 -m pip install flake8
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+          sudo apt remove shellcheck
+          curl -L https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz -o shellcheck.tar.xz
+          tar -xf shellcheck.tar.xz
+          chmod +x shellcheck-v0.8.0/shellcheck
+          sudo mv shellcheck-v0.8.0/shellcheck /bin/shellcheck
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ endif
 .PHONY: build-mo
 build-mo: $(MOFILES)
 
+SHELLCHECK_VERSION := $(shell shellcheck --version | grep version: | cut -d ' ' -f2)
 .PHONY: static-analysis
 static-analysis:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
@@ -242,6 +243,9 @@ endif
 ifeq ($(shell command -v shellcheck 2> /dev/null),)
 	echo "Please install shellcheck"
 	exit 1
+endif
+ifneq "$(SHELLCHECK_VERSION)" "0.8.0"
+	@echo "WARN: shellcheck version is not 0.8.0"
 endif
 ifeq ($(shell command -v flake8 2> /dev/null),)
 	echo "Please install flake8"

--- a/test/backends/btrfs.sh
+++ b/test/backends/btrfs.sh
@@ -1,5 +1,5 @@
 btrfs_setup() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +8,7 @@ btrfs_setup() {
 }
 
 btrfs_configure() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +20,7 @@ btrfs_configure() {
 }
 
 btrfs_teardown() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/ceph.sh
+++ b/test/backends/ceph.sh
@@ -1,5 +1,5 @@
 ceph_setup() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +8,7 @@ ceph_setup() {
 }
 
 ceph_configure() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +20,7 @@ ceph_configure() {
 }
 
 ceph_teardown() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/dir.sh
+++ b/test/backends/dir.sh
@@ -4,7 +4,7 @@
 
 # Any necessary backend-specific setup
 dir_setup() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -14,7 +14,7 @@ dir_setup() {
 
 # Do the API voodoo necessary to configure LXD to use this backend
 dir_configure() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -26,7 +26,7 @@ dir_configure() {
 }
 
 dir_teardown() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/lvm.sh
+++ b/test/backends/lvm.sh
@@ -1,5 +1,5 @@
 lvm_setup() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +8,7 @@ lvm_setup() {
 }
 
 lvm_configure() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +20,7 @@ lvm_configure() {
 }
 
 lvm_teardown() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/zfs.sh
+++ b/test/backends/zfs.sh
@@ -1,5 +1,5 @@
 zfs_setup() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +8,7 @@ zfs_setup() {
 }
 
 zfs_configure() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +20,7 @@ zfs_configure() {
 }
 
 zfs_teardown() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/includes/check.sh
+++ b/test/includes/check.sh
@@ -1,7 +1,7 @@
 # Miscellaneous test checks.
 
 check_dependencies() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local dep missing
     missing=""
 

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -110,7 +110,7 @@ teardown_clustering_netns() {
 }
 
 spawn_lxd_and_bootstrap_cluster() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_NETNS
 
   set -e
@@ -198,7 +198,7 @@ EOF
 }
 
 spawn_lxd_and_join_cluster() {
-  # shellcheck disable=2039,2034
+  # shellcheck disable=2039,2034,3043
   local LXD_NETNS
 
   set -e
@@ -273,7 +273,7 @@ EOF
 }
 
 respawn_lxd_cluster_member() {
-  # shellcheck disable=2039,2034
+  # shellcheck disable=2039,2034,3043
   local LXD_NETNS
 
   set -e

--- a/test/includes/external_auth.sh
+++ b/test/includes/external_auth.sh
@@ -7,7 +7,7 @@ start_external_auth_daemon() {
         # Use -buildvcs=false here to prevent git complaining about untrusted directory when tests are run as root.
         go build -v -buildvcs=false ./...
     )
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local credentials_file tcp_port
     credentials_file="$1/macaroon-identity-credentials.csv"
     tcp_port="$(local_tcp_port)"
@@ -23,7 +23,7 @@ EOF
 }
 
 kill_external_auth_daemon() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local pidfile="$1/macaroon-identity.pid"
     kill "$(cat "$pidfile")" || true
     rm -f macaroon-identity/macaroon-identity

--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -6,7 +6,7 @@ lxc() {
 
 lxc_remote() {
     set +x
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local injected cmd arg
 
     injected=0

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -5,7 +5,7 @@ spawn_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local LXD_DIR lxddir lxd_backend
 
     lxddir=${1}
@@ -83,7 +83,7 @@ respawn_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local LXD_DIR
 
     lxddir=${1}
@@ -118,7 +118,7 @@ kill_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local LXD_DIR daemon_dir daemon_pid check_leftovers lxd_backend
 
     daemon_dir=${1}
@@ -253,7 +253,7 @@ shutdown_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local LXD_DIR
 
     daemon_dir=${1}
@@ -271,7 +271,7 @@ shutdown_lxd() {
 }
 
 wait_for() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local addr op
 
     addr=${1}
@@ -288,7 +288,7 @@ wipe() {
         fi
     fi
 
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local pid
     # shellcheck disable=SC2009
     ps aux | grep lxc-monitord | grep "${1}" | awk '{print $2}' | while read -r pid; do
@@ -304,7 +304,7 @@ wipe() {
 
 # Kill and cleanup LXD instances and related resources
 cleanup_lxds() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local test_dir daemon_dir
     test_dir="$1"
 

--- a/test/includes/net.sh
+++ b/test/includes/net.sh
@@ -13,7 +13,7 @@ EOF
         return
     fi
 
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local port pid
 
     while true; do

--- a/test/includes/setup.sh
+++ b/test/includes/setup.sh
@@ -1,8 +1,8 @@
 # Test setup helper functions.
 
 ensure_has_localhost_remote() {
-    # shellcheck disable=SC2039
-    local addr=${1}
+    # shellcheck disable=SC2039,3043
+    local addr="${1}"
     if ! lxc remote list | grep -q "localhost"; then
         lxc remote add localhost "https://${addr}" --accept-certificate --password foo
     fi

--- a/test/includes/storage.sh
+++ b/test/includes/storage.sh
@@ -2,10 +2,10 @@
 
 # Whether a storage backend is available
 storage_backend_available() {
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local backends
     backends="$(available_storage_backends)"
-    if [ "${backends#*$1}" != "$backends" ]; then
+    if [ "${backends#*"$1"}" != "$backends" ]; then
         true
         return
     elif [ "${1}" = "cephfs" ] && [ "${backends#*"ceph"}" != "$backends" ] && [ -n "${LXD_CEPH_CEPHFS:-}" ]; then
@@ -29,7 +29,7 @@ storage_backend() {
 
 # Return a list of available storage backends
 available_storage_backends() {
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local backend backends storage_backends
 
     backends="dir" # always available
@@ -49,7 +49,7 @@ available_storage_backends() {
 }
 
 import_storage_backends() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local backend
     for backend in $(available_storage_backends); do
         # shellcheck disable=SC1090
@@ -58,7 +58,7 @@ import_storage_backends() {
 }
 
 configure_loop_device() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local lv_loop_file pvloopdev
 
     # shellcheck disable=SC2153
@@ -75,17 +75,17 @@ configure_loop_device() {
     # The following code enables to return a value from a shell function by
     # calling the function as: fun VAR1
 
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local __tmp1="${1}"
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local res1="${lv_loop_file}"
     if [ "${__tmp1}" ]; then
         eval "${__tmp1}='${res1}'"
     fi
 
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local __tmp2="${2}"
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local res2="${pvloopdev}"
     if [ "${__tmp2}" ]; then
         eval "${__tmp2}='${res2}'"
@@ -93,7 +93,7 @@ configure_loop_device() {
 }
 
 deconfigure_loop_device() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local lv_loop_file loopdev success
     lv_loop_file="${1}"
     loopdev="${2}"
@@ -118,7 +118,7 @@ deconfigure_loop_device() {
 }
 
 umount_loops() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local line test_dir
     test_dir="$1"
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -29,7 +29,7 @@ LXD_NETNS=""
 
 import_subdir_files() {
     test "$1"
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local file
     for file in "$1"/*.sh; do
         # shellcheck disable=SC1090

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -12,7 +12,7 @@ LXD_NETNS=""
 
 import_subdir_files() {
     test  "$1"
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local file
     for file in "$1"/*.sh; do
         # shellcheck disable=SC1090
@@ -27,7 +27,7 @@ log_message() {
 }
 
 run_benchmark() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local label description
     label="$1"
     description="$2"

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -207,7 +207,7 @@ EOF
     lxc project delete test
   )
 
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR=${LXD_DIR}
   kill_lxd "${LXD_IMPORT_DIR}"
 }

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1,5 +1,5 @@
 test_basic_usage() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -330,7 +330,7 @@ test_basic_usage() {
     lxc delete autostart --force --force-local
     lxc storage volume delete "${storage_pool}" vol --force-local
   )
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR=${LXD_DIR}
   kill_lxd "${LXD_ACTIVATION_DIR}"
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1,5 +1,5 @@
 test_clustering_enable() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
@@ -179,7 +179,7 @@ test_clustering_enable() {
 }
 
 test_clustering_membership() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -337,7 +337,7 @@ test_clustering_membership() {
 }
 
 test_clustering_containers() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -510,7 +510,7 @@ test_clustering_containers() {
 }
 
 test_clustering_storage() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -870,7 +870,7 @@ test_clustering_storage() {
 # two-stage process required multi-node clusters, or directly with the normal
 # procedure for non-clustered daemons.
 test_clustering_storage_single_node() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -942,7 +942,7 @@ test_clustering_storage_single_node() {
 }
 
 test_clustering_network() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1142,7 +1142,7 @@ test_clustering_network() {
 # Perform an upgrade of a 2-member cluster, then a join a third member and
 # perform one more upgrade
 test_clustering_upgrade() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR LXD_NETNS
 
   setup_clustering_bridge
@@ -1238,7 +1238,7 @@ test_clustering_upgrade() {
 
 # Perform an upgrade of an 8-member cluster.
 test_clustering_upgrade_large() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR LXD_NETNS N
 
   setup_clustering_bridge
@@ -1294,7 +1294,7 @@ test_clustering_upgrade_large() {
 }
 
 test_clustering_publish() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1346,7 +1346,7 @@ test_clustering_publish() {
 }
 
 test_clustering_profiles() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1420,7 +1420,7 @@ EOF
 }
 
 test_clustering_update_cert() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1499,7 +1499,7 @@ test_clustering_update_cert() {
 }
 
 test_clustering_join_api() {
-  # shellcheck disable=2039,2034
+  # shellcheck disable=2039,2034,3043
   local LXD_DIR LXD_NETNS
 
   setup_clustering_bridge
@@ -1539,7 +1539,7 @@ test_clustering_join_api() {
 }
 
 test_clustering_shutdown_nodes() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1611,7 +1611,7 @@ test_clustering_shutdown_nodes() {
 }
 
 test_clustering_projects() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1676,7 +1676,7 @@ test_clustering_projects() {
 }
 
 test_clustering_address() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1754,7 +1754,7 @@ test_clustering_address() {
 }
 
 test_clustering_image_replication() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1917,7 +1917,7 @@ test_clustering_image_replication() {
 }
 
 test_clustering_dns() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   # Because we do not want tests to only run on Ubuntu (due to cluster's fan network dependency)
@@ -2003,7 +2003,7 @@ test_clustering_dns() {
 }
 
 test_clustering_recover() {
-  # shellcheck disable=2039,2034
+  # shellcheck disable=2039,2034,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2085,7 +2085,7 @@ test_clustering_recover() {
 # When a voter cluster member is shutdown, its role gets transferred to a spare
 # node.
 test_clustering_handover() {
-  # shellcheck disable=2039,2034
+  # shellcheck disable=2039,2034,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2203,7 +2203,7 @@ test_clustering_handover() {
 # If a voter node crashes and is detected as offline, its role is migrated to a
 # stand-by.
 test_clustering_rebalance() {
-  # shellcheck disable=2039,2034
+  # shellcheck disable=2039,2034,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2292,7 +2292,7 @@ test_clustering_rebalance() {
 # Recover a cluster where a raft node was removed from the nodes table but not
 # from the raft configuration.
 test_clustering_remove_raft_node() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2413,7 +2413,7 @@ test_clustering_remove_raft_node() {
 }
 
 test_clustering_failure_domains() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2517,7 +2517,7 @@ test_clustering_failure_domains() {
 }
 
 test_clustering_image_refresh() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2744,7 +2744,7 @@ test_clustering_image_refresh() {
 }
 
 test_clustering_evacuation() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2882,7 +2882,7 @@ test_clustering_evacuation() {
 }
 
 test_clustering_edit_configuration() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3031,7 +3031,7 @@ test_clustering_edit_configuration() {
 }
 
 test_clustering_remove_members() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3118,7 +3118,7 @@ test_clustering_remove_members() {
 }
 
 test_clustering_autotarget() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3170,7 +3170,7 @@ test_clustering_autotarget() {
 }
 
 test_clustering_groups() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3298,7 +3298,7 @@ test_clustering_groups() {
 }
 
 test_clustering_events() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -288,7 +288,7 @@ test_config_edit() {
 }
 
 test_config_edit_container_snapshot_pool_config() {
-    # shellcheck disable=2034,2039,2155
+    # shellcheck disable=2034,2039,2155,3043
     local storage_pool="lxdtest-$(basename "${LXD_DIR}")"
 
     ensure_import_testimage

--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -94,7 +94,7 @@ test_container_devices_raw_mount_options() {
 }
 
 test_container_devices_disk_ceph() {
-  # shellcheck disable=SC2039
+  # shellcheck disable=SC2039,3043
   local LXD_BACKEND
 
   LXD_BACKEND=$(storage_backend "$LXD_DIR")
@@ -119,7 +119,7 @@ test_container_devices_disk_ceph() {
 }
 
 test_container_devices_disk_cephfs() {
-  # shellcheck disable=SC2039
+  # shellcheck disable=SC2039,3043
   local LXD_BACKEND
 
   LXD_BACKEND=$(storage_backend "$LXD_DIR")

--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -290,7 +290,7 @@ container_devices_proxy_unix() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -313,7 +313,7 @@ container_devices_proxy_unix() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -336,7 +336,7 @@ container_devices_proxy_unix() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -445,7 +445,7 @@ container_devices_proxy_unix_tcp() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -463,7 +463,7 @@ container_devices_proxy_unix_tcp() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -481,7 +481,7 @@ container_devices_proxy_unix_tcp() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -575,7 +575,7 @@ container_devices_proxy_unix_udp() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -593,7 +593,7 @@ container_devices_proxy_unix_udp() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 
@@ -611,7 +611,7 @@ container_devices_proxy_unix_udp() {
   NSENTER_PID=$!
   sleep 0.5
 
-  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#$(pwd)/}")
+  ECHO=$( (echo "${MESSAGE}" ; sleep 0.5) | socat - unix:"${HOST_SOCK#"$(pwd)"/}")
   kill "${NSENTER_PID}" 2>/dev/null || true
   wait "${NSENTER_PID}" 2>/dev/null || true
 

--- a/test/suites/container_local_cross_pool_handling.sh
+++ b/test/suites/container_local_cross_pool_handling.sh
@@ -1,7 +1,7 @@
 test_container_local_cross_pool_handling() {
   ensure_import_testimage
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
   # shellcheck disable=SC2034
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -121,7 +121,7 @@ test_container_local_cross_pool_handling() {
     lxc network delete "${brName}"
   )
 
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"
   kill_lxd "${LXD_STORAGE_DIR}"
 }

--- a/test/suites/database.sh
+++ b/test/suites/database.sh
@@ -43,7 +43,7 @@ EOF
 }
 
 test_database_no_disk_space(){
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_NOSPACE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)

--- a/test/suites/external_auth.sh
+++ b/test/suites/external_auth.sh
@@ -1,5 +1,5 @@
 test_macaroon_auth() {
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,3043
     local identity_endpoint
     # shellcheck disable=SC2086
     identity_endpoint="$(cat ${TEST_DIR}/macaroon-identity.endpoint)"

--- a/test/suites/filtering.sh
+++ b/test/suites/filtering.sh
@@ -1,6 +1,6 @@
 # Test API filtering.
 test_filtering() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_FILTERING_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -1,5 +1,5 @@
 test_image_expiry() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"
@@ -50,8 +50,8 @@ test_image_expiry() {
 
 test_image_list_all_aliases() {
     ensure_import_testimage
-    # shellcheck disable=2039,2034,2155
-    local sum=$(lxc image info testimage | grep ^Fingerprint | cut -d' ' -f2)
+    # shellcheck disable=2039,2034,2155,3043
+    local sum="$(lxc image info testimage | grep ^Fingerprint | cut -d' ' -f2)"
     lxc image alias create zzz "$sum"
     lxc image list | grep -vq zzz
     # both aliases are listed if the "aliases" column is included in output
@@ -63,16 +63,16 @@ test_image_list_all_aliases() {
 test_image_import_dir() {
     ensure_import_testimage
     lxc image export testimage
-    # shellcheck disable=2039,2034,2155
-    local image=$(ls -1 -- *.tar.xz)
+    # shellcheck disable=2039,2034,2155,3043
+    local image="$(ls -1 -- *.tar.xz)"
     mkdir -p unpacked
     tar -C unpacked -xf "$image"
-    # shellcheck disable=2039,2034,2155
-    local fingerprint=$(lxc image import unpacked | awk '{print $NF;}')
+    # shellcheck disable=2039,2034,2155,3043
+    local fingerprint="$(lxc image import unpacked | awk '{print $NF;}')"
     rm -rf "$image" unpacked
 
     lxc image export "$fingerprint"
-    # shellcheck disable=2039,2034,2155
+    # shellcheck disable=2039,2034,2155,3043
     local exported="${fingerprint}.tar.xz"
 
     tar tvf "$exported" | grep -Fq metadata.yaml
@@ -92,7 +92,7 @@ test_image_import_existing_alias() {
 }
 
 test_image_refresh() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/image_auto_update.sh
+++ b/test/suites/image_auto_update.sh
@@ -3,7 +3,7 @@ test_image_auto_update() {
       lxc image delete testimage
   fi
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/image_prefer_cached.sh
+++ b/test/suites/image_prefer_cached.sh
@@ -6,7 +6,7 @@ test_image_prefer_cached() {
       lxc image delete testimage
   fi
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/incremental_copy.sh
+++ b/test/suites/incremental_copy.sh
@@ -5,7 +5,7 @@ test_incremental_copy() {
   do_copy "" ""
 
   # cross-pool copy
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local source_pool
   source_pool="lxdtest-$(basename "${LXD_DIR}")-dir-pool"
   lxc storage create "${source_pool}" dir
@@ -14,10 +14,10 @@ test_incremental_copy() {
 }
 
 do_copy() {
-  # shellcheck disable=2039
-  local source_pool=$1
-  # shellcheck disable=2039
-  local target_pool=$2
+  # shellcheck disable=2039,3043
+  local source_pool="${1}"
+  # shellcheck disable=2039,3043
+  local target_pool="${2}"
 
   # Make sure the containers don't exist
   lxc rm -f c1 c2 || true

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -1,6 +1,6 @@
 test_migration() {
   # setup a second LXD
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR lxd_backend
   # shellcheck disable=2153
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -26,7 +26,7 @@ test_migration() {
   if [ "${LXD_BACKEND}" = "lvm" ]; then
     # Test that non-thinpool lvm backends work fine with migration.
 
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local storage_pool1 storage_pool2
     # shellcheck disable=2153
     storage_pool1="lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-migration"
@@ -52,7 +52,7 @@ test_migration() {
 }
 
 migration() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd2_dir lxd_backend lxd2_backend
   lxd2_dir="$1"
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/pki.sh
+++ b/test/suites/pki.sh
@@ -53,7 +53,7 @@ test_pki() {
   # Confirm that a valid client certificate works.
   (
     set -e
-    export LXD_CONF=${LXC5_DIR}
+    export LXD_CONF="${LXC5_DIR}"
 
     # Try adding remote using an incorrect password.
     # This should fail, as if the certificate is unknown and password is wrong then no access should be allowed.

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -714,7 +714,7 @@ test_projects_limits() {
   # too small for resize2fs.
   if [ "${LXD_BACKEND}" = "dir" ] || [ "${LXD_BACKEND}" = "zfs" ]; then
      # Add a remote LXD to be used as image server.
-    # shellcheck disable=2039
+    # shellcheck disable=2039,3043
     local LXD_REMOTE_DIR
     LXD_REMOTE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
     chmod +x "${LXD_REMOTE_DIR}"

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -154,7 +154,7 @@ test_remote_admin() {
 }
 
 test_remote_usage() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -87,7 +87,7 @@ test_security() {
 
   lxc delete test-unpriv --force
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR
 
   LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)
@@ -136,7 +136,7 @@ test_security() {
     lxc delete -f c1
   )
 
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"
   kill_lxd "${LXD_STORAGE_DIR}"
 }

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -38,7 +38,7 @@ test_server_config_access() {
 }
 
 test_server_config_storage() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -15,7 +15,7 @@ test_snapshots() {
 }
 
 snapshots() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -105,7 +105,7 @@ test_snap_restore() {
 }
 
 snap_restore() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -250,7 +250,7 @@ restore_and_compare_fs() {
 }
 
 test_snap_expiry() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -276,7 +276,7 @@ test_snap_expiry() {
 }
 
 test_snap_schedule() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -303,7 +303,7 @@ test_snap_schedule() {
 }
 
 test_snap_volume_db_recovery() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -1,7 +1,7 @@
 test_storage() {
   ensure_import_testimage
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -10,7 +10,7 @@ test_storage() {
   spawn_lxd "${LXD_STORAGE_DIR}" false
 
   # edit storage and pool description
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local storage_pool storage_volume
   storage_pool="lxdtest-$(basename "${LXD_DIR}")-pool"
   storage_volume="${storage_pool}-vol"
@@ -36,7 +36,7 @@ test_storage() {
 
   # Test btrfs resize
   if [ "$lxd_backend" = "lvm" ] || [ "$lxd_backend" = "ceph" ]; then
-      # shellcheck disable=2039
+      # shellcheck disable=2039,3043
       local btrfs_storage_pool btrfs_storage_volume
       btrfs_storage_pool="lxdtest-$(basename "${LXD_DIR}")-pool-btrfs"
       btrfs_storage_volume="${storage_pool}-vol"
@@ -881,7 +881,7 @@ test_storage() {
   fi
 
   # Test removing storage pools only containing image volumes
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"
   storage_pool="lxdtest-$(basename "${LXD_DIR}")-pool26"
   lxc storage create "$storage_pool" "$lxd_backend"
@@ -894,7 +894,7 @@ test_storage() {
   lxc storage delete "${storage_pool}"
   lxc image show testimage
 
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"
   kill_lxd "${LXD_STORAGE_DIR}"
 }

--- a/test/suites/storage_driver_btrfs.sh
+++ b/test/suites/storage_driver_btrfs.sh
@@ -1,5 +1,5 @@
 test_storage_driver_btrfs() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_driver_ceph.sh
+++ b/test/suites/storage_driver_ceph.sh
@@ -1,5 +1,5 @@
 test_storage_driver_ceph() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_driver_cephfs.sh
+++ b/test/suites/storage_driver_cephfs.sh
@@ -1,5 +1,5 @@
 test_storage_driver_cephfs() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -1,7 +1,7 @@
 test_storage_local_volume_handling() {
   ensure_import_testimage
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
   # shellcheck disable=SC2034
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -252,7 +252,7 @@ test_storage_local_volume_handling() {
     done
   )
 
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"
   kill_lxd "${LXD_STORAGE_DIR}"
 }

--- a/test/suites/storage_profiles.sh
+++ b/test/suites/storage_profiles.sh
@@ -134,7 +134,7 @@ test_storage_profiles() {
 
   )
 
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"
   kill_lxd "${LXD_STORAGE_DIR}"
 }

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -1,7 +1,7 @@
 test_storage_volume_snapshots() {
   ensure_import_testimage
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -9,7 +9,7 @@ test_storage_volume_snapshots() {
   chmod +x "${LXD_STORAGE_DIR}"
   spawn_lxd "${LXD_STORAGE_DIR}" false
 
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local storage_pool storage_volume
   storage_pool="lxdtest-$(basename "${LXD_STORAGE_DIR}")-pool"
   storage_volume="${storage_pool}-vol"
@@ -101,7 +101,7 @@ test_storage_volume_snapshots() {
 
   lxc storage delete "${storage_pool}"
 
-  # shellcheck disable=SC2031
+  # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"
   kill_lxd "${LXD_STORAGE_DIR}"
 }

--- a/test/suites/template.sh
+++ b/test/suites/template.sh
@@ -1,5 +1,5 @@
 test_template() {
-  # shellcheck disable=2039
+  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 


### PR DESCRIPTION
Installs a shellcheck 0.8.0 in the static analysis workflow. `make static-analysis` prints a warning if the shellcheck version is not 0.8.0.

Closes #10623.