### PR TITLE
Procs limit

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1706,3 +1706,7 @@ It reports the number of times the out of memory killer (`OOM`) has been trigger
 
 ## `storage_buckets`
 This introduces the storage bucket API. It allows the management of S3 object storage buckets for storage pools.
+
+## `metrics_procs_limit`
+This introduces a new `lxd_procs_limit` metric to the `/1.0/metrics` API.
+It reports the hard limit of processes.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6970,6 +6970,13 @@ func (d *lxc) Metrics() (*metrics.MetricSet, error) {
 		out.AddSamples(metrics.ProcsTotal, metrics.Sample{Value: float64(pids)})
 	}
 
+	pidsLimit, err := cg.GetEffectiveLimitProcesses()
+	if err != nil {
+		d.logger.Warn("Failed to get limit of processes", logger.Ctx{"err": err})
+	} else {
+		out.AddSamples(metrics.ProcsLimit, metrics.Sample{Value: float64(pidsLimit)})
+	}
+
 	return out, nil
 }
 

--- a/lxd/metrics/api.go
+++ b/lxd/metrics/api.go
@@ -8,6 +8,7 @@ type Metrics struct {
 	Memory         MemoryMetrics                `json:"memory" yaml:"memory"`
 	Network        map[string]NetworkMetrics    `json:"network" yaml:"network"`
 	ProcessesTotal uint64                       `json:"procs_total" yaml:"procs_total"`
+	ProcessesLimit uint64                       `json:"procs_limit" yaml:"procs_limit"`
 }
 
 // CPUMetrics represents CPU metrics for an instance.

--- a/lxd/metrics/metrics.go
+++ b/lxd/metrics/metrics.go
@@ -71,7 +71,7 @@ func (m *MetricSet) String() string {
 		metricTypeName := ""
 
 		// ProcsTotal is a gauge according to the OpenMetrics spec as its value can decrease.
-		if metricType == ProcsTotal {
+		if metricType == ProcsTotal || metricType == ProcsLimit {
 			metricTypeName = "gauge"
 		} else if strings.HasSuffix(MetricNames[metricType], "_total") {
 			metricTypeName = "counter"
@@ -242,6 +242,7 @@ func MetricSetFromAPI(metrics *Metrics, labels map[string]string) (*MetricSet, e
 
 	// Procs stats
 	set.AddSamples(ProcsTotal, Sample{Value: float64(metrics.ProcessesTotal)})
+	set.AddSamples(ProcsLimit, Sample{Value: float64(metrics.ProcessesLimit)})
 
 	return set, nil
 }

--- a/lxd/metrics/types.go
+++ b/lxd/metrics/types.go
@@ -90,6 +90,8 @@ const (
 	NetworkTransmitPacketsTotal
 	// ProcsTotal represents the number of running processes.
 	ProcsTotal
+	// ProcsLimit represents the hard limit of processes.
+	ProcsLimit
 )
 
 // MetricNames associates a metric type to its name.
@@ -131,6 +133,7 @@ var MetricNames = map[MetricType]string{
 	NetworkTransmitErrsTotal:    "lxd_network_transmit_errs_total",
 	NetworkTransmitPacketsTotal: "lxd_network_transmit_packets_total",
 	ProcsTotal:                  "lxd_procs_total",
+	ProcsLimit:                  "lxd_procs_limit",
 }
 
 // MetricHeaders represents the metric headers which contain help messages as specified by OpenMetrics.
@@ -172,4 +175,5 @@ var MetricHeaders = map[MetricType]string{
 	NetworkTransmitErrsTotal:    "# HELP lxd_network_transmit_errs_total The amount of transmitted errors on a given interface.",
 	NetworkTransmitPacketsTotal: "# HELP lxd_network_transmit_packets_total The amount of transmitted packets on a given interface.",
 	ProcsTotal:                  "# HELP lxd_procs_total The number of running processes.",
+	ProcsLimit:                  "# HELP lxd_procs_limit The hard limit of running processes.",
 }

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -4,6 +4,7 @@ package shared
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"unsafe"
@@ -336,6 +338,20 @@ func GetMeminfo(field string) (int64, error) {
 	}
 
 	return -1, fmt.Errorf("Couldn't find %s", field)
+}
+
+func DevicePidMax() (int64, error) {
+	b, err := os.ReadFile("/proc/sys/kernel/pid_max")
+	if err != nil {
+		return -1, err
+	}
+
+	i, err := strconv.ParseInt(string(bytes.TrimSpace(b)), 10, 64)
+	if err != nil {
+		return -1, err
+	}
+
+	return i, nil
 }
 
 // OpenPtyInDevpts creates a new PTS pair, configures them and returns them.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -343,6 +343,7 @@ var APIExtensions = []string{
 	"storage_volumes_all_projects",
 	"metrics_memory_oom_total",
 	"storage_buckets",
+	"metrics_procs_limit",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Added new metric for containers: lxd_procs_limit - The hard limit of processes.

From man 5 proc:

>        /proc/sys/kernel/pid_max (since Linux 2.5.34)
>              This file specifies the value at which PIDs wrap around (i.e., the value in this file is one greater than the maximum PID).  PIDs greater than this value are not allocated; thus, the value in this file also acts as a system-wide limit on the total number of processes and  threads.   The  default
>              value for this file, 32768, results in the same range of PIDs as on earlier kernels.  On 32-bit platforms, 32768 is the maximum value for pid_max.  On 64-bit systems, pid_max can be set to any value up to 2^22 (PID_MAX_LIMIT, approximately 4 million).

Change system limit:
`# sysctl -a | grep kernel.pid_max`
`# sysctl -w kernel.pid_max=65536`


