### PR TITLE
doc/storage/ceph: remove YouTube link from content that is reused

### DIFF
--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -1,11 +1,10 @@
 (storage-ceph)=
 # Ceph RBD - `ceph`
 
-<!-- Include start Ceph intro -->
-
 ```{youtube} https://youtube.com/watch?v=kVLGbvRU98A
 ```
 
+<!-- Include start Ceph intro -->
 [Ceph](https://ceph.io/) is an open-source storage platform that stores its data in a storage cluster based on {abbr}`RADOS (Reliable Autonomic Distributed Object Store)`.
 It is highly scalable and, as a distributed system without a single point of failure, very reliable.
 

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -1,6 +1,9 @@
 (storage-cephfs)=
 # CephFS - `cephfs`
 
+```{youtube} https://youtube.com/watch?v=kVLGbvRU98A
+```
+
 % Include content from [storage_ceph.md](storage_ceph.md)
 ```{include} storage_ceph.md
     :start-after: <!-- Include start Ceph intro -->


### PR DESCRIPTION
I cannot include the other commit (https://github.com/tomponline/lxd/pull/5/commits/e8821a455ed63114e040f3ee1b5ab4e99c999fd8) here since the file isn't on master yet.