### PR TITLE
Adds instance type to instance-created lifecycle event context.

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -309,7 +309,9 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 	if d.snapshot {
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotCreated.Event(d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, map[string]any{
+			"type": api.InstanceTypeContainer,
+		}))
 	}
 
 	cleanup := revert.Clone().Fail

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -285,7 +285,9 @@ func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert
 	if d.snapshot {
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotCreated.Event(d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, map[string]any{
+			"type": api.InstanceTypeVM,
+		}))
 	}
 
 	cleanup := revert.Clone().Fail


### PR DESCRIPTION
As discussed in https://github.com/canonical/lxd-cloud/issues/136#issuecomment-1209589892 for tracking instance types in upstream servers and listing associated filesystem storage volumes.