### PR TITLE
lxd-generate join config

### DIFF
--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -301,12 +301,11 @@ func (s *Stmt) create(buf *file.Buffer, replace bool) error {
 			}
 
 			columns[i] = referenceColumn
-			table := entityTable(ref, "")
-			params[i] = fmt.Sprintf("(SELECT %s.id FROM %s", table, table)
+			params[i] = fmt.Sprintf("(SELECT %s.id FROM %s", joinTable, joinTable)
 			for _, other := range via[ref] {
 				otherRef := lex.Snake(other.Name)
 				otherTable := entityTable(otherRef, "")
-				params[i] += fmt.Sprintf(" JOIN %s ON %s.id = %s.%s_id", otherTable, otherTable, table, otherRef)
+				params[i] += fmt.Sprintf(" JOIN %s ON %s.id = %s.%s_id", otherTable, otherTable, joinTable, otherRef)
 			}
 
 			params[i] += " WHERE"

--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -181,7 +181,12 @@ func (s *Stmt) objects(buf *file.Buffer) error {
 		orderBy = make([]string, len(nk))
 		for i, field := range nk {
 			if field.IsScalar() {
-				orderBy[i] = lex.Plural(lex.Snake(field.Name)) + ".id"
+				table, _, err := field.ScalarTableColumn()
+				if err != nil {
+					return err
+				}
+
+				orderBy[i] = table + ".id"
 			} else {
 				orderBy[i] = mapping.FieldColumnName(field.Name, table)
 				if mapping.Type == ReferenceTable || mapping.Type == MapTable {


### PR DESCRIPTION
Uses the join configuration in the `db` struct tag to set correct table and column names in the where, join, and order by clauses or generated statements.

`make update-schema` does not change generated statements for LXD.

@masnax I've made the changes necessary to fix the issues in #10844 but I'm not sure if there are any other parts of the generator that might need similar changes. Also in the `whereClause` function, I'm not sure if it's ok to use the singular form of the join table name in the `via` map. Let me know what you think.

Closes #10844.