### PR TITLE
Remove duplicate prepared statement store

### DIFF
--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -79,12 +79,12 @@ func (c *ClusterTx) GetClusterGroups(filter ClusterGroupFilter) ([]ClusterGroup,
 	var args []any
 
 	if filter.Name != nil && filter.ID == nil {
-		stmt = c.stmt(clusterGroupObjectsByName)
+		stmt = cluster.Stmt(c.tx, clusterGroupObjectsByName)
 		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID == nil && filter.Name == nil {
-		stmt = c.stmt(clusterGroupObjects)
+		stmt = cluster.Stmt(c.tx, clusterGroupObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -141,7 +141,7 @@ func (c *ClusterTx) GetClusterGroup(name string) (*ClusterGroup, error) {
 // GetClusterGroupID return the ID of the ClusterGroup with the given key.
 // generator: ClusterGroup ID
 func (c *ClusterTx) GetClusterGroupID(name string) (int64, error) {
-	stmt := c.stmt(clusterGroupID)
+	stmt := cluster.Stmt(c.tx, clusterGroupID)
 	rows, err := stmt.Query(name)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to get cluster group ID: %w", err)
@@ -207,7 +207,7 @@ func (c *ClusterTx) CreateClusterGroup(object ClusterGroup) (int64, error) {
 	args[1] = object.Description
 
 	// Prepared statement to use.
-	stmt := c.stmt(clusterGroupCreate)
+	stmt := cluster.Stmt(c.tx, clusterGroupCreate)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
@@ -232,7 +232,7 @@ func (c *ClusterTx) CreateClusterGroup(object ClusterGroup) (int64, error) {
 // RenameClusterGroup renames the ClusterGroup matching the given key parameters.
 // generator: ClusterGroup Rename
 func (c *ClusterTx) RenameClusterGroup(name string, to string) error {
-	stmt := c.stmt(clusterGroupRename)
+	stmt := cluster.Stmt(c.tx, clusterGroupRename)
 	result, err := stmt.Exec(to, name)
 	if err != nil {
 		return fmt.Errorf("Failed to rename cluster group: %w", err)
@@ -253,7 +253,7 @@ func (c *ClusterTx) RenameClusterGroup(name string, to string) error {
 // DeleteClusterGroup deletes the ClusterGroup matching the given key parameters.
 // generator: ClusterGroup DeleteOne-by-Name
 func (c *ClusterTx) DeleteClusterGroup(name string) error {
-	stmt := c.stmt(clusterGroupDeleteByName)
+	stmt := cluster.Stmt(c.tx, clusterGroupDeleteByName)
 	result, err := stmt.Exec(name)
 	if err != nil {
 		return fmt.Errorf("Failed to delete cluster group: %w", err)
@@ -279,7 +279,7 @@ func (c *ClusterTx) UpdateClusterGroup(name string, object ClusterGroup) error {
 		return fmt.Errorf("Failed to get cluster group: %w", err)
 	}
 
-	stmt := c.stmt(clusterGroupUpdate)
+	stmt := cluster.Stmt(c.tx, clusterGroupUpdate)
 	result, err := stmt.Exec(object.Name, object.Description, id)
 	if err != nil {
 		return fmt.Errorf("Failed to update cluster group: %w", err)
@@ -295,7 +295,7 @@ func (c *ClusterTx) UpdateClusterGroup(name string, object ClusterGroup) error {
 	}
 
 	// Delete current nodes.
-	stmt = c.stmt(clusterGroupDeleteNodesRef)
+	stmt = cluster.Stmt(c.tx, clusterGroupDeleteNodesRef)
 	_, err = stmt.Exec(id)
 	if err != nil {
 		return fmt.Errorf("Failed to delete current nodes: %w", err)

--- a/lxd/db/cluster/certificate_projects.mapper.go
+++ b/lxd/db/cluster/certificate_projects.mapper.go
@@ -38,7 +38,7 @@ func GetCertificateProjects(ctx context.Context, tx *sql.Tx, certificateID int) 
 	// Result slice.
 	objects := make([]CertificateProject, 0)
 
-	sqlStmt := stmt(tx, certificateProjectObjectsByCertificateID)
+	sqlStmt := Stmt(tx, certificateProjectObjectsByCertificateID)
 	args := []any{certificateID}
 
 	// Dest function for scanning a row.
@@ -72,7 +72,7 @@ func GetCertificateProjects(ctx context.Context, tx *sql.Tx, certificateID int) 
 // DeleteCertificateProjects deletes the certificate_project matching the given key parameters.
 // generator: certificate_project DeleteMany
 func DeleteCertificateProjects(ctx context.Context, tx *sql.Tx, certificateID int) error {
-	stmt := stmt(tx, certificateProjectDeleteByCertificateID)
+	stmt := Stmt(tx, certificateProjectDeleteByCertificateID)
 	result, err := stmt.Exec(int(certificateID))
 	if err != nil {
 		return fmt.Errorf("Delete \"certificates_projects\" entry failed: %w", err)
@@ -97,7 +97,7 @@ func CreateCertificateProjects(ctx context.Context, tx *sql.Tx, objects []Certif
 		args[1] = object.ProjectID
 
 		// Prepared statement to use.
-		stmt := stmt(tx, certificateProjectCreate)
+		stmt := Stmt(tx, certificateProjectCreate)
 
 		// Execute the statement.
 		_, err := stmt.Exec(args...)

--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -71,17 +71,17 @@ func GetCertificates(ctx context.Context, tx *sql.Tx, filter CertificateFilter) 
 	var args []any
 
 	if filter.ID != nil && filter.Fingerprint == nil && filter.Name == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, certificateObjectsByID)
+		sqlStmt = Stmt(tx, certificateObjectsByID)
 		args = []any{
 			filter.ID,
 		}
 	} else if filter.Fingerprint != nil && filter.ID == nil && filter.Name == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, certificateObjectsByFingerprint)
+		sqlStmt = Stmt(tx, certificateObjectsByFingerprint)
 		args = []any{
 			filter.Fingerprint,
 		}
 	} else if filter.ID == nil && filter.Fingerprint == nil && filter.Name == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, certificateObjects)
+		sqlStmt = Stmt(tx, certificateObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -133,7 +133,7 @@ func GetCertificate(ctx context.Context, tx *sql.Tx, fingerprint string) (*Certi
 // GetCertificateID return the ID of the certificate with the given key.
 // generator: certificate ID
 func GetCertificateID(ctx context.Context, tx *sql.Tx, fingerprint string) (int64, error) {
-	stmt := stmt(tx, certificateID)
+	stmt := Stmt(tx, certificateID)
 	rows, err := stmt.Query(fingerprint)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to get \"certificates\" ID: %w", err)
@@ -202,7 +202,7 @@ func CreateCertificate(ctx context.Context, tx *sql.Tx, object Certificate) (int
 	args[4] = object.Restricted
 
 	// Prepared statement to use.
-	stmt := stmt(tx, certificateCreate)
+	stmt := Stmt(tx, certificateCreate)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
@@ -221,7 +221,7 @@ func CreateCertificate(ctx context.Context, tx *sql.Tx, object Certificate) (int
 // DeleteCertificate deletes the certificate matching the given key parameters.
 // generator: certificate DeleteOne-by-Fingerprint
 func DeleteCertificate(ctx context.Context, tx *sql.Tx, fingerprint string) error {
-	stmt := stmt(tx, certificateDeleteByFingerprint)
+	stmt := Stmt(tx, certificateDeleteByFingerprint)
 	result, err := stmt.Exec(fingerprint)
 	if err != nil {
 		return fmt.Errorf("Delete \"certificates\": %w", err)
@@ -244,7 +244,7 @@ func DeleteCertificate(ctx context.Context, tx *sql.Tx, fingerprint string) erro
 // DeleteCertificates deletes the certificate matching the given key parameters.
 // generator: certificate DeleteMany-by-Name-and-Type
 func DeleteCertificates(ctx context.Context, tx *sql.Tx, name string, certificateType CertificateType) error {
-	stmt := stmt(tx, certificateDeleteByNameAndType)
+	stmt := Stmt(tx, certificateDeleteByNameAndType)
 	result, err := stmt.Exec(name, certificateType)
 	if err != nil {
 		return fmt.Errorf("Delete \"certificates\": %w", err)
@@ -266,7 +266,7 @@ func UpdateCertificate(ctx context.Context, tx *sql.Tx, fingerprint string, obje
 		return err
 	}
 
-	stmt := stmt(tx, certificateUpdate)
+	stmt := Stmt(tx, certificateUpdate)
 	result, err := stmt.Exec(object.Fingerprint, object.Type, object.Name, object.Certificate, object.Restricted, id)
 	if err != nil {
 		return fmt.Errorf("Update \"certificates\" entry failed: %w", err)

--- a/lxd/db/cluster/images.mapper.go
+++ b/lxd/db/cluster/images.mapper.go
@@ -77,44 +77,44 @@ func GetImages(ctx context.Context, tx *sql.Tx, filter ImageFilter) ([]Image, er
 	var args []any
 
 	if filter.Project != nil && filter.Public != nil && filter.ID == nil && filter.Fingerprint == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-		sqlStmt = stmt(tx, imageObjectsByProjectAndPublic)
+		sqlStmt = Stmt(tx, imageObjectsByProjectAndPublic)
 		args = []any{
 			filter.Project,
 			filter.Public,
 		}
 	} else if filter.Project != nil && filter.Cached != nil && filter.ID == nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
-		sqlStmt = stmt(tx, imageObjectsByProjectAndCached)
+		sqlStmt = Stmt(tx, imageObjectsByProjectAndCached)
 		args = []any{
 			filter.Project,
 			filter.Cached,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-		sqlStmt = stmt(tx, imageObjectsByProject)
+		sqlStmt = Stmt(tx, imageObjectsByProject)
 		args = []any{
 			filter.Project,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-		sqlStmt = stmt(tx, imageObjectsByID)
+		sqlStmt = Stmt(tx, imageObjectsByID)
 		args = []any{
 			filter.ID,
 		}
 	} else if filter.Fingerprint != nil && filter.ID == nil && filter.Project == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-		sqlStmt = stmt(tx, imageObjectsByFingerprint)
+		sqlStmt = Stmt(tx, imageObjectsByFingerprint)
 		args = []any{
 			filter.Fingerprint,
 		}
 	} else if filter.Cached != nil && filter.ID == nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
-		sqlStmt = stmt(tx, imageObjectsByCached)
+		sqlStmt = Stmt(tx, imageObjectsByCached)
 		args = []any{
 			filter.Cached,
 		}
 	} else if filter.AutoUpdate != nil && filter.ID == nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil {
-		sqlStmt = stmt(tx, imageObjectsByAutoUpdate)
+		sqlStmt = Stmt(tx, imageObjectsByAutoUpdate)
 		args = []any{
 			filter.AutoUpdate,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-		sqlStmt = stmt(tx, imageObjects)
+		sqlStmt = Stmt(tx, imageObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")

--- a/lxd/db/cluster/instance_profiles.go
+++ b/lxd/db/cluster/instance_profiles.go
@@ -55,7 +55,7 @@ func UpdateInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int, pro
 	}
 
 	applyOrder := 1
-	stmt := stmt(tx, instanceProfileCreate)
+	stmt := Stmt(tx, instanceProfileCreate)
 
 	for _, name := range profiles {
 		profileID, err := GetProfileID(ctx, tx, project, name)

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -44,7 +44,7 @@ func GetProfileInstances(ctx context.Context, tx *sql.Tx, profileID int) ([]Inst
 	// Result slice.
 	objects := make([]InstanceProfile, 0)
 
-	sqlStmt := stmt(tx, instanceProfileObjectsByProfileID)
+	sqlStmt := Stmt(tx, instanceProfileObjectsByProfileID)
 	args := []any{profileID}
 
 	// Dest function for scanning a row.
@@ -84,7 +84,7 @@ func GetInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) ([]Pro
 	// Result slice.
 	objects := make([]InstanceProfile, 0)
 
-	sqlStmt := stmt(tx, instanceProfileObjectsByInstanceID)
+	sqlStmt := Stmt(tx, instanceProfileObjectsByInstanceID)
 	args := []any{instanceID}
 
 	// Dest function for scanning a row.
@@ -128,7 +128,7 @@ func CreateInstanceProfiles(ctx context.Context, tx *sql.Tx, objects []InstanceP
 		args[2] = object.ApplyOrder
 
 		// Prepared statement to use.
-		stmt := stmt(tx, instanceProfileCreate)
+		stmt := Stmt(tx, instanceProfileCreate)
 
 		// Execute the statement.
 		_, err := stmt.Exec(args...)
@@ -144,7 +144,7 @@ func CreateInstanceProfiles(ctx context.Context, tx *sql.Tx, objects []InstanceP
 // DeleteInstanceProfiles deletes the instance_profile matching the given key parameters.
 // generator: instance_profile DeleteMany
 func DeleteInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) error {
-	stmt := stmt(tx, instanceProfileDeleteByInstanceID)
+	stmt := Stmt(tx, instanceProfileDeleteByInstanceID)
 	result, err := stmt.Exec(int(instanceID))
 	if err != nil {
 		return fmt.Errorf("Delete \"instances_profiles\" entry failed: %w", err)

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -155,7 +155,7 @@ func GetInstances(ctx context.Context, tx *sql.Tx, filter InstanceFilter) ([]Ins
 	var args []any
 
 	if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.Name != nil && filter.ID == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProjectAndTypeAndNodeAndName)
+		sqlStmt = Stmt(tx, instanceObjectsByProjectAndTypeAndNodeAndName)
 		args = []any{
 			filter.Project,
 			filter.Type,
@@ -163,96 +163,96 @@ func GetInstances(ctx context.Context, tx *sql.Tx, filter InstanceFilter) ([]Ins
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProjectAndTypeAndNode)
+		sqlStmt = Stmt(tx, instanceObjectsByProjectAndTypeAndNode)
 		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProjectAndTypeAndName)
+		sqlStmt = Stmt(tx, instanceObjectsByProjectAndTypeAndName)
 		args = []any{
 			filter.Project,
 			filter.Type,
 			filter.Name,
 		}
 	} else if filter.Type != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil {
-		sqlStmt = stmt(tx, instanceObjectsByTypeAndNameAndNode)
+		sqlStmt = Stmt(tx, instanceObjectsByTypeAndNameAndNode)
 		args = []any{
 			filter.Type,
 			filter.Name,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProjectAndNameAndNode)
+		sqlStmt = Stmt(tx, instanceObjectsByProjectAndNameAndNode)
 		args = []any{
 			filter.Project,
 			filter.Name,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Type != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProjectAndType)
+		sqlStmt = Stmt(tx, instanceObjectsByProjectAndType)
 		args = []any{
 			filter.Project,
 			filter.Type,
 		}
 	} else if filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, instanceObjectsByTypeAndNode)
+		sqlStmt = Stmt(tx, instanceObjectsByTypeAndNode)
 		args = []any{
 			filter.Type,
 			filter.Node,
 		}
 	} else if filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil {
-		sqlStmt = stmt(tx, instanceObjectsByTypeAndName)
+		sqlStmt = Stmt(tx, instanceObjectsByTypeAndName)
 		args = []any{
 			filter.Type,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProjectAndNode)
+		sqlStmt = Stmt(tx, instanceObjectsByProjectAndNode)
 		args = []any{
 			filter.Project,
 			filter.Node,
 		}
 	} else if filter.Project != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProjectAndName)
+		sqlStmt = Stmt(tx, instanceObjectsByProjectAndName)
 		args = []any{
 			filter.Project,
 			filter.Name,
 		}
 	} else if filter.Node != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByNodeAndName)
+		sqlStmt = Stmt(tx, instanceObjectsByNodeAndName)
 		args = []any{
 			filter.Node,
 			filter.Name,
 		}
 	} else if filter.Type != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil {
-		sqlStmt = stmt(tx, instanceObjectsByType)
+		sqlStmt = Stmt(tx, instanceObjectsByType)
 		args = []any{
 			filter.Type,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByProject)
+		sqlStmt = Stmt(tx, instanceObjectsByProject)
 		args = []any{
 			filter.Project,
 		}
 	} else if filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByNode)
+		sqlStmt = Stmt(tx, instanceObjectsByNode)
 		args = []any{
 			filter.Node,
 		}
 	} else if filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByName)
+		sqlStmt = Stmt(tx, instanceObjectsByName)
 		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjectsByID)
+		sqlStmt = Stmt(tx, instanceObjectsByID)
 		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt = stmt(tx, instanceObjects)
+		sqlStmt = Stmt(tx, instanceObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -348,7 +348,7 @@ func GetInstance(ctx context.Context, tx *sql.Tx, project string, name string) (
 // GetInstanceID return the ID of the instance with the given key.
 // generator: instance ID
 func GetInstanceID(ctx context.Context, tx *sql.Tx, project string, name string) (int64, error) {
-	stmt := stmt(tx, instanceID)
+	stmt := Stmt(tx, instanceID)
 	rows, err := stmt.Query(project, name)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to get \"instances\" ID: %w", err)
@@ -423,7 +423,7 @@ func CreateInstance(ctx context.Context, tx *sql.Tx, object Instance) (int64, er
 	args[10] = object.ExpiryDate
 
 	// Prepared statement to use.
-	stmt := stmt(tx, instanceCreate)
+	stmt := Stmt(tx, instanceCreate)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
@@ -479,7 +479,7 @@ func CreateInstanceConfig(ctx context.Context, tx *sql.Tx, instanceID int64, con
 // RenameInstance renames the instance matching the given key parameters.
 // generator: instance Rename
 func RenameInstance(ctx context.Context, tx *sql.Tx, project string, name string, to string) error {
-	stmt := stmt(tx, instanceRename)
+	stmt := Stmt(tx, instanceRename)
 	result, err := stmt.Exec(to, project, name)
 	if err != nil {
 		return fmt.Errorf("Rename Instance failed: %w", err)
@@ -500,7 +500,7 @@ func RenameInstance(ctx context.Context, tx *sql.Tx, project string, name string
 // DeleteInstance deletes the instance matching the given key parameters.
 // generator: instance DeleteOne-by-Project-and-Name
 func DeleteInstance(ctx context.Context, tx *sql.Tx, project string, name string) error {
-	stmt := stmt(tx, instanceDeleteByProjectAndName)
+	stmt := Stmt(tx, instanceDeleteByProjectAndName)
 	result, err := stmt.Exec(project, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"instances\": %w", err)
@@ -528,7 +528,7 @@ func UpdateInstance(ctx context.Context, tx *sql.Tx, project string, name string
 		return err
 	}
 
-	stmt := stmt(tx, instanceUpdate)
+	stmt := Stmt(tx, instanceUpdate)
 	result, err := stmt.Exec(object.Project, object.Name, object.Node, object.Type, object.Architecture, object.Ephemeral, object.CreationDate, object.Stateful, object.LastUseDate, object.Description, object.ExpiryDate, id)
 	if err != nil {
 		return fmt.Errorf("Update \"instances\" entry failed: %w", err)

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -66,22 +66,22 @@ func GetOperations(ctx context.Context, tx *sql.Tx, filter OperationFilter) ([]O
 	var args []any
 
 	if filter.UUID != nil && filter.ID == nil && filter.NodeID == nil {
-		sqlStmt = stmt(tx, operationObjectsByUUID)
+		sqlStmt = Stmt(tx, operationObjectsByUUID)
 		args = []any{
 			filter.UUID,
 		}
 	} else if filter.NodeID != nil && filter.ID == nil && filter.UUID == nil {
-		sqlStmt = stmt(tx, operationObjectsByNodeID)
+		sqlStmt = Stmt(tx, operationObjectsByNodeID)
 		args = []any{
 			filter.NodeID,
 		}
 	} else if filter.ID != nil && filter.NodeID == nil && filter.UUID == nil {
-		sqlStmt = stmt(tx, operationObjectsByID)
+		sqlStmt = Stmt(tx, operationObjectsByID)
 		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.NodeID == nil && filter.UUID == nil {
-		sqlStmt = stmt(tx, operationObjects)
+		sqlStmt = Stmt(tx, operationObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -121,7 +121,7 @@ func CreateOrReplaceOperation(ctx context.Context, tx *sql.Tx, object Operation)
 	args[3] = object.Type
 
 	// Prepared statement to use.
-	stmt := stmt(tx, operationCreateOrReplace)
+	stmt := Stmt(tx, operationCreateOrReplace)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
@@ -140,7 +140,7 @@ func CreateOrReplaceOperation(ctx context.Context, tx *sql.Tx, object Operation)
 // DeleteOperation deletes the operation matching the given key parameters.
 // generator: operation DeleteOne-by-UUID
 func DeleteOperation(ctx context.Context, tx *sql.Tx, uuid string) error {
-	stmt := stmt(tx, operationDeleteByUUID)
+	stmt := Stmt(tx, operationDeleteByUUID)
 	result, err := stmt.Exec(uuid)
 	if err != nil {
 		return fmt.Errorf("Delete \"operations\": %w", err)
@@ -163,7 +163,7 @@ func DeleteOperation(ctx context.Context, tx *sql.Tx, uuid string) error {
 // DeleteOperations deletes the operation matching the given key parameters.
 // generator: operation DeleteMany-by-NodeID
 func DeleteOperations(ctx context.Context, tx *sql.Tx, nodeID int64) error {
-	stmt := stmt(tx, operationDeleteByNodeID)
+	stmt := Stmt(tx, operationDeleteByNodeID)
 	result, err := stmt.Exec(nodeID)
 	if err != nil {
 		return fmt.Errorf("Delete \"operations\": %w", err)

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -73,7 +73,7 @@ DELETE FROM profiles WHERE project_id = (SELECT projects.id FROM projects WHERE 
 // GetProfileID return the ID of the profile with the given key.
 // generator: profile ID
 func GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) (int64, error) {
-	stmt := stmt(tx, profileID)
+	stmt := Stmt(tx, profileID)
 	rows, err := stmt.Query(project, name)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to get \"profiles\" ID: %w", err)
@@ -132,28 +132,28 @@ func GetProfiles(ctx context.Context, tx *sql.Tx, filter ProfileFilter) ([]Profi
 	var args []any
 
 	if filter.Project != nil && filter.Name != nil && filter.ID == nil {
-		sqlStmt = stmt(tx, profileObjectsByProjectAndName)
+		sqlStmt = Stmt(tx, profileObjectsByProjectAndName)
 		args = []any{
 			filter.Project,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, profileObjectsByProject)
+		sqlStmt = Stmt(tx, profileObjectsByProject)
 		args = []any{
 			filter.Project,
 		}
 	} else if filter.Name != nil && filter.ID == nil && filter.Project == nil {
-		sqlStmt = stmt(tx, profileObjectsByName)
+		sqlStmt = Stmt(tx, profileObjectsByName)
 		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, profileObjectsByID)
+		sqlStmt = Stmt(tx, profileObjectsByID)
 		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, profileObjects)
+		sqlStmt = Stmt(tx, profileObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -260,7 +260,7 @@ func CreateProfile(ctx context.Context, tx *sql.Tx, object Profile) (int64, erro
 	args[2] = object.Description
 
 	// Prepared statement to use.
-	stmt := stmt(tx, profileCreate)
+	stmt := Stmt(tx, profileCreate)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
@@ -316,7 +316,7 @@ func CreateProfileConfig(ctx context.Context, tx *sql.Tx, profileID int64, confi
 // RenameProfile renames the profile matching the given key parameters.
 // generator: profile Rename
 func RenameProfile(ctx context.Context, tx *sql.Tx, project string, name string, to string) error {
-	stmt := stmt(tx, profileRename)
+	stmt := Stmt(tx, profileRename)
 	result, err := stmt.Exec(to, project, name)
 	if err != nil {
 		return fmt.Errorf("Rename Profile failed: %w", err)
@@ -342,7 +342,7 @@ func UpdateProfile(ctx context.Context, tx *sql.Tx, project string, name string,
 		return err
 	}
 
-	stmt := stmt(tx, profileUpdate)
+	stmt := Stmt(tx, profileUpdate)
 	result, err := stmt.Exec(object.Project, object.Name, object.Description, id)
 	if err != nil {
 		return fmt.Errorf("Update \"profiles\" entry failed: %w", err)
@@ -385,7 +385,7 @@ func UpdateProfileConfig(ctx context.Context, tx *sql.Tx, profileID int64, confi
 // DeleteProfile deletes the profile matching the given key parameters.
 // generator: profile DeleteOne-by-Project-and-Name
 func DeleteProfile(ctx context.Context, tx *sql.Tx, project string, name string) error {
-	stmt := stmt(tx, profileDeleteByProjectAndName)
+	stmt := Stmt(tx, profileDeleteByProjectAndName)
 	result, err := stmt.Exec(project, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"profiles\": %w", err)

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -156,7 +156,7 @@ func UpdateProject(ctx context.Context, tx *sql.Tx, name string, object api.Proj
 		return fmt.Errorf("Fetch project ID: %w", err)
 	}
 
-	stmt := stmt(tx, projectUpdate)
+	stmt := Stmt(tx, projectUpdate)
 	result, err := stmt.Exec(object.Description, id)
 	if err != nil {
 		return fmt.Errorf("Update project: %w", err)

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -71,17 +71,17 @@ func GetProjects(ctx context.Context, tx *sql.Tx, filter ProjectFilter) ([]Proje
 	var args []any
 
 	if filter.Name != nil && filter.ID == nil {
-		sqlStmt = stmt(tx, projectObjectsByName)
+		sqlStmt = Stmt(tx, projectObjectsByName)
 		args = []any{
 			filter.Name,
 		}
 	} else if filter.ID != nil && filter.Name == nil {
-		sqlStmt = stmt(tx, projectObjectsByID)
+		sqlStmt = Stmt(tx, projectObjectsByID)
 		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, projectObjects)
+		sqlStmt = Stmt(tx, projectObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -178,7 +178,7 @@ func CreateProject(ctx context.Context, tx *sql.Tx, object Project) (int64, erro
 	args[1] = object.Name
 
 	// Prepared statement to use.
-	stmt := stmt(tx, projectCreate)
+	stmt := Stmt(tx, projectCreate)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
@@ -218,7 +218,7 @@ func CreateProjectConfig(ctx context.Context, tx *sql.Tx, projectID int64, confi
 // GetProjectID return the ID of the project with the given key.
 // generator: project ID
 func GetProjectID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
-	stmt := stmt(tx, projectID)
+	stmt := Stmt(tx, projectID)
 	rows, err := stmt.Query(name)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to get \"projects\" ID: %w", err)
@@ -252,7 +252,7 @@ func GetProjectID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
 // RenameProject renames the project matching the given key parameters.
 // generator: project Rename
 func RenameProject(ctx context.Context, tx *sql.Tx, name string, to string) error {
-	stmt := stmt(tx, projectRename)
+	stmt := Stmt(tx, projectRename)
 	result, err := stmt.Exec(to, name)
 	if err != nil {
 		return fmt.Errorf("Rename Project failed: %w", err)
@@ -273,7 +273,7 @@ func RenameProject(ctx context.Context, tx *sql.Tx, name string, to string) erro
 // DeleteProject deletes the project matching the given key parameters.
 // generator: project DeleteOne-by-Name
 func DeleteProject(ctx context.Context, tx *sql.Tx, name string) error {
-	stmt := stmt(tx, projectDeleteByName)
+	stmt := Stmt(tx, projectDeleteByName)
 	result, err := stmt.Exec(name)
 	if err != nil {
 		return fmt.Errorf("Delete \"projects\": %w", err)

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -71,25 +71,25 @@ func GetInstanceSnapshots(ctx context.Context, tx *sql.Tx, filter InstanceSnapsh
 	var args []any
 
 	if filter.Project != nil && filter.Instance != nil && filter.Name != nil && filter.ID == nil {
-		sqlStmt = stmt(tx, instanceSnapshotObjectsByProjectAndInstanceAndName)
+		sqlStmt = Stmt(tx, instanceSnapshotObjectsByProjectAndInstanceAndName)
 		args = []any{
 			filter.Project,
 			filter.Instance,
 			filter.Name,
 		}
 	} else if filter.Project != nil && filter.Instance != nil && filter.ID == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, instanceSnapshotObjectsByProjectAndInstance)
+		sqlStmt = Stmt(tx, instanceSnapshotObjectsByProjectAndInstance)
 		args = []any{
 			filter.Project,
 			filter.Instance,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Instance == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, instanceSnapshotObjectsByID)
+		sqlStmt = Stmt(tx, instanceSnapshotObjectsByID)
 		args = []any{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Instance == nil && filter.Name == nil {
-		sqlStmt = stmt(tx, instanceSnapshotObjects)
+		sqlStmt = Stmt(tx, instanceSnapshotObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -182,7 +182,7 @@ func GetInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, instan
 // GetInstanceSnapshotID return the ID of the instance_snapshot with the given key.
 // generator: instance_snapshot ID
 func GetInstanceSnapshotID(ctx context.Context, tx *sql.Tx, project string, instance string, name string) (int64, error) {
-	stmt := stmt(tx, instanceSnapshotID)
+	stmt := Stmt(tx, instanceSnapshotID)
 	rows, err := stmt.Query(project, instance, name)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to get \"instances_snapshots\" ID: %w", err)
@@ -253,7 +253,7 @@ func CreateInstanceSnapshot(ctx context.Context, tx *sql.Tx, object InstanceSnap
 	args[6] = object.ExpiryDate
 
 	// Prepared statement to use.
-	stmt := stmt(tx, instanceSnapshotCreate)
+	stmt := Stmt(tx, instanceSnapshotCreate)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
@@ -309,7 +309,7 @@ func CreateInstanceSnapshotConfig(ctx context.Context, tx *sql.Tx, instanceSnaps
 // RenameInstanceSnapshot renames the instance_snapshot matching the given key parameters.
 // generator: instance_snapshot Rename
 func RenameInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, instance string, name string, to string) error {
-	stmt := stmt(tx, instanceSnapshotRename)
+	stmt := Stmt(tx, instanceSnapshotRename)
 	result, err := stmt.Exec(to, project, instance, name)
 	if err != nil {
 		return fmt.Errorf("Rename InstanceSnapshot failed: %w", err)
@@ -330,7 +330,7 @@ func RenameInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, ins
 // DeleteInstanceSnapshot deletes the instance_snapshot matching the given key parameters.
 // generator: instance_snapshot DeleteOne-by-Project-and-Instance-and-Name
 func DeleteInstanceSnapshot(ctx context.Context, tx *sql.Tx, project string, instance string, name string) error {
-	stmt := stmt(tx, instanceSnapshotDeleteByProjectAndInstanceAndName)
+	stmt := Stmt(tx, instanceSnapshotDeleteByProjectAndInstanceAndName)
 	result, err := stmt.Exec(project, instance, name)
 	if err != nil {
 		return fmt.Errorf("Delete \"instances_snapshots\": %w", err)

--- a/lxd/db/cluster/stmt.go
+++ b/lxd/db/cluster/stmt.go
@@ -41,8 +41,8 @@ var stmts = map[int]string{} // Statement code to statement SQL text.
 // PreparedStmts is a placeholder for transitioning to package-scoped transaction functions.
 var PreparedStmts = map[int]*sql.Stmt{}
 
-// stmt prepares the in-memory prepared statement for the transaction.
-func stmt(tx *sql.Tx, code int) *sql.Stmt {
+// Stmt prepares the in-memory prepared statement for the transaction.
+func Stmt(tx *sql.Tx, code int) *sql.Stmt {
 	stmt, ok := PreparedStmts[code]
 	if !ok {
 		panic(fmt.Sprintf("No prepared statement registered with code %d", code))

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -84,7 +84,7 @@ func GetWarnings(ctx context.Context, tx *sql.Tx, filter WarningFilter) ([]Warni
 	var args []any
 
 	if filter.Node != nil && filter.TypeCode != nil && filter.Project != nil && filter.EntityTypeCode != nil && filter.EntityID != nil && filter.ID == nil && filter.UUID == nil && filter.Status == nil {
-		sqlStmt = stmt(tx, warningObjectsByNodeAndTypeCodeAndProjectAndEntityTypeCodeAndEntityID)
+		sqlStmt = Stmt(tx, warningObjectsByNodeAndTypeCodeAndProjectAndEntityTypeCodeAndEntityID)
 		args = []any{
 			filter.Node,
 			filter.TypeCode,
@@ -93,35 +93,35 @@ func GetWarnings(ctx context.Context, tx *sql.Tx, filter WarningFilter) ([]Warni
 			filter.EntityID,
 		}
 	} else if filter.Node != nil && filter.TypeCode != nil && filter.Project != nil && filter.ID == nil && filter.UUID == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
-		sqlStmt = stmt(tx, warningObjectsByNodeAndTypeCodeAndProject)
+		sqlStmt = Stmt(tx, warningObjectsByNodeAndTypeCodeAndProject)
 		args = []any{
 			filter.Node,
 			filter.TypeCode,
 			filter.Project,
 		}
 	} else if filter.Node != nil && filter.TypeCode != nil && filter.ID == nil && filter.UUID == nil && filter.Project == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
-		sqlStmt = stmt(tx, warningObjectsByNodeAndTypeCode)
+		sqlStmt = Stmt(tx, warningObjectsByNodeAndTypeCode)
 		args = []any{
 			filter.Node,
 			filter.TypeCode,
 		}
 	} else if filter.UUID != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
-		sqlStmt = stmt(tx, warningObjectsByUUID)
+		sqlStmt = Stmt(tx, warningObjectsByUUID)
 		args = []any{
 			filter.UUID,
 		}
 	} else if filter.Status != nil && filter.ID == nil && filter.UUID == nil && filter.Project == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil {
-		sqlStmt = stmt(tx, warningObjectsByStatus)
+		sqlStmt = Stmt(tx, warningObjectsByStatus)
 		args = []any{
 			filter.Status,
 		}
 	} else if filter.Project != nil && filter.ID == nil && filter.UUID == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
-		sqlStmt = stmt(tx, warningObjectsByProject)
+		sqlStmt = Stmt(tx, warningObjectsByProject)
 		args = []any{
 			filter.Project,
 		}
 	} else if filter.ID == nil && filter.UUID == nil && filter.Project == nil && filter.Node == nil && filter.TypeCode == nil && filter.EntityTypeCode == nil && filter.EntityID == nil && filter.Status == nil {
-		sqlStmt = stmt(tx, warningObjects)
+		sqlStmt = Stmt(tx, warningObjects)
 		args = []any{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
@@ -180,7 +180,7 @@ func GetWarning(ctx context.Context, tx *sql.Tx, uuid string) (*Warning, error) 
 // DeleteWarning deletes the warning matching the given key parameters.
 // generator: warning DeleteOne-by-UUID
 func DeleteWarning(ctx context.Context, tx *sql.Tx, uuid string) error {
-	stmt := stmt(tx, warningDeleteByUUID)
+	stmt := Stmt(tx, warningDeleteByUUID)
 	result, err := stmt.Exec(uuid)
 	if err != nil {
 		return fmt.Errorf("Delete \"warnings\": %w", err)
@@ -203,7 +203,7 @@ func DeleteWarning(ctx context.Context, tx *sql.Tx, uuid string) error {
 // DeleteWarnings deletes the warning matching the given key parameters.
 // generator: warning DeleteMany-by-EntityTypeCode-and-EntityID
 func DeleteWarnings(ctx context.Context, tx *sql.Tx, entityTypeCode int, entityID int) error {
-	stmt := stmt(tx, warningDeleteByEntityTypeCodeAndEntityID)
+	stmt := Stmt(tx, warningDeleteByEntityTypeCodeAndEntityID)
 	result, err := stmt.Exec(entityTypeCode, entityID)
 	if err != nil {
 		return fmt.Errorf("Delete \"warnings\": %w", err)
@@ -220,7 +220,7 @@ func DeleteWarnings(ctx context.Context, tx *sql.Tx, entityTypeCode int, entityI
 // GetWarningID return the ID of the warning with the given key.
 // generator: warning ID
 func GetWarningID(ctx context.Context, tx *sql.Tx, uuid string) (int64, error) {
-	stmt := stmt(tx, warningID)
+	stmt := Stmt(tx, warningID)
 	rows, err := stmt.Query(uuid)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to get \"warnings\" ID: %w", err)

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -167,7 +167,7 @@ func (m *Method) uris(buf *file.Buffer) error {
 		buf.L("%s %s {", branch, activeCriteria(filter, ignoredFilters[i]))
 
 		if m.db == "" {
-			buf.L("stmt = stmt(tx, %s)", stmtCodeVar(m.entity, "objects", filter...))
+			buf.L("stmt = Stmt(tx, %s)", stmtCodeVar(m.entity, "objects", filter...))
 		} else {
 			buf.L("stmt = %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "objects", filter...))
 		}
@@ -192,7 +192,7 @@ func (m *Method) uris(buf *file.Buffer) error {
 
 	buf.L("%s %s {", branch, activeCriteria([]string{}, FieldNames(mapping.Filters)))
 	if m.db == "" {
-		buf.L("stmt = stmt(tx, %s)", stmtCodeVar(m.entity, "objects"))
+		buf.L("stmt = Stmt(tx, %s)", stmtCodeVar(m.entity, "objects"))
 	} else {
 		buf.L("stmt = %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "objects"))
 	}
@@ -279,7 +279,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 	} else if mapping.Type == AssociationTable {
 		filter := m.config["struct"] + "ID"
 		if m.db == "" {
-			buf.L("sqlStmt := stmt(tx, %s)", stmtCodeVar(m.entity, "objects", filter))
+			buf.L("sqlStmt := Stmt(tx, %s)", stmtCodeVar(m.entity, "objects", filter))
 		} else {
 			buf.L("sqlStmt := %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "objects", filter))
 		}
@@ -302,7 +302,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 			buf.L("%s %s {", branch, activeCriteria(filter, ignoredFilters[i]))
 
 			if m.db == "" {
-				buf.L("sqlStmt = stmt(tx, %s)", stmtCodeVar(m.entity, "objects", filter...))
+				buf.L("sqlStmt = Stmt(tx, %s)", stmtCodeVar(m.entity, "objects", filter...))
 			} else {
 				buf.L("sqlStmt = %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "objects", filter...))
 			}
@@ -328,7 +328,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 
 		buf.L("%s %s {", branch, activeCriteria([]string{}, FieldNames(mapping.Filters)))
 		if m.db == "" {
-			buf.L("sqlStmt = stmt(tx, %s)", stmtCodeVar(m.entity, "objects"))
+			buf.L("sqlStmt = Stmt(tx, %s)", stmtCodeVar(m.entity, "objects"))
 		} else {
 			buf.L("sqlStmt = %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "objects"))
 		}
@@ -584,7 +584,7 @@ func (m *Method) id(buf *file.Buffer) error {
 	defer m.end(buf)
 
 	if m.db == "" {
-		buf.L("stmt := stmt(tx, %s)", stmtCodeVar(m.entity, "ID"))
+		buf.L("stmt := Stmt(tx, %s)", stmtCodeVar(m.entity, "ID"))
 	} else {
 		buf.L("stmt := %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "ID"))
 	}
@@ -753,7 +753,7 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 
 		buf.L("// Prepared statement to use. ")
 		if m.db == "" {
-			buf.L("stmt := stmt(tx, %s)", stmtCodeVar(m.entity, kind))
+			buf.L("stmt := Stmt(tx, %s)", stmtCodeVar(m.entity, kind))
 		} else {
 			buf.L("stmt := %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, kind))
 		}
@@ -893,7 +893,7 @@ func (m *Method) rename(buf *file.Buffer) error {
 	defer m.end(buf)
 
 	if m.db == "" {
-		buf.L("stmt := stmt(tx, %s)", stmtCodeVar(m.entity, "rename"))
+		buf.L("stmt := Stmt(tx, %s)", stmtCodeVar(m.entity, "rename"))
 	} else {
 		buf.L("stmt := %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "rename"))
 	}
@@ -1013,7 +1013,7 @@ func (m *Method) update(buf *file.Buffer) error {
 		buf.L("id, err := Get%sID(ctx, tx, %s)", lex.Camel(m.entity), mapping.FieldParams(nk))
 		m.ifErrNotNil(buf, true, "err")
 		if m.db == "" {
-			buf.L("stmt := stmt(tx, %s)", stmtCodeVar(m.entity, "update"))
+			buf.L("stmt := Stmt(tx, %s)", stmtCodeVar(m.entity, "update"))
 		} else {
 			buf.L("stmt := %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "update"))
 		}
@@ -1100,7 +1100,7 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 	defer m.end(buf)
 	if mapping.Type == AssociationTable {
 		if m.db == "" {
-			buf.L("stmt := stmt(tx, %s)", stmtCodeVar(m.entity, "delete", m.config["struct"]+"ID"))
+			buf.L("stmt := Stmt(tx, %s)", stmtCodeVar(m.entity, "delete", m.config["struct"]+"ID"))
 		} else {
 			buf.L("stmt := %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "delete", m.config["struct"]+"ID"))
 		}
@@ -1123,7 +1123,7 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 	} else {
 		activeFilters := mapping.ActiveFilters(m.kind)
 		if m.db == "" {
-			buf.L("stmt := stmt(tx, %s)", stmtCodeVar(m.entity, "delete", FieldNames(activeFilters)...))
+			buf.L("stmt := Stmt(tx, %s)", stmtCodeVar(m.entity, "delete", FieldNames(activeFilters)...))
 		} else {
 			buf.L("stmt := %s.Stmt(tx, %s)", m.db, stmtCodeVar(m.entity, "delete", FieldNames(activeFilters)...))
 		}

--- a/lxd/db/testing.go
+++ b/lxd/db/testing.go
@@ -85,7 +85,7 @@ func NewTestClusterTx(t *testing.T) (*ClusterTx, func()) {
 
 	var err error
 
-	clusterTx := &ClusterTx{nodeID: cluster.nodeID, stmts: cluster.stmts}
+	clusterTx := &ClusterTx{nodeID: cluster.nodeID}
 	clusterTx.tx, err = cluster.db.Begin()
 	require.NoError(t, err)
 

--- a/lxd/db/transaction.go
+++ b/lxd/db/transaction.go
@@ -20,9 +20,8 @@ type NodeTx struct {
 // It wraps low-level sql.Tx objects and offers a high-level API to fetch and
 // update data.
 type ClusterTx struct {
-	tx     *sql.Tx           // Handle to a transaction in the cluster dqlite database.
-	nodeID int64             // Node ID of this LXD instance.
-	stmts  map[int]*sql.Stmt // Prepared statements by code.
+	tx     *sql.Tx // Handle to a transaction in the cluster dqlite database.
+	nodeID int64   // Node ID of this LXD instance.
 }
 
 // Tx retrieves the underlying transaction on the cluster database.
@@ -38,15 +37,6 @@ func (c *ClusterTx) NodeID(id int64) {
 // GetNodeID gets the ID of the node associated with this cluster transaction.
 func (c *ClusterTx) GetNodeID() int64 {
 	return c.nodeID
-}
-
-func (c *ClusterTx) stmt(code int) *sql.Stmt {
-	stmt, ok := c.stmts[code]
-	if !ok {
-		panic(fmt.Sprintf("No prepared statement registered with code %d", code))
-	}
-
-	return c.tx.Stmt(stmt)
 }
 
 // prepare prepares a new statement from a SQL string.

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -212,7 +212,7 @@ func (c *ClusterTx) createWarning(ctx context.Context, object cluster.Warning) (
 	args[11] = object.Count
 
 	// Prepared statement to use.
-	stmt := c.stmt(warningCreate)
+	stmt := cluster.Stmt(c.tx, warningCreate)
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)


### PR DESCRIPTION
Closes #10183 

With all uses of lxd-generate moved into the cluster package, this PR removes the `stmts` maps from `Cluster` and `ClusterTx` in favour of the global `PreparedStatements` map defined in the cluster package. The refactor of the lxd-generate helpers to facilitate usage from external packages removed the reliance on the `Cluster` and `ClusterTx` structs, so this just consolidates all prepared statements into the map that lxd-generate expects to exist.

And with that, finally we can close that long running issue :)