### PR TITLE
doc/storage: move content from FAQ to storage section

### DIFF
--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -6,7 +6,7 @@ You could think of a storage pool as the disk that is used to store data, while 
 ## Storage pools
 
 During initialization, LXD prompts you to create a first storage pool.
-If required, you can create additional storage pools later.
+If required, you can create additional storage pools later (see {ref}`storage-create-pool`).
 
 Each storage pool uses a storage driver.
 The following storage drivers are supported:

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -44,34 +44,6 @@ lxc config trust add client.crt
 
 See {doc}`authentication` for detailed information.
 
-### How do I configure LXD storage?
-LXD supports Btrfs, Ceph, directory, LVM and ZFS based storage.
-
-First make sure you have the relevant tools for your file system of
-choice installed on the machine (btrfs-progs, lvm2 or zfsutils-linux).
-
-By default, LXD comes with no configured network or storage.
-You can get a basic configuration done with:
-
-```bash
-    lxd init
-```
-
-`lxd init` supports both directory-based storage and ZFS.
-If you want something else, you'll need to use the `lxc storage` command:
-
-```bash
-lxc storage create default BACKEND [OPTIONS...]
-lxc profile device add default root disk path=/ pool=default
-```
-
-BACKEND is one of `btrfs`, `ceph`, `dir`, `lvm` or `zfs`.
-
-Unless specified otherwise, LXD will set up loop-based storage with a sane default size.
-
-For production environments, you should be using block-backed storage
-instead, both for performance and reliability reasons.
-
 ### How can I live-migrate a container using LXD?
 Live migration requires a tool installed on both hosts called
 [CRIU](https://criu.org), which is available in Ubuntu via:

--- a/doc/howto/storage_create_pool.md
+++ b/doc/howto/storage_create_pool.md
@@ -1,4 +1,4 @@
-(storage_create_pool)=
+(storage-create-pool)=
 # How to create a storage pool
 
 LXD creates a storage pool during initialization.
@@ -7,6 +7,8 @@ You can add more storage pools later, using the same driver or different drivers
 To create a storage pool, use the following command:
 
     lxc storage create <pool_name> <driver> [configuration_options...]
+
+Unless specified otherwise, LXD sets up loop-based storage with a sensible default size (20% of the free disk space, but at least 5 GiB and at most 30 GiB).
 
 See the {ref}`storage-drivers` documentation for a list of available configuration options for each driver.
 

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -7,6 +7,8 @@ Unlike other file systems, Btrfs is extent-based, which means that it stores dat
 
 In addition to basic file system features, Btrfs offers RAID and volume management, pooling, snapshots, checksums, compression and other features.
 
+To use Btrfs, make sure you have `btrfs-progs` installed on your machine.
+
 ## Terminology
 
 A Btrfs file system can have *subvolumes*, which are named binary subtrees of the main tree of the file system with their own independent file and directory hierarchy.

--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -21,18 +21,19 @@ See the corresponding pages for driver-specific information and configuration op
 Where possible, LXD uses the advanced features of each storage system to optimize operations.
 
 Feature                                     | Directory | Btrfs | LVM   | ZFS  | Ceph RBD | CephFS
-:---                                        | :---      | :---  | :---  | :--- | :--- | :---
-{ref}`storage-optimized-image-storage`      | no        | yes   | yes   | yes  | yes  | n/a
-Optimized instance creation                 | no        | yes   | yes   | yes  | yes  | n/a
-Optimized snapshot creation                 | no        | yes   | yes   | yes  | yes  | yes
-Optimized image transfer                    | no        | yes   | no    | yes  | yes  | n/a
-{ref}`storage-optimized-instance-transfer`  | no        | yes   | no    | yes  | yes  | n/a
-Copy on write                               | no        | yes   | yes   | yes  | yes  | yes
-Block based                                 | no        | no    | yes   | no   | yes  | no
-Instant cloning                             | no        | yes   | yes   | yes  | yes  | yes
-Storage driver usable inside a container    | yes       | yes   | no    | no   | no   | n/a
-Restore from older snapshots (not latest)   | yes       | yes   | yes   | no   | yes  | yes
+:---                                        | :---      | :---  | :---  | :--- | :---     | :---
+{ref}`storage-optimized-image-storage`      | no        | yes   | yes   | yes  | yes      | n/a
+Optimized instance creation                 | no        | yes   | yes   | yes  | yes      | n/a
+Optimized snapshot creation                 | no        | yes   | yes   | yes  | yes      | yes
+Optimized image transfer                    | no        | yes   | no    | yes  | yes      | n/a
+{ref}`storage-optimized-instance-transfer`  | no        | yes   | no    | yes  | yes      | n/a
+Copy on write                               | no        | yes   | yes   | yes  | yes      | yes
+Block based                                 | no        | no    | yes   | no   | yes      | no
+Instant cloning                             | no        | yes   | yes   | yes  | yes      | yes
+Storage driver usable inside a container    | yes       | yes   | no    | no   | no       | n/a
+Restore from older snapshots (not latest)   | yes       | yes   | yes   | no   | yes      | yes
 Storage quotas                              | yes<sup>{ref}`* <storage-dir-quotas>`</sup>| yes   | yes   | yes  | yes  | yes
+Available on `lxd init`                     | yes       | yes   | yes   | yes  | yes      | no
 
 (storage-optimized-image-storage)=
 ### Optimized image storage

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -6,6 +6,8 @@ It is used to manage physical storage devices, allowing you to create a number o
 
 Note that it is possible to over-commit the physical storage in the process, to allow flexibility for scenarios where not all available storage is in use at the same time.
 
+To use LVM, make sure you have `lvm2` installed on your machine.
+
 ## Terminology
 
 LVM can combine several physical storage devices into a *volume group*.

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -9,6 +9,8 @@ To run at a sufficient speed, this mechanism requires a powerful environment wit
 
 In addition, ZFS offers snapshots and replication, RAID management, copy-on-write clones, compression and other features.
 
+To use ZFS, make sure you have `zfsutils-linux` installed on your machine.
+
 ## Terminology
 
 ZFS creates logical units based on physical storage devices.


### PR DESCRIPTION
Move some details from the FAQ about creating storage to the
storage section and remove the question from the FAQ.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>