### PR TITLE
Database: Adds remote storage aware unique index to `storage_volumes`

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -562,6 +562,7 @@ CREATE TABLE "storage_volumes_snapshots_config" (
     FOREIGN KEY (storage_volume_snapshot_id) REFERENCES "storage_volumes_snapshots" (id) ON DELETE CASCADE,
     UNIQUE (storage_volume_snapshot_id, key)
 );
+CREATE UNIQUE INDEX storage_volumes_unique_storage_pool_id_node_id_project_id_name_type ON "storage_volumes" (storage_pool_id, IFNULL(node_id, -1), project_id, name, type);
 CREATE TABLE "warnings" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	node_id INTEGER,
@@ -582,5 +583,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (62, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (63, strftime("%s"))
 `


### PR DESCRIPTION
- I noticed whilst working on the object storage feature that the current `storage_volumes` table's unique index was not guarding against duplicate volumes when using remote storage pools (where the `node_id` field is set to NULL). This is because NULL fields are not considered as part of unique indexes normally. Duplicate volumes should still be impossible due to LXD checking whether an existing volume exists before attempting a `INSERT`, however for consistency with the forthcoming `storage_buckets` table, and to be extra cautious (as doing SELECT then INSERT could be racy) this PR adds an extra unique index that handles NULL `node_id` fields. We have previously added a similar fix for `storage_pools_config`: `CREATE UNIQUE INDEX storage_pools_unique_storage_pool_id_node_id_key ON storage_pools_config (storage_pool_id, IFNULL(node_id, -1), key);
`.
- Additionally, following on from https://github.com/lxc/lxd/pull/10780, this patch also ensures that the `default` project has `features.networks` set to `true`. This is to cover anyone who did a fresh install of LXD 5.4 before the snap got the fix and so has a `default` project without the `features.networks` setting.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>