### PR TITLE
Storage: Improve and simplify `/1.0/storage-pools/<pool>/volumes` endpoint

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -912,7 +912,9 @@ func (c *ClusterTx) GetInstanceSnapshotsWithName(ctx context.Context, project st
 		return nil, err
 	}
 
-	sort.Slice(snapshots, func(i, j int) bool { return snapshots[i].CreationDate.Before(snapshots[j].CreationDate) })
+	sort.SliceStable(snapshots, func(i, j int) bool {
+		return snapshots[i].CreationDate.Before(snapshots[j].CreationDate)
+	})
 
 	instances := make([]cluster.Instance, len(snapshots))
 	for i, snapshot := range snapshots {

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -788,10 +788,6 @@ func (c *ClusterTx) GetStorageVolumeNodes(poolID int64, projectName string, volu
 		return nil, err
 	}
 
-	if len(nodes) == 0 {
-		return nil, api.StatusErrorf(http.StatusNotFound, "Storage pool volume not found")
-	}
-
 	for _, node := range nodes {
 		// Volume is defined without a cluster member.
 		if node.ID == 0 {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -286,7 +286,7 @@ func (d *common) Snapshots() ([]instance.Instance, error) {
 		snapshots = append(snapshots, instance.Instance(snapInst))
 	}
 
-	sort.Slice(snapshots, func(i, j int) bool {
+	sort.SliceStable(snapshots, func(i, j int) bool {
 		return snapshots[i].CreationDate().Before(snapshots[j].CreationDate())
 	})
 

--- a/lxd/instance/drivers/driver_qemu_config_override.go
+++ b/lxd/instance/drivers/driver_qemu_config_override.go
@@ -26,7 +26,7 @@ func sortedConfigKeys(cfgMap configMap) []rawConfigKey {
 		rv = append(rv, k)
 	}
 
-	sort.Slice(rv, func(i, j int) bool {
+	sort.SliceStable(rv, func(i, j int) bool {
 		return rv[i].sectionName < rv[j].sectionName ||
 			rv[i].index < rv[j].index ||
 			rv[i].entryKey < rv[j].entryKey
@@ -227,7 +227,7 @@ func appendSections(newCfg []cfgSection, cfgMap configMap) []cfgSection {
 	}
 
 	// Sort to have deterministic output in the appended sections
-	sort.Slice(rawSections, func(i, j int) bool {
+	sort.SliceStable(rawSections, func(i, j int) bool {
 		return rawSections[i].sectionName < rawSections[j].sectionName ||
 			rawSections[i].index < rawSections[j].index
 	})

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -511,9 +511,10 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 
 	if recursion == 1 {
 		// Sort the result list by name.
-		sort.Slice(resultList, func(i, j int) bool {
+		sort.SliceStable(resultList, func(i, j int) bool {
 			return resultList[i].Name < resultList[j].Name
 		})
+
 		if clauses != nil {
 			resultList = instance.Filter(resultList, clauses)
 		}
@@ -522,7 +523,7 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 	}
 
 	// Sort the result list by name.
-	sort.Slice(resultFullList, func(i, j int) bool {
+	sort.SliceStable(resultFullList, func(i, j int) bool {
 		return resultFullList[i].Name < resultFullList[j].Name
 	})
 

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -65,10 +65,17 @@ func StorageVolumeParts(projectStorageVolumeName string) (string, string) {
 }
 
 // StorageVolumeProject returns the project name to use to for the volume based on the requested project.
+// For image volume types the default project is always returned.
 // For custom volume type, if the project specified has the "features.storage.volumes" flag enabled then the
-// project name is returned, otherwise the default project name is returned. For all other volume types the
-// supplied project name is returned.
+// project name is returned, otherwise the default project name is returned.
+// For all other volume types the supplied project name is returned.
 func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (string, error) {
+	// Image volumes are effectively a cache and so are always linked to default project.
+	// Optimisation to avoid loading project record.
+	if volumeType == db.StoragePoolVolumeTypeImage {
+		return Default, nil
+	}
+
 	// Non-custom volumes always use the project specified. Optimisation to avoid loading project record.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
 		return projectName, nil
@@ -93,10 +100,16 @@ func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (st
 }
 
 // StorageVolumeProjectFromRecord returns the project name to use to for the volume based on the supplied project.
+// For image volume types the default project is always returned.
 // For custom volume type, if the project supplied has the "features.storage.volumes" flag enabled then the
-// project name is returned, otherwise the default project name is returned. For all other volume types the
-// supplied project's name is returned.
+// project name is returned, otherwise the default project name is returned.
+// For all other volume types the supplied project's name is returned.
 func StorageVolumeProjectFromRecord(p *api.Project, volumeType int) string {
+	// Image volumes are effectively a cache and so are always linked to default project.
+	if volumeType == db.StoragePoolVolumeTypeImage {
+		return Default
+	}
+
 	// Non-custom volumes always use the project specified.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
 		return p.Name

--- a/lxd/resources/cpu.go
+++ b/lxd/resources/cpu.go
@@ -458,11 +458,11 @@ func GetCPU() (*api.ResourcesCPU, error) {
 			socket.Frequency = coreFrequency / coreFrequencyCount
 		}
 
-		sort.Slice(socket.Cores, func(i int, j int) bool { return socket.Cores[i].Core < socket.Cores[j].Core })
+		sort.SliceStable(socket.Cores, func(i int, j int) bool { return socket.Cores[i].Core < socket.Cores[j].Core })
 		cpu.Sockets = append(cpu.Sockets, *socket)
 	}
 
-	sort.Slice(cpu.Sockets, func(i int, j int) bool { return cpu.Sockets[i].Socket < cpu.Sockets[j].Socket })
+	sort.SliceStable(cpu.Sockets, func(i int, j int) bool { return cpu.Sockets[i].Socket < cpu.Sockets[j].Socket })
 
 	// Set the architecture name
 	uname := unix.Utsname{}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1323,7 +1323,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	projectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
+	projectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectParam(r), volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/lxc/lxd/lxd/archive"
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/operationtype"
 	"github.com/lxc/lxd/lxd/filter"
 	"github.com/lxc/lxd/lxd/instance"
@@ -203,33 +205,41 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Get all instance volumes currently attached to the storage pool by ID of the pool and project.
-	volumes, err := d.db.Cluster.GetStoragePoolVolumes(projectName, poolID, supportedVolumeTypesInstances)
-	if err != nil && !response.IsNotFoundError(err) {
-		return response.SmartError(err)
-	}
+	var projectsVolumes map[string]map[int64]*api.StorageVolume
 
-	// The project name used for custom volumes varies based on whether the project has the
-	// featues.storage.volumes feature enabled.
-	customVolProjectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectName, db.StoragePoolVolumeTypeCustom)
+	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return err
+		}
+
+		p, err := dbProject.ToAPI(ctx, tx.Tx())
+		if err != nil {
+			return err
+		}
+
+		volTypesProjects := make(map[int]string)
+		for _, instanceType := range supportedVolumeTypesInstances {
+			volTypesProjects[instanceType] = projectName
+		}
+
+		// The project name used for custom volumes varies based on whether the project has the
+		// featues.storage.volumes feature enabled.
+		customVolProjectName := project.StorageVolumeProjectFromRecord(p, db.StoragePoolVolumeTypeCustom)
+		volTypesProjects[db.StoragePoolVolumeTypeCustom] = customVolProjectName
+
+		// Image volumes are effectively a cache and so are always linked to default project.
+		// We filter the ones relevant to requested project below.
+		volTypesProjects[db.StoragePoolVolumeTypeImage] = project.Default
+
+		projectsVolumes, err = tx.GetStoragePoolVolumes(poolID, volTypesProjects)
+		if err != nil {
+			return fmt.Errorf("Failed loading volumes: %w", err)
+		}
+
+		return err
+	})
 	if err != nil {
-		return response.SmartError(err)
-	}
-
-	// Get all custom volumes currently attached to the storage pool by ID of the pool and project.
-	custVolumes, err := d.db.Cluster.GetStoragePoolVolumes(customVolProjectName, poolID, []int{db.StoragePoolVolumeTypeCustom})
-	if err != nil && !response.IsNotFoundError(err) {
-		return response.SmartError(err)
-	}
-
-	volumes = append(volumes, custVolumes...)
-
-	// We exclude volumes of type image, since those are special: they are stored using the storage_volumes
-	// table, but are effectively a cache which is not tied to projects, so we always link the to the default
-	// project. This means that we want to filter image volumes and return only the ones that have fingerprint
-	// matching images actually in use by the project.
-	imageVolumes, err := d.db.Cluster.GetStoragePoolVolumes(project.Default, poolID, []int{db.StoragePoolVolumeTypeImage})
-	if err != nil && !response.IsNotFoundError(err) {
 		return response.SmartError(err)
 	}
 
@@ -238,51 +248,49 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	for _, volume := range imageVolumes {
-		if shared.StringInSlice(volume.Name, projectImages) {
+	var volumes []*api.StorageVolume
+
+	for _, projectVolumes := range projectsVolumes {
+		for _, volume := range projectVolumes {
+			// Filter out image volumes that are not used by this project.
+			if volume.Type == db.StoragePoolVolumeTypeNameImage && !shared.StringInSlice(volume.Name, projectImages) {
+				continue
+			}
+
 			volumes = append(volumes, volume)
 		}
 	}
 
+	// Sort by type then volume name.
+	sort.SliceStable(volumes, func(i, j int) bool {
+		volA := volumes[i]
+		volB := volumes[j]
+
+		if volA.Type != volB.Type {
+			return volumes[i].Type < volumes[j].Type
+		}
+
+		return volA.Name < volB.Name
+	})
+
 	volumes = filterVolumes(volumes, clauses)
 
-	resultString := []string{}
-	for _, volume := range volumes {
+	var urls []string
+	for _, vol := range volumes {
 		if !recursion {
-			volName, snapName, ok := shared.InstanceGetParentAndSnapshotName(volume.Name)
-			if ok {
-				if projectName == project.Default {
-					resultString = append(resultString,
-						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s/snapshots/%s",
-							version.APIVersion, poolName, volume.Type, volName, snapName))
-				} else {
-					resultString = append(resultString,
-						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s/snapshots/%s?project=%s",
-							version.APIVersion, poolName, volume.Type, volName, snapName, projectName))
-				}
-			} else {
-				if projectName == project.Default {
-					resultString = append(resultString,
-						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s",
-							version.APIVersion, poolName, volume.Type, volume.Name))
-				} else {
-					resultString = append(resultString,
-						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s?project=%s",
-							version.APIVersion, poolName, volume.Type, volume.Name, projectName))
-				}
-			}
+			urls = append(urls, vol.URL(version.APIVersion, poolName, projectName).String())
 		} else {
-			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, volume)
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, vol)
 			if err != nil {
 				return response.InternalError(err)
 			}
 
-			volume.UsedBy = project.FilterUsedBy(r, volumeUsedBy)
+			vol.UsedBy = project.FilterUsedBy(r, volumeUsedBy)
 		}
 	}
 
 	if !recursion {
-		return response.SyncResponse(true, resultString)
+		return response.SyncResponse(true, urls)
 	}
 
 	return response.SyncResponse(true, volumes)

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -1,8 +1,19 @@
 package api
 
 import (
+	"strings"
 	"time"
 )
+
+// GetParentAndSnapshotName returns the parent name, snapshot name, and whether it actually was a snapshot name.
+func GetParentAndSnapshotName(name string) (string, string, bool) {
+	fields := strings.SplitN(name, "/", 2)
+	if len(fields) == 1 {
+		return name, "", false
+	}
+
+	return fields[0], fields[1], true
+}
 
 // InstanceType represents the type if instance being returned or requested via the API.
 type InstanceType string

--- a/shared/api/storage_pool_volume.go
+++ b/shared/api/storage_pool_volume.go
@@ -120,6 +120,17 @@ type StorageVolume struct {
 	ContentType string `json:"content_type" yaml:"content_type"`
 }
 
+// URL returns the URL for the volume.
+func (v *StorageVolume) URL(apiVersion string, poolName string, projectName string) *URL {
+	u := NewURL()
+	volName, snapName, isSnap := GetParentAndSnapshotName(v.Name)
+	if isSnap {
+		return u.Path(apiVersion, "storage-pools", poolName, "volumes", v.Type, volName, "snapshots", snapName).Project(projectName)
+	}
+
+	return u.Path(apiVersion, "storage-pools", poolName, "volumes", v.Type, volName).Project(projectName)
+}
+
 // StorageVolumePut represents the modifiable fields of a LXD storage volume
 //
 // swagger:model


### PR DESCRIPTION
- Makes `/1.0/storage-pools/<pool>/volumes` generate far fewer queries than before - it still loads volume config (even when doing a non-recursive request), but it is much more efficient than before. Previously it was performing a query per-volume-type to get volume names, and then for each volume name loading the volume info (which just for a single volume was doing multiple queries to get ID, description, node and config!).
- Lays the ground work for supporting `all-projects` argument (see https://github.com/lxc/lxd/issues/10753).
- I considered using the DB generator for this, but the query was complicated enough that I couldn't justify it.
- Fixes `/1.0/storage-pools/<pool>/volumes/<volType>/<volName>` effective storage project logic (as previously hard-coded to custom volume type).
- Fixes `StorageVolumeProjectFromRecord()` to always return default project for image storage volumes so that the correct storage project is used when retrieving the volume info.