### PR TITLE
Client: Add 30s HTTP header timeout for image download

### DIFF
--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -402,6 +402,10 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 			return nil, err
 		}
 
+		// Use relatively short response header timeout so as not to hold the image lock open too long.
+		httpTransport := httpClient.Transport.(*http.Transport)
+		httpTransport.ResponseHeaderTimeout = 30 * time.Second
+
 		req, err := http.NewRequest("GET", args.Server, nil)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes #10279

This is to avoid LXD holding the image download lock too long when a remote source is not responding in a timely manner.

This can occur when the remote image server is up and running, but is not generating the HTTP header response due to internal I/O issues.