### PR TITLE
Storage: Fix typo in `cephobject.radosgw.endpoint*` settings

### DIFF
--- a/doc/howto/storage_create_pool.md
+++ b/doc/howto/storage_create_pool.md
@@ -134,7 +134,7 @@ Use the sub-directory `my-directory` from the `my-filesystem` file system for `p
 When using the Ceph Object driver, you must have a running Ceph Object Gateway [`radosgw`](https://docs.ceph.com/en/latest/radosgw/) URL available beforehand.
 ```
 
-    lxc storage create s3 cephobject cephobject.radosgsw.endpoint=http://<radosgw URL>
+    lxc storage create s3 cephobject cephobject.radosgw.endpoint=http://<radosgw URL>
 ````
 `````
 

--- a/doc/reference/storage_cephobject.md
+++ b/doc/reference/storage_cephobject.md
@@ -42,7 +42,7 @@ For storage volumes, use the {ref}`Ceph <storage-ceph>` or {ref}`CephFS <storage
 You must setup a `radosgw` environment beforehand and ensure that its HTTP/HTTPS endpoint URL is reachable from the LXD server(s).
 See [Manual Deployment](https://docs.ceph.com/en/latest/install/manual-deployment/) for information on how to set up a Ceph cluster and [`radosgw`](https://docs.ceph.com/en/latest/radosgw/) on how to set up a `radosgw` environment.
 
-The `radosgw` URL can be specified at pool creation time using the [`cephobject.radosgsw.endpoint`](storage-cephobject-pool-config) option.
+The `radosgw` URL can be specified at pool creation time using the [`cephobject.radosgw.endpoint`](storage-cephobject-pool-config) option.
 LXD also uses the `radosgw-admin` command to manage buckets. So this command must be available and operational on the LXD servers(s).
 
 % Include content from [storage_ceph.md](storage_ceph.md)
@@ -67,8 +67,8 @@ Key                                      | Type                          | Defau
 :--                                      | :---                          | :------ | :----------
 `cephobject.bucket.name_prefix`          | string                        | -       | Prefix to add to bucket names in Ceph
 `cephobject.cluster_name`                | string                        | `ceph`  | The Ceph cluster to use
-`cephobject.radosgsw.endpoint`           | string                        | -       | URL of the `radosgw` gateway process
-`cephobject.radosgsw.endpoint_cert_file` | string                        | -       | Path to the file containing the TLS client certificate to use for endpoint communication
+`cephobject.radosgw.endpoint`            | string                        | -       | URL of the `radosgw` gateway process
+`cephobject.radosgw.endpoint_cert_file`  | string                        | -       | Path to the file containing the TLS client certificate to use for endpoint communication
 `cephobject.user.name`                   | string                        | `admin` | The Ceph user to use
 `volatile.pool.pristine`                 | string                        | `true`  | Whether the `radosgw` `lxd-admin` user existed at creation time
 

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -102,6 +102,22 @@ var updates = map[int]schema.Update{
 	63: updateFromV62,
 	64: updateFromV63,
 	65: updateFromV64,
+	66: updateFromV65,
+}
+
+// updateFromV65 fixes typo in cephobject.radosgw.endpoint* settings.
+func updateFromV65(tx *sql.Tx) error {
+	q := `
+	UPDATE storage_pools_config
+	SET key = REPLACE(key, "cephobject.radosgsw.endpoint", "cephobject.radosgw.endpoint")
+	WHERE key IN ("cephobject.radosgsw.endpoint", "cephobject.radosgsw.endpoint_cert_file")
+	`
+	_, err := tx.Exec(q)
+	if err != nil {
+		return fmt.Errorf("Failed replacing storage pool config cephobject.radosgsw.endpoint* with cephobject.radosgw.endpoint*: %w", err)
+	}
+
+	return nil
 }
 
 // updatefromV64 updates nodes_cluster_groups to include an ID field so that it works well with lxd-generate.

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -92,12 +92,12 @@ func (d *cephobject) Info() Info {
 // Validate checks that all provide keys are supported and that no conflicting or missing configuration is present.
 func (d *cephobject) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"cephobject.cluster_name":                validate.IsAny,
-		"cephobject.user.name":                   validate.IsAny,
-		"cephobject.radosgsw.endpoint":           validate.Optional(validate.IsRequestURL),
-		"cephobject.radosgsw.endpoint_cert_file": validate.Optional(validate.IsAbsFilePath),
-		"cephobject.bucket.name_prefix":          validate.Optional(validate.IsAny),
-		"volatile.pool.pristine":                 validate.Optional(validate.IsBool),
+		"cephobject.cluster_name":               validate.IsAny,
+		"cephobject.user.name":                  validate.IsAny,
+		"cephobject.radosgw.endpoint":           validate.Optional(validate.IsRequestURL),
+		"cephobject.radosgw.endpoint_cert_file": validate.Optional(validate.IsAbsFilePath),
+		"cephobject.bucket.name_prefix":         validate.Optional(validate.IsAny),
+		"volatile.pool.pristine":                validate.Optional(validate.IsBool),
 	}
 
 	return d.validatePool(config, rules, nil)
@@ -115,8 +115,8 @@ func (d *cephobject) Create() error {
 		d.config["cephobject.user.name"] = CephDefaultUser
 	}
 
-	if d.config["cephobject.radosgsw.endpoint"] == "" {
-		return fmt.Errorf(`"cephobject.radosgsw.endpoint" option is required`)
+	if d.config["cephobject.radosgw.endpoint"] == "" {
+		return fmt.Errorf(`"cephobject.radosgw.endpoint" option is required`)
 	}
 
 	// Check if there is an existing cephobjectRadosgwAdminUser user.

--- a/lxd/storage/drivers/driver_cephobject_buckets.go
+++ b/lxd/storage/drivers/driver_cephobject_buckets.go
@@ -23,14 +23,14 @@ import (
 
 // s3Client returns a configured minio S3 client.
 func (d *cephobject) s3Client(creds S3Credentials) (*minio.Client, error) {
-	u, err := url.ParseRequestURI(d.config["cephobject.radosgsw.endpoint"])
+	u, err := url.ParseRequestURI(d.config["cephobject.radosgw.endpoint"])
 	if err != nil {
-		return nil, fmt.Errorf("Failed parsing cephobject.radosgsw.endpoint: %w", err)
+		return nil, fmt.Errorf("Failed parsing cephobject.radosgw.endpoint: %w", err)
 	}
 
 	var transport http.RoundTripper
 
-	certFilePath := d.config["cephobject.radosgsw.endpoint_cert_file"]
+	certFilePath := d.config["cephobject.radosgw.endpoint_cert_file"]
 
 	if u.Scheme == "https" && certFilePath != "" {
 		certFilePath = shared.HostPath(certFilePath)
@@ -276,7 +276,7 @@ func (d *cephobject) DeleteBucketKey(bucket Bucket, keyName string, op *operatio
 
 // BucketURL returns the URL of the specified bucket.
 func (d *cephobject) BucketURL(bucketName string) *url.URL {
-	u, err := url.ParseRequestURI(d.config["cephobject.radosgsw.endpoint"])
+	u, err := url.ParseRequestURI(d.config["cephobject.radosgw.endpoint"])
 	if err != nil {
 		return nil
 	}

--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -29,10 +29,10 @@ test_storage_buckets() {
     return
   fi
 
-  # Check cephobject.radosgsw.endpoint is required for cephobject pools.
+  # Check cephobject.radosgw.endpoint is required for cephobject pools.
   if [ "$lxd_backend" = "ceph" ]; then
     ! lxc storage create s3 cephobject || false
-    lxc storage create s3 cephobject cephobject.radosgsw.endpoint="${LXD_CEPH_CEPHOBJECT_RADOSGW}"
+    lxc storage create s3 cephobject cephobject.radosgw.endpoint="${LXD_CEPH_CEPHOBJECT_RADOSGW}"
   fi
 
   lxc storage show s3


### PR DESCRIPTION
Typo began in the spec https://discuss.linuxcontainers.org/t/lxd-object-storage-s3-api/14579 (also now fixed) and was propagated into the code and tests.