### PR TITLE
LXC: Fix expanded show of instance snapshot

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -696,7 +696,7 @@ func (c *cmdConfigShow) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			brief = &snap
+			brief = snap
 			if c.flagExpanded {
 				brief.(*api.InstanceSnapshot).Config = snap.ExpandedConfig
 				brief.(*api.InstanceSnapshot).Devices = snap.ExpandedDevices


### PR DESCRIPTION
Otherwise `lxc config show <instance>/<snapshot> --expanded` would panic.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>