### PR TITLE
doc: Update cloud-init.md with user-data examples

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -31,7 +31,118 @@ For LXD instances, `vendor-data` should be used in profiles rather than the inst
 
 Cloud-config examples can be found here: https://cloudinit.readthedocs.io/en/latest/topics/examples.html
 
-## Custom network configuration
+## Working with cloud-init
+
+For a safe way to test, use a new profile that's copied from the default profile.
+
+    lxc profile copy default test
+
+Then edit the new `test` profile. You might want to set your `EDITOR` environment variable first.
+
+    lxc profile edit test
+
+For a new LXD installation, the configuration file should look similar to this example:
+
+```yaml
+config: {}
+description: Default LXD profile
+devices:
+  eth0:
+    name: eth0
+    network: lxdbr0
+    type: nic
+  root:
+    path: /
+    pool: default
+    type: disk
+```
+
+Once you've set up the `cloud-init` configuration, use `lxc launch` with `--profile <profilename>` to apply the profile to the instance.
+
+### Adding cloud-init keys to the configuration
+
+`cloud-init` keys require a specific syntax. You use a pipe symbol (`|`) to indicate that all indented text after the pipe should be passed to `cloud-init` as a single string, with new lines and indentation preserved; this is YAML's [literal style format](https://yaml.org/spec/1.2.2/#812-literal-style).
+
+```yaml
+config:
+  cloud-init.user-data: |
+```
+
+```yaml
+config:
+  cloud-init.vendor-data: |
+```
+
+```yaml
+config:
+  cloud-init.network-config: |
+```
+
+### Custom user-data configuration
+
+cloud-init uses the `user-data` (and `vendor-data`) section to do things like upgrade packages, install packages or run arbitrary commands.
+
+A `cloud-init.user-data` key must have a first line that indicates what type of [data format](https://cloudinit.readthedocs.io/en/latest/topics/format.html) is being passed to `cloud-init`. For activities like upgrading packages or setting up a user, `#cloud-config` is the data format to use.
+
+An instance's `rootfs` will contain the following files as a result:
+* `/var/lib/cloud/instance/cloud-config.txt`
+* `/var/lib/cloud/instance/user-data.txt`
+
+#### Upgrade packages on instance creation
+To trigger a package upgrade from the repositories for the instance, use the `package_upgrade` key:
+
+```yaml
+config:
+  cloud-init.user-data: |
+    #cloud-config
+    package_upgrade: true
+```
+
+#### Install packages on instance creation
+To install specific packages when the instance is set up, use the `packages` key and specify the package names as a list:
+
+```yaml
+config:
+  cloud-init.user-data: |
+    #cloud-config
+    packages:
+      - git
+      - openssh-server
+```
+
+#### Set the time zone on instance creation
+To set the time zone for the instance, use the `timezone` key:
+
+```yaml
+config:
+  cloud-init.user-data: |
+    #cloud-config
+    timezone: Europe/Rome
+```
+
+#### Run commands
+To run a command (such as writing a marker file), use the `runcmd` key and specify commands as a list:
+
+```yaml
+config:
+  cloud-init.user-data: |
+    #cloud-config
+    runcmd:
+      - [touch, /run/cloud.init.ran]
+```
+
+#### Add a user account
+To add a user account, use the `user` key. See the [documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html#including-users-and-groups) for more details about default users and which keys are supported.
+
+```yaml
+config:
+  cloud-init.user-data: |
+    #cloud-config
+    user:
+      - name: documentation_example
+```
+
+### Custom network configuration
 
 cloud-init uses the network-config data to render the relevant network
 configuration on the system using either ifupdown or netplan depending


### PR DESCRIPTION
Context
==
I found the current documentation to be very lacking in terms of a clear explanation of how to apply the `user-data` configuration options, and how to confirm that the `cloud-init` process had received the data. It was only through a lot of searching that I found out that `#cloud-config` is actually not just a comment, but actually required for `cloud-init` to even process that set of piped configuration keys.

Approach
==
This change
* Adds a small "how to" for setting up a new profile for testing
* Adds documentation on the pipe syntax that's needed to pipe the configuration to cloud-init
* Adds documentation for the specific syntax required to get `cloud-init.user-data` to work (`#cloud-config`)
* Adds documentation on where to check on the instance to see if the user-data was passed in properly
* Adds examples of using the `user-data` section to take actions in an instance

Errata
==
I acknowledge that v5 is meant to bring a documentation rewrite per the comment on the YouTube video linked from this document, but I don't think that's a good reason to not have some clear examples in the documentation right now. Google searches tend (for me) to find documentation from 2018 that use the old config syntax (user.user-data), and that documentation doesn't say `#cloud-config` is crucial.

Testing of instructions
==

With the `#cloud-config` line in the `cloud-init.user-data` block:
```
$ ls -l /var/lib/cloud/instance | grep -E 'cloud-config.txt|user-data.txt'
-rw------- 1 root root  149 Jul 16 08:47 cloud-config.txt
-rw------- 1 root root  117 Jul 16 08:47 user-data.txt
```
`/var/log/syslog` confirms `apt upgrade` and `apt install` were run.

Without the `#cloud-config` line:
```
$ ls -l /var/lib/cloud/instance | grep -E 'cloud-config.txt|user-data.txt'
-rw------- 1 root root    0 Jul 16 08:09 cloud-config.txt
-rw------- 1 root root  103 Jul 16 08:09 user-data.txt
```

`/var/log/syslog` confirms that none of the upgrades etcetera ran.



Signed-off-by: Duncan Hill <github.com@cricalix.net>