### PR TITLE
[Proposal] Implement VGA console for container instances

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5416,25 +5416,7 @@ func (d *qemu) Console(protocol string) (*os.File, chan error, error) {
 		return nil, nil, fmt.Errorf("Unknown protocol %q", protocol)
 	}
 
-	// Disconnection notification.
-	chDisconnect := make(chan error, 1)
-
-	// Open the console socket.
-	conn, err := net.Dial("unix", path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Connect to console socket %q: %w", path, err)
-	}
-
-	file, err := (conn.(*net.UnixConn)).File()
-	if err != nil {
-		return nil, nil, fmt.Errorf("Get socket file: %w", err)
-	}
-
-	_ = conn.Close()
-
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceConsole.Event(d, logger.Ctx{"type": protocol}))
-
-	return file, chDisconnect, nil
+	return d.connectConsoleSocket(path, protocol)
 }
 
 // Exec a command inside the instance.

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -462,10 +462,6 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	if post.Type == instance.ConsoleTypeVGA && inst.Type() != instancetype.VM {
-		return response.BadRequest(fmt.Errorf("VGA console is only supported by virtual machines"))
-	}
-
 	if !inst.IsRunning() {
 		return response.BadRequest(fmt.Errorf("Instance is not running"))
 	}


### PR DESCRIPTION
This is an attempt to implement VGA console type for container instances by using a very simple approach: When `lxc console --type=vga` is launched for a container instance, it will create a proxy device for a SPICE server listening on the container. That means it is entirely up to the container/image to do most of the heavy lifting, and all this PR does is reuse the existing VM VGA console infrastructure.

To simplify testing this PR, I've created a script which creates a local image for a Debian MATE desktop using Xorg spiceqxl driver: https://gist.github.com/tarruda/b6886fc7be3c21f2f878ea74e0ea7891. After running the script to create the image, use this to test the VGA display:

```
lxc launch debian-mate-desktop-xspice mate --console=vga
```

I'm not sure if there's a better way to expose the instance's socket, but creating a proxy device on demand was the easiest path I've found. IMO it ended up being more flexible too, since the user can override the proxy device in the instance config.
