### PR TITLE
grafana: Only use instant queries on piechart graphs

### DIFF
--- a/grafana/LXD.json
+++ b/grafana/LXD.json
@@ -376,6 +376,7 @@
           "exemplar": true,
           "expr": "sum(lxd_filesystem_size_bytes{job=\"$job\",project=\"$project\",mountpoint=\"/\"} - lxd_filesystem_avail_bytes) - \nsum(topk(${top}, lxd_filesystem_size_bytes{job=\"$job\",project=\"$project\",mountpoint=\"/\"} - lxd_filesystem_avail_bytes))",
           "hide": false,
+          "instant": true,
           "interval": "",
           "legendFormat": "Others",
           "refId": "B"


### PR DESCRIPTION
Since we only care about the current topk() metrics to display
the piecharts, there is no point in calculating with old data.