### PR TITLE
Project rename response docs

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -12305,8 +12305,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          $ref: '#/responses/EmptySyncResponse'
+        "202":
+          $ref: '#/responses/Operation'
         "400":
           $ref: '#/responses/BadRequest'
         "403":

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -743,8 +743,8 @@ func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response
 //     schema:
 //       $ref: "#/definitions/ProjectPost"
 // responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
+//   "202":
+//     $ref: "#/responses/Operation"
 //   "400":
 //     $ref: "#/responses/BadRequest"
 //   "403":


### PR DESCRIPTION
Change swagger documentation for `POST /1.0/projects/{projectName}` to an operation response (`EmptySyncResponse` was incorrect).