### PR TITLE
doc/storage: add link to video about benchmarking storage drivers

### DIFF
--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: https://www.youtube.com/watch?v=z_OKwO5TskA
+---
+
 (storage-drivers)=
 # Storage drivers
 


### PR DESCRIPTION
Added as a related link instead of "embedded" video, because the
video isn't illustrating the same content as the page, but presents
additional, related information.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>