### PR TITLE
Adds storage pool to instance-created lifecycle context

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -310,7 +310,8 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotCreated.Event(d, nil))
 	} else {
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, map[string]any{
-			"type": api.InstanceTypeContainer,
+			"type":         api.InstanceTypeContainer,
+			"storage-pool": d.storagePool.Name(),
 		}))
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -286,7 +286,8 @@ func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotCreated.Event(d, nil))
 	} else {
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, map[string]any{
-			"type": api.InstanceTypeVM,
+			"type":         api.InstanceTypeVM,
+			"storage-pool": d.storagePool.Name(),
 		}))
 	}
 


### PR DESCRIPTION
This is required for https://github.com/canonical/lxd-cloud/issues/155 so that the cell/region are aware of instance storage pools.