### PR TITLE
Instance: Use more efficient snapshot loading query when deleting snapshots

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3618,7 +3618,7 @@ func (d *lxc) Delete(force bool) error {
 		} else {
 			// Remove all snapshots by initialising each snapshot as an Instance and
 			// calling its Delete function.
-			err := instance.DeleteSnapshots(d.state, d.Project(), d.Name())
+			err := instance.DeleteSnapshots(d)
 			if err != nil {
 				d.logger.Error("Failed to delete instance snapshots", logger.Ctx{"err": err})
 				return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4956,7 +4956,7 @@ func (d *qemu) Delete(force bool) error {
 		} else {
 			// Remove all snapshots by initialising each snapshot as an Instance and
 			// calling its Delete function.
-			err := instance.DeleteSnapshots(d.state, d.Project(), d.Name())
+			err := instance.DeleteSnapshots(d)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This is something I noticed when deleting the instance I used for snapshot listing testing - snapshots are removed in alphabetical order.

So this PR deletes them in reverse creation date order, rather than alphabetically. To avoid any restrictions on deletion order from the underlying storage driver.
And uses the more efficient snapshot loading function `inst.Snapshots()` rather than perform the same queries over and over again for each snapshot.

