### PR TITLE
Network: Fix regression in GetNetworkLoadBalancers

### DIFF
--- a/lxd/db/network_load_balancers.go
+++ b/lxd/db/network_load_balancers.go
@@ -400,7 +400,7 @@ func (c *Cluster) GetNetworkLoadBalancers(ctx context.Context, networkID int64, 
 	}
 
 	if len(listenAddresses) > 0 {
-		q.WriteString(fmt.Sprintf("AND networks_forwards.listen_address IN %s ", query.Params(len(listenAddresses))))
+		q.WriteString(fmt.Sprintf("AND networks_load_balancers.listen_address IN %s ", query.Params(len(listenAddresses))))
 		for _, listenAddress := range listenAddresses {
 			args = append(args, listenAddress)
 		}


### PR DESCRIPTION
Introduced with df55120483f11031266ab67c5a35f977813e11db

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>