### PR TITLE
Storage: Use `Volume` to represent buckets with a new VolumeType

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -227,23 +227,6 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 	return nil
 }
 
-// GetBucket returns a drivers.Bucket containing copies of the supplied bucket config and the pools config.
-func (b *lxdBackend) GetBucket(bucketName string, bucketconfig map[string]string) drivers.Bucket {
-	// Copy the config map to avoid internal modifications affecting external state.
-	newConfig := make(map[string]string, len(bucketconfig))
-	for k, v := range bucketconfig {
-		newConfig[k] = v
-	}
-
-	// Copy the pool config map to avoid internal modifications affecting external state.
-	newPoolConfig := make(map[string]string, len(b.db.Config))
-	for k, v := range b.db.Config {
-		newPoolConfig[k] = v
-	}
-
-	return drivers.NewBucket(b.driver, b.name, bucketName, newConfig, newPoolConfig)
-}
-
 // GetVolume returns a drivers.Volume containing copies of the supplied volume config and the pools config.
 func (b *lxdBackend) GetVolume(volType drivers.VolumeType, contentType drivers.ContentType, volName string, volConfig map[string]string) drivers.Volume {
 	// Copy the config map to avoid internal modifications affecting external state.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3279,25 +3279,20 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 		return fmt.Errorf("Storage pool does not support buckets")
 	}
 
-	// Validate config.
-	storageBucket := b.GetBucket(bucket.Name, bucket.Config)
-
-	err = b.driver.ValidateBucket(storageBucket)
-	if err != nil {
-		return err
-	}
-
+	// Validate config and create database entry for new storage bucket.
 	revert := revert.New()
 	defer revert.Fail()
 
 	memberSpecific := !b.Driver().Info().Remote // Member specific if storage pool isn't remote.
 
-	bucketID, err := b.state.DB.Cluster.CreateStoragePoolBucket(context.TODO(), b.id, projectName, memberSpecific, bucket)
+	bucketID, err := BucketDBCreate(context.TODO(), b, projectName, memberSpecific, &bucket)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = b.state.DB.Cluster.DeleteStoragePoolBucket(context.TODO(), b.id, bucketID) })
+	revert.Add(func() { _ = BucketDBDelete(context.TODO(), b, bucketID) })
+
+	storageBucket := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucket.Name, bucket.Config)
 
 	// Create the bucket on the storage device.
 	err = b.driver.CreateBucket(storageBucket, op)
@@ -3336,12 +3331,17 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 		return err
 	}
 
-	curStorageBucket := b.GetBucket(curBucket.Name, curBucket.Config)
+	curStorageBucket := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, curBucket.Name, curBucket.Config)
 
 	// Validate config.
-	newStorageBucket := b.GetBucket(curBucket.Name, bucket.Config)
+	newStorageBucket := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, curBucket.Name, bucket.Config)
 
 	err = b.driver.ValidateBucket(newStorageBucket)
+	if err != nil {
+		return err
+	}
+
+	err = b.driver.ValidateVolume(newStorageBucket, false)
 	if err != nil {
 		return err
 	}
@@ -3408,16 +3408,16 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 		return err
 	}
 
-	storageBucket := b.GetBucket(bucket.Name, bucket.Config)
+	storageBucket := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucket.Name, bucket.Config)
 
 	err = b.driver.DeleteBucket(storageBucket, op)
 	if err != nil {
 		return err
 	}
 
-	err = b.state.DB.Cluster.DeleteStoragePoolBucket(context.TODO(), b.id, bucket.ID)
+	_ = BucketDBDelete(context.TODO(), b, bucket.ID)
 	if err != nil {
-		return fmt.Errorf("Failed deleting bucket from database: %w", err)
+		return err
 	}
 
 	return nil
@@ -3449,12 +3449,7 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 		return nil, err
 	}
 
-	storageBucket := b.GetBucket(bucket.Name, bucket.Config)
-
-	err = b.driver.ValidateBucket(storageBucket)
-	if err != nil {
-		return nil, err
-	}
+	storageBucket := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucket.Name, bucket.Config)
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -3554,11 +3549,7 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 		return nil // Nothing has changed.
 	}
 
-	storageBucket := b.GetBucket(bucket.Name, bucket.Config)
-	err = b.driver.ValidateBucket(storageBucket)
-	if err != nil {
-		return err
-	}
+	storageBucket := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucket.Name, bucket.Config)
 
 	creds := drivers.S3Credentials{
 		AccessKey: newBucketKey.AccessKey,
@@ -3623,7 +3614,7 @@ func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyN
 		return err
 	}
 
-	storageBucket := b.GetBucket(bucket.Name, bucket.Config)
+	storageBucket := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucket.Name, bucket.Config)
 
 	// Delete the bucket key from the storage device.
 	err = b.driver.DeleteBucketKey(storageBucket, keyName, op)

--- a/lxd/storage/drivers/bucket.go
+++ b/lxd/storage/drivers/bucket.go
@@ -5,38 +5,3 @@ type S3Credentials struct {
 	AccessKey string `json:"access_key"`
 	SecretKey string `json:"secret_key"`
 }
-
-// Bucket represents a storage bucket.
-type Bucket struct {
-	name       string
-	pool       string
-	poolConfig map[string]string
-	config     map[string]string
-	driver     Driver
-}
-
-// NewBucket instantiates a new Bucket struct.
-func NewBucket(driver Driver, poolName string, bucketName string, bucketConfig map[string]string, poolConfig map[string]string) Bucket {
-	return Bucket{
-		name:       bucketName,
-		pool:       poolName,
-		poolConfig: poolConfig,
-		config:     bucketConfig,
-		driver:     driver,
-	}
-}
-
-// Name returns volume's name.
-func (b Bucket) Name() string {
-	return b.name
-}
-
-// Pool returns the volume's pool name.
-func (b Bucket) Pool() string {
-	return b.pool
-}
-
-// Config returns the volume's (unexpanded) config.
-func (b Bucket) Config() map[string]string {
-	return b.config
-}

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -17,6 +17,7 @@ import (
 var cephobjectVersion string
 var cephobjectLoaded bool
 
+// cephobjectRadosgwAdminUser admin user in radosgw.
 const cephobjectRadosgwAdminUser = "lxd-admin"
 
 type cephobject struct {

--- a/lxd/storage/drivers/driver_cephobject_buckets.go
+++ b/lxd/storage/drivers/driver_cephobject_buckets.go
@@ -84,15 +84,15 @@ func (d *cephobject) CreateBucket(bucket Bucket, op *operations.Operation) error
 		}
 	}
 
+	storageBucketName := d.radosgwBucketName(bucket.name)
+
+	minioCtx, minioCtxCancel := context.WithTimeout(context.TODO(), time.Second*30)
+	defer minioCtxCancel()
+
 	minioClient, err := d.s3Client(*adminUserInfo)
 	if err != nil {
 		return err
 	}
-
-	storageBucketName := d.radosgwBucketName(bucket.name)
-
-	minioCtx, cancel := context.WithTimeout(context.TODO(), time.Second*30)
-	defer cancel()
 
 	bucketExists, err := minioClient.BucketExists(minioCtx, storageBucketName)
 	if err != nil {

--- a/lxd/storage/drivers/driver_cephobject_buckets.go
+++ b/lxd/storage/drivers/driver_cephobject_buckets.go
@@ -21,6 +21,11 @@ import (
 	"github.com/lxc/lxd/shared/units"
 )
 
+// ValidateVolume validates the supplied volume config.
+func (d *cephobject) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
+	return d.validateVolume(vol, nil, removeUnknownKeys)
+}
+
 // s3Client returns a configured minio S3 client.
 func (d *cephobject) s3Client(creds S3Credentials) (*minio.Client, error) {
 	u, err := url.ParseRequestURI(d.config["cephobject.radosgw.endpoint"])
@@ -69,7 +74,7 @@ func (d *cephobject) s3Client(creds S3Credentials) (*minio.Client, error) {
 }
 
 // CreateBucket creates a new bucket.
-func (d *cephobject) CreateBucket(bucket Bucket, op *operations.Operation) error {
+func (d *cephobject) CreateBucket(bucket Volume, op *operations.Operation) error {
 	// Check if there is an existing cephobjectRadosgwAdminUser user.
 	adminUserInfo, _, err := d.radosgwadminGetUser(context.TODO(), cephobjectRadosgwAdminUser)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -141,7 +146,7 @@ func (d *cephobject) CreateBucket(bucket Bucket, op *operations.Operation) error
 }
 
 // setBucketQuota sets the bucket quota.
-func (d *cephobject) setBucketQuota(bucket Bucket, quotaSize string) error {
+func (d *cephobject) setBucketQuota(bucket Volume, quotaSize string) error {
 	storageBucketName := d.radosgwBucketName(bucket.name)
 
 	sizeBytes, err := units.ParseByteSizeString(quotaSize)
@@ -158,7 +163,7 @@ func (d *cephobject) setBucketQuota(bucket Bucket, quotaSize string) error {
 }
 
 // DeleteBucket deletes an existing bucket.
-func (d *cephobject) DeleteBucket(bucket Bucket, op *operations.Operation) error {
+func (d *cephobject) DeleteBucket(bucket Volume, op *operations.Operation) error {
 	storageBucketName := d.radosgwBucketName(bucket.name)
 
 	err := d.radosgwadminBucketDelete(context.TODO(), storageBucketName)
@@ -175,7 +180,7 @@ func (d *cephobject) DeleteBucket(bucket Bucket, op *operations.Operation) error
 }
 
 // UpdateBucket updates an existing bucket.
-func (d *cephobject) UpdateBucket(bucket Bucket, changedConfig map[string]string) error {
+func (d *cephobject) UpdateBucket(bucket Volume, changedConfig map[string]string) error {
 	newSize, sizeChanged := changedConfig["size"]
 	if sizeChanged {
 		err := d.setBucketQuota(bucket, newSize)
@@ -200,7 +205,7 @@ func (d *cephobject) bucketKeyRadosgwAccessRole(roleName string) (string, error)
 }
 
 // CreateBucket creates a new bucket.
-func (d *cephobject) CreateBucketKey(bucket Bucket, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
+func (d *cephobject) CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
 	storageBucketName := d.radosgwBucketName(bucket.name)
 
 	accessRole, err := d.bucketKeyRadosgwAccessRole(roleName)
@@ -228,7 +233,7 @@ func (d *cephobject) CreateBucketKey(bucket Bucket, keyName string, creds S3Cred
 }
 
 // UpdateBucketKey updates bucket key.
-func (d *cephobject) UpdateBucketKey(bucket Bucket, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
+func (d *cephobject) UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error) {
 	storageBucketName := d.radosgwBucketName(bucket.name)
 
 	accessRole, err := d.bucketKeyRadosgwAccessRole(roleName)
@@ -263,7 +268,7 @@ func (d *cephobject) UpdateBucketKey(bucket Bucket, keyName string, creds S3Cred
 }
 
 // DeleteBucketKey deletes an existing bucket key.
-func (d *cephobject) DeleteBucketKey(bucket Bucket, keyName string, op *operations.Operation) error {
+func (d *cephobject) DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error {
 	storageBucketName := d.radosgwBucketName(bucket.name)
 
 	err := d.radosgwadminSubUserDelete(context.TODO(), storageBucketName, keyName)

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -48,15 +48,15 @@ type Driver interface {
 	ApplyPatch(name string) error
 
 	// Buckets.
-	ValidateBucket(bucket Bucket) error
+	ValidateBucket(bucket Volume) error
 	BucketURL(bucketName string) *url.URL
-	CreateBucket(bucket Bucket, op *operations.Operation) error
-	DeleteBucket(bucket Bucket, op *operations.Operation) error
-	UpdateBucket(bucket Bucket, changedConfig map[string]string) error
+	CreateBucket(bucket Volume, op *operations.Operation) error
+	DeleteBucket(bucket Volume, op *operations.Operation) error
+	UpdateBucket(bucket Volume, changedConfig map[string]string) error
 	ValidateBucketKey(keyName string, creds S3Credentials, roleName string) error
-	CreateBucketKey(bucket Bucket, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
-	UpdateBucketKey(bucket Bucket, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
-	DeleteBucketKey(bucket Bucket, keyName string, op *operations.Operation) error
+	CreateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
+	UpdateBucketKey(bucket Volume, keyName string, creds S3Credentials, roleName string, op *operations.Operation) (*S3Credentials, error)
+	DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error
 
 	// Volumes.
 	FillVolumeConfig(vol Volume) error

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -42,6 +42,9 @@ func (t VolumeType) IsInstance() bool {
 	return false
 }
 
+// VolumeTypeBucket represents a bucket storage volume.
+const VolumeTypeBucket = VolumeType("buckets")
+
 // VolumeTypeImage represents an image storage volume.
 const VolumeTypeImage = VolumeType("images")
 
@@ -69,6 +72,7 @@ type VolumePostHook func(vol Volume) error
 
 // BaseDirectories maps volume types to the expected directories.
 var BaseDirectories = map[VolumeType][]string{
+	VolumeTypeBucket:    {"buckets"},
 	VolumeTypeContainer: {"containers", "containers-snapshots"},
 	VolumeTypeCustom:    {"custom", "custom-snapshots"},
 	VolumeTypeImage:     {"images"},

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -99,7 +99,7 @@ func VolumeTypeToDBType(volType drivers.VolumeType) (int, error) {
 		return db.StoragePoolVolumeTypeCustom, nil
 	}
 
-	return -1, fmt.Errorf("Invalid storage volume type")
+	return -1, fmt.Errorf("Invalid storage volume type: %q", volType)
 }
 
 // VolumeDBTypeToType converts internal volume type DB code to storage driver volume type.
@@ -115,7 +115,7 @@ func VolumeDBTypeToType(volDBType int) (drivers.VolumeType, error) {
 		return drivers.VolumeTypeCustom, nil
 	}
 
-	return "", fmt.Errorf("Invalid storage volume type")
+	return "", fmt.Errorf("Invalid storage volume DB type: %d", volDBType)
 }
 
 // InstanceTypeToVolumeType converts instance type to storage driver volume type.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -212,6 +212,10 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 		return fmt.Errorf("Pool is not a lxdBackend")
 	}
 
+	if volumeType == drivers.VolumeTypeBucket {
+		return fmt.Errorf("Cannot storage volume using bucket type")
+	}
+
 	// If the volumeType represents an instance type then check that the volumeConfig doesn't contain any of
 	// the instance disk effective override fields (which should not be stored in the database).
 	if volumeType.IsInstance() {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -194,7 +194,7 @@ func VolumeDBGet(pool Pool, projectName string, volumeName string, volumeType dr
 	_, vol, err := p.state.DB.Cluster.GetLocalStoragePoolVolume(projectName, volumeName, volDBType, pool.ID())
 	if err != nil {
 		if response.IsNotFoundError(err) {
-			return vol, fmt.Errorf("Storage volume %q in project %q of type %q does not exist on pool %q: %w", volumeName, projectName, volumeType, pool.Name(), err)
+			return nil, fmt.Errorf("Storage volume %q in project %q of type %q does not exist on pool %q: %w", volumeName, projectName, volumeType, pool.Name(), err)
 		}
 
 		return nil, err

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -317,6 +317,64 @@ func VolumeDBSnapshotsGet(pool Pool, projectName string, volume string, volumeTy
 	return snapshots, nil
 }
 
+// BucketDBCreate creates a bucket in the database.
+// The supplied bucket's config may be modified with defaults for the storage pool being used.
+// Returns bucket DB record ID.
+func BucketDBCreate(ctx context.Context, pool Pool, projectName string, memberSpecific bool, bucket *api.StorageBucketsPost) (int64, error) {
+	p, ok := pool.(*lxdBackend)
+	if !ok {
+		return -1, fmt.Errorf("Pool is not a lxdBackend")
+	}
+
+	// Make sure that we don't pass a nil to the next function.
+	if bucket.Config == nil {
+		bucket.Config = map[string]string{}
+	}
+
+	bucketVol := drivers.NewVolume(pool.Driver(), pool.Name(), drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucket.Name, bucket.Config, pool.Driver().Config())
+
+	// Fill default config.
+	err := pool.Driver().FillVolumeConfig(bucketVol)
+	if err != nil {
+		return -1, err
+	}
+
+	// Validate bucket name.
+	err = pool.Driver().ValidateBucket(bucketVol)
+	if err != nil {
+		return -1, err
+	}
+
+	// Validate bucket volume config.
+	err = pool.Driver().ValidateVolume(bucketVol, false)
+	if err != nil {
+		return -1, err
+	}
+
+	// Create the database entry for the storage bucket.
+	bucketID, err := p.state.DB.Cluster.CreateStoragePoolBucket(ctx, p.ID(), projectName, memberSpecific, *bucket)
+	if err != nil {
+		return -1, fmt.Errorf("Failed inserting storage bucket %q for project %q in pool %q into database: %w", bucket.Name, projectName, pool.Name(), err)
+	}
+
+	return bucketID, nil
+}
+
+// BucketDBDelete deletes a bucket from the database.
+func BucketDBDelete(ctx context.Context, pool Pool, bucketID int64) error {
+	p, ok := pool.(*lxdBackend)
+	if !ok {
+		return fmt.Errorf("Pool is not a lxdBackend")
+	}
+
+	err := p.state.DB.Cluster.DeleteStoragePoolBucket(ctx, p.ID(), bucketID)
+	if err != nil && !response.IsNotFoundError(err) {
+		return fmt.Errorf("Failed deleting storage bucket from database: %w", err)
+	}
+
+	return nil
+}
+
 // poolAndVolumeCommonRules returns a map of pool and volume config common rules common to all drivers.
 // When vol argument is nil function returns pool specific rules.
 func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error {

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -301,7 +301,10 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	bucket.S3URL = pool.Driver().BucketURL(bucket.Name).String()
+	u := pool.Driver().BucketURL(bucket.Name)
+	if u != nil {
+		bucket.S3URL = u.String()
+	}
 
 	return response.SyncResponseETag(true, bucket, bucket.Etag())
 }


### PR DESCRIPTION
As part of implementing local storage buckets we need to use local volumes to back the MinIO process that is providing the S3 bucket service.

Because each storage driver can provide pool level volume defaults (some of these necessary for mounting the volume) I think it makes sense to re-use the `Volume` struct, with all of its existing config handling logic rather than duplicate/merge/over complicate it with a dedicated `Bucket` struct type.

This was OK when we only had `cephobject` pool type as that didn't have the concept of volumes at all.

Note: We are still not creating bucket DB records in the `storage_volumes` table, and there is a specific check to prevent this should it be accidentally tried.