### PR TITLE
doc: Note AIO requirement

### DIFF
--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -11,6 +11,7 @@ LXD requires a kernel with support for:
 
  * Namespaces (`pid`, `net`, `uts`, `ipc` and `mount`)
  * Seccomp
+ * POSIX AIO
 
 The following optional features also require extra kernel options:
 


### PR DESCRIPTION
LXD depends on dqlite depends on C-raft depends on AIO.

See https://github.com/canonical/raft/issues/228.

Signed-off-by: Cole Miller <m@cole-miller.net>