### PR TITLE
lxd-generate Allow Type field in filter struct

### DIFF
--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -530,7 +530,12 @@ func (m *Method) getOne(buf *file.Buffer) error {
 
 	buf.L("filter := %s{}", entityFilter(m.entity))
 	for _, field := range nk {
-		buf.L("filter.%s = &%s", field.Name, lex.Minuscule(field.Name))
+		name := lex.Minuscule(field.Name)
+		if name == "type" {
+			name = lex.Minuscule(m.entity) + field.Name
+		}
+
+		buf.L("filter.%s = &%s", field.Name, name)
 	}
 
 	buf.N()


### PR DESCRIPTION
#10833 causes `make update-schema` in LXD Cloud with:
```
Error: Can't format generated source code: 7:16: expected operand, found 'type'
```
This is the same error as in #10802 and this PR fixes it in the same way.