### PR TITLE
Generator: Use variadic filter structs

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -571,7 +571,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		var projects []dbCluster.Project
 
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			projects, err = dbCluster.GetProjects(ctx, tx.Tx(), dbCluster.ProjectFilter{})
+			projects, err = dbCluster.GetProjects(ctx, tx.Tx())
 			return err
 		})
 		if err != nil {
@@ -2907,7 +2907,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 	// List the instances.
 	var dbInstances []dbCluster.Instance
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbInstances, err = dbCluster.GetInstances(ctx, tx.Tx(), dbCluster.InstanceFilter{})
+		dbInstances, err = dbCluster.GetInstances(ctx, tx.Tx())
 		if err != nil {
 			return fmt.Errorf("Failed to get instances: %w", err)
 		}
@@ -3300,7 +3300,7 @@ func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		if recursion {
-			clusterGroups, err := dbCluster.GetClusterGroups(ctx, tx.Tx(), dbCluster.ClusterGroupFilter{})
+			clusterGroups, err := dbCluster.GetClusterGroups(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -79,7 +79,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 	// imported instances and volumes, and avoid repeatedly querying the same information.
 	err = d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Load list of projects for validation.
-		ps, err := dbCluster.GetProjects(ctx, tx.Tx(), dbCluster.ProjectFilter{})
+		ps, err := dbCluster.GetProjects(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 		}
 
 		// Load list of project/profile names for validation.
-		profiles, err := dbCluster.GetProfiles(ctx, tx.Tx(), dbCluster.ProfileFilter{})
+		profiles, err := dbCluster.GetProfiles(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -87,7 +87,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	} else {
 		// Get all projects.
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			projects, err := dbCluster.GetProjects(ctx, tx.Tx(), dbCluster.ProjectFilter{})
+			projects, err := dbCluster.GetProjects(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -140,8 +140,7 @@ func projectsGet(d *Daemon, r *http.Request) response.Response {
 
 	var result any
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		filter := cluster.ProjectFilter{}
-		projects, err := cluster.GetProjects(ctx, tx.Tx(), filter)
+		projects, err := cluster.GetProjects(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -147,7 +147,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 		var baseCerts []dbCluster.Certificate
 		var err error
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			baseCerts, err = dbCluster.GetCertificates(ctx, tx.Tx(), dbCluster.CertificateFilter{})
+			baseCerts, err = dbCluster.GetCertificates(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}
@@ -195,7 +195,7 @@ func updateCertificateCache(d *Daemon) {
 	var localCerts []dbCluster.Certificate
 	var err error
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbCerts, err = dbCluster.GetCertificates(ctx, tx.Tx(), dbCluster.CertificateFilter{})
+		dbCerts, err = dbCluster.GetCertificates(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -88,7 +88,7 @@ func ConnectIfInstanceIsRemote(cluster *db.Cluster, projectName string, instName
 	var address string // Cluster member address.
 	err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		address, err = tx.GetNodeAddressOfInstance(projectName, instName, db.InstanceTypeFilter(instanceType))
+		address, err = tx.GetNodeAddressOfInstance(projectName, instName, instanceType)
 		return err
 	})
 	if err != nil {

--- a/lxd/db/cluster/certificate_projects.mapper.go
+++ b/lxd/db/cluster/certificate_projects.mapper.go
@@ -18,7 +18,7 @@ var _ = api.ServerEnvironment{}
 var certificateProjectObjectsByCertificateID = RegisterStmt(`
 SELECT certificates_projects.certificate_id, certificates_projects.project_id
   FROM certificates_projects
-  WHERE certificates_projects.certificate_id = ? ORDER BY certificates_projects.certificate_id
+  WHERE ( certificates_projects.certificate_id = ? ) ORDER BY certificates_projects.certificate_id
 `)
 
 var certificateProjectCreate = RegisterStmt(`

--- a/lxd/db/cluster/certificates.interface.mapper.go
+++ b/lxd/db/cluster/certificates.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type CertificateGenerated interface {
 	// GetCertificates returns all available certificates.
 	// generator: certificate GetMany
-	GetCertificates(ctx context.Context, tx *sql.Tx, filter CertificateFilter) ([]Certificate, error)
+	GetCertificates(ctx context.Context, tx *sql.Tx, filters ...CertificateFilter) ([]Certificate, error)
 
 	// GetCertificate returns the certificate with the given key.
 	// generator: certificate GetOne

--- a/lxd/db/cluster/cluster_groups.interface.mapper.go
+++ b/lxd/db/cluster/cluster_groups.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type ClusterGroupGenerated interface {
 	// GetClusterGroups returns all available cluster_groups.
 	// generator: cluster_group GetMany
-	GetClusterGroups(ctx context.Context, tx *sql.Tx, filter ClusterGroupFilter) ([]ClusterGroup, error)
+	GetClusterGroups(ctx context.Context, tx *sql.Tx, filters ...ClusterGroupFilter) ([]ClusterGroup, error)
 
 	// GetClusterGroup returns the cluster_group with the given key.
 	// generator: cluster_group GetOne

--- a/lxd/db/cluster/config.go
+++ b/lxd/db/cluster/config.go
@@ -23,3 +23,9 @@ type Config struct {
 	Key         string
 	Value       string
 }
+
+// ConfigFilter specifies potential query parameter fields.
+type ConfigFilter struct {
+	Key   *string
+	Value *string
+}

--- a/lxd/db/cluster/config.interface.mapper.go
+++ b/lxd/db/cluster/config.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type ConfigGenerated interface {
 	// GetConfig returns all available config.
 	// generator: config GetMany
-	GetConfig(ctx context.Context, tx *sql.Tx, parent string) (map[int]map[string]string, error)
+	GetConfig(ctx context.Context, tx *sql.Tx, parent string, filters ...ConfigFilter) (map[int]map[string]string, error)
 
 	// CreateConfig adds a new config to the database.
 	// generator: config Create

--- a/lxd/db/cluster/devices.go
+++ b/lxd/db/cluster/devices.go
@@ -32,6 +32,13 @@ type Device struct {
 	Config      map[string]string
 }
 
+// DeviceFilter specifies potential query parameter fields.
+type DeviceFilter struct {
+	Name   *string
+	Type   *DeviceType
+	Config *ConfigFilter
+}
+
 // Supported device types.
 const (
 	TypeNone        = DeviceType(0)

--- a/lxd/db/cluster/devices.interface.mapper.go
+++ b/lxd/db/cluster/devices.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type DeviceGenerated interface {
 	// GetDevices returns all available devices for the parent entity.
 	// generator: device GetMany
-	GetDevices(ctx context.Context, tx *sql.Tx, parent string) (map[int][]Device, error)
+	GetDevices(ctx context.Context, tx *sql.Tx, parent string, filters ...DeviceFilter) (map[int][]Device, error)
 
 	// CreateDevices adds a new device to the database.
 	// generator: device Create

--- a/lxd/db/cluster/images.interface.mapper.go
+++ b/lxd/db/cluster/images.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type ImageGenerated interface {
 	// GetImages returns all available images.
 	// generator: image GetMany
-	GetImages(ctx context.Context, tx *sql.Tx, filter ImageFilter) ([]Image, error)
+	GetImages(ctx context.Context, tx *sql.Tx, filters ...ImageFilter) ([]Image, error)
 
 	// GetImage returns the image with the given key.
 	// generator: image GetOne

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -18,13 +18,13 @@ var _ = api.ServerEnvironment{}
 var instanceProfileObjectsByProfileID = RegisterStmt(`
 SELECT instances_profiles.instance_id, instances_profiles.profile_id, instances_profiles.apply_order
   FROM instances_profiles
-  WHERE instances_profiles.profile_id = ? ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
+  WHERE ( instances_profiles.profile_id = ? ) ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
 `)
 
 var instanceProfileObjectsByInstanceID = RegisterStmt(`
 SELECT instances_profiles.instance_id, instances_profiles.profile_id, instances_profiles.apply_order
   FROM instances_profiles
-  WHERE instances_profiles.instance_id = ? ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
+  WHERE ( instances_profiles.instance_id = ? ) ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
 `)
 
 var instanceProfileCreate = RegisterStmt(`

--- a/lxd/db/cluster/instances.interface.mapper.go
+++ b/lxd/db/cluster/instances.interface.mapper.go
@@ -11,15 +11,15 @@ import (
 type InstanceGenerated interface {
 	// GetInstanceConfig returns all available Instance Config
 	// generator: instance GetMany
-	GetInstanceConfig(ctx context.Context, tx *sql.Tx, instanceID int) (map[string]string, error)
+	GetInstanceConfig(ctx context.Context, tx *sql.Tx, instanceID int, filters ...ConfigFilter) (map[string]string, error)
 
 	// GetInstanceDevices returns all available Instance Devices
 	// generator: instance GetMany
-	GetInstanceDevices(ctx context.Context, tx *sql.Tx, instanceID int) (map[string]Device, error)
+	GetInstanceDevices(ctx context.Context, tx *sql.Tx, instanceID int, filters ...DeviceFilter) (map[string]Device, error)
 
 	// GetInstances returns all available instances.
 	// generator: instance GetMany
-	GetInstances(ctx context.Context, tx *sql.Tx, filter InstanceFilter) ([]Instance, error)
+	GetInstances(ctx context.Context, tx *sql.Tx, filters ...InstanceFilter) ([]Instance, error)
 
 	// GetInstance returns the instance with the given key.
 	// generator: instance GetOne

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
@@ -25,97 +26,97 @@ SELECT instances.id, projects.name AS project, instances.name, nodes.name AS nod
 var instanceObjectsByID = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.id = ? ORDER BY projects.id, instances.name
+  WHERE ( instances.id = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProject = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndType = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndTypeAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? AND node = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? AND node = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndTypeAndNodeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? AND node = ? AND instances.name = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? AND node = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndTypeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? AND instances.name = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.name = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndNameAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.name = ? AND node = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.name = ? AND node = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND node = ? ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND node = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByType = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByTypeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? AND instances.name = ? ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByTypeAndNameAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? AND instances.name = ? AND node = ? ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? AND instances.name = ? AND node = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByTypeAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? AND node = ? ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? AND node = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE node = ? ORDER BY projects.id, instances.name
+  WHERE ( node = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByNodeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE node = ? AND instances.name = ? ORDER BY projects.id, instances.name
+  WHERE ( node = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.name = ? ORDER BY projects.id, instances.name
+  WHERE ( instances.name = ? ) ORDER BY projects.id, instances.name
 `)
 
 var instanceID = RegisterStmt(`
@@ -144,7 +145,7 @@ UPDATE instances
 
 // GetInstances returns all available instances.
 // generator: instance GetMany
-func GetInstances(ctx context.Context, tx *sql.Tx, filter InstanceFilter) ([]Instance, error) {
+func GetInstances(ctx context.Context, tx *sql.Tx, filters ...InstanceFilter) ([]Instance, error) {
 	var err error
 
 	// Result slice.
@@ -152,178 +153,406 @@ func GetInstances(ctx context.Context, tx *sql.Tx, filter InstanceFilter) ([]Ins
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var sqlStmt *sql.Stmt
-	var args []any
+	args := []any{}
+	queryParts := [2]string{}
 
-	if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.Name != nil && filter.ID == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndTypeAndNodeAndName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndTypeAndNodeAndName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Type,
-			filter.Node,
-			filter.Name,
-		}
-	} else if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndTypeAndNode)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndTypeAndNode\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Type,
-			filter.Node,
-		}
-	} else if filter.Project != nil && filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndTypeAndName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndTypeAndName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Type,
-			filter.Name,
-		}
-	} else if filter.Type != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByTypeAndNameAndNode)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByTypeAndNameAndNode\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Type,
-			filter.Name,
-			filter.Node,
-		}
-	} else if filter.Project != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndNameAndNode)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndNameAndNode\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Name,
-			filter.Node,
-		}
-	} else if filter.Project != nil && filter.Type != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndType)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndType\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Type,
-		}
-	} else if filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByTypeAndNode)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByTypeAndNode\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Type,
-			filter.Node,
-		}
-	} else if filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByTypeAndName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByTypeAndName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Type,
-			filter.Name,
-		}
-	} else if filter.Project != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndNode)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndNode\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Node,
-		}
-	} else if filter.Project != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Name,
-		}
-	} else if filter.Node != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByNodeAndName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByNodeAndName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Node,
-			filter.Name,
-		}
-	} else if filter.Type != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByType)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByType\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Type,
-		}
-	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByProject)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByProject\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-		}
-	} else if filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByNode)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByNode\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Node,
-		}
-	} else if filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Name,
-		}
-	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
-		sqlStmt, err = Stmt(tx, instanceObjectsByID)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"instanceObjectsByID\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.ID,
-		}
-	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
+	if len(filters) == 0 {
 		sqlStmt, err = Stmt(tx, instanceObjects)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
 		}
+	}
 
-		args = []any{}
-	} else {
-		return nil, fmt.Errorf("No statement exists for the given Filter")
+	for i, filter := range filters {
+		if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.Name != nil && filter.ID == nil {
+			args = append(args, []any{filter.Project, filter.Type, filter.Node, filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndTypeAndNodeAndName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndTypeAndNodeAndName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProjectAndTypeAndNodeAndName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil {
+			args = append(args, []any{filter.Project, filter.Type, filter.Node}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndTypeAndNode)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndTypeAndNode\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProjectAndTypeAndNode)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil {
+			args = append(args, []any{filter.Project, filter.Type, filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndTypeAndName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndTypeAndName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProjectAndTypeAndName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Type != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil {
+			args = append(args, []any{filter.Type, filter.Name, filter.Node}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByTypeAndNameAndNode)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByTypeAndNameAndNode\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByTypeAndNameAndNode)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.Name != nil && filter.Node != nil && filter.ID == nil && filter.Type == nil {
+			args = append(args, []any{filter.Project, filter.Name, filter.Node}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndNameAndNode)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndNameAndNode\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProjectAndNameAndNode)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.Type != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil {
+			args = append(args, []any{filter.Project, filter.Type}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndType)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndType\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProjectAndType)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Type != nil && filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil {
+			args = append(args, []any{filter.Type, filter.Node}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByTypeAndNode)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByTypeAndNode\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByTypeAndNode)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Type != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil {
+			args = append(args, []any{filter.Type, filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByTypeAndName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByTypeAndName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByTypeAndName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.Node != nil && filter.ID == nil && filter.Name == nil && filter.Type == nil {
+			args = append(args, []any{filter.Project, filter.Node}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndNode)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndNode\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProjectAndNode)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.Name != nil && filter.ID == nil && filter.Node == nil && filter.Type == nil {
+			args = append(args, []any{filter.Project, filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProjectAndName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProjectAndName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProjectAndName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Node != nil && filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Type == nil {
+			args = append(args, []any{filter.Node, filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByNodeAndName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByNodeAndName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByNodeAndName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Type != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil {
+			args = append(args, []any{filter.Type}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByType)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByType\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByType)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.ID == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
+			args = append(args, []any{filter.Project}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByProject)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByProject\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByProject)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Node != nil && filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Type == nil {
+			args = append(args, []any{filter.Node}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByNode)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByNode\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByNode)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Name != nil && filter.ID == nil && filter.Project == nil && filter.Node == nil && filter.Type == nil {
+			args = append(args, []any{filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.ID != nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
+			args = append(args, []any{filter.ID}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, instanceObjectsByID)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"instanceObjectsByID\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(instanceObjectsByID)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"instanceObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.ID == nil && filter.Project == nil && filter.Name == nil && filter.Node == nil && filter.Type == nil {
+			return nil, fmt.Errorf("Cannot filter on empty InstanceFilter")
+		} else {
+			return nil, fmt.Errorf("No statement exists for the given Filter")
+		}
 	}
 
 	// Dest function for scanning a row.
@@ -340,7 +569,13 @@ func GetInstances(ctx context.Context, tx *sql.Tx, filter InstanceFilter) ([]Ins
 	}
 
 	// Select.
-	err = query.SelectObjects(sqlStmt, dest, args...)
+	if sqlStmt != nil {
+		err = query.SelectObjects(sqlStmt, dest, args...)
+	} else {
+		queryStr := strings.Join(queryParts[:], "ORDER BY")
+		err = query.Scan(tx, queryStr, dest, args...)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"instances\" table: %w", err)
 	}
@@ -350,8 +585,8 @@ func GetInstances(ctx context.Context, tx *sql.Tx, filter InstanceFilter) ([]Ins
 
 // GetInstanceDevices returns all available Instance Devices
 // generator: instance GetMany
-func GetInstanceDevices(ctx context.Context, tx *sql.Tx, instanceID int) (map[string]Device, error) {
-	instanceDevices, err := GetDevices(ctx, tx, "instance")
+func GetInstanceDevices(ctx context.Context, tx *sql.Tx, instanceID int, filters ...DeviceFilter) (map[string]Device, error) {
+	instanceDevices, err := GetDevices(ctx, tx, "instance", filters...)
 	if err != nil {
 		return nil, err
 	}
@@ -371,8 +606,8 @@ func GetInstanceDevices(ctx context.Context, tx *sql.Tx, instanceID int) (map[st
 
 // GetInstanceConfig returns all available Instance Config
 // generator: instance GetMany
-func GetInstanceConfig(ctx context.Context, tx *sql.Tx, instanceID int) (map[string]string, error) {
-	instanceConfig, err := GetConfig(ctx, tx, "instance")
+func GetInstanceConfig(ctx context.Context, tx *sql.Tx, instanceID int, filters ...ConfigFilter) (map[string]string, error) {
+	instanceConfig, err := GetConfig(ctx, tx, "instance", filters...)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/cluster/operations.interface.mapper.go
+++ b/lxd/db/cluster/operations.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type OperationGenerated interface {
 	// GetOperations returns all available operations.
 	// generator: operation GetMany
-	GetOperations(ctx context.Context, tx *sql.Tx, filter OperationFilter) ([]Operation, error)
+	GetOperations(ctx context.Context, tx *sql.Tx, filters ...OperationFilter) ([]Operation, error)
 
 	// CreateOrReplaceOperation adds a new operation to the database.
 	// generator: operation CreateOrReplace

--- a/lxd/db/cluster/profiles.interface.mapper.go
+++ b/lxd/db/cluster/profiles.interface.mapper.go
@@ -19,15 +19,15 @@ type ProfileGenerated interface {
 
 	// GetProfileConfig returns all available Profile Config
 	// generator: profile GetMany
-	GetProfileConfig(ctx context.Context, tx *sql.Tx, profileID int) (map[string]string, error)
+	GetProfileConfig(ctx context.Context, tx *sql.Tx, profileID int, filters ...ConfigFilter) (map[string]string, error)
 
 	// GetProfileDevices returns all available Profile Devices
 	// generator: profile GetMany
-	GetProfileDevices(ctx context.Context, tx *sql.Tx, profileID int) (map[string]Device, error)
+	GetProfileDevices(ctx context.Context, tx *sql.Tx, profileID int, filters ...DeviceFilter) (map[string]Device, error)
 
 	// GetProfiles returns all available profiles.
 	// generator: profile GetMany
-	GetProfiles(ctx context.Context, tx *sql.Tx, filter ProfileFilter) ([]Profile, error)
+	GetProfiles(ctx context.Context, tx *sql.Tx, filters ...ProfileFilter) ([]Profile, error)
 
 	// GetProfile returns the profile with the given key.
 	// generator: profile GetOne

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
@@ -25,25 +26,25 @@ SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name
 var profileObjectsByID = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE profiles.id = ? ORDER BY projects.id, profiles.name
+  WHERE ( profiles.id = ? ) ORDER BY projects.id, profiles.name
 `)
 
 var profileObjectsByName = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE profiles.name = ? ORDER BY projects.id, profiles.name
+  WHERE ( profiles.name = ? ) ORDER BY projects.id, profiles.name
 `)
 
 var profileObjectsByProject = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE project = ? ORDER BY projects.id, profiles.name
+  WHERE ( project = ? ) ORDER BY projects.id, profiles.name
 `)
 
 var profileObjectsByProjectAndName = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE project = ? AND profiles.name = ? ORDER BY projects.id, profiles.name
+  WHERE ( project = ? AND profiles.name = ? ) ORDER BY projects.id, profiles.name
 `)
 
 var profileID = RegisterStmt(`
@@ -125,7 +126,7 @@ func ProfileExists(ctx context.Context, tx *sql.Tx, project string, name string)
 
 // GetProfiles returns all available profiles.
 // generator: profile GetMany
-func GetProfiles(ctx context.Context, tx *sql.Tx, filter ProfileFilter) ([]Profile, error) {
+func GetProfiles(ctx context.Context, tx *sql.Tx, filters ...ProfileFilter) ([]Profile, error) {
 	var err error
 
 	// Result slice.
@@ -133,54 +134,118 @@ func GetProfiles(ctx context.Context, tx *sql.Tx, filter ProfileFilter) ([]Profi
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var sqlStmt *sql.Stmt
-	var args []any
+	args := []any{}
+	queryParts := [2]string{}
 
-	if filter.Project != nil && filter.Name != nil && filter.ID == nil {
-		sqlStmt, err = Stmt(tx, profileObjectsByProjectAndName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"profileObjectsByProjectAndName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-			filter.Name,
-		}
-	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil {
-		sqlStmt, err = Stmt(tx, profileObjectsByProject)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"profileObjectsByProject\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Project,
-		}
-	} else if filter.Name != nil && filter.ID == nil && filter.Project == nil {
-		sqlStmt, err = Stmt(tx, profileObjectsByName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"profileObjectsByName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Name,
-		}
-	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil {
-		sqlStmt, err = Stmt(tx, profileObjectsByID)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"profileObjectsByID\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.ID,
-		}
-	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
+	if len(filters) == 0 {
 		sqlStmt, err = Stmt(tx, profileObjects)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get \"profileObjects\" prepared statement: %w", err)
 		}
+	}
 
-		args = []any{}
-	} else {
-		return nil, fmt.Errorf("No statement exists for the given Filter")
+	for i, filter := range filters {
+		if filter.Project != nil && filter.Name != nil && filter.ID == nil {
+			args = append(args, []any{filter.Project, filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, profileObjectsByProjectAndName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"profileObjectsByProjectAndName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(profileObjectsByProjectAndName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"profileObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Project != nil && filter.ID == nil && filter.Name == nil {
+			args = append(args, []any{filter.Project}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, profileObjectsByProject)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"profileObjectsByProject\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(profileObjectsByProject)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"profileObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.Name != nil && filter.ID == nil && filter.Project == nil {
+			args = append(args, []any{filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, profileObjectsByName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"profileObjectsByName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(profileObjectsByName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"profileObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.ID != nil && filter.Project == nil && filter.Name == nil {
+			args = append(args, []any{filter.ID}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, profileObjectsByID)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"profileObjectsByID\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(profileObjectsByID)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"profileObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
+			return nil, fmt.Errorf("Cannot filter on empty ProfileFilter")
+		} else {
+			return nil, fmt.Errorf("No statement exists for the given Filter")
+		}
 	}
 
 	// Dest function for scanning a row.
@@ -197,7 +262,13 @@ func GetProfiles(ctx context.Context, tx *sql.Tx, filter ProfileFilter) ([]Profi
 	}
 
 	// Select.
-	err = query.SelectObjects(sqlStmt, dest, args...)
+	if sqlStmt != nil {
+		err = query.SelectObjects(sqlStmt, dest, args...)
+	} else {
+		queryStr := strings.Join(queryParts[:], "ORDER BY")
+		err = query.Scan(tx, queryStr, dest, args...)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"profiles\" table: %w", err)
 	}
@@ -207,8 +278,8 @@ func GetProfiles(ctx context.Context, tx *sql.Tx, filter ProfileFilter) ([]Profi
 
 // GetProfileDevices returns all available Profile Devices
 // generator: profile GetMany
-func GetProfileDevices(ctx context.Context, tx *sql.Tx, profileID int) (map[string]Device, error) {
-	profileDevices, err := GetDevices(ctx, tx, "profile")
+func GetProfileDevices(ctx context.Context, tx *sql.Tx, profileID int, filters ...DeviceFilter) (map[string]Device, error) {
+	profileDevices, err := GetDevices(ctx, tx, "profile", filters...)
 	if err != nil {
 		return nil, err
 	}
@@ -228,8 +299,8 @@ func GetProfileDevices(ctx context.Context, tx *sql.Tx, profileID int) (map[stri
 
 // GetProfileConfig returns all available Profile Config
 // generator: profile GetMany
-func GetProfileConfig(ctx context.Context, tx *sql.Tx, profileID int) (map[string]string, error) {
-	profileConfig, err := GetConfig(ctx, tx, "profile")
+func GetProfileConfig(ctx context.Context, tx *sql.Tx, profileID int, filters ...ConfigFilter) (map[string]string, error) {
+	profileConfig, err := GetConfig(ctx, tx, "profile", filters...)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/cluster/projects.interface.mapper.go
+++ b/lxd/db/cluster/projects.interface.mapper.go
@@ -11,11 +11,11 @@ import (
 type ProjectGenerated interface {
 	// GetProjectConfig returns all available Project Config
 	// generator: project GetMany
-	GetProjectConfig(ctx context.Context, tx *sql.Tx, projectID int) (map[string]string, error)
+	GetProjectConfig(ctx context.Context, tx *sql.Tx, projectID int, filters ...ConfigFilter) (map[string]string, error)
 
 	// GetProjects returns all available projects.
 	// generator: project GetMany
-	GetProjects(ctx context.Context, tx *sql.Tx, filter ProjectFilter) ([]Project, error)
+	GetProjects(ctx context.Context, tx *sql.Tx, filters ...ProjectFilter) ([]Project, error)
 
 	// GetProject returns the project with the given key.
 	// generator: project GetOne

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
@@ -25,13 +26,13 @@ SELECT projects.id, projects.description, projects.name
 var projectObjectsByName = RegisterStmt(`
 SELECT projects.id, projects.description, projects.name
   FROM projects
-  WHERE projects.name = ? ORDER BY projects.name
+  WHERE ( projects.name = ? ) ORDER BY projects.name
 `)
 
 var projectObjectsByID = RegisterStmt(`
 SELECT projects.id, projects.description, projects.name
   FROM projects
-  WHERE projects.id = ? ORDER BY projects.name
+  WHERE ( projects.id = ? ) ORDER BY projects.name
 `)
 
 var projectCreate = RegisterStmt(`
@@ -60,7 +61,7 @@ DELETE FROM projects WHERE name = ?
 
 // GetProjects returns all available projects.
 // generator: project GetMany
-func GetProjects(ctx context.Context, tx *sql.Tx, filter ProjectFilter) ([]Project, error) {
+func GetProjects(ctx context.Context, tx *sql.Tx, filters ...ProjectFilter) ([]Project, error) {
 	var err error
 
 	// Result slice.
@@ -68,35 +69,70 @@ func GetProjects(ctx context.Context, tx *sql.Tx, filter ProjectFilter) ([]Proje
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var sqlStmt *sql.Stmt
-	var args []any
+	args := []any{}
+	queryParts := [2]string{}
 
-	if filter.Name != nil && filter.ID == nil {
-		sqlStmt, err = Stmt(tx, projectObjectsByName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"projectObjectsByName\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.Name,
-		}
-	} else if filter.ID != nil && filter.Name == nil {
-		sqlStmt, err = Stmt(tx, projectObjectsByID)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"projectObjectsByID\" prepared statement: %w", err)
-		}
-
-		args = []any{
-			filter.ID,
-		}
-	} else if filter.ID == nil && filter.Name == nil {
+	if len(filters) == 0 {
 		sqlStmt, err = Stmt(tx, projectObjects)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get \"projectObjects\" prepared statement: %w", err)
 		}
+	}
 
-		args = []any{}
-	} else {
-		return nil, fmt.Errorf("No statement exists for the given Filter")
+	for i, filter := range filters {
+		if filter.Name != nil && filter.ID == nil {
+			args = append(args, []any{filter.Name}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, projectObjectsByName)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"projectObjectsByName\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(projectObjectsByName)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"projectObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.ID != nil && filter.Name == nil {
+			args = append(args, []any{filter.ID}...)
+			if len(filters) == 1 {
+				sqlStmt, err = Stmt(tx, projectObjectsByID)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to get \"projectObjectsByID\" prepared statement: %w", err)
+				}
+
+				break
+			}
+
+			query, err := StmtString(projectObjectsByID)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get \"projectObjects\" prepared statement: %w", err)
+			}
+
+			parts := strings.SplitN(query, "ORDER BY", 2)
+			if i == 0 {
+				copy(queryParts[:], parts)
+				continue
+			}
+
+			_, where, _ := strings.Cut(parts[0], "WHERE")
+			queryParts[0] += "OR" + where
+		} else if filter.ID == nil && filter.Name == nil {
+			return nil, fmt.Errorf("Cannot filter on empty ProjectFilter")
+		} else {
+			return nil, fmt.Errorf("No statement exists for the given Filter")
+		}
 	}
 
 	// Dest function for scanning a row.
@@ -113,7 +149,13 @@ func GetProjects(ctx context.Context, tx *sql.Tx, filter ProjectFilter) ([]Proje
 	}
 
 	// Select.
-	err = query.SelectObjects(sqlStmt, dest, args...)
+	if sqlStmt != nil {
+		err = query.SelectObjects(sqlStmt, dest, args...)
+	} else {
+		queryStr := strings.Join(queryParts[:], "ORDER BY")
+		err = query.Scan(tx, queryStr, dest, args...)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"projects\" table: %w", err)
 	}
@@ -123,8 +165,8 @@ func GetProjects(ctx context.Context, tx *sql.Tx, filter ProjectFilter) ([]Proje
 
 // GetProjectConfig returns all available Project Config
 // generator: project GetMany
-func GetProjectConfig(ctx context.Context, tx *sql.Tx, projectID int) (map[string]string, error) {
-	projectConfig, err := GetConfig(ctx, tx, "project")
+func GetProjectConfig(ctx context.Context, tx *sql.Tx, projectID int, filters ...ConfigFilter) (map[string]string, error) {
+	projectConfig, err := GetConfig(ctx, tx, "project", filters...)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/cluster/snapshots.interface.mapper.go
+++ b/lxd/db/cluster/snapshots.interface.mapper.go
@@ -11,15 +11,15 @@ import (
 type InstanceSnapshotGenerated interface {
 	// GetInstanceSnapshotConfig returns all available InstanceSnapshot Config
 	// generator: instance_snapshot GetMany
-	GetInstanceSnapshotConfig(ctx context.Context, tx *sql.Tx, instanceSnapshotID int) (map[string]string, error)
+	GetInstanceSnapshotConfig(ctx context.Context, tx *sql.Tx, instanceSnapshotID int, filters ...ConfigFilter) (map[string]string, error)
 
 	// GetInstanceSnapshotDevices returns all available InstanceSnapshot Devices
 	// generator: instance_snapshot GetMany
-	GetInstanceSnapshotDevices(ctx context.Context, tx *sql.Tx, instanceSnapshotID int) (map[string]Device, error)
+	GetInstanceSnapshotDevices(ctx context.Context, tx *sql.Tx, instanceSnapshotID int, filters ...DeviceFilter) (map[string]Device, error)
 
 	// GetInstanceSnapshots returns all available instance_snapshots.
 	// generator: instance_snapshot GetMany
-	GetInstanceSnapshots(ctx context.Context, tx *sql.Tx, filter InstanceSnapshotFilter) ([]InstanceSnapshot, error)
+	GetInstanceSnapshots(ctx context.Context, tx *sql.Tx, filters ...InstanceSnapshotFilter) ([]InstanceSnapshot, error)
 
 	// GetInstanceSnapshot returns the instance_snapshot with the given key.
 	// generator: instance_snapshot GetOne

--- a/lxd/db/cluster/warnings.interface.mapper.go
+++ b/lxd/db/cluster/warnings.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type WarningGenerated interface {
 	// GetWarnings returns all available warnings.
 	// generator: warning GetMany
-	GetWarnings(ctx context.Context, tx *sql.Tx, filter WarningFilter) ([]Warning, error)
+	GetWarnings(ctx context.Context, tx *sql.Tx, filters ...WarningFilter) ([]Warning, error)
 
 	// GetWarning returns the warning with the given key.
 	// generator: warning GetOne-by-UUID

--- a/lxd/db/entity.go
+++ b/lxd/db/entity.go
@@ -32,7 +32,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var images []cluster.Image
 
 		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			images, err = cluster.GetImages(ctx, tx.tx, cluster.ImageFilter{})
+			images, err = cluster.GetImages(ctx, tx.tx)
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var profiles []cluster.Profile
 
 		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			profiles, err = cluster.GetProfiles(ctx, tx.Tx(), cluster.ProfileFilter{})
+			profiles, err = cluster.GetProfiles(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var certificates []cluster.Certificate
 
 		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			certificates, err = cluster.GetCertificates(context.Background(), tx.tx, cluster.CertificateFilter{})
+			certificates, err = cluster.GetCertificates(context.Background(), tx.tx)
 			if err != nil {
 				return err
 			}
@@ -139,7 +139,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var instances []cluster.Instance
 
 		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			instances, err = cluster.GetInstances(ctx, tx.tx, cluster.InstanceFilter{})
+			instances, err = cluster.GetInstances(ctx, tx.tx)
 			if err != nil {
 				return err
 			}
@@ -172,7 +172,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var instances []cluster.Instance
 
 		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			instances, err = cluster.GetInstances(ctx, tx.tx, cluster.InstanceFilter{})
+			instances, err = cluster.GetInstances(ctx, tx.tx)
 			if err != nil {
 				return err
 			}
@@ -200,7 +200,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var snapshots []cluster.InstanceSnapshot
 
 		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			snapshots, err = cluster.GetInstanceSnapshots(ctx, tx.Tx(), cluster.InstanceSnapshotFilter{})
+			snapshots, err = cluster.GetInstanceSnapshots(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -170,11 +170,6 @@ func Parse(pkg *ast.Package, name string, kind string) (*Mapping, error) {
 		Filterable: true,
 	}
 
-	// Reference tables rely on ReferenceID for filtering, instead of a Filter struct.
-	if m.Type == ReferenceTable || m.Type == MapTable {
-		m.Filterable = false
-	}
-
 	if m.Filterable {
 		// The 'EntityFilter' struct. This is used for filtering on specific fields of the entity.
 		filterName := name + "Filter"

--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -223,8 +223,8 @@ func (s *Stmt) objects(buf *file.Buffer) error {
 
 	var filterStr strings.Builder
 	if len(where) > 0 {
-		filterStr.WriteString("WHERE ")
-		filterStr.WriteString(strings.Join(where, "AND "))
+		filterStr.WriteString("WHERE ( ")
+		filterStr.WriteString(strings.Join(where, "AND ") + ") ")
 	}
 
 	sql := fmt.Sprintf(boiler, strings.Join(columns, ", "), table, filterStr.String(), strings.Join(orderBy, ", "))

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -38,8 +38,8 @@ func TestContainerList(t *testing.T) {
 	addContainerDevice(t, tx, "c2", "eth0", "nic", nil)
 	addContainerDevice(t, tx, "c3", "root", "disk", map[string]string{"x": "y"})
 
-	filter := db.InstanceTypeFilter(instancetype.Container)
-	containers, err := cluster.GetInstances(context.TODO(), tx.Tx(), filter)
+	instType := instancetype.Container
+	containers, err := cluster.GetInstances(context.TODO(), tx.Tx(), cluster.InstanceFilter{Type: &instType})
 	require.NoError(t, err)
 	assert.Len(t, containers, 3)
 
@@ -93,11 +93,10 @@ func TestContainerList_FilterByNode(t *testing.T) {
 	addContainer(t, tx, nodeID1, "c2")
 	addContainer(t, tx, nodeID2, "c3")
 
-	filter := db.InstanceTypeFilter(instancetype.Container)
 	project := "default"
 	node := "node2"
-	filter.Project = &project
-	filter.Node = &node
+	instType := instancetype.Container
+	filter := cluster.InstanceFilter{Project: &project, Node: &node, Type: &instType}
 
 	containers, err := cluster.GetInstances(context.TODO(), tx.Tx(), filter)
 	require.NoError(t, err)
@@ -177,7 +176,7 @@ func TestInstanceList_ContainerWithSameNameInDifferentProjects(t *testing.T) {
 	err = cluster.UpdateInstanceProfiles(context.TODO(), tx.Tx(), int(id), c1p2.Project, []string{"intranet"})
 	require.NoError(t, err)
 
-	containers, err := cluster.GetInstances(context.TODO(), tx.Tx(), cluster.InstanceFilter{})
+	containers, err := cluster.GetInstances(context.TODO(), tx.Tx())
 	require.NoError(t, err)
 
 	c1Profiles, err := cluster.GetInstanceProfiles(context.TODO(), tx.Tx(), containers[0].ID)
@@ -266,7 +265,7 @@ func TestInstanceList(t *testing.T) {
 	require.NoError(t, err)
 
 	var instances []db.InstanceArgs
-	err = c.InstanceList(nil, func(dbInst db.InstanceArgs, p api.Project) error {
+	err = c.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
 
@@ -424,7 +423,8 @@ func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 	addContainer(t, tx, nodeID3, "c3")
 	addContainer(t, tx, nodeID2, "c4")
 
-	result, err := tx.GetProjectAndInstanceNamesByNodeAddress([]string{"default"}, db.InstanceTypeFilter(instancetype.Container))
+	instType := instancetype.Container
+	result, err := tx.GetProjectAndInstanceNamesByNodeAddress([]string{"default"}, instType)
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -448,7 +448,8 @@ func TestGetInstanceToNodeMap(t *testing.T) {
 	addContainer(t, tx, nodeID2, "c1")
 	addContainer(t, tx, nodeID1, "c2")
 
-	result, err := tx.GetProjectInstanceToNodeMap([]string{"default"}, db.InstanceTypeFilter(instancetype.Container))
+	instType := instancetype.Container
+	result, err := tx.GetProjectInstanceToNodeMap([]string{"default"}, instType)
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -519,7 +520,8 @@ func TestGetLocalInstancesInProject(t *testing.T) {
 	addContainerDevice(t, tx, "c2", "eth0", "nic", nil)
 	addContainerDevice(t, tx, "c4", "root", "disk", map[string]string{"x": "y"})
 
-	containers, err := tx.GetLocalInstancesInProject(context.TODO(), db.InstanceTypeFilter(instancetype.Container))
+	instType := instancetype.Container
+	containers, err := tx.GetLocalInstancesInProject(context.TODO(), cluster.InstanceFilter{Type: &instType})
 	require.NoError(t, err)
 	assert.Len(t, containers, 3)
 

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -62,7 +62,7 @@ func TestImportPreClusteringData(t *testing.T) {
 
 	// certificates
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		certs, err := cluster.GetCertificates(context.Background(), tx.Tx(), cluster.CertificateFilter{})
+		certs, err := cluster.GetCertificates(context.Background(), tx.Tx())
 		require.NoError(t, err)
 		assert.Len(t, certs, 1)
 		cert := certs[0]

--- a/lxd/db/snapshots_test.go
+++ b/lxd/db/snapshots_test.go
@@ -33,8 +33,7 @@ func TestGetInstanceSnapshots(t *testing.T) {
 	addInstanceSnapshotDevice(t, tx, "c2", "snap2", "eth0", "nic", nil)
 	addInstanceSnapshotDevice(t, tx, "c2", "snap3", "root", "disk", map[string]string{"x": "y"})
 
-	filter := cluster.InstanceSnapshotFilter{}
-	snapshots, err := cluster.GetInstanceSnapshots(context.TODO(), tx.Tx(), filter)
+	snapshots, err := cluster.GetInstanceSnapshots(context.TODO(), tx.Tx())
 	require.NoError(t, err)
 	assert.Len(t, snapshots, 3)
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2233,7 +2233,7 @@ func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation
 	var projects []api.Project
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		dbProjects, err := dbCluster.GetProjects(ctx, tx.Tx(), dbCluster.ProjectFilter{})
+		dbProjects, err := dbCluster.GetProjects(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -450,15 +450,12 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 	var err error
 	var instances []Instance
 
-	filter := cluster.InstanceFilter{
-		Type: &instanceType,
-	}
-
+	filter := cluster.InstanceFilter{Type: instanceType.Filter()}
 	if s.ServerName != "" {
 		filter.Node = &s.ServerName
 	}
 
-	err = s.DB.Cluster.InstanceList(&filter, func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
 		inst, err := Load(s, dbInst, dbInst.Profiles)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
@@ -467,7 +464,7 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 		instances = append(instances, inst)
 
 		return nil
-	})
+	}, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/instancetype/instance_type.go
+++ b/lxd/instance/instancetype/instance_type.go
@@ -50,3 +50,13 @@ func (instanceType Type) String() string {
 
 	return ""
 }
+
+// Filter returns a valid filter field compatible with cluster.InstanceFilter.
+// 'Any' represents any possible instance type, and so it is omitted.
+func (instanceType Type) Filter() *Type {
+	if instanceType == Any {
+		return nil
+	}
+
+	return &instanceType
+}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -141,7 +141,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			targetNodeOffline = node.IsOffline(s.GlobalConfig.OfflineThreshold())
 
 			// Load source node.
-			address, err := tx.GetNodeAddressOfInstance(projectName, name, db.InstanceTypeFilter(instanceType))
+			address, err := tx.GetNodeAddressOfInstance(projectName, name, instanceType)
 			if err != nil {
 				return fmt.Errorf("Failed to get address of instance's member: %w", err)
 			}

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -284,7 +284,7 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 		var err error
 
 		if allProjects {
-			projects, err := dbCluster.GetProjects(context.Background(), tx.Tx(), dbCluster.ProjectFilter{})
+			projects, err := dbCluster.GetProjects(context.Background(), tx.Tx())
 			if err != nil {
 				return err
 			}
@@ -300,12 +300,12 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 			filteredProjects = []string{projectName}
 		}
 
-		nodesProjectsInstances, err = tx.GetProjectAndInstanceNamesByNodeAddress(filteredProjects, db.InstanceTypeFilter(instanceType))
+		nodesProjectsInstances, err = tx.GetProjectAndInstanceNamesByNodeAddress(filteredProjects, instanceType)
 		if err != nil {
 			return err
 		}
 
-		projectInstanceToNodeName, err = tx.GetProjectInstanceToNodeMap(filteredProjects, db.InstanceTypeFilter(instanceType))
+		projectInstanceToNodeName, err = tx.GetProjectInstanceToNodeMap(filteredProjects, instanceType)
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1225,7 +1225,7 @@ func clusterCopyContainerInternal(d *Daemon, r *http.Request, source instance.In
 		var err error
 
 		// Load source node.
-		nodeAddress, err = tx.GetNodeAddressOfInstance(projectName, name, db.InstanceTypeFilter(source.Type()))
+		nodeAddress, err = tx.GetNodeAddressOfInstance(projectName, name, source.Type())
 		if err != nil {
 			return fmt.Errorf("Failed to get address of instance's member: %w", err)
 		}

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -117,7 +117,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 	var profiles []cluster.Profile
 	profileDevices := map[string]map[string]cluster.Device{}
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		profiles, err = cluster.GetProfiles(ctx, tx.Tx(), cluster.ProfileFilter{})
+		profiles, err = cluster.GetProfiles(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
@@ -204,7 +204,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 	}
 
 	// Find instances using the ACLs. Most expensive to do.
-	err = s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -74,7 +74,7 @@ func MACDevName(mac net.HardwareAddr) string {
 
 // usedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 func usedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error) error {
-	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	return s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -157,7 +157,7 @@ func UsedBy(s *state.State, networkProjectName string, networkID int64, networkN
 
 	// Look for profiles. Next cheapest to do.
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		profiles, err := cluster.GetProfiles(ctx, tx.Tx(), cluster.ProfileFilter{})
+		profiles, err := cluster.GetProfiles(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/db/cluster"
+	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/device/pci"
 	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
@@ -53,14 +53,11 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 		return nil, err
 	}
 
-	filter := cluster.InstanceFilter{
-		Node: &s.ServerName,
-	}
-
+	filter := dbCluster.InstanceFilter{Node: &s.ServerName}
 	reservedDevices := map[string]struct{}{}
 
 	// Check if any instances are using the VF device.
-	err = s.DB.Cluster.InstanceList(&filter, func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
 		// Expand configs so we take into account profile devices.
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
@@ -80,7 +77,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 		}
 
 		return nil
-	})
+	}, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -145,7 +145,7 @@ func patchDnsmasqEntriesIncludeDeviceName(name string, d *Daemon) error {
 
 func patchRemoveWarningsWithEmptyNode(name string, d *Daemon) error {
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		warnings, err := dbCluster.GetWarnings(ctx, tx.Tx(), dbCluster.WarningFilter{})
+		warnings, err := dbCluster.GetWarnings(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func patchClusteringServerCertTrust(name string, d *Daemon) error {
 		var err error
 		var dbCerts []dbCluster.Certificate
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			dbCerts, err = dbCluster.GetCertificates(ctx, tx.Tx(), dbCluster.CertificateFilter{})
+			dbCerts, err = dbCluster.GetCertificates(ctx, tx.Tx())
 			return err
 		})
 		if err != nil {
@@ -401,7 +401,7 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	return d.State().DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -44,11 +44,8 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 
 	// Get instances on this local server (as the DB helper functions return volumes on local server), also
 	// avoids running the same queries on every cluster member for instances on shared storage.
-	filter := cluster.InstanceFilter{
-		Node: &localNode,
-	}
-
-	err = b.state.DB.Cluster.InstanceList(&filter, func(inst db.InstanceArgs, p api.Project) error {
+	filter := cluster.InstanceFilter{Node: &localNode}
+	err = b.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
 		// Check we can convert the instance to the volume type needed.
 		volType, err := InstanceTypeToVolumeType(inst.Type)
 		if err != nil {
@@ -120,7 +117,7 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 		}
 
 		return nil
-	})
+	}, filter)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/storage.go
+++ b/lxd/storage/storage.go
@@ -199,7 +199,7 @@ func UsedBy(ctx context.Context, s *state.State, pool Pool, firstOnly bool, memb
 		}
 
 		// Get all the profiles using the storage pool.
-		profiles, err := cluster.GetProfiles(ctx, tx.Tx(), cluster.ProfileFilter{})
+		profiles, err := cluster.GetProfiles(ctx, tx.Tx())
 		if err != nil {
 			return fmt.Errorf("Failed loading profiles: %w", err)
 		}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -623,7 +623,7 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 	var profileProjects []*api.Project
 	// Retrieve required info from the database in single transaction for performance.
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projects, err := cluster.GetProjects(ctx, tx.Tx(), cluster.ProjectFilter{})
+		projects, err := cluster.GetProjects(ctx, tx.Tx())
 		if err != nil {
 			return fmt.Errorf("Failed loading projects: %w", err)
 		}
@@ -633,7 +633,7 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 			projectMap[project.Name] = projects[i]
 		}
 
-		dbProfiles, err := cluster.GetProfiles(ctx, tx.Tx(), cluster.ProfileFilter{})
+		dbProfiles, err := cluster.GetProfiles(ctx, tx.Tx())
 		if err != nil {
 			return fmt.Errorf("Failed loading profiles: %w", err)
 		}
@@ -719,7 +719,7 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 		return err
 	}
 
-	return s.DB.Cluster.InstanceList(nil, func(inst db.InstanceArgs, p api.Project) error {
+	return s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
 		// If the volume has a specific cluster member which is different than the instance then skip as
 		// instance cannot be using this volume.
 		if vol.Location != "" && inst.Node != vol.Location {

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1141,7 +1141,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		var volumes, remoteVolumes []db.StorageVolumeArgs
 		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			projs, err := dbCluster.GetProjects(ctx, tx.Tx(), dbCluster.ProjectFilter{})
+			projs, err := dbCluster.GetProjects(ctx, tx.Tx())
 			if err != nil {
 				return fmt.Errorf("Failed loading projects: %w", err)
 			}

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -170,13 +170,13 @@ func warningsGet(d *Daemon, r *http.Request) response.Response {
 
 	var warnings []api.Warning
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		filter := cluster.WarningFilter{}
-
+		filters := []cluster.WarningFilter{}
 		if projectName != "" {
-			filter.Project = &projectName
+			filter := cluster.WarningFilter{Project: &projectName}
+			filters = append(filters, filter)
 		}
 
-		dbWarnings, err := cluster.GetWarnings(ctx, tx.Tx(), filter)
+		dbWarnings, err := cluster.GetWarnings(ctx, tx.Tx(), filters...)
 		if err != nil {
 			return fmt.Errorf("Failed to get warnings: %w", err)
 		}

--- a/lxd/warnings/warnings.go
+++ b/lxd/warnings/warnings.go
@@ -32,7 +32,7 @@ func ResolveWarningsByLocalNodeOlderThan(dbCluster *db.Cluster, date time.Time) 
 	}
 
 	err = dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		warnings, err := cluster.GetWarnings(ctx, tx.Tx(), cluster.WarningFilter{})
+		warnings, err := cluster.GetWarnings(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This updates `lxd-generate` to use variadic filter structs on `GetMany` functions. The non-nil fields within each struct will be `AND`ed together, and each filter will be `OR`ed together. `Config` and `Devices` tables can now also be filtered.

If an empty filter is provided, the function errors out. There was some refactoring of the existing calls that had to be done to support this, namely  the`InstanceTypeFilter` is now gone, and `InstanceList` accepts a `map[instancetype.Type][]cluster.InstanceFilter`. The reason for the map is that `InstanceList` will set `InstanceFilter.Type` to `nil` if it is `instancetype.Any`, potentially creating an empty filter. Rather than trying to ensure we never pass a filter with only `instancetype.Any` filter into `InstanceList`, using a map lets us handle the `instancetype` within `InstanceList` itself.

If 1 or fewer filters are given, we will fall back to the in-memory prepared statement. I tested this with `lxd-benchmark init -C 30` run 100 times back to back for each implementation, and falling back to the prepared statements resulted in a slightly less than 10% performance improvement. If we end up using multiple filters primarily, then maybe this logic can be removed then.