### PR TITLE
Network: Fixes impossibility to set MTU for a pair of veths connecting OVN uplink and ovs-system bridges

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1219,17 +1219,24 @@ func (n *ovn) startUplinkPortBridgeNative(uplinkNet Network, bridgeDevice string
 
 	// Ensure that the veth interfaces inherit the uplink bridge's MTU (which the OVS bridge also inherits).
 	uplinkNetConfig := uplinkNet.Config()
-	if uplinkNetConfig["bridge.mtu"] != "" {
+
+	// Uplink may have type "bridge" or "physical"
+	uplinkNetMTU, hasBridgeMTU := uplinkNetConfig["bridge.mtu"]
+	if !hasBridgeMTU {
+		uplinkNetMTU = uplinkNetConfig["mtu"]
+	}
+
+	if uplinkNetMTU != "" {
 		uplinkEndLink := &ip.Link{Name: vars.uplinkEnd}
-		err := uplinkEndLink.SetMTU(uplinkNetConfig["bridge.mtu"])
+		err := uplinkEndLink.SetMTU(uplinkNetMTU)
 		if err != nil {
-			return fmt.Errorf("Failed setting MTU %q on %q: %w", uplinkNetConfig["bridge.mtu"], uplinkEndLink.Name, err)
+			return fmt.Errorf("Failed setting MTU %q on %q: %w", uplinkNetMTU, uplinkEndLink.Name, err)
 		}
 
 		ovsEndLink := &ip.Link{Name: vars.ovsEnd}
-		err = ovsEndLink.SetMTU(uplinkNetConfig["bridge.mtu"])
+		err = ovsEndLink.SetMTU(uplinkNetMTU)
 		if err != nil {
-			return fmt.Errorf("Failed setting MTU %q on %q: %w", uplinkNetConfig["bridge.mtu"], ovsEndLink.Name, err)
+			return fmt.Errorf("Failed setting MTU %q on %q: %w", uplinkNetMTU, ovsEndLink.Name, err)
 		}
 	}
 


### PR DESCRIPTION
If an existing Linux native bridge is used as an uplink for OVN, the (managed) uplink interface type is "physical". So it hasn't "bridge.mtu" option, only "mtu" one. But only "bridge.mtu" option of uplink interface is honored by the "startUplinkPortBridgeNative" function. Because of this, the interfaces of the veths pair connecting the uplink and the ovs-system bridges always gets MTU value 1500. When such interface is added to the uplink bridge, the MTU of the uplink bridge is automatically reduced to 1500 even if the physical interface has a higher MTU.