### PR TITLE
Network: BGP peer holdtime option configuration

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1693,3 +1693,6 @@ This introduces a bidirectional `vsock` interface which allows the `lxd-agent` a
 
 ## `instance_ready_state`
 This introduces a new `Ready` state for instances which can be set using `devlxd`.
+
+## `network_bgp_holdtime`
+This introduces a new `bgp.peers.<name>.holdtime` configuration key to control the BGP hold time for a particular peer.

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -68,6 +68,7 @@ Set the following configuration options on the uplink network:
 - `bgp.peers.<name>.address` - the peer address to be used by the downstream networks
 - `bgp.peers.<name>.asn` - the {abbr}`ASN (Autonomous System Number)` for the local server
 - `bgp.peers.<name>.password` - an optional password for the peer session
+- `bgp.peers.<name>.holdtime` - an optional hold time for the peer session (in seconds)
 
 Once the uplink network is configured, downstream OVN networks will get their external subnets and addresses announced over BGP.
 The next-hop is set to the address of the OVN router on the uplink network.

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -54,6 +54,7 @@ Key                                  | Type      | Condition             | Defau
 `bgp.peers.NAME.address`             | string    | BGP server            | -                         | Peer address (IPv4 or IPv6)
 `bgp.peers.NAME.asn`                 | integer   | BGP server            | -                         | Peer AS number
 `bgp.peers.NAME.password`            | string    | BGP server            | - (no password)           | Peer session password (optional)
+`bgp.peers.NAME.holdtime`            | integer   | BGP server            | `180`                     | Peer session hold time (in seconds; optional)
 `bgp.ipv4.nexthop`                   | string    | BGP server            | local address             | Override the next-hop for advertised prefixes
 `bgp.ipv6.nexthop`                   | string    | BGP server            | local address             | Override the next-hop for advertised prefixes
 `bridge.driver`                      | string    | -                     | `native`                  | Bridge driver: `native` or `openvswitch`

--- a/doc/reference/network_physical.md
+++ b/doc/reference/network_physical.md
@@ -36,6 +36,7 @@ Key                             | Type      | Condition             | Default   
 `bgp.peers.NAME.address`        | string    | BGP server            | -                         | Peer address (IPv4 or IPv6) for use by `ovn` downstream networks
 `bgp.peers.NAME.asn`            | integer   | BGP server            | -                         | Peer AS number for use by `ovn` downstream networks
 `bgp.peers.NAME.password`       | string    | BGP server            | - (no password)           | Peer session password (optional) for use by `ovn` downstream networks
+`bgp.peers.NAME.holdtime`       | integer   | BGP server            | `180`                     | Peer session hold time (in seconds; optional)
 `dns.nameservers`               | string    | standard mode         | -                         | List of DNS server IPs on `physical` network
 `ipv4.gateway`                  | string    | standard mode         | -                         | IPv4 address for the gateway and network (CIDR)
 `ipv4.ovn.ranges`               | string    | -                     | -                         | Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)

--- a/lxd/bgp/debug.go
+++ b/lxd/bgp/debug.go
@@ -28,6 +28,7 @@ type DebugInfoPeer struct {
 	ASN      uint32 `json:"asn" yaml:"asn"`
 	Password string `json:"password" yaml:"password"`
 	Count    int    `json:"count" yaml:"count"`
+	HoldTime uint64 `json:"holdtime" yaml:"holdtime"`
 }
 
 // Debug returns a dump of the current configuration.
@@ -56,6 +57,7 @@ func (s *Server) debug() DebugInfo {
 		entry.ASN = peer.asn
 		entry.Password = peer.password
 		entry.Count = peer.count
+		entry.HoldTime = peer.holdtime
 
 		debug.Peers = append(debug.Peers, entry)
 	}

--- a/lxd/bgp/server.go
+++ b/lxd/bgp/server.go
@@ -436,13 +436,15 @@ func (s *Server) addPeer(address net.IP, asn uint32, password string, holdTime u
 			Enabled:     true,
 			MultihopTtl: 255,
 		},
+	}
 
-		// Configure peer holdtime.
-		Timers: &bgpAPI.Timers{
+	// Add hold time if configured.
+	if holdTime > 0 {
+		n.Timers = &bgpAPI.Timers{
 			Config: &bgpAPI.TimersConfig{
 				HoldTime: holdTime,
 			},
-		},
+		}
 	}
 
 	// Setup peer for dual-stack.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -651,9 +651,12 @@ func (n *common) bgpSetupPeers(oldConfig map[string]string) error {
 			return err
 		}
 
-		holdTime, err := strconv.ParseUint(fields[3], 10, 32)
-		if err != nil {
-			return err
+		var holdTime uint64
+		if fields[3] != "" {
+			holdTime, err = strconv.ParseUint(fields[3], 10, 32)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = n.state.BGP.AddPeer(net.ParseIP(fields[0]), uint32(asn), fields[2], holdTime)
@@ -757,11 +760,6 @@ func (n *common) bgpGetPeers(config map[string]string) []string {
 		peerASN := config[fmt.Sprintf("bgp.peers.%s.asn", peerName)]
 		peerPassword := config[fmt.Sprintf("bgp.peers.%s.password", peerName)]
 		peerHoldTime := config[fmt.Sprintf("bgp.peers.%s.holdtime", peerName)]
-
-		// If hold time not found in configuration use default value.
-		if peerHoldTime == "" {
-			peerHoldTime = "180"
-		}
 
 		if peerAddress != "" && peerASN != "" && peerHoldTime != "" {
 			peers = append(peers, fmt.Sprintf("%s,%s,%s,%s", peerAddress, peerASN, peerPassword, peerHoldTime))

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -339,6 +339,7 @@ var APIExtensions = []string{
 	"network_load_balancer",
 	"vsock_api",
 	"instance_ready_state",
+	"network_bgp_holdtime",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Hi,
BGP peer holdtime option configuration with proper documentation
Mine need to have ability to set peer's holdtime on lxd side.
I've already created additional optional configuration node and change complementary code with documentation.
This leads to adding new peer configuration `lxc network set lxdbr0 bgp.peers.foo.holdtime=1`
Сonsider including this option please.
