### PR TITLE
api: metrics_memory_oom_total

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1699,3 +1699,7 @@ This introduces a new `bgp.peers.<name>.holdtime` configuration key to control t
 
 ## `storage_volumes_all_projects`
 This introduces the ability to list storage volumes from all projects.
+
+## `metrics_memory_oom_total`
+This introduces a new `lxd_memory_OOM_kills_total` metric to the `/1.0/metrics` API.
+It reports the number of times the out of memory killer (`OOM`) has been triggered.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -341,6 +341,7 @@ var APIExtensions = []string{
 	"instance_ready_state",
 	"network_bgp_holdtime",
 	"storage_volumes_all_projects",
+	"metrics_memory_oom_total",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This adds the API extension missing in #10791

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>