### PR TITLE
doc/migration: clean up "live migration" documentation

### DIFF
--- a/doc/migration.md
+++ b/doc/migration.md
@@ -1,46 +1,43 @@
-# Live Migration in LXD
+# How to migrate existing LXD instances between servers
 
-## Overview
-Migration has two pieces, a "source", that is, the host that already has the
-instance, and a "sink", the host that's getting the instance. Currently,
-in the `pull` mode, the source sets up an operation, and the sink connects
-to the source and pulls the instance.
+To move an instance from one LXD server to another, use the `lxc move` command:
 
-There are three WebSockets (channels) used in migration:
+    lxc move [<source_remote>:]<source_instance_name> <target_remote>:[<target_instance_name>]
 
-  1. the control stream
-  2. the CRIU images stream
-  3. the file-system stream
+```{note}
+When moving a container, you must stop it first.
+See {ref}`live-migration` for more information.
+```
 
-When a migration is initiated, information about the instance, its
-configuration, etc. are sent over the control channel (a full
-description of this process is below), the CRIU images and instance
-file system are synced over their respective channels, and the result of
-the restore operation is sent from the sink to the source over the
-control channel.
+You don't need to specify the source remote if it is your default remote, and you can leave out the target instance name if you want to use the same instance name.
+If you want to move the instance to a specific cluster member, specify it with the `--target` flag.
 
-In particular, the protocol that is spoken over the CRIU channel and file-system
-channel can vary, depending on what is negotiated over the control socket. For
-example, both the source and the sink's LXD directory is on Btrfs, the
-file-system socket can speak `btrfs-send/receive`. Additionally, although we do a
-"stop the world" type migration right now, support for the `p.haul` protocol in CRIU
-will happen over the CRIU socket at some later time.
+You can add the `--mode` flag to choose a transfer mode, depending on your network setup:
 
-## Control Socket
-Once all three WebSockets are connected between the two endpoints, the
-source sends a `MigrationHeader` (`protobuf` description found in
-`/lxd/migration/migrate.proto`). This header contains the instance
-configuration which will be added to the new instance.
+`pull` (default)
+: Instruct the target server to pull the respective instance.
 
-There are also two fields indicating the file system and CRIU protocol to speak.
-For example, if a server is hosted on a Btrfs file system, it can indicate that it
-wants to do a `btrfs send` instead of a simple `rsync` (similarly, it could
-indicate that it wants to speak the `p.haul` protocol, instead of just using `rsync`
-to transfer the images over slowly).
+`push`
+: Push the instance from the source server to the target server.
 
-The sink then examines this message and responds with whatever it
-supports. Continuing our example, if the sink is not on a Btrfs
-file system, it responds with the lowest common denominator (`rsync`, in
-this case), and the source is to send the root file system using `rsync`.
-Similarly with the CRIU connection; if the sink doesn't have support for
-the `p.haul` protocol (or whatever), we fall back to `rsync`.
+`relay`
+: Pull the instance from the source server to the local client, and then push it to the target server.
+
+If you need to adapt the configuration for the instance to run on the target server, you can either specify the new configuration directly (using `--config`, `--device`, `--storage` or `--target-project`) or through profiles (using `--no-profiles` or `--profile`). See `lxc move --help` for all available flags.
+
+(live-migration)=
+## Live migration
+
+Virtual machines can be moved to another server while they are running, thus without any downtime.
+
+For containers, there is limited support for live migration using [{abbr}`CRIU (Checkpoint/Restore in Userspace)`](https://criu.org/).
+However, because of extensive kernel dependencies, only very basic containers (non-`systemd` containers without a network device) can be migrated reliably.
+In most real-world scenarios, you should stop the container, move it over and then start it again.
+
+If you want to use live migration for containers, you must enable CRIU on both the source and the target server.
+If you are using the snap, use the following commands to enable CRIU:
+
+    snap set lxd criu.enable=true
+    systemctl reload snap.lxd.daemon
+
+Otherwise, make sure you have CRIU installed on both systems.


### PR DESCRIPTION
This doesn't really fit in the place where the docs currently
are, but the content should be a bit clearer than what we have.
The page will be moved into a migration section in a follow-up
PR.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>