### PR TITLE
lxc/remote: Allow specifying alternate server address for tokens

### DIFF
--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -646,15 +646,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -688,11 +688,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -736,11 +736,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -801,7 +801,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -824,6 +824,10 @@ msgstr "Aliasname fehlt"
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
+msgstr ""
 
 #: lxc/config_trust.go:103
 #, fuzzy
@@ -899,7 +903,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -918,7 +922,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1082,7 +1086,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1111,7 +1115,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1143,13 +1147,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1163,7 +1167,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1398,12 +1402,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1432,7 +1436,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -1763,9 +1767,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2258,11 +2262,11 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2272,7 +2276,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2282,12 +2286,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2317,7 +2321,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2399,7 +2403,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2436,7 +2440,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2452,7 +2456,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -2765,7 +2769,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2854,7 +2858,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3219,7 +3223,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3831,7 +3835,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3849,8 +3853,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3877,7 +3881,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4085,7 +4089,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4152,11 +4156,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -4186,6 +4190,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+#, fuzzy
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr "Alternatives config Verzeichnis."
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -4195,7 +4204,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4329,7 +4338,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4342,7 +4351,7 @@ msgstr "Eigenschaften:\n"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4425,37 +4434,37 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4540,7 +4549,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4594,7 +4603,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4732,7 +4741,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4756,21 +4765,21 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4972,7 +4981,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -5319,7 +5328,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5597,7 +5606,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5624,6 +5633,11 @@ msgstr ""
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+#, fuzzy
+msgid "Unavailable remote server"
+msgstr "Neue entfernte Server hinzufügen"
 
 #: lxc/config_trust.go:120
 #, fuzzy, c-format
@@ -5883,8 +5897,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -7018,7 +7032,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -7043,7 +7057,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -7333,11 +7347,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7349,7 +7363,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7386,7 +7400,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 
@@ -7684,10 +7698,6 @@ msgstr ""
 
 #~ msgid "No fingerprint specified."
 #~ msgstr "Kein Fingerabdruck angegeben."
-
-#, fuzzy
-#~ msgid "Path to an alternate server directory"
-#~ msgstr "Alternatives config Verzeichnis."
 
 #~ msgid "Show all commands (not just interesting ones)"
 #~ msgstr "Zeigt alle Befehle (nicht nur die interessanten)"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -488,11 +488,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -572,6 +572,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -641,7 +645,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -660,7 +664,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -812,7 +816,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -841,7 +845,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -869,13 +873,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1115,12 +1119,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1149,7 +1153,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1460,9 +1464,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1923,11 +1927,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -1937,7 +1941,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1947,12 +1951,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1981,7 +1985,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2059,7 +2063,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2112,7 +2116,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2412,7 +2416,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2835,7 +2839,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3097,11 +3101,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3403,7 +3407,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3421,8 +3425,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3449,7 +3453,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3653,7 +3657,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3720,11 +3724,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3753,6 +3757,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3762,7 +3770,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3891,7 +3899,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3903,7 +3911,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3982,37 +3990,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4090,7 +4098,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4140,7 +4148,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4270,7 +4278,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4294,19 +4302,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4502,7 +4510,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4641,7 +4649,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4829,7 +4837,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5095,7 +5103,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5121,6 +5129,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5364,8 +5376,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5938,7 +5950,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5950,7 +5962,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6236,11 +6248,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6252,7 +6264,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6289,7 +6301,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -633,15 +633,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -671,11 +671,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -717,11 +717,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -780,7 +780,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Contraseña admin para %s: "
@@ -802,6 +802,10 @@ msgstr ""
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Aliases:"
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
+msgstr ""
 
 #: lxc/config_trust.go:103
 #, fuzzy
@@ -872,7 +876,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1074,7 +1078,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1102,13 +1106,13 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1122,7 +1126,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1353,12 +1357,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1387,7 +1391,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1703,9 +1707,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2171,11 +2175,11 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2185,7 +2189,7 @@ msgstr "Acepta certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2195,12 +2199,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr "Acepta certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2308,7 +2312,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2345,7 +2349,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2667,7 +2671,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2754,7 +2758,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3098,7 +3102,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3362,11 +3366,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3678,7 +3682,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3696,8 +3700,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3724,7 +3728,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3926,7 +3930,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3993,11 +3997,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -4026,6 +4030,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -4035,7 +4043,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4168,7 +4176,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4180,7 +4188,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4259,37 +4267,37 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4368,7 +4376,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4419,7 +4427,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4553,7 +4561,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4577,19 +4585,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4785,7 +4793,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4924,7 +4932,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -5113,7 +5121,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5384,7 +5392,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5410,6 +5418,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5654,8 +5666,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6357,7 +6369,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6372,7 +6384,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6658,11 +6670,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6674,7 +6686,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6711,7 +6723,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -637,17 +637,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -686,12 +686,12 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -735,11 +735,11 @@ msgstr "Création du conteneur"
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -809,7 +809,7 @@ msgstr "Création du conteneur"
 msgid "Address: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -831,6 +831,10 @@ msgstr ""
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Alias :"
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
+msgstr ""
 
 #: lxc/config_trust.go:103
 #, fuzzy
@@ -905,7 +909,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -924,7 +928,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
@@ -1080,7 +1084,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1112,7 +1116,7 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1140,13 +1144,13 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1160,7 +1164,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1404,12 +1408,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1438,7 +1442,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1790,9 +1794,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2292,12 +2296,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2307,7 +2311,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2317,12 +2321,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2352,7 +2356,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2434,7 +2438,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2471,7 +2475,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2487,7 +2491,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -2811,7 +2815,7 @@ msgstr "Conteneur publié avec l'empreinte : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -2899,7 +2903,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3306,7 +3310,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3588,11 +3592,11 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3918,7 +3922,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr "NOM"
@@ -3936,8 +3940,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr "NON"
 
@@ -3965,7 +3969,7 @@ msgstr ""
 msgid "Name"
 msgstr "Nom : %s"
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4179,7 +4183,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4251,11 +4255,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4286,6 +4290,11 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+#, fuzzy
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr "Chemin vers un dossier de configuration serveur alternatif"
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -4295,7 +4304,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4430,7 +4439,7 @@ msgstr "Profil %s supprimé"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4442,7 +4451,7 @@ msgstr "Propriétés :"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -4528,37 +4537,37 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4643,7 +4652,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4697,7 +4706,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4852,7 +4861,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -4878,21 +4887,21 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -5096,7 +5105,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5249,7 +5258,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5451,7 +5460,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5735,7 +5744,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr "URL"
 
@@ -5762,6 +5771,11 @@ msgstr ""
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+#, fuzzy
+msgid "Unavailable remote server"
+msgstr "Ajouter de nouveaux serveurs distants"
 
 #: lxc/config_trust.go:120
 #, c-format
@@ -6021,8 +6035,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr "OUI"
 
@@ -7261,7 +7275,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -7289,7 +7303,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -7598,11 +7612,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -7615,7 +7629,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7652,7 +7666,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr "o"
 
@@ -8052,9 +8066,6 @@ msgstr "oui"
 
 #~ msgid "Path to an alternate client configuration directory"
 #~ msgstr "Chemin vers un dossier de configuration client alternatif"
-
-#~ msgid "Path to an alternate server directory"
-#~ msgstr "Chemin vers un dossier de configuration serveur alternatif"
 
 #~ msgid "Permission denied, are you in the lxd group?"
 #~ msgstr "Permission refusée, êtes-vous dans le groupe lxd ?"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -407,15 +407,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -444,11 +444,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -488,11 +488,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -571,6 +571,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -640,7 +644,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -659,7 +663,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -810,7 +814,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -839,7 +843,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -867,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -887,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1113,12 +1117,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1147,7 +1151,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1453,9 +1457,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1908,11 +1912,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1922,7 +1926,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1932,12 +1936,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1966,7 +1970,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2044,7 +2048,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2081,7 +2085,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2097,7 +2101,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2391,7 +2395,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2477,7 +2481,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2812,7 +2816,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3067,11 +3071,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3368,7 +3372,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3386,8 +3390,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3414,7 +3418,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3616,7 +3620,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3683,11 +3687,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3716,6 +3720,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3724,7 +3732,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3853,7 +3861,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3865,7 +3873,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3944,37 +3952,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4048,7 +4056,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4097,7 +4105,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4226,7 +4234,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4250,19 +4258,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4452,7 +4460,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4584,7 +4592,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4772,7 +4780,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5038,7 +5046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5064,6 +5072,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5298,8 +5310,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5872,7 +5884,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5884,7 +5896,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6170,11 +6182,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6186,7 +6198,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6223,7 +6235,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -627,15 +627,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -665,11 +665,11 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -711,11 +711,11 @@ msgstr "Creazione del container in corso"
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Password amministratore per %s: "
@@ -796,6 +796,10 @@ msgstr "Nome dell'alias mancante"
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Alias:"
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
+msgstr ""
 
 #: lxc/config_trust.go:103
 #, fuzzy
@@ -866,7 +870,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -885,7 +889,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -1037,7 +1041,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1066,7 +1070,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1094,13 +1098,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1114,7 +1118,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1341,12 +1345,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1375,7 +1379,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1694,9 +1698,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2161,11 +2165,11 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2175,7 +2179,7 @@ msgstr "Accetta certificato"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2185,12 +2189,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2219,7 +2223,7 @@ msgstr "Accetta certificato"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2298,7 +2302,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2335,7 +2339,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2351,7 +2355,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2654,7 +2658,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2742,7 +2746,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3087,7 +3091,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3356,11 +3360,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3670,7 +3674,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3688,8 +3692,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3716,7 +3720,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3919,7 +3923,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3986,11 +3990,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -4020,6 +4024,10 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -4029,7 +4037,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4160,7 +4168,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4172,7 +4180,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4252,37 +4260,37 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4362,7 +4370,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4413,7 +4421,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4547,7 +4555,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4571,19 +4579,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4777,7 +4785,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4916,7 +4924,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -5107,7 +5115,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5377,7 +5385,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5404,6 +5412,11 @@ msgstr ""
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+#, fuzzy
+msgid "Unavailable remote server"
+msgstr "Aggiungi un nuovo server remoto"
 
 #: lxc/config_trust.go:120
 #, c-format
@@ -5646,8 +5659,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6351,7 +6364,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
@@ -6366,7 +6379,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6652,11 +6665,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -6669,7 +6682,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6706,7 +6719,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -624,15 +624,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -662,11 +662,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -706,11 +706,11 @@ msgstr "インスタンスにデバイスを追加します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -787,7 +787,7 @@ msgstr "ACLにルールを追加します"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr "%s の管理者パスワード:"
@@ -809,6 +809,10 @@ msgstr "エイリアスを指定してください"
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "エイリアス:"
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
+msgstr ""
 
 #: lxc/config_trust.go:103
 msgid "Alternative certificate name"
@@ -882,7 +886,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -901,7 +905,7 @@ msgstr "自動更新は pull モードのときのみ有効です"
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
@@ -1054,7 +1058,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1083,7 +1087,7 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr "使用する Candid ドメイン"
 
@@ -1111,14 +1115,14 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1132,7 +1136,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1377,12 +1381,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1411,7 +1415,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1723,9 +1727,9 @@ msgstr "警告を削除します"
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2213,11 +2217,11 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -2227,7 +2231,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2237,12 +2241,12 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2271,7 +2275,7 @@ msgstr "エイリアス %s の削除に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
@@ -2364,7 +2368,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
@@ -2401,7 +2405,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2417,7 +2421,7 @@ msgstr "GPUs:"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2721,7 +2725,7 @@ msgstr "インスタンスは以下のフィンガープリントで publish さ
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -2815,7 +2819,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3274,7 +3278,7 @@ msgstr ""
 "    L - インスタンスの場所 (例: its cluster member)\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -3563,15 +3567,15 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
@@ -3886,7 +3890,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr "NAME"
@@ -3904,8 +3908,8 @@ msgid "NICs:"
 msgstr "NICs:"
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr "NO"
 
@@ -3932,7 +3936,7 @@ msgstr "NVRM バージョン: %v"
 msgid "Name"
 msgstr "名前"
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
@@ -4138,7 +4142,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4205,11 +4209,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4238,6 +4242,11 @@ msgstr "インスタンスを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
+#: lxc/remote.go:181
+#, fuzzy
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr "別のサーバ用設定ディレクトリ"
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
@@ -4246,7 +4255,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -4377,7 +4386,7 @@ msgstr "プロジェクト %s を削除しました"
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
@@ -4389,7 +4398,7 @@ msgstr "プロパティ:"
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -4468,37 +4477,37 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
@@ -4575,7 +4584,7 @@ msgstr "フォワードからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -4624,7 +4633,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -4760,7 +4769,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -4784,19 +4793,19 @@ msgstr "STP"
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -5040,7 +5049,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -5174,7 +5183,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -5362,7 +5371,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -5654,7 +5663,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr "URL"
 
@@ -5681,6 +5690,11 @@ msgstr "UUID: %v"
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
+
+#: lxc/remote.go:212 lxc/remote.go:246
+#, fuzzy
+msgid "Unavailable remote server"
+msgstr "新たにリモートサーバを追加します"
 
 #: lxc/config_trust.go:120
 #, c-format
@@ -5923,8 +5937,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr "YES"
 
@@ -6514,7 +6528,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
@@ -6526,7 +6540,7 @@ msgstr "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr "現在値"
 
@@ -6944,8 +6958,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 "lxc storage volume show default data\n"
 "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
@@ -6955,7 +6969,7 @@ msgstr ""
 "    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを表"
 "示します。"
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr "n"
 
@@ -6967,7 +6981,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -7006,7 +7020,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr "y"
 
@@ -7484,9 +7498,6 @@ msgstr "yes"
 
 #~ msgid "Path to an alternate client configuration directory"
 #~ msgstr "別のクライアント用設定ディレクトリ"
-
-#~ msgid "Path to an alternate server directory"
-#~ msgstr "別のサーバ用設定ディレクトリ"
 
 #~ msgid "Permission denied, are you in the lxd group?"
 #~ msgstr "アクセスが拒否されました。lxd グループに所属していますか?"
@@ -8658,8 +8669,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect \"custom"
-#~ "\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect "
+#~ "\"custom\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-07-21 18:03-0400\n"
+        "POT-Creation-Date: 2022-07-25 15:02+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -381,15 +381,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -417,11 +417,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -461,11 +461,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -516,7 +516,7 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid   "Admin password for %s:"
 msgstr  ""
@@ -537,6 +537,10 @@ msgstr  ""
 
 #: lxc/image.go:975
 msgid   "Aliases:"
+msgstr  ""
+
+#: lxc/remote.go:180
+msgid   "All server addresses are unavailable"
 msgstr  ""
 
 #: lxc/config_trust.go:103
@@ -605,7 +609,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -624,7 +628,7 @@ msgstr  ""
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid   "Available projects:"
 msgstr  ""
 
@@ -772,7 +776,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -801,7 +805,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid   "Candid domain to use"
 msgstr  ""
 
@@ -829,12 +833,12 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -848,7 +852,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1039,12 +1043,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1073,7 +1077,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1300,7 +1304,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203 lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380 lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713 lxc/cluster.go:784 lxc/cluster.go:883 lxc/cluster.go:962 lxc/cluster.go:1069 lxc/cluster.go:1090 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:518 lxc/config_trust.go:564 lxc/config_trust.go:635 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:239 lxc/file.go:449 lxc/file.go:957 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1332 lxc/image.go:1412 lxc/image.go:1471 lxc/image.go:1523 lxc/image.go:1579 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:167 lxc/network_acl.go:220 lxc/network_acl.go:266 lxc/network_acl.go:315 lxc/network_acl.go:398 lxc/network_acl.go:458 lxc/network_acl.go:485 lxc/network_acl.go:616 lxc/network_acl.go:665 lxc/network_acl.go:714 lxc/network_acl.go:729 lxc/network_acl.go:850 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610 lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592 lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842 lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632 lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:518 lxc/storage_volume.go:597 lxc/storage_volume.go:672 lxc/storage_volume.go:754 lxc/storage_volume.go:835 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1263 lxc/storage_volume.go:1345 lxc/storage_volume.go:1537 lxc/storage_volume.go:1570 lxc/storage_volume.go:1683 lxc/storage_volume.go:1771 lxc/storage_volume.go:1870 lxc/storage_volume.go:1904 lxc/storage_volume.go:2001 lxc/storage_volume.go:2068 lxc/storage_volume.go:2212 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203 lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380 lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713 lxc/cluster.go:784 lxc/cluster.go:883 lxc/cluster.go:962 lxc/cluster.go:1069 lxc/cluster.go:1090 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:518 lxc/config_trust.go:564 lxc/config_trust.go:635 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:42 lxc/export.go:32 lxc/file.go:80 lxc/file.go:120 lxc/file.go:169 lxc/file.go:239 lxc/file.go:449 lxc/file.go:957 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1332 lxc/image.go:1412 lxc/image.go:1471 lxc/image.go:1523 lxc/image.go:1579 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:35 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:31 lxc/network_acl.go:96 lxc/network_acl.go:167 lxc/network_acl.go:220 lxc/network_acl.go:266 lxc/network_acl.go:315 lxc/network_acl.go:398 lxc/network_acl.go:458 lxc/network_acl.go:485 lxc/network_acl.go:616 lxc/network_acl.go:665 lxc/network_acl.go:714 lxc/network_acl.go:729 lxc/network_acl.go:850 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610 lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217 lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632 lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:518 lxc/storage_volume.go:597 lxc/storage_volume.go:672 lxc/storage_volume.go:754 lxc/storage_volume.go:835 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1263 lxc/storage_volume.go:1345 lxc/storage_volume.go:1537 lxc/storage_volume.go:1570 lxc/storage_volume.go:1683 lxc/storage_volume.go:1771 lxc/storage_volume.go:1870 lxc/storage_volume.go:1904 lxc/storage_volume.go:2001 lxc/storage_volume.go:2068 lxc/storage_volume.go:2212 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1721,11 +1725,11 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -1735,7 +1739,7 @@ msgstr  ""
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -1745,12 +1749,12 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -1779,7 +1783,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -1844,7 +1848,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:99 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557 lxc/storage_volume.go:1363 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:99 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557 lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -1880,7 +1884,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -1896,7 +1900,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2187,7 +2191,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2272,7 +2276,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2591,7 +2595,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -2846,7 +2850,7 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -3082,7 +3086,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:866 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561 lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607 lxc/storage_volume.go:1445
+#: lxc/cluster.go:180 lxc/cluster.go:866 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561 lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607 lxc/storage_volume.go:1445
 msgid   "NAME"
 msgstr  ""
 
@@ -3098,7 +3102,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440 lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649 lxc/remote.go:654 lxc/remote.go:659
+#: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440 lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid   "NO"
 msgstr  ""
 
@@ -3124,7 +3128,7 @@ msgstr  ""
 msgid   "Name"
 msgstr  ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
@@ -3325,7 +3329,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3392,11 +3396,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -3425,6 +3429,10 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
+#: lxc/remote.go:181
+msgid   "Please provide an alternate server address (empty to abort):"
+msgstr  ""
+
 #: lxc/config_trust.go:149
 msgid   "Please provide client name: "
 msgstr  ""
@@ -3433,7 +3441,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -3555,7 +3563,7 @@ msgstr  ""
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid   "Project to use for the remote"
 msgstr  ""
 
@@ -3567,7 +3575,7 @@ msgstr  ""
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid   "Public image server"
 msgstr  ""
 
@@ -3646,36 +3654,36 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862 lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895 lxc/remote.go:933
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
@@ -3749,7 +3757,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -3797,7 +3805,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -3923,7 +3931,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid   "STATIC"
 msgstr  ""
 
@@ -3947,19 +3955,19 @@ msgstr  ""
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid   "Server authentication type (tls or candid)"
 msgstr  ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -4123,7 +4131,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4255,7 +4263,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -4443,7 +4451,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -4695,7 +4703,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid   "URL"
 msgstr  ""
 
@@ -4719,6 +4727,10 @@ msgstr  ""
 #: lxc/file.go:194
 #, c-format
 msgid   "Unable to create a temporary file: %v"
+msgstr  ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid   "Unavailable remote server"
 msgstr  ""
 
 #: lxc/config_trust.go:120
@@ -4945,7 +4957,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442 lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651 lxc/remote.go:656 lxc/remote.go:661
+#: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442 lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid   "YES"
 msgstr  ""
 
@@ -5489,7 +5501,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
@@ -5501,7 +5513,7 @@ msgstr  ""
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid   "current"
 msgstr  ""
 
@@ -5747,7 +5759,7 @@ msgid   "lxc storage volume show default data\n"
         "    Will show the properties of the filesystem for a container called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid   "n"
 msgstr  ""
 
@@ -5759,7 +5771,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -5796,7 +5808,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -612,15 +612,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -649,11 +649,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -693,11 +693,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -755,7 +755,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -776,6 +776,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -845,7 +849,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -864,7 +868,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -1015,7 +1019,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1072,13 +1076,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1092,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1318,12 +1322,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1352,7 +1356,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1658,9 +1662,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2113,11 +2117,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2137,12 +2141,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2171,7 +2175,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2249,7 +2253,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2286,7 +2290,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2302,7 +2306,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2596,7 +2600,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2682,7 +2686,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3017,7 +3021,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3272,11 +3276,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3573,7 +3577,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3591,8 +3595,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3619,7 +3623,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3821,7 +3825,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3888,11 +3892,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3921,6 +3925,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3929,7 +3937,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4058,7 +4066,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4070,7 +4078,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4149,37 +4157,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4253,7 +4261,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4302,7 +4310,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4431,7 +4439,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4455,19 +4463,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4657,7 +4665,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4789,7 +4797,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4977,7 +4985,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5243,7 +5251,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5269,6 +5277,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5503,8 +5515,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6077,7 +6089,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6089,7 +6101,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6375,11 +6387,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6391,7 +6403,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6428,7 +6440,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -646,15 +646,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -683,11 +683,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -727,11 +727,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -789,7 +789,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -810,6 +810,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -879,7 +883,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -898,7 +902,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -1049,7 +1053,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1078,7 +1082,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1106,13 +1110,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1126,7 +1130,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1352,12 +1356,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1386,7 +1390,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1692,9 +1696,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2147,11 +2151,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2161,7 +2165,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2171,12 +2175,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2283,7 +2287,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2320,7 +2324,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2336,7 +2340,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2630,7 +2634,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2716,7 +2720,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3051,7 +3055,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3306,11 +3310,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3607,7 +3611,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3625,8 +3629,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3653,7 +3657,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3855,7 +3859,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3922,11 +3926,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3955,6 +3959,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3963,7 +3971,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4092,7 +4100,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4104,7 +4112,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4183,37 +4191,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4287,7 +4295,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4336,7 +4344,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4465,7 +4473,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4489,19 +4497,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4691,7 +4699,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4823,7 +4831,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -5011,7 +5019,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5277,7 +5285,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5303,6 +5311,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5537,8 +5549,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6111,7 +6123,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6123,7 +6135,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6409,11 +6421,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6425,7 +6437,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6462,7 +6474,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -643,15 +643,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
@@ -728,11 +728,11 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -794,7 +794,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Senha de administrador para %s: "
@@ -816,6 +816,10 @@ msgstr "Nome do alias ausente"
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Aliases:"
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
+msgstr ""
 
 #: lxc/config_trust.go:103
 #, fuzzy
@@ -891,7 +895,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -910,7 +914,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
@@ -1063,7 +1067,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1093,7 +1097,7 @@ msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1121,13 +1125,13 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1141,7 +1145,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1379,12 +1383,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1413,7 +1417,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1744,9 +1748,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2219,11 +2223,11 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2233,7 +2237,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2243,12 +2247,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2277,7 +2281,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2355,7 +2359,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2392,7 +2396,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2408,7 +2412,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2715,7 +2719,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2802,7 +2806,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3144,7 +3148,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3417,11 +3421,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3731,7 +3735,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3749,8 +3753,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3777,7 +3781,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3979,7 +3983,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4046,11 +4050,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -4079,6 +4083,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -4088,7 +4096,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4222,7 +4230,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4234,7 +4242,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4314,37 +4322,37 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4426,7 +4434,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4479,7 +4487,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4617,7 +4625,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4641,19 +4649,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4854,7 +4862,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5009,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -5191,7 +5199,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5464,7 +5472,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5491,6 +5499,11 @@ msgstr ""
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+#, fuzzy
+msgid "Unavailable remote server"
+msgstr "Adicionar novos servidores remoto"
 
 #: lxc/config_trust.go:120
 #, c-format
@@ -5741,8 +5754,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6369,7 +6382,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
@@ -6383,7 +6396,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6669,11 +6682,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6685,7 +6698,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6722,7 +6735,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -643,15 +643,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -685,11 +685,11 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -732,11 +732,11 @@ msgstr "Копирование образа: %s"
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -795,7 +795,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Пароль администратора для %s: "
@@ -817,6 +817,10 @@ msgstr ""
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Псевдонимы:"
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
+msgstr ""
 
 #: lxc/config_trust.go:103
 #, fuzzy
@@ -888,7 +892,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -907,7 +911,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
@@ -1061,7 +1065,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1090,7 +1094,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -1118,13 +1122,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1138,7 +1142,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1367,12 +1371,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1401,7 +1405,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1728,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2204,11 +2208,11 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2218,7 +2222,7 @@ msgstr "Принять сертификат"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2228,12 +2232,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2262,7 +2266,7 @@ msgstr "Принять сертификат"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2340,7 +2344,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2377,7 +2381,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2393,7 +2397,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2700,7 +2704,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2787,7 +2791,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3134,7 +3138,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3409,11 +3413,11 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3727,7 +3731,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3745,8 +3749,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3773,7 +3777,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3979,7 +3983,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4046,11 +4050,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -4079,6 +4083,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -4088,7 +4096,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4217,7 +4225,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4229,7 +4237,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4310,37 +4318,37 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4420,7 +4428,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4471,7 +4479,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4608,7 +4616,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4632,19 +4640,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4840,7 +4848,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4983,7 +4991,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -5177,7 +5185,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5444,7 +5452,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5470,6 +5478,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5715,8 +5727,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6809,7 +6821,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -6833,7 +6845,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -7119,11 +7131,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7135,7 +7147,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7172,7 +7184,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -407,15 +407,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -444,11 +444,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -488,11 +488,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -571,6 +571,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -640,7 +644,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -659,7 +663,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -810,7 +814,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -839,7 +843,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -867,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -887,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1113,12 +1117,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1147,7 +1151,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1453,9 +1457,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1908,11 +1912,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1922,7 +1926,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1932,12 +1936,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1966,7 +1970,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2044,7 +2048,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2081,7 +2085,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2097,7 +2101,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2391,7 +2395,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2477,7 +2481,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2812,7 +2816,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3067,11 +3071,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3368,7 +3372,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3386,8 +3390,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3414,7 +3418,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3616,7 +3620,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3683,11 +3687,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3716,6 +3720,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3724,7 +3732,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3853,7 +3861,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3865,7 +3873,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3944,37 +3952,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4048,7 +4056,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4097,7 +4105,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4226,7 +4234,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4250,19 +4258,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4452,7 +4460,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4584,7 +4592,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4772,7 +4780,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5038,7 +5046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5064,6 +5072,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5298,8 +5310,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5872,7 +5884,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5884,7 +5896,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6170,11 +6182,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6186,7 +6198,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6223,7 +6235,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -407,15 +407,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -444,11 +444,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -488,11 +488,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -571,6 +571,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -640,7 +644,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -659,7 +663,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -810,7 +814,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -839,7 +843,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -867,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -887,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1113,12 +1117,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1147,7 +1151,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1453,9 +1457,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1908,11 +1912,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1922,7 +1926,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1932,12 +1936,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1966,7 +1970,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2044,7 +2048,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2081,7 +2085,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2097,7 +2101,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2391,7 +2395,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2477,7 +2481,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2812,7 +2816,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3067,11 +3071,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3368,7 +3372,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3386,8 +3390,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3414,7 +3418,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3616,7 +3620,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3683,11 +3687,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3716,6 +3720,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3724,7 +3732,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3853,7 +3861,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3865,7 +3873,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3944,37 +3952,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4048,7 +4056,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4097,7 +4105,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4226,7 +4234,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4250,19 +4258,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4452,7 +4460,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4584,7 +4592,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4772,7 +4780,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5038,7 +5046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5064,6 +5072,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5298,8 +5310,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5872,7 +5884,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5884,7 +5896,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6170,11 +6182,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6186,7 +6198,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6223,7 +6235,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -403,15 +403,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -440,11 +440,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -484,11 +484,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -567,6 +567,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -636,7 +640,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -655,7 +659,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -835,7 +839,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -863,13 +867,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -883,7 +887,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1109,12 +1113,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1143,7 +1147,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1449,9 +1453,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1904,11 +1908,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1918,7 +1922,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1928,12 +1932,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1962,7 +1966,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2040,7 +2044,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2077,7 +2081,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2093,7 +2097,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2387,7 +2391,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2473,7 +2477,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2808,7 +2812,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3063,11 +3067,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3364,7 +3368,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3382,8 +3386,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3410,7 +3414,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3612,7 +3616,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3679,11 +3683,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3712,6 +3716,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3720,7 +3728,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3849,7 +3857,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3861,7 +3869,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3940,37 +3948,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4044,7 +4052,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4093,7 +4101,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4222,7 +4230,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4246,19 +4254,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4448,7 +4456,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4580,7 +4588,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4768,7 +4776,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5034,7 +5042,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5060,6 +5068,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5294,8 +5306,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5868,7 +5880,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5880,7 +5892,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6166,11 +6178,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6182,7 +6194,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6219,7 +6231,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage.go:229
@@ -407,15 +407,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -444,11 +444,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -488,11 +488,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -571,6 +571,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -640,7 +644,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -659,7 +663,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -810,7 +814,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -839,7 +843,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -867,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -887,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1113,12 +1117,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1147,7 +1151,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1453,9 +1457,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1908,11 +1912,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1922,7 +1926,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1932,12 +1936,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1966,7 +1970,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2044,7 +2048,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2081,7 +2085,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2097,7 +2101,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2391,7 +2395,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2477,7 +2481,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2812,7 +2816,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3067,11 +3071,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3368,7 +3372,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3386,8 +3390,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3414,7 +3418,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3616,7 +3620,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3683,11 +3687,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3716,6 +3720,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3724,7 +3732,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3853,7 +3861,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3865,7 +3873,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3944,37 +3952,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4048,7 +4056,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4097,7 +4105,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4226,7 +4234,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4250,19 +4258,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4452,7 +4460,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4584,7 +4592,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4772,7 +4780,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5038,7 +5046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5064,6 +5072,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5298,8 +5310,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5872,7 +5884,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5884,7 +5896,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6170,11 +6182,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6186,7 +6198,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6223,7 +6235,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -509,15 +509,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -590,11 +590,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -652,7 +652,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -673,6 +673,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -742,7 +746,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -761,7 +765,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -912,7 +916,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -969,13 +973,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -989,7 +993,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1215,12 +1219,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1249,7 +1253,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1555,9 +1559,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -2010,11 +2014,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2034,12 +2038,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2068,7 +2072,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2146,7 +2150,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2183,7 +2187,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2199,7 +2203,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2493,7 +2497,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2579,7 +2583,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2914,7 +2918,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3169,11 +3173,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3470,7 +3474,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3488,8 +3492,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3516,7 +3520,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3718,7 +3722,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3785,11 +3789,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3818,6 +3822,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3826,7 +3834,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3955,7 +3963,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3967,7 +3975,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4046,37 +4054,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4150,7 +4158,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4199,7 +4207,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4328,7 +4336,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4352,19 +4360,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4554,7 +4562,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4686,7 +4694,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4874,7 +4882,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5140,7 +5148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5166,6 +5174,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5400,8 +5412,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5974,7 +5986,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5986,7 +5998,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6272,11 +6284,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6288,7 +6300,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6325,7 +6337,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-07-18 13:44+0100\n"
+"POT-Creation-Date: 2022-07-25 15:02+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:840
+#: lxc/remote.go:818 lxc/remote.go:873
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:878
+#: lxc/remote.go:911
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:713
+#: lxc/remote.go:746
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -443,11 +443,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:696
+#: lxc/remote.go:729
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:525
+#: lxc/remote.go:558
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -570,6 +570,10 @@ msgstr ""
 
 #: lxc/image.go:975
 msgid "Aliases:"
+msgstr ""
+
+#: lxc/remote.go:180
+msgid "All server addresses are unavailable"
 msgstr ""
 
 #: lxc/config_trust.go:103
@@ -639,7 +643,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:511
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -658,7 +662,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:135
 msgid "Available projects:"
 msgstr ""
 
@@ -809,7 +813,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:853
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -838,7 +842,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Candid domain to use"
 msgstr ""
 
@@ -866,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:217
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:412
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -886,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:598
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1112,12 +1116,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:187 lxc/remote.go:431
+#: lxc/remote.go:223 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,9 +1456,9 @@ msgstr ""
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
 #: lxc/project.go:394 lxc/project.go:495 lxc/project.go:550 lxc/project.go:610
 #: lxc/project.go:639 lxc/project.go:692 lxc/project.go:751 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:592
-#: lxc/remote.go:628 lxc/remote.go:716 lxc/remote.go:788 lxc/remote.go:842
-#: lxc/remote.go:880 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
+#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
+#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
 #: lxc/storage.go:34 lxc/storage.go:93 lxc/storage.go:167 lxc/storage.go:217
 #: lxc/storage.go:339 lxc/storage.go:399 lxc/storage.go:555 lxc/storage.go:632
 #: lxc/storage.go:706 lxc/storage.go:790 lxc/storage_volume.go:43
@@ -1907,11 +1911,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:189
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:204
+#: lxc/remote.go:240
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1921,7 +1925,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:230
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1931,12 +1935,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:226
+#: lxc/remote.go:262
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -1965,7 +1969,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:199
+#: lxc/remote.go:235
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2043,7 +2047,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:753 lxc/remote.go:632 lxc/storage.go:557
+#: lxc/project.go:753 lxc/remote.go:665 lxc/storage.go:557
 #: lxc/storage_volume.go:1363 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:699
+#: lxc/remote.go:732
 msgid "GLOBAL"
 msgstr ""
 
@@ -2096,7 +2100,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:358
+#: lxc/remote.go:158 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2390,7 +2394,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:310
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2476,7 +2480,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:660 lxc/remote.go:661
 msgid "List the available remotes"
 msgstr ""
 
@@ -3066,11 +3070,11 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:499 lxc/list.go:561
 #: lxc/network.go:959 lxc/network_acl.go:149 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:472 lxc/remote.go:693 lxc/storage.go:607
+#: lxc/project.go:472 lxc/remote.go:726 lxc/storage.go:607
 #: lxc/storage_volume.go:1445
 msgid "NAME"
 msgstr ""
@@ -3385,8 +3389,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
-#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:649
-#: lxc/remote.go:654 lxc/remote.go:659
+#: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/remote.go:682
+#: lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3413,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:140
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3615,7 +3619,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:695
+#: lxc/remote.go:728
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:697
+#: lxc/image.go:1058 lxc/remote.go:730
 msgid "PUBLIC"
 msgstr ""
 
@@ -3715,6 +3719,10 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
+#: lxc/remote.go:181
+msgid "Please provide an alternate server address (empty to abort):"
+msgstr ""
+
 #: lxc/config_trust.go:149
 msgid "Please provide client name: "
 msgstr ""
@@ -3723,7 +3731,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:423
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -3864,7 +3872,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -3943,37 +3951,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:718 lxc/remote.go:736 lxc/remote.go:808 lxc/remote.go:862
-#: lxc/remote.go:900
+#: lxc/project.go:718 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:816
+#: lxc/remote.go:849
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:740 lxc/remote.go:812 lxc/remote.go:904
+#: lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:937
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4047,7 +4055,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:787 lxc/remote.go:788
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4096,7 +4104,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:715 lxc/remote.go:716
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Rename remotes"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:698
+#: lxc/remote.go:731
 msgid "STATIC"
 msgstr ""
 
@@ -4249,19 +4257,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:421
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:594
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4451,7 +4459,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:912 lxc/remote.go:913
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4583,7 +4591,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:591 lxc/remote.go:592
+#: lxc/remote.go:624 lxc/remote.go:625
 msgid "Show the default remote"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:842
+#: lxc/remote.go:874 lxc/remote.go:875
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5037,7 +5045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:694
+#: lxc/cluster.go:181 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5063,6 +5071,10 @@ msgstr ""
 #: lxc/file.go:194
 #, c-format
 msgid "Unable to create a temporary file: %v"
+msgstr ""
+
+#: lxc/remote.go:212 lxc/remote.go:246
+msgid "Unavailable remote server"
 msgstr ""
 
 #: lxc/config_trust.go:120
@@ -5297,8 +5309,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
-#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:651
-#: lxc/remote.go:656 lxc/remote.go:661
+#: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/remote.go:684
+#: lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -5871,7 +5883,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -5883,7 +5895,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:462 lxc/remote.go:684
+#: lxc/project.go:462 lxc/remote.go:717
 msgid "current"
 msgstr ""
 
@@ -6169,11 +6181,11 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:420
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6185,7 +6197,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:413
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6222,7 +6234,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:422
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
