### PR TITLE
Doc: Separate storage howtos to cover pool and volumes separately

### DIFF
--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -52,7 +52,7 @@ The loop files reside in `/var/snap/lxd/common/lxd/disks/` if you are using the 
 
 Loop files usually cannot be shrunk.
 They will grow up to the configured limit, but deleting instances or images will not cause the file to shrink.
-You can increase their size though; see {ref}`storage-resize-grow-pool`.
+You can increase their size though; see {ref}`storage-resize-pool`.
 
 #### Remote storage
 The `ceph` and `cephfs` drivers store the data in a completely independent Ceph storage cluster that must be set up separately.

--- a/doc/howto/storage_backup_volume.md
+++ b/doc/howto/storage_backup_volume.md
@@ -65,7 +65,7 @@ To delete a snapshot, use the following command:
 ### Schedule snapshots of a custom storage volume
 
 You can configure a custom storage volume to automatically create snapshots at specific times.
-To do so, set the `snapshots.schedule` configuration option for the storage volume (see {ref}`storage-configure-volumes`).
+To do so, set the `snapshots.schedule` configuration option for the storage volume (see {ref}`storage-configure-volume`).
 
 For example, to configure daily snapshots, use the following command:
 

--- a/doc/howto/storage_backup_volume.md
+++ b/doc/howto/storage_backup_volume.md
@@ -4,7 +4,7 @@ There are different ways of backing up your custom storage volumes:
 
 - {ref}`storage-backup-snapshots`
 - {ref}`storage-backup-export`
-- {ref}`storage-copy`
+- {ref}`storage-copy-volume`
 
 Which method to choose depends both on your use case and on the storage driver you use.
 

--- a/doc/howto/storage_configure_pool.md
+++ b/doc/howto/storage_configure_pool.md
@@ -1,0 +1,18 @@
+# How to configure storage pool settings
+
+See the {ref}`storage-drivers` documentation for the available configuration options for each storage driver.
+
+General keys for a storage pool (like `source`) are top-level.
+Driver-specific keys are namespaced by the driver name.
+
+Use the following command to set configuration options for a storage pool:
+
+    lxc storage set <pool_name> <key> <value>
+
+For example, to turn off compression during storage pool migration for a `dir` storage pool, use the following command:
+
+    lxc storage set my-dir-pool rsync.compression false
+
+You can also edit the storage pool configuration by using the following command:
+
+    lxc storage edit <pool_name>

--- a/doc/howto/storage_configure_volume.md
+++ b/doc/howto/storage_configure_volume.md
@@ -1,26 +1,7 @@
-# How to configure storage settings
+(storage-configure-volume)=
+# How to configure storage volume settings
 
 See the {ref}`storage-drivers` documentation for the available configuration options for each storage driver.
-
-General keys for a storage pool (like `source`) are top-level.
-Driver-specific keys are namespaced by the driver name.
-
-## Configure storage pools
-
-Use the following command to set configuration options for a storage pool:
-
-    lxc storage set <pool_name> <key> <value>
-
-For example, to turn off compression during storage pool migration for a `dir` storage pool, use the following command:
-
-    lxc storage set my-dir-pool rsync.compression false
-
-You can also edit the storage pool configuration by using the following command:
-
-    lxc storage edit <pool_name>
-
-(storage-configure-volumes)=
-## Configure storage volumes
 
 Use the following command to set configuration options for a storage volume:
 

--- a/doc/howto/storage_create_instance.md
+++ b/doc/howto/storage_create_instance.md
@@ -10,7 +10,7 @@ For example:
 
     lxc launch <image> <instance_name> --storage <storage_pool>
 
-% Include content from [storage_move.md](storage_move.md)
-```{include} storage_move.md
+% Include content from [storage_move_volume.md](storage_move_volume.md)
+```{include} storage_move_volume.md
     :start-after: (storage-move-instance)=
 ```

--- a/doc/howto/storage_create_volume.md
+++ b/doc/howto/storage_create_volume.md
@@ -1,5 +1,4 @@
-(storage-add-volume)=
-# How to add a custom storage volume
+# How to create a custom storage volume
 
 When you create an instance, LXD automatically creates a storage volume that is used as the root disk for the instance.
 

--- a/doc/howto/storage_move_volume.md
+++ b/doc/howto/storage_move_volume.md
@@ -4,13 +4,13 @@ discourse: 10877
 
 # How to move or copy storage volumes
 
-You can {ref}`copy <storage-copy>` or {ref}`move <storage-move>` custom storage volumes from one storage pool to another, or copy or rename them within the same storage pool.
+You can {ref}`copy <storage-copy-volume>` or {ref}`move <storage-move-volume>` custom storage volumes from one storage pool to another, or copy or rename them within the same storage pool.
 
 To move instance storage volumes from one storage pool to another, {ref}`move the corresponding instance <storage-move-instance>` to another pool.
 
 When copying or moving a volume between storage pools that use different drivers, the volume is automatically converted.
 
-(storage-copy)=
+(storage-copy-volume)=
 ## Copy custom storage volumes
 
 Use the following command to copy a custom storage volume:
@@ -25,7 +25,7 @@ You must specify different volume names for source and target in this case.
 
 When copying from one storage pool to another, you can either use the same name for both volumes or rename the new volume.
 
-(storage-move)=
+(storage-move-volume)=
 ## Move or rename custom storage volumes
 
 Before you can move or rename a custom storage volume, all instances that use it must be [stopped](https://linuxcontainers.org/lxd/getting-started-cli/#start-and-stop-an-instance).

--- a/doc/howto/storage_resize_pool.md
+++ b/doc/howto/storage_resize_pool.md
@@ -2,13 +2,10 @@
 discourse: 1333
 ---
 
-# How to resize storage
+(storage-resize-pool)=
+# How to resize a storage pool
 
-If you need more storage, you can increase the size of your storage pool or your storage volume.
-In some cases, it is also possible to reduce the size of a storage volume.
-
-(storage-resize-grow-pool)=
-## Grow a storage pool
+If you need more storage, you can increase the size of your storage pool.
 
 To increase the size of a storage pool, follow these general steps:
 
@@ -94,17 +91,3 @@ Replace the following variables:
 ```
 
 ````
-
-## Resize a storage volume
-
-To resize a storage volume, set its size configuration:
-
-    lxc storage volume set <pool_name> <volume_name> size <new_size>
-
-```{important}
-- Growing a storage volume usually works (if the storage pool has sufficient storage).
-- Shrinking a storage volume is only possible for storage volumes with content type `filesystem`.
-  It is not guaranteed to work though, because you cannot shrink storage below its current used size.
-- Shrinking a storage volume with content type `block` is not possible.
-
-```

--- a/doc/howto/storage_resize_volume.md
+++ b/doc/howto/storage_resize_volume.md
@@ -1,0 +1,16 @@
+# How to resize a storage volume
+
+If you need more storage in a volume, you can increase the size of your storage volume.
+In some cases, it is also possible to reduce the size of a storage volume.
+
+To resize a storage volume, set its size configuration:
+
+    lxc storage volume set <pool_name> <volume_name> size <new_size>
+
+```{important}
+- Growing a storage volume usually works (if the storage pool has sufficient storage).
+- Shrinking a storage volume is only possible for storage volumes with content type `filesystem`.
+  It is not guaranteed to work though, because you cannot shrink storage below its current used size.
+- Shrinking a storage volume with content type `block` is not possible.
+
+```

--- a/doc/howto/storage_view_pools.md
+++ b/doc/howto/storage_view_pools.md
@@ -1,0 +1,13 @@
+# How to view storage pools
+
+You can display a list of all available storage pools and check their configuration.
+
+Use the following command to list all available storage pools:
+
+    lxc storage list
+
+The resulting table contains the storage pool that you created during initialization (usually called `default` or `local`) and any storage pools that you added.
+
+To show detailed information about a specific pool, use the following command:
+
+    lxc storage show <pool_name>

--- a/doc/howto/storage_view_volumes.md
+++ b/doc/howto/storage_view_volumes.md
@@ -1,20 +1,6 @@
-# How to list storage pools and volumes
+# How to view storage volumes
 
-You can display a list of all available storage pools and the volumes in these pools and check their configuration.
-
-## Show storage pool information
-
-Use the following command to list all available storage pools:
-
-    lxc storage list
-
-The resulting table contains the storage pool that you created during initialization (usually called `default` or `local`) and any storage pools that you added.
-
-To show detailed information about a specific pool, use the following command:
-
-    lxc storage show <pool_name>
-
-## Show storage volume information
+You can display a list of all available storage volumes in a storage pool and check their configuration.
 
 To list all available storage volumes in a storage pool, use the following command:
 

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -8,13 +8,16 @@ discourse: 7735
 :maxdepth: 1
 
 About storage </explanation/storage>
-Create a storage pool <howto/storage_create_pool>
+Create a pool <howto/storage_create_pool>
+Configure a pool <howto/storage_configure_pool>
+View pools <howto/storage_view_pools>
+Resize a pool <howto/storage_resize_pool>
 Create an instance in a pool <howto/storage_create_instance>
-Add a storage volume <howto/storage_add_volume>
-Configure storage settings <howto/storage_configure>
-List pools and volumes <howto/storage_list>
-Move or copy volumes <howto/storage_move>
-Back up storage volumes <howto/storage_backup>
-Resize storage <howto/storage_resize>
+Create a volume <howto/storage_create_volume>
+Configure a volume <howto/storage_configure_volume>
+View volumes <howto/storage_view_volumes>
+Resize a volume <howto/storage_resize_volume>
+Move or copy a volume <howto/storage_move_volume>
+Back up a volume <howto/storage_backup_volume>
 reference/storage_drivers
 ```


### PR DESCRIPTION
As well as better SEO in the resulting URLs, this makes way for allowing storage bucket howtos whilst keeping the howto structure consistent and not merging multiple concepts into a single howto.