### PR TITLE
Generator: Fixes for external calling

### DIFF
--- a/lxd/db/generate/db/lex.go
+++ b/lxd/db/generate/db/lex.go
@@ -8,7 +8,11 @@ import (
 )
 
 // Return the table name for the given database entity.
-func entityTable(entity string) string {
+func entityTable(entity string, override string) string {
+	if override != "" {
+		return override
+	}
+
 	entityParts := strings.Split(lex.Snake(entity), "_")
 	tableParts := make([]string, len(entityParts))
 	for i, part := range entityParts {


### PR DESCRIPTION
This adds some small changes/fixes for using `lxd-generate` from outside the lxd project.

* When the `-d` or `--database` flag is passed, the keyword will now properly be used as a package receiver. The actual package path is imported via `goimports`. 
* The above flag will now no longer affect other generated helpers. The generator will assume that any necessary helper is defined within the package from which the generator was called. Instead, the `-d` flag will now only work on the globally defined prepared statement helpers: `Stmt` and `RegisterStmt`. It makes sense to have these be referenced since there should only be one collection of statements prepared when the database first opens.
*  A table name override flag has been added as well: Sometimes the generator just isn't too smart, or language is just too inconsistent to generate sensible table names. This lets us override the generated table name with one defined by us.
 