### PR TITLE
lxc: Clarify that monitor --log-level can only be used with pretty formatting mode

### DIFF
--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -49,7 +49,7 @@ lxc monitor --type=lifecycle
 	cmd.Flags().BoolVar(&c.flagPretty, "pretty", false, i18n.G("Pretty rendering (short for --format=pretty)"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Show events from all projects"))
 	cmd.Flags().StringArrayVar(&c.flagType, "type", nil, i18n.G("Event type to listen for")+"``")
-	cmd.Flags().StringVar(&c.flagLogLevel, "loglevel", "", i18n.G("Minimum level for log messages")+"``")
+	cmd.Flags().StringVar(&c.flagLogLevel, "loglevel", "", i18n.G("Minimum level for log messages (only available when using pretty format)")+"``")
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "yaml", i18n.G("Format (json|pretty|yaml)")+"``")
 
 	return cmd
@@ -74,6 +74,10 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 	// Setup format.
 	if c.flagPretty {
 		c.flagFormat = "pretty"
+	}
+
+	if c.flagFormat != "pretty" && c.flagLogLevel != "" {
+		return fmt.Errorf(i18n.G("Log level filtering can only be used with pretty formatting"))
 	}
 
 	// Connect to the event source.

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1219,7 +1219,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1744,7 +1744,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3264,6 +3264,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3582,7 +3586,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3619,7 +3624,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3651,7 +3656,7 @@ msgstr "Profilname kann nicht geändert werden"
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3805,7 +3810,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4033,7 +4038,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4488,7 +4493,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4525,7 +4530,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6540,7 +6545,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -944,7 +944,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1441,7 +1441,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2879,6 +2879,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3172,7 +3176,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3206,7 +3211,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3235,7 +3240,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3378,7 +3383,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3602,7 +3607,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4042,7 +4047,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4076,7 +4081,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
@@ -5698,7 +5703,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1178,7 +1178,7 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1684,7 +1684,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3143,6 +3143,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr "Registro:"
@@ -3436,7 +3440,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3473,7 +3478,7 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
@@ -3504,7 +3509,7 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3653,7 +3658,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3875,7 +3880,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4320,7 +4325,7 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4354,7 +4359,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
@@ -6060,7 +6065,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1216,7 +1216,7 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1771,7 +1771,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3351,6 +3351,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr "Journal : "
@@ -3665,7 +3669,8 @@ msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3702,7 +3707,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3734,7 +3739,7 @@ msgstr "Nom du réseau"
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3892,7 +3897,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4121,7 +4126,7 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4591,7 +4596,7 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4628,7 +4633,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
@@ -6753,7 +6758,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -942,7 +942,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1434,7 +1434,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2856,6 +2856,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3140,7 +3144,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3173,7 +3178,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3202,7 +3207,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3343,7 +3348,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4003,7 +4008,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4035,7 +4040,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5632,7 +5637,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1170,7 +1170,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1675,7 +1675,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3132,6 +3132,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3430,7 +3434,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3466,7 +3471,7 @@ msgstr "Il nome del container è: %s"
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
@@ -3497,7 +3502,7 @@ msgstr "Il nome del container è: %s"
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3645,7 +3650,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3867,7 +3872,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4313,7 +4318,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4348,7 +4353,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
@@ -6054,7 +6059,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1177,7 +1177,7 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1683,7 +1683,7 @@ msgstr "警告を削除します"
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3315,6 +3315,10 @@ msgstr "バックグラウンド操作の一覧表示、表示、削除を行い
 msgid "Location: %s"
 msgstr "ロケーション: %s"
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr "ログ:"
@@ -3619,8 +3623,9 @@ msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
-msgstr "表示するログメッセージの最小レベル"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
+msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
 msgid "Missing certificate fingerprint"
@@ -3652,7 +3657,7 @@ msgstr "インスタンス名を指定する必要があります"
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
@@ -3681,7 +3686,7 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3827,7 +3832,7 @@ msgstr "コピー／移動元とは異なるプロジェクトに移動します
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
@@ -4055,7 +4060,7 @@ msgstr "このストレージボリュームに対するデバイスがありま
 msgid "No matching backend found"
 msgstr "マッチするルールが見つかりません"
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
@@ -4496,7 +4501,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
@@ -4530,7 +4535,7 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "フォワードからポートを削除します"
@@ -6243,7 +6248,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
@@ -6979,6 +6984,9 @@ msgstr "y"
 #: lxc/image.go:1116
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "Minimum level for log messages"
+#~ msgstr "表示するログメッセージの最小レベル"
 
 #~ msgid "<pool>/<volume> <pool>/<volume>"
 #~ msgstr "<pool>/<volume> <pool>/<volume>"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-07-04 11:12+0100\n"
+        "POT-Creation-Date: 2022-07-18 13:44+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -892,7 +892,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:47 lxc/init.go:54 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713 lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178 lxc/network.go:1240 lxc/network_forward.go:171 lxc/network_forward.go:235 lxc/network_forward.go:390 lxc/network_forward.go:491 lxc/network_forward.go:633 lxc/network_forward.go:710 lxc/network_forward.go:776 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636 lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944 lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638 lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:841 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1541 lxc/storage_volume.go:1573 lxc/storage_volume.go:1689 lxc/storage_volume.go:1780 lxc/storage_volume.go:1873 lxc/storage_volume.go:1910 lxc/storage_volume.go:2003 lxc/storage_volume.go:2075 lxc/storage_volume.go:2217
+#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:47 lxc/init.go:54 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713 lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178 lxc/network.go:1240 lxc/network_forward.go:171 lxc/network_forward.go:235 lxc/network_forward.go:390 lxc/network_forward.go:491 lxc/network_forward.go:633 lxc/network_forward.go:710 lxc/network_forward.go:776 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636 lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939 lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638 lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:841 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1541 lxc/storage_volume.go:1573 lxc/storage_volume.go:1689 lxc/storage_volume.go:1780 lxc/storage_volume.go:1873 lxc/storage_volume.go:1910 lxc/storage_volume.go:2003 lxc/storage_volume.go:2075 lxc/storage_volume.go:2217
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1300,7 +1300,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203 lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380 lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713 lxc/cluster.go:784 lxc/cluster.go:883 lxc/cluster.go:962 lxc/cluster.go:1069 lxc/cluster.go:1090 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:518 lxc/config_trust.go:564 lxc/config_trust.go:635 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:239 lxc/file.go:449 lxc/file.go:957 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1332 lxc/image.go:1412 lxc/image.go:1471 lxc/image.go:1523 lxc/image.go:1579 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:167 lxc/network_acl.go:220 lxc/network_acl.go:266 lxc/network_acl.go:315 lxc/network_acl.go:398 lxc/network_acl.go:458 lxc/network_acl.go:485 lxc/network_acl.go:616 lxc/network_acl.go:665 lxc/network_acl.go:714 lxc/network_acl.go:729 lxc/network_acl.go:850 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610 lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592 lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842 lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632 lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:518 lxc/storage_volume.go:597 lxc/storage_volume.go:672 lxc/storage_volume.go:754 lxc/storage_volume.go:835 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1263 lxc/storage_volume.go:1345 lxc/storage_volume.go:1537 lxc/storage_volume.go:1570 lxc/storage_volume.go:1683 lxc/storage_volume.go:1771 lxc/storage_volume.go:1870 lxc/storage_volume.go:1904 lxc/storage_volume.go:2001 lxc/storage_volume.go:2068 lxc/storage_volume.go:2212 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203 lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380 lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713 lxc/cluster.go:784 lxc/cluster.go:883 lxc/cluster.go:962 lxc/cluster.go:1069 lxc/cluster.go:1090 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:518 lxc/config_trust.go:564 lxc/config_trust.go:635 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:239 lxc/file.go:449 lxc/file.go:957 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1332 lxc/image.go:1412 lxc/image.go:1471 lxc/image.go:1523 lxc/image.go:1579 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:167 lxc/network_acl.go:220 lxc/network_acl.go:266 lxc/network_acl.go:315 lxc/network_acl.go:398 lxc/network_acl.go:458 lxc/network_acl.go:485 lxc/network_acl.go:616 lxc/network_acl.go:665 lxc/network_acl.go:714 lxc/network_acl.go:729 lxc/network_acl.go:850 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610 lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592 lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842 lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632 lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:518 lxc/storage_volume.go:597 lxc/storage_volume.go:672 lxc/storage_volume.go:754 lxc/storage_volume.go:835 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1263 lxc/storage_volume.go:1345 lxc/storage_volume.go:1537 lxc/storage_volume.go:1570 lxc/storage_volume.go:1683 lxc/storage_volume.go:1771 lxc/storage_volume.go:1870 lxc/storage_volume.go:1904 lxc/storage_volume.go:2001 lxc/storage_volume.go:2068 lxc/storage_volume.go:2212 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -2634,6 +2634,10 @@ msgstr  ""
 msgid   "Location: %s"
 msgstr  ""
 
+#: lxc/monitor.go:80
+msgid   "Log level filtering can only be used with pretty formatting"
+msgstr  ""
+
 #: lxc/info.go:713
 msgid   "Log:"
 msgstr  ""
@@ -2915,7 +2919,7 @@ msgid   "Migration operation failure: %w"
 msgstr  ""
 
 #: lxc/monitor.go:52
-msgid   "Minimum level for log messages"
+msgid   "Minimum level for log messages (only available when using pretty format)"
 msgstr  ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -2934,7 +2938,7 @@ msgstr  ""
 msgid   "Missing instance name"
 msgstr  ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260 lxc/network_forward.go:355 lxc/network_forward.go:415 lxc/network_forward.go:539 lxc/network_forward.go:658 lxc/network_forward.go:735 lxc/network_forward.go:801 lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262 lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417 lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661 lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_forward.go:196 lxc/network_forward.go:260 lxc/network_forward.go:355 lxc/network_forward.go:415 lxc/network_forward.go:539 lxc/network_forward.go:658 lxc/network_forward.go:735 lxc/network_forward.go:801 lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262 lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417 lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661 lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -2946,7 +2950,7 @@ msgstr  ""
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:388 lxc/network.go:438 lxc/network.go:523 lxc/network.go:628 lxc/network.go:736 lxc/network.go:794 lxc/network.go:1009 lxc/network.go:1079 lxc/network.go:1134 lxc/network.go:1201 lxc/network_forward.go:116 lxc/network_forward.go:192 lxc/network_forward.go:256 lxc/network_forward.go:351 lxc/network_forward.go:411 lxc/network_forward.go:535 lxc/network_forward.go:654 lxc/network_forward.go:731 lxc/network_forward.go:797 lxc/network_load_balancer.go:120 lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413 lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657 lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797 lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965 lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238 lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519 lxc/network_peer.go:628
+#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:388 lxc/network.go:438 lxc/network.go:523 lxc/network.go:628 lxc/network.go:736 lxc/network.go:794 lxc/network.go:1009 lxc/network.go:1079 lxc/network.go:1134 lxc/network.go:1201 lxc/network_forward.go:116 lxc/network_forward.go:192 lxc/network_forward.go:256 lxc/network_forward.go:351 lxc/network_forward.go:411 lxc/network_forward.go:535 lxc/network_forward.go:654 lxc/network_forward.go:731 lxc/network_forward.go:797 lxc/network_load_balancer.go:120 lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413 lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657 lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797 lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960 lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238 lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519 lxc/network_peer.go:628
 msgid   "Missing network name"
 msgstr  ""
 
@@ -3062,7 +3066,7 @@ msgstr  ""
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
@@ -3275,7 +3279,7 @@ msgstr  ""
 msgid   "No matching backend found"
 msgstr  ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid   "No matching port(s) found"
 msgstr  ""
 
@@ -3705,7 +3709,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid   "Remove all ports that match"
 msgstr  ""
 
@@ -3737,7 +3741,7 @@ msgstr  ""
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
@@ -5257,7 +5261,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -1147,7 +1147,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1639,7 +1639,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3061,6 +3061,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3345,7 +3349,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3378,7 +3383,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3407,7 +3412,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3548,7 +3553,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3770,7 +3775,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4208,7 +4213,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4240,7 +4245,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5837,7 +5842,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1181,7 +1181,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1673,7 +1673,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3095,6 +3095,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3379,7 +3383,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3412,7 +3417,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3441,7 +3446,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3582,7 +3587,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3804,7 +3809,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4242,7 +4247,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4274,7 +4279,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5871,7 +5876,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1197,7 +1197,7 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1725,7 +1725,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3188,6 +3188,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3492,7 +3496,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3528,7 +3533,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
@@ -3559,7 +3564,7 @@ msgstr "Nome de membro do cluster"
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3706,7 +3711,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3928,7 +3933,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4375,7 +4380,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4411,7 +4416,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
@@ -6107,7 +6112,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1194,7 +1194,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1709,7 +1709,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -3179,6 +3179,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3485,7 +3489,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3521,7 +3526,7 @@ msgstr "Имя контейнера: %s"
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
@@ -3552,7 +3557,7 @@ msgstr "Имя контейнера: %s"
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3702,7 +3707,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3927,7 +3932,7 @@ msgstr "Копирование образа: %s"
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4371,7 +4376,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4406,7 +4411,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
@@ -6341,7 +6346,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -942,7 +942,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1434,7 +1434,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2856,6 +2856,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3140,7 +3144,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3173,7 +3178,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3202,7 +3207,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3343,7 +3348,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4003,7 +4008,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4035,7 +4040,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5632,7 +5637,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -942,7 +942,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1434,7 +1434,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2856,6 +2856,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3140,7 +3144,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3173,7 +3178,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3202,7 +3207,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3343,7 +3348,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4003,7 +4008,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4035,7 +4040,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5632,7 +5637,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -938,7 +938,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1430,7 +1430,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2852,6 +2852,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3136,7 +3140,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3169,7 +3174,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3198,7 +3203,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3339,7 +3344,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3561,7 +3566,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -3999,7 +4004,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4031,7 +4036,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5628,7 +5633,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -942,7 +942,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1434,7 +1434,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2856,6 +2856,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3140,7 +3144,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3173,7 +3178,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3202,7 +3207,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3343,7 +3348,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3565,7 +3570,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4003,7 +4008,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4035,7 +4040,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5632,7 +5637,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1044,7 +1044,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1536,7 +1536,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2958,6 +2958,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3242,7 +3246,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3275,7 +3280,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3304,7 +3309,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3445,7 +3450,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3667,7 +3672,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4105,7 +4110,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4137,7 +4142,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5734,7 +5739,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-04 11:12+0100\n"
+"POT-Creation-Date: 2022-07-18 13:44+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -941,7 +941,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
 #: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
 #: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:944
+#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
 #: lxc/storage.go:96 lxc/storage.go:342 lxc/storage.go:403 lxc/storage.go:638
 #: lxc/storage.go:710 lxc/storage.go:793 lxc/storage_volume.go:335
 #: lxc/storage_volume.go:521 lxc/storage_volume.go:600
@@ -1433,7 +1433,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
 #: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
 #: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
 #: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
 #: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
 #: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
@@ -2855,6 +2855,10 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
+#: lxc/monitor.go:80
+msgid "Log level filtering can only be used with pretty formatting"
+msgstr ""
+
 #: lxc/info.go:713
 msgid "Log:"
 msgstr ""
@@ -3139,7 +3143,8 @@ msgid "Migration operation failure: %w"
 msgstr ""
 
 #: lxc/monitor.go:52
-msgid "Minimum level for log messages"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: lxc/config_trust.go:262 lxc/config_trust.go:660
@@ -3172,7 +3177,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
 #: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
 #: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:969
+#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
 msgid "Missing listen address"
 msgstr ""
 
@@ -3201,7 +3206,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
 #: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
 #: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:965
+#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
 #: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
 #: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
 #: lxc/network_peer.go:628
@@ -3342,7 +3347,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3564,7 +3569,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1024
+#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:941
+#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4034,7 +4039,7 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5631,7 +5636,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:938
+#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 


### PR DESCRIPTION


Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>