### PR TITLE
Test: Adds timeout to `lxc` command calls

### DIFF
--- a/scripts/empty-lxd.sh
+++ b/scripts/empty-lxd.sh
@@ -42,11 +42,18 @@ done
 ## Delete the storage pools
 echo "==> Deleting all storage pools"
 for storage_pool in $(lxc query "/1.0/storage-pools?recursion=1" | jq .[].name -r); do
+    # Delete the storage volumes.
     for volume in $(lxc query "/1.0/storage-pools/${storage_pool}/volumes/custom?recursion=1" | jq .[].name -r); do
         echo "==> Deleting storage volume ${volume} on ${storage_pool}"
         lxc storage volume delete "${storage_pool}" "${volume}"
     done
 
-    ## Delete the custom storage volumes
+    # Delete the storage buckets.
+    for bucket in $(lxc query "/1.0/storage-pools/${storage_pool}/buckets?recursion=1" | jq .[].name -r); do
+        echo "==> Deleting storage bucket ${bucket} on ${storage_pool}"
+        lxc storage volume delete "${storage_pool}" "${bucket}"
+    done
+
+    ## Delete the storage pool.
     lxc storage delete "${storage_pool}"
 done

--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -33,7 +33,7 @@ lxc_remote() {
     if [ -n "${DEBUG:-}" ]; then
         set -x
     fi
-    eval "${cmd}"
+    eval "timeout --foreground 60 ${cmd}"
 }
 
 gen_cert() {

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -165,8 +165,21 @@ kill_lxd() {
         printf 'config: {}\ndevices: {}' | timeout -k 5 5 lxc profile edit default
 
         echo "==> Deleting all storage pools"
-        for storage in $(timeout -k 2 2 lxc storage list --force-local --format csv | cut -d, -f1); do
-            timeout -k 20 20 lxc storage delete "${storage}" --force-local || true
+        for storage_pool in $(lxc query "/1.0/storage-pools?recursion=1" | jq .[].name -r); do
+            # Delete the storage volumes.
+            for volume in $(lxc query "/1.0/storage-pools/${storage_pool}/volumes/custom?recursion=1" | jq .[].name -r); do
+                echo "==> Deleting storage volume ${volume} on ${storage_pool}"
+                timeout -k 20 20 lxc storage volume delete "${storage_pool}" "${volume}" --force-local || true
+            done
+
+            # Delete the storage buckets.
+            for bucket in $(lxc query "/1.0/storage-pools/${storage_pool}/buckets?recursion=1" | jq .[].name -r); do
+                echo "==> Deleting storage bucket ${bucket} on ${storage_pool}"
+                timeout -k 20 20 lxc storage bucket delete "${storage_pool}" "${bucket}" --force-local || true
+            done
+
+            ## Delete the storage pool.
+            timeout -k 20 20 lxc storage delete "${storage_pool}" --force-local || true
         done
 
         echo "==> Checking for locked DB tables"

--- a/test/includes/storage.sh
+++ b/test/includes/storage.sh
@@ -100,6 +100,11 @@ deconfigure_loop_device() {
     success=0
     # shellcheck disable=SC2034
     for i in $(seq 20); do
+        if ! losetup "${loopdev}"; then
+            success=1
+            break
+        fi
+
         if losetup -d "${loopdev}"; then
             success=1
             break


### PR DESCRIPTION
- If a `lxc` call (or the associated LXD API handler) hangs for some reason then don't hold up the tests and quickly fail.
- Cleanup storage buckets when cleaning up storage pools in tests.
- Allow use of `losetup -d` during tests to allow automatic removal of loop devices when unmounted.