### PR TITLE
lxd/apparmor: apparmor profile for qemu-img

### DIFF
--- a/lxd/apparmor/qemuimg.go
+++ b/lxd/apparmor/qemuimg.go
@@ -1,0 +1,165 @@
+package apparmor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/lxc/lxd/lxd/sys"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/subprocess"
+)
+
+var qemuImgProfileTpl = template.Must(template.New("qemuImgProfile").Parse(`#include <tunables/global>
+profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability dac_override,
+  capability dac_read_search,
+
+  {{range $index, $element := .allowedCmdPaths}}
+  	{{$element}} mixr,
+  {{- end }}
+
+  {{ .pathToImg }} rk,
+
+  {{- if .dstPath }}
+    {{ .dstPath }} rwk,
+  {{- end }}
+}
+`))
+
+type nullWriteCloser struct {
+	*bytes.Buffer
+}
+
+func (nwc *nullWriteCloser) Close() error {
+	return nil
+}
+
+func QemuImg(sysOS *sys.OS, cmd []string, imgPath string, dstPath string) (string, error) {
+	allowedCmds := []string{"qemu-img"}
+	//It is assumed that command starts with a program which sets resource limits, like prlimit or nice
+	allowedCmds = append(allowedCmds, cmd[0])
+
+	allowedCmdPaths := []string{}
+	for _, c := range allowedCmds {
+		cmdPath, err := exec.LookPath(c)
+		if err != nil {
+			return "", fmt.Errorf("Failed to start qemu-img: Failed to find executable: %w", err)
+		}
+
+		allowedCmdPaths = append(allowedCmdPaths, cmdPath)
+	}
+
+	err := qemuImgProfileLoad(sysOS, imgPath, dstPath, allowedCmdPaths)
+	if err != nil {
+		return "", fmt.Errorf("Failed to start extract: Failed to load profile: %w", err)
+	}
+
+	defer func() { _ = qemuImgDelete(sysOS, imgPath) }()
+	defer func() { _ = qemuImgUnload(sysOS, imgPath) }()
+
+	var buffer bytes.Buffer
+	var output bytes.Buffer
+	p := subprocess.NewProcessWithFds(cmd[0], cmd[1:], nil, &nullWriteCloser{&output}, &nullWriteCloser{&buffer})
+	if err != nil {
+		return "", fmt.Errorf("Failed to start extract: Failed to creating subprocess: %w", err)
+	}
+
+	p.SetApparmor(qemuImgProfileName(imgPath))
+
+	err = p.Start(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("Failed to start extract: Failed running: qemu-img: %w", err)
+	}
+
+	_, err = p.Wait(context.Background())
+	if err != nil {
+		return "", shared.NewRunError(cmd[0], cmd[1:], err, nil, &buffer)
+	}
+
+	return output.String(), nil
+}
+
+// qemuImgProfileLoad ensures that the qemu-img's policy is loaded into the kernel.
+func qemuImgProfileLoad(sysOS *sys.OS, imgPath string, dstPath string, allowedCmdPaths []string) error {
+	profile := filepath.Join(aaPath, "profiles", qemuImgProfileFilename(imgPath))
+	content, err := ioutil.ReadFile(profile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	updated, err := qemuImgProfile(imgPath, dstPath, allowedCmdPaths)
+	if err != nil {
+		return err
+	}
+
+	if string(content) != string(updated) {
+		err = ioutil.WriteFile(profile, []byte(updated), 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = loadProfile(sysOS, qemuImgProfileFilename(imgPath))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// qemuImgUnload ensures that the qemu-img's policy namespace is unloaded to free kernel memory.
+// This does not delete the policy from disk or cache.
+func qemuImgUnload(sysOS *sys.OS, imgPath string) error {
+	err := unloadProfile(sysOS, qemuImgProfileName(imgPath), qemuImgProfileFilename(imgPath))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// qemuImgDelete removes the profile from cache/disk.
+func qemuImgDelete(sysOS *sys.OS, imgPath string) error {
+	return deleteProfile(sysOS, qemuImgProfileName(imgPath), qemuImgProfileFilename(imgPath))
+}
+
+// qemuImgProfile generates the AppArmor profile template from the given destination path.
+func qemuImgProfile(imgPath string, dstPath string, allowedCmdPaths []string) (string, error) {
+	// Render the profile.
+	var sb *strings.Builder = &strings.Builder{}
+	err := qemuImgProfileTpl.Execute(sb, map[string]any{
+		"name":            qemuImgProfileName(imgPath),
+		"pathToImg":       imgPath,
+		"dstPath":         dstPath,
+		"allowedCmdPaths": allowedCmdPaths,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
+}
+
+// qemuImgProfileName returns the AppArmor profile name.
+func qemuImgProfileName(outputPath string) string {
+	return getProfileName(outputPath)
+}
+
+// qemuImgProfileFilename returns the name of the on-disk profile name.
+func qemuImgProfileFilename(outputPath string) string {
+	return getProfileName(outputPath)
+}
+
+func getProfileName(outputPath string) string {
+	name := strings.Replace(strings.Trim(outputPath, "/"), "/", "-", -1)
+	return profileName("qemu-img", name)
+}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5331,7 +5331,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 
 	cmd = append(cmd, mountInfo.DiskPath, fPath)
 
-	_, err = shared.RunCommand(cmd[0], cmd[1:]...)
+	_, err = apparmor.QemuImg(d.state.OS, cmd, mountInfo.DiskPath, fPath)
 	if err != nil {
 		return meta, fmt.Errorf("Failed converting instance to qcow2: %w", err)
 	}


### PR DESCRIPTION
Hi, this is first step to cover qemu-img calls with apparmor.
Only one call is currently covered: `rlimit --cpu=2 --as=1000000000 qemu-img info -f qcow2 --output=json /var/lib/lxd/images/zxy.rootfs`
It is triggered by `lxc launch images:ubuntu/20.04 vm1 --vm`

I appreciate any comment or reviews.

Fixes #10253