### PR TITLE
lxd: Deprecates `ceph.osd.force_reuse` Ceph storage pool setting

### DIFF
--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -170,6 +170,8 @@ func (d *ceph) Create() error {
 	} else {
 		ok := d.HasVolume(placeholderVol)
 		if ok {
+			// ceph.osd.force_reuse is deprecated and should not be used. OSD pools are a logical
+			// construct there is no good reason not to create one for dedicated use by LXD.
 			if shared.IsFalseOrEmpty(d.config["ceph.osd.force_reuse"]) {
 				return fmt.Errorf("Pool '%s' in cluster '%s' seems to be in use by another LXD instance. Use 'ceph.osd.force_reuse=true' to force", d.config["ceph.osd.pool_name"], d.config["ceph.cluster_name"])
 			}
@@ -256,7 +258,7 @@ func (d *ceph) Delete(op *operations.Operation) error {
 func (d *ceph) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		"ceph.cluster_name":          validate.IsAny,
-		"ceph.osd.force_reuse":       validate.Optional(validate.IsBool),
+		"ceph.osd.force_reuse":       validate.Optional(validate.IsBool), // Deprecated, should not be used.
 		"ceph.osd.pg_num":            validate.IsAny,
 		"ceph.osd.pool_name":         validate.IsAny,
 		"ceph.osd.data_pool_name":    validate.IsAny,

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -151,7 +151,7 @@ _have lxc && {
       restricted.devices.pci restricted.devices.proxy"
 
     storage_pool_keys="source size btrfs.mount_options ceph.cluster_name \
-      ceph.osd.force_reuse ceph.osd.pg_num ceph.osd.pool_name ceph.osd.data_pool_name \
+      ceph.osd.pg_num ceph.osd.pool_name ceph.osd.data_pool_name \
       ceph.rbd.clone_copy ceph.rbd.du ceph.rbd.features ceph.user.name cephfs.cluster_name cephfs.path \
       cephfs.fscache cephfs.vg_name lvm.thinpool_name lvm.thinpool_metadata_size lvm.use_thinpool \
       lvm.vg_name rsync.bwlimit volatile.initial_source \


### PR DESCRIPTION
Ceph OSD pools are a logical construct, so there's no good reason not to allocate a new one and because Ceph is by-designed accessible by multiple systems, the likelihood of someone using this to have two or more LXD servers on the same pool is pretty high and will fail quite disastrously (data loss).

Fixes #10659

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>