### PR TITLE
Storage: Scan pool device source for BTRFS filesystems before mounting

### DIFF
--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -353,6 +353,13 @@ func (d *btrfs) Mount() (bool, error) {
 		mntSrc = fmt.Sprintf("/dev/disk/by-uuid/%s", d.config["source"])
 	}
 
+	if shared.IsBlockdevPath(mntSrc) {
+		_, err := shared.RunCommand("btrfs", "device", "scan", mntSrc)
+		if err != nil {
+			return false, fmt.Errorf("Failed scanning device %q for BTRFS filesystem: %w", mntSrc, err)
+		}
+	}
+
 	// Get the custom mount flags/options.
 	mntFlags, mntOptions := resolveMountOptions(d.getMountOptions())
 


### PR DESCRIPTION
Attempts to fix the BTRFS "invalid argument" errors when mounting the storage pool.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>