### PR TITLE
lxd: Adds `RunCommandContext` function and updates `RunError` with `Unwrap` function

### DIFF
--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -69,11 +69,7 @@ func ExtractWithFds(cmd string, args []string, allowedCmds []string, stdin io.Re
 
 	_, err = p.Wait(context.Background())
 	if err != nil {
-		return shared.RunError{
-			Msg:    fmt.Sprintf("Failed to run: %s %s: %s", cmd, strings.Join(args, " "), strings.TrimSpace(buffer.String())),
-			Stderr: buffer.String(),
-			Err:    err,
-		}
+		return shared.NewRunError(cmd, args, err, nil, &buffer)
 	}
 
 	return nil

--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -222,13 +222,18 @@ func Unpack(file string, path string, blockBackend bool, sysOS *sys.OS, tracker 
 		// We can't create char/block devices in unpriv containers so ignore related errors.
 		if sysOS.RunningInUserNS && command == "unsquashfs" {
 			runError, ok := err.(shared.RunError)
-			if !ok || runError.Stderr == "" {
+			if !ok {
+				return err
+			}
+
+			stdErr := runError.StdErr().String()
+			if stdErr == "" {
 				return err
 			}
 
 			// Confirm that all errors are related to character or block devices.
 			found := false
-			for _, line := range strings.Split(runError.Stderr, "\n") {
+			for _, line := range strings.Split(stdErr, "\n") {
 				line = strings.TrimSpace(line)
 				if line == "" {
 					continue

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -208,7 +208,7 @@ again:
 	if err != nil {
 		runError, ok := err.(shared.RunError)
 		if ok {
-			exitError, ok := runError.Err.(*exec.ExitError)
+			exitError, ok := runError.Unwrap().(*exec.ExitError)
 			if ok {
 				if exitError.ExitCode() == 22 {
 					// EINVAL (already unmapped)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1726,7 +1726,7 @@ func (d *lxc) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 
 			ueventArray[5] = fmt.Sprintf("%d", length)
 			ueventArray = append(ueventArray, eventParts...)
-			_, _, err := shared.RunCommandSplit(nil, []*os.File{pidFd}, d.state.OS.ExecPath, ueventArray...)
+			_, _, err := shared.RunCommandSplit(context.TODO(), nil, []*os.File{pidFd}, d.state.OS.ExecPath, ueventArray...)
 			if err != nil {
 				return err
 			}
@@ -5894,6 +5894,7 @@ func (d *lxc) networkState() map[string]api.InstanceStateNetwork {
 
 		// Get the network state from the container
 		out, _, err := shared.RunCommandSplit(
+			context.TODO(),
 			nil,
 			[]*os.File{pidFd},
 			d.state.OS.ExecPath,
@@ -6137,6 +6138,7 @@ func (d *lxc) insertMountLXD(source, target, fstype string, flags int, mntnsPID 
 	}
 
 	_, err = shared.RunCommandInheritFds(
+		context.TODO(),
 		[]*os.File{pidFd},
 		d.state.OS.ExecPath,
 		"forkmount",
@@ -6229,6 +6231,7 @@ func (d *lxc) removeMount(mount string) error {
 		}
 
 		_, err := shared.RunCommandInheritFds(
+			context.TODO(),
 			[]*os.File{pidFd},
 			d.state.OS.ExecPath,
 			"forkmount",

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -281,7 +281,7 @@ func SRIOVSwitchdevEnabled(deviceName string) bool {
 
 	slotName := fmt.Sprintf("pci/%s", pciDev.SlotName)
 
-	err = shared.RunCommandWithFds(nil, &buf, "devlink", "-j", "dev", "eswitch", "show", slotName)
+	err = shared.RunCommandWithFds(context.TODO(), nil, &buf, "devlink", "-j", "dev", "eswitch", "show", slotName)
 	if err != nil {
 		return false
 	}

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -47,7 +47,7 @@ func (o *OVS) BridgeExists(bridgeName string) (bool, error) {
 	if err != nil {
 		runErr, ok := err.(shared.RunError)
 		if ok {
-			exitError, ok := runErr.Err.(*exec.ExitError)
+			exitError, ok := runErr.Unwrap().(*exec.ExitError)
 
 			// ovs-vsctl manpage says that br-exists exits with code 2 if bridge doesn't exist.
 			if ok && exitError.ExitCode() == 2 {

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -67,7 +67,7 @@ func LocalCopy(source string, dest string, bwlimit string, xattrs bool, rsyncArg
 	if err != nil {
 		runError, ok := err.(shared.RunError)
 		if ok {
-			exitError, ok := runError.Err.(*exec.ExitError)
+			exitError, ok := runError.Unwrap().(*exec.ExitError)
 			if ok {
 				if exitError.ExitCode() == 24 {
 					return msg, nil

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -3,6 +3,7 @@
 package seccomp
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1228,6 +1229,7 @@ func CallForkmknod(c Instance, dev deviceConfig.Device, requestPID int, s *state
 	}
 
 	_, stderr, err := shared.RunCommandSplit(
+		context.TODO(),
 		nil,
 		[]*os.File{pidFd},
 		util.GetExecPath(),
@@ -1536,6 +1538,7 @@ func (s *Server) HandleSetxattrSyscall(c Instance, siov *Iovec) int {
 	}
 
 	_, stderr, err := shared.RunCommandSplit(
+		context.TODO(),
 		nil,
 		[]*os.File{pidFd},
 		util.GetExecPath(),
@@ -1687,6 +1690,7 @@ func (s *Server) HandleSchedSetschedulerSyscall(c Instance, siov *Iovec) int {
 	args.schedPriority = schedParamArgs.sched_priority
 
 	_, stderr, err := shared.RunCommandSplit(
+		context.TODO(),
 		nil,
 		[]*os.File{pidFd},
 		util.GetExecPath(),
@@ -2165,6 +2169,7 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 		ctx["fuse_target"] = args.target
 		ctx["fuse_opts"] = fuseOpts
 		_, _, err = shared.RunCommandSplit(
+			context.TODO(),
 			nil,
 			[]*os.File{pidFd},
 			util.GetExecPath(),
@@ -2182,6 +2187,7 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 			fuseOpts)
 	} else {
 		_, _, err = shared.RunCommandSplit(
+			context.TODO(),
 			nil,
 			[]*os.File{pidFd},
 			util.GetExecPath(),

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -410,7 +411,7 @@ func (d *btrfs) getSubvolumesMetaData(vol Volume) ([]BTRFSSubVolume, error) {
 
 	if !d.state.OS.RunningInUserNS {
 		// List all subvolumes in the given filesystem with their UUIDs and received UUIDs.
-		err = shared.RunCommandWithFds(nil, &stdout, "btrfs", "subvolume", "list", "-u", "-R", poolMountPath)
+		err = shared.RunCommandWithFds(context.TODO(), nil, &stdout, "btrfs", "subvolume", "list", "-u", "-R", poolMountPath)
 		if err != nil {
 			return nil, err
 		}
@@ -448,7 +449,7 @@ func (d *btrfs) getSubVolumeReceivedUUID(vol Volume) (string, error) {
 	poolMountPath := GetPoolMountPath(vol.pool)
 
 	// List all subvolumes in the given filesystem with their UUIDs.
-	err := shared.RunCommandWithFds(nil, &stdout, "btrfs", "subvolume", "list", "-R", poolMountPath)
+	err := shared.RunCommandWithFds(context.TODO(), nil, &stdout, "btrfs", "subvolume", "list", "-R", poolMountPath)
 	if err != nil {
 		return "", err
 	}
@@ -561,7 +562,7 @@ func (d *btrfs) receiveSubVolume(r io.Reader, receivePath string) (string, error
 		return "", fmt.Errorf("Failed listing contents of %q: %w", receivePath, err)
 	}
 
-	err = shared.RunCommandWithFds(r, nil, "btrfs", "receive", "-e", receivePath)
+	err = shared.RunCommandWithFds(context.TODO(), r, nil, "btrfs", "receive", "-e", receivePath)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1521,7 +1521,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 
 		// Write the subvolume to the file.
 		d.logger.Debug("Generating optimized volume file", logger.Ctx{"sourcePath": path, "parent": parent, "file": tmpFile.Name(), "name": fileName})
-		err = shared.RunCommandWithFds(nil, tmpFile, "btrfs", args...)
+		err = shared.RunCommandWithFds(context.TODO(), nil, tmpFile, "btrfs", args...)
 		if err != nil {
 			return err
 		}
@@ -1806,7 +1806,7 @@ func (d *btrfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string,
 func (d *btrfs) volumeSnapshotsSorted(vol Volume, op *operations.Operation) ([]string, error) {
 	stdout := bytes.Buffer{}
 
-	err := shared.RunCommandWithFds(nil, &stdout, "btrfs", "subvolume", "list", GetPoolMountPath(vol.pool))
+	err := shared.RunCommandWithFds(context.TODO(), nil, &stdout, "btrfs", "subvolume", "list", GetPoolMountPath(vol.pool))
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -295,7 +296,7 @@ func (d *ceph) Unmount() (bool, error) {
 func (d *ceph) GetResources() (*api.ResourcesStoragePool, error) {
 	var stdout bytes.Buffer
 
-	err := shared.RunCommandWithFds(nil, &stdout,
+	err := shared.RunCommandWithFds(context.TODO(), nil, &stdout,
 		"ceph",
 		"--name", fmt.Sprintf("client.%s", d.config["ceph.user.name"]),
 		"--cluster", d.config["ceph.cluster_name"],

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -188,7 +188,7 @@ again:
 	if err != nil {
 		runError, ok := err.(shared.RunError)
 		if ok {
-			exitError, ok := runError.Err.(*exec.ExitError)
+			exitError, ok := runError.Unwrap().(*exec.ExitError)
 			if ok {
 				if exitError.ExitCode() == 22 {
 					// EINVAL (already unmapped).
@@ -240,7 +240,7 @@ again:
 	if err != nil {
 		runError, ok := err.(shared.RunError)
 		if ok {
-			exitError, ok := runError.Err.(*exec.ExitError)
+			exitError, ok := runError.Unwrap().(*exec.ExitError)
 			if ok {
 				if exitError.ExitCode() == 22 {
 					// EINVAL (already unmapped).
@@ -292,7 +292,7 @@ func (d *ceph) rbdProtectVolumeSnapshot(vol Volume, snapshotName string) error {
 	if err != nil {
 		runError, ok := err.(shared.RunError)
 		if ok {
-			exitError, ok := runError.Err.(*exec.ExitError)
+			exitError, ok := runError.Unwrap().(*exec.ExitError)
 			if ok {
 				if exitError.ExitCode() == 16 {
 					// EBUSY (snapshot already protected).
@@ -323,7 +323,7 @@ func (d *ceph) rbdUnprotectVolumeSnapshot(vol Volume, snapshotName string) error
 	if err != nil {
 		runError, ok := err.(shared.RunError)
 		if ok {
-			exitError, ok := runError.Err.(*exec.ExitError)
+			exitError, ok := runError.Unwrap().(*exec.ExitError)
 			if ok {
 				if exitError.ExitCode() == 22 {
 					// EBUSY (snapshot already unprotected).

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -273,7 +273,7 @@ func (d *common) moveGPTAltHeader(devPath string) error {
 
 	runErr, ok := err.(shared.RunError)
 	if ok {
-		exitError, ok := runErr.Err.(*exec.ExitError)
+		exitError, ok := runErr.Unwrap().(*exec.ExitError)
 		if ok {
 			// sgdisk manpage says exit status 3 means:
 			// "Non-GPT disk detected and no -g option, but operation requires a write action".

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -74,7 +74,7 @@ func (d *lvm) openLoopFile(source string) (string, error) {
 func (d *lvm) isLVMNotFoundExitError(err error) bool {
 	runErr, ok := err.(shared.RunError)
 	if ok {
-		exitError, ok := runErr.Err.(*exec.ExitError)
+		exitError, ok := runErr.Unwrap().(*exec.ExitError)
 		if ok {
 			if exitError.ExitCode() == 5 {
 				return true

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -346,9 +346,9 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 			if hdr.Name == srcFile {
 				// Extract the backup.
 				if v.ContentType() == ContentTypeBlock {
-					err = shared.RunCommandWithFds(tr, nil, "zfs", "receive", "-F", target)
+					err = shared.RunCommandWithFds(context.TODO(), tr, nil, "zfs", "receive", "-F", target)
 				} else {
-					err = shared.RunCommandWithFds(tr, nil, "zfs", "receive", "-x", "mountpoint", "-F", target)
+					err = shared.RunCommandWithFds(context.TODO(), tr, nil, "zfs", "receive", "-x", "mountpoint", "-F", target)
 				}
 
 				if err != nil {
@@ -2194,7 +2194,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 		d.logger.Debug("Generating optimized volume file", logger.Ctx{"sourcePath": path, "file": tmpFile.Name(), "name": fileName})
 
 		// Write the subvolume to the file.
-		err = shared.RunCommandWithFds(nil, tmpFile, "zfs", args...)
+		err = shared.RunCommandWithFds(context.TODO(), nil, tmpFile, "zfs", args...)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -529,7 +529,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64,
 				exitCodeFSModified := false
 				runErr, ok := err.(shared.RunError)
 				if ok {
-					exitError, ok := runErr.Err.(*exec.ExitError)
+					exitError, ok := runErr.Unwrap().(*exec.ExitError)
 					if ok {
 						if exitError.ExitCode() == 1 {
 							exitCodeFSModified = true

--- a/shared/util.go
+++ b/shared/util.go
@@ -915,8 +915,8 @@ func (e RunError) Error() string {
 // resulting stdout and stderr output as separate variables. If the supplied environment is nil then
 // the default environment is used. If the command fails to start or returns a non-zero exit code
 // then an error is returned containing the output of stderr too.
-func RunCommandSplit(env []string, filesInherit []*os.File, name string, arg ...string) (string, string, error) {
-	cmd := exec.Command(name, arg...)
+func RunCommandSplit(ctx context.Context, env []string, filesInherit []*os.File, name string, arg ...string) (string, string, error) {
+	cmd := exec.CommandContext(ctx, name, arg...)
 
 	if env != nil {
 		cmd.Env = env
@@ -949,7 +949,7 @@ func RunCommandSplit(env []string, filesInherit []*os.File, name string, arg ...
 // RunCommand runs a command with optional arguments and returns stdout. If the command fails to
 // start or returns a non-zero exit code then an error is returned containing the output of stderr.
 func RunCommand(name string, arg ...string) (string, error) {
-	stdout, _, err := RunCommandSplit(nil, nil, name, arg...)
+	stdout, _, err := RunCommandSplit(context.TODO(), nil, nil, name, arg...)
 	return stdout, err
 }
 
@@ -957,8 +957,8 @@ func RunCommand(name string, arg ...string) (string, error) {
 // of file descriptors to the newly created process, returning stdout. If the
 // command fails to start or returns a non-zero exit code then an error is
 // returned containing the output of stderr.
-func RunCommandInheritFds(filesInherit []*os.File, name string, arg ...string) (string, error) {
-	stdout, _, err := RunCommandSplit(nil, filesInherit, name, arg...)
+func RunCommandInheritFds(ctx context.Context, filesInherit []*os.File, name string, arg ...string) (string, error) {
+	stdout, _, err := RunCommandSplit(ctx, nil, filesInherit, name, arg...)
 	return stdout, err
 }
 
@@ -966,12 +966,13 @@ func RunCommandInheritFds(filesInherit []*os.File, name string, arg ...string) (
 // returns stdout. If the command fails to start or returns a non-zero exit code then an error is
 // returned containing the output of stderr.
 func RunCommandCLocale(name string, arg ...string) (string, error) {
-	stdout, _, err := RunCommandSplit(append(os.Environ(), "LANG=C.UTF-8"), nil, name, arg...)
+	stdout, _, err := RunCommandSplit(context.TODO(), append(os.Environ(), "LANG=C.UTF-8"), nil, name, arg...)
 	return stdout, err
 }
 
-func RunCommandWithFds(stdin io.Reader, stdout io.Writer, name string, arg ...string) error {
-	cmd := exec.Command(name, arg...)
+// RunCommandWithFds runs a command with supplied file descriptors.
+func RunCommandWithFds(ctx context.Context, stdin io.Reader, stdout io.Writer, name string, arg ...string) error {
+	cmd := exec.CommandContext(ctx, name, arg...)
 
 	if stdin != nil {
 		cmd.Stdin = stdin

--- a/shared/util.go
+++ b/shared/util.go
@@ -964,14 +964,7 @@ func RunCommandSplit(ctx context.Context, env []string, filesInherit []*os.File,
 
 	err := cmd.Run()
 	if err != nil {
-		err := RunError{
-			Msg:    fmt.Sprintf("Failed to run: %s %s: %s", name, strings.Join(arg, " "), strings.TrimSpace(stderr.String())),
-			Stdout: stdout.String(),
-			Stderr: stderr.String(),
-			Err:    err,
-		}
-
-		return stdout.String(), stderr.String(), err
+		return stdout.String(), stderr.String(), NewRunError(name, arg, err, &stdout, &stderr)
 	}
 
 	return stdout.String(), stderr.String(), nil
@@ -1026,13 +1019,7 @@ func RunCommandWithFds(ctx context.Context, stdin io.Reader, stdout io.Writer, n
 
 	err := cmd.Run()
 	if err != nil {
-		err := RunError{
-			Msg:    fmt.Sprintf("Failed to run: %s %s: %s", name, strings.Join(arg, " "), strings.TrimSpace(buffer.String())),
-			Stderr: buffer.String(),
-			Err:    err,
-		}
-
-		return err
+		return NewRunError(name, arg, err, nil, &buffer)
 	}
 
 	return nil

--- a/shared/util.go
+++ b/shared/util.go
@@ -946,8 +946,16 @@ func RunCommandSplit(ctx context.Context, env []string, filesInherit []*os.File,
 	return stdout.String(), stderr.String(), nil
 }
 
+// RunCommandContext runs a command with optional arguments and returns stdout. If the command fails to
+// start or returns a non-zero exit code then an error is returned containing the output of stderr.
+func RunCommandContext(ctx context.Context, name string, arg ...string) (string, error) {
+	stdout, _, err := RunCommandSplit(ctx, nil, nil, name, arg...)
+	return stdout, err
+}
+
 // RunCommand runs a command with optional arguments and returns stdout. If the command fails to
 // start or returns a non-zero exit code then an error is returned containing the output of stderr.
+// Deprecated: Use RunCommandContext.
 func RunCommand(name string, arg ...string) (string, error) {
 	stdout, _, err := RunCommandSplit(context.TODO(), nil, nil, name, arg...)
 	return stdout, err

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -5,6 +5,7 @@ package shared
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -666,16 +667,10 @@ func ExitStatus(err error) (int, error) {
 		return 0, err // No error exit status.
 	}
 
-	checkErr := err
+	var exitErr *exec.ExitError
 
-	// Detect and extract RunError to check the embedded error.
-	runErr, isRunError := checkErr.(RunError)
-	if isRunError {
-		checkErr = runErr.Err
-	}
-
-	exitErr, isExitError := checkErr.(*exec.ExitError)
-	if isExitError {
+	// Detect and extract ExitError to check the embedded exit status.
+	if errors.As(err, &exitErr) {
 		// If the process was signaled, extract the signal.
 		status, isWaitStatus := exitErr.Sys().(unix.WaitStatus)
 		if isWaitStatus && status.Signaled() {


### PR DESCRIPTION
- Adds `RunCommandContext` function to allow timeouts.
- Reworks `RunError` to use unexported fields and support the Go >=1.13 error unwrapping by adding an `Unwrap()` function.
- Makes the string message returned from `RunError.Error()` dynamically generated and include the underlying error message.
- Stores a pointer to the stdout and stderror `bytes.Buffer` rather than passing around (potentially) large strings, and makes these accessible via `RunError.StdOut()` and `RunError.StdErr()` function.
- Updates `ExitStatus` to take advantage of `RunError.Unwrap()` by using `errors.As()` (which now means it supports detecting `ExitError` in any wrapped error type not just `RunError`).

I needed this lot in order to run `radosgw-admin` commands with a sensible timeout, as unlike the `ceph` commands it doesn't support `--connect-timeout` flag.