### PR TITLE
Network: Lower case OVN DNS names

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1157,7 +1157,7 @@ func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPo
 	}
 
 	cmdArgs := []string{
-		fmt.Sprintf(`records={"%s"="%s"}`, dnsName, strings.Join(dnsIPs, " ")),
+		fmt.Sprintf(`records={"%s"="%s"}`, strings.ToLower(dnsName), strings.Join(dnsIPs, " ")),
 		fmt.Sprintf("external_ids:%s=%s", ovnExtIDLXDSwitch, switchName),
 		fmt.Sprintf("external_ids:%s=%s", ovnExtIDLXDSwitchPort, portName),
 	}


### PR DESCRIPTION
Otherwise if the instance name includes upper case characters it won't be resolvable.

Reported from https://discuss.linuxcontainers.org/t/temporary-failure-in-name-resolution-when-pinging-container-with-uppercase-name/14813

Without that `nslookup C1.lxd` fails, whereas once its stored in OVN as lower case `nslookup C1.lxd` succeeds.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>