### PR TITLE
DB: Don't use query parameters with IN statement when loading instance config in InstanceList

### DIFF
--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -380,14 +380,7 @@ func (c *ClusterTx) AddNodeToClusterGroup(groupName string, nodeName string) err
 		return fmt.Errorf("Failed to get node info: %w", err)
 	}
 
-	q := `INSERT INTO nodes_cluster_groups (node_id, group_id) VALUES(?, ?);`
-
-	stmt, err := c.prepare(q)
-	if err != nil {
-		return err
-	}
-
-	_, err = stmt.Exec(nodeInfo.ID, groupID)
+	_, err = c.tx.Exec(`INSERT INTO nodes_cluster_groups (node_id, group_id) VALUES(?, ?);`, nodeInfo.ID, groupID)
 	if err != nil {
 		return err
 	}
@@ -407,14 +400,7 @@ func (c *ClusterTx) RemoveNodeFromClusterGroup(groupName string, nodeName string
 		return fmt.Errorf("Failed to get node info: %w", err)
 	}
 
-	q := `DELETE FROM nodes_cluster_groups WHERE node_id = ? AND group_id = ?`
-
-	stmt, err := c.prepare(q)
-	if err != nil {
-		return err
-	}
-
-	_, err = stmt.Exec(nodeInfo.ID, groupID)
+	_, err = c.tx.Exec(`DELETE FROM nodes_cluster_groups WHERE node_id = ? AND group_id = ?`, nodeInfo.ID, groupID)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -244,7 +244,7 @@ func (c *ClusterTx) GetProjectAndInstanceNamesByNodeAddress(projects []string, f
 	var filters strings.Builder
 
 	// Project filter.
-	filters.WriteString(fmt.Sprintf("projects.name IN (%s)", generateInClauseParams(len(projects))))
+	filters.WriteString(fmt.Sprintf("projects.name IN %s", query.Params(len(projects))))
 	for _, project := range projects {
 		args = append(args, project)
 	}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -637,7 +637,7 @@ func (c *ClusterTx) GetProjectInstanceToNodeMap(projects []string, filter cluste
 	var filters strings.Builder
 
 	// Project filter.
-	filters.WriteString(fmt.Sprintf("projects.name IN (%s)", generateInClauseParams(len(projects))))
+	filters.WriteString(fmt.Sprintf("projects.name IN %s", query.Params(len(projects))))
 	for _, project := range projects {
 		args = append(args, project)
 	}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -950,7 +950,7 @@ SELECT storage_pools.name FROM storage_pools
   JOIN projects ON projects.id=instances.project_id
  WHERE projects.name=?
    AND storage_volumes_all.name=?
-   AND storage_volumes_all.type IN(?,?)
+   AND storage_volumes_all.type IN (?,?)
    AND storage_volumes_all.project_id = instances.project_id
    AND (storage_volumes_all.node_id=? OR storage_volumes_all.node_id IS NULL AND storage_pools.driver IN %s)`, query.Params(len(remoteDrivers)))
 	inargs := []any{projectName, instanceName, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeVM, c.nodeID}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -1192,13 +1192,3 @@ func UpdateInstance(tx *sql.Tx, id int, description string, architecture int, ep
 
 	return nil
 }
-
-// Generates '?' signs for sql IN clause.
-func generateInClauseParams(length int) string {
-	result := []string{}
-	for i := 0; i < length; i++ {
-		result = append(result, "?")
-	}
-
-	return strings.Join(result, ",")
-}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -322,21 +323,30 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func
 	// instanceConfig function loads config for all specified instanceIDs in a single query and then updates
 	// the entries in the instances map.
 	instanceConfig := func(tx *ClusterTx, instanceIDs []int) error {
-		q := `
-		SELECT
+		// Don't use query parameters for the IN statement to workaround an issue in Dqlite (apparently)
+		// that means that >255 query parameters causes partial result sets. See #10705
+		// This is safe as the inputs are ints.
+		var q strings.Builder
+
+		q.WriteString(`SELECT
 			instance_id,
 			key,
 			value
 		FROM instances_config
-		WHERE instance_id IN
-		` + query.Params(len(instanceIDs))
+		WHERE instance_id IN (`)
+		q.Grow(len(instanceIDs) * 2) // We know the minimum length of the separators and integers.
 
-		args := make([]any, 0, len(instanceIDs))
-		for _, instanceID := range instanceIDs {
-			args = append(args, instanceID)
+		for i := range instanceIDs {
+			if i > 0 {
+				q.WriteString(",")
+			}
+
+			q.WriteString(strconv.Itoa(instanceIDs[i]))
 		}
 
-		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
+		q.WriteString(`)`)
+
+		return tx.QueryScan(q.String(), func(scan func(dest ...any) error) error {
 			var instanceID int
 			var key, value string
 
@@ -364,13 +374,18 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func
 			instances[instanceID].Config[key] = value
 
 			return nil
-		}, args...)
+		})
 	}
 
 	// instanceDevices loads the device config for all instanceIDs specified in a single query and then updates
 	// the entries in the instances map.
 	instanceDevices := func(tx *ClusterTx, instanceIDs []int) error {
-		q := `
+		// Don't use query parameters for the IN statement to workaround an issue in Dqlite (apparently)
+		// that means that >255 query parameters causes partial result sets. See #10705
+		// This is safe as the inputs are ints.
+		var q strings.Builder
+
+		q.WriteString(`
 		SELECT
 			instances_devices.instance_id AS instance_id,
 			instances_devices.name AS device_name,
@@ -379,15 +394,21 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func
 			instances_devices_config.value
 		FROM instances_devices_config
 		JOIN instances_devices ON instances_devices.id = instances_devices_config.instance_device_id
-		WHERE instances_devices.instance_id IN
-		` + query.Params(len(instanceIDs))
+		WHERE instances_devices.instance_id IN (`)
 
-		args := make([]any, 0, len(instanceIDs))
-		for _, instanceID := range instanceIDs {
-			args = append(args, instanceID)
+		q.Grow(len(instanceIDs) * 2) // We know the minimum length of the separators and integers.
+
+		for i := range instanceIDs {
+			if i > 0 {
+				q.WriteString(",")
+			}
+
+			q.WriteString(strconv.Itoa(instanceIDs[i]))
 		}
 
-		return tx.QueryScan(q, func(scan func(dest ...any) error) error {
+		q.WriteString(`)`)
+
+		return tx.QueryScan(q.String(), func(scan func(dest ...any) error) error {
 			var instanceID int
 			var deviceType cluster.DeviceType
 			var deviceName, key, value string
@@ -425,27 +446,38 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func
 			instances[instanceID].Devices[deviceName][key] = value
 
 			return nil
-		}, args...)
+		})
 	}
 
 	// instanceProfiles loads the profile IDs to apply to an instance (in the application order) for all
 	// instanceIDs in a single query and then updates the instanceApplyProfileIDs and profilesByID maps.
 	instanceProfiles := func(tx *ClusterTx, instanceIDs []int) error {
-		instanceProjectProfilesSQL := `
+		// Don't use query parameters for the IN statement to workaround an issue in Dqlite (apparently)
+		// that means that >255 query parameters causes partial result sets. See #10705
+		// This is safe as the inputs are ints.
+		var q strings.Builder
+
+		q.WriteString(`
 		SELECT
 			instances_profiles.instance_id AS instance_id,
 			instances_profiles.profile_id AS profile_id
 		FROM instances_profiles
-		WHERE instances_profiles.instance_id IN
-		` + query.Params(len(instanceIDs)) +
-			`ORDER BY instances_profiles.instance_id, instances_profiles.apply_order`
+		WHERE instances_profiles.instance_id IN (`)
 
-		args := make([]any, 0, len(instanceIDs))
-		for _, instanceID := range instanceIDs {
-			args = append(args, instanceID)
+		q.Grow(len(instanceIDs) * 2) // We know the minimum length of the separators and integers.
+
+		for i := range instanceIDs {
+			if i > 0 {
+				q.WriteString(",")
+			}
+
+			q.WriteString(strconv.Itoa(instanceIDs[i]))
 		}
 
-		return tx.QueryScan(instanceProjectProfilesSQL, func(scan func(dest ...any) error) error {
+		q.WriteString(`)
+		ORDER BY instances_profiles.instance_id, instances_profiles.apply_order`)
+
+		return tx.QueryScan(q.String(), func(scan func(dest ...any) error) error {
 			var instanceID int64
 			var profileID int
 
@@ -463,7 +495,7 @@ func (c *Cluster) InstanceList(filter *cluster.InstanceFilter, instanceFunc func
 			}
 
 			return nil
-		}, args...)
+		})
 	}
 
 	// Retrieve required info from the database in single transaction for performance.

--- a/lxd/db/network_forwards.go
+++ b/lxd/db/network_forwards.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -384,7 +385,7 @@ func (c *Cluster) GetNetworkForwards(ctx context.Context, networkID int64, membe
 	}
 
 	if len(listenAddresses) > 0 {
-		q.WriteString(fmt.Sprintf("AND networks_forwards.listen_address IN (%s) ", generateInClauseParams(len(listenAddresses))))
+		q.WriteString(fmt.Sprintf("AND networks_forwards.listen_address IN %s ", query.Params(len(listenAddresses))))
 		for _, listenAddress := range listenAddresses {
 			args = append(args, listenAddress)
 		}

--- a/lxd/db/network_load_balancers.go
+++ b/lxd/db/network_load_balancers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -399,7 +400,7 @@ func (c *Cluster) GetNetworkLoadBalancers(ctx context.Context, networkID int64, 
 	}
 
 	if len(listenAddresses) > 0 {
-		q.WriteString(fmt.Sprintf("AND networks_forwards.listen_address IN (%s) ", generateInClauseParams(len(listenAddresses))))
+		q.WriteString(fmt.Sprintf("AND networks_forwards.listen_address IN %s ", query.Params(len(listenAddresses))))
 		for _, listenAddress := range listenAddresses {
 			args = append(args, listenAddress)
 		}

--- a/lxd/db/transaction.go
+++ b/lxd/db/transaction.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
 )
 
 // NodeTx models a single interaction with a LXD node-local database.
@@ -37,16 +36,6 @@ func (c *ClusterTx) NodeID(id int64) {
 // GetNodeID gets the ID of the node associated with this cluster transaction.
 func (c *ClusterTx) GetNodeID() int64 {
 	return c.nodeID
-}
-
-// prepare prepares a new statement from a SQL string.
-func (c *ClusterTx) prepare(sql string) (*sql.Stmt, error) {
-	stmt, err := c.tx.Prepare(sql)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to prepare statement with error: %w", err)
-	}
-
-	return stmt, nil
 }
 
 // QueryScan runs a query with inArgs and provides the rowFunc with the scan function for each row.


### PR DESCRIPTION
There seems to be an issue with Dqlite that returns partial result sets (with no error) if using >255 query parameters.

Fixes #10705

This is safe because the inputs are `int` and not `string` so cannot be used to modify the query in a malicious way.

Tested with 512 containers.

Also : 

- Uses a standard way of generating IN statement argument placeholders and remove `generateInClauseParams`.
- Removes the `prepare()` function as it was being used in an inefficient way.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>