### PR TITLE
Storage: Precursor changes before local bucket support

### DIFF
--- a/lxd/storage/storage.go
+++ b/lxd/storage/storage.go
@@ -184,7 +184,12 @@ func UsedBy(ctx context.Context, s *state.State, pool Pool, firstOnly bool, memb
 		}
 
 		// Get all buckets using the storage pool.
-		buckets, err := tx.GetStoragePoolBuckets(pool.ID(), memberSpecific)
+		poolID := pool.ID()
+		filters := []db.StorageBucketFilter{{
+			PoolID: &poolID,
+		}}
+
+		buckets, err := tx.GetStoragePoolBuckets(memberSpecific, filters...)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage buckets: %w", err)
 		}

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -174,11 +174,13 @@ func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 	var dbBuckets []*db.StorageBucket
 
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		poolID := pool.ID()
 		filters := []db.StorageBucketFilter{{
+			PoolID:  &poolID,
 			Project: &bucketProjectName,
 		}}
 
-		dbBuckets, err = tx.GetStoragePoolBuckets(pool.ID(), memberSpecific, filters...)
+		dbBuckets, err = tx.GetStoragePoolBuckets(memberSpecific, filters...)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage buckets: %w", err)
 		}


### PR DESCRIPTION
- Initialise ZFS pool datasets on mounts. So we can be sure that they exist and have the correct policy. Will also mean that existing ZFS pools get the forthcoming buckets datasets. This is similar to how `backendLXD.Mount()` already creates any missing pool directories if needed.
- Add support for searching for buckets across pools (required for looking up local buckets by name).