### PR TITLE
lxd-generate: Allow GetOne filter to include a 'type' field.

### DIFF
--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -539,7 +539,12 @@ func (m *Method) getOne(buf *file.Buffer) error {
 
 	buf.L("filter := %s{}", entityFilter(m.entity))
 	for _, field := range nk {
-		buf.L("filter.%s = &%s", field.Name, lex.Minuscule(field.Name))
+		name := lex.Minuscule(field.Name)
+		if name == "type" {
+			name = lex.Minuscule(m.entity) + field.Name
+		}
+
+		buf.L("filter.%s = &%s", field.Name, name)
 	}
 
 	buf.N()


### PR DESCRIPTION
We discovered in https://github.com/canonical/lxd-cloud/pull/151 that when a `Type` field is tagged as a primary key, generation fails with `Error: Can't format generated source code: 7:16: expected operand, found 'type' (and 1 more errors)`. See https://github.com/canonical/lxd-cloud/pull/151#discussion_r947782558.

This occurred because generation of the filter in the `GetOne` method was lowercasing all of the filter fields. This fix applies the same transformation as in the [mapping field args](https://github.com/lxc/lxd/blob/a7563fac60d1588948766ada061607b9571dee2c/lxd/db/generate/db/mapping.go#L188-L191) so that the `Type` field in the filter is set to the value of the `{entity}Type` argument.

