### PR TITLE
Client: Set transport.DialTLSContext in tlsHTTPClient

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -23,7 +23,6 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 	// Define the http transport
 	transport := &http.Transport{
 		TLSClientConfig:       tlsConfig,
-		DialContext:           shared.RFC3493Dialer,
 		Proxy:                 shared.ProxyFromEnvironment,
 		DisableKeepAlives:     true,
 		ExpectContinueTimeout: time.Second * 30,
@@ -37,12 +36,9 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 	}
 
 	// Special TLS handling
-	//lint:ignore SA1019 DialContext doesn't exist in Go 1.13
-	transport.DialTLS = func(network string, addr string) (net.Conn, error) {
+	transport.DialTLSContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
 		tlsDial := func(network string, addr string, config *tls.Config, resetName bool) (net.Conn, error) {
-			// TCP connection
-			//lint:ignore SA1019 DialContext doesn't exist in Go 1.13
-			conn, err := transport.DialContext(context.Background(), network, addr)
+			conn, err := shared.RFC3493Dialer(ctx, network, addr)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes regression caused by 9cda9c2135601e223a462f2fbd8a4e0f8dc0e017

Fixes #10734

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>