### PR TITLE
lxd/resources: Fix VPD parser crash

### DIFF
--- a/lxd/resources/pci_vpd.go
+++ b/lxd/resources/pci_vpd.go
@@ -36,6 +36,10 @@ func vpdKnownKey(name string) bool {
 }
 
 func vpdReadInt(buf []byte, length int) ([]byte, int) {
+	if length > len(buf) {
+		return []byte{}, 0
+	}
+
 	value := 0
 	for i, n := range buf[:length] {
 		value += int(n) << (i * 8)


### PR DESCRIPTION
Another case of invalid VPD data (length larger than record) causing the
parser to crash.

Closes #10708

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>