### PR TITLE
lxd/storage/drivers/zfs: set atime=off and relatime=on

### DIFF
--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -25,6 +25,8 @@ var zfsTrim bool
 var zfsRaw bool
 
 var zfsDefaultSettings = map[string]string{
+	"atime":      "off",
+	"relatime":   "on",
 	"mountpoint": "legacy",
 	"setuid":     "on",
 	"exec":       "on",


### PR DESCRIPTION
This reduces the amount of write ops associated with read ops and also
aligns ZFS with other file systems supported by LXD.