### PR TITLE
doc: use HTTPS for links to CRIU site and inotify man

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -13,7 +13,7 @@ They are implemented through the use of `liblxc` (LXC).
 See [instance configuration](instances.md) for valid configuration options.
 
 ## Live migration
-LXD supports live migration of containers using [CRIU](http://criu.org). In
+LXD supports live migration of containers using [CRIU](https://criu.org). In
 order to optimize the memory transfer for a container LXD can be instructed to
 make use of the pre-copy features in CRIU by setting the
 `migration.incremental.memory` property to `true`. This means LXD will request

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -54,7 +54,7 @@ Parameter                           | Value      | Default   | Description
 Then, reboot the server.
 
 
-[1]: http://man7.org/linux/man-pages/man7/inotify.7.html
+[1]: https://man7.org/linux/man-pages/man7/inotify.7.html
 [2]: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
 
 ### Prevent container name leakage


### PR DESCRIPTION
Both pages redirect http to https and the CRIU site also has
HSTS with preload.