### PR TITLE
Instance: Load api.Project into instance common struct

### DIFF
--- a/lxd-agent/server.go
+++ b/lxd-agent/server.go
@@ -94,9 +94,9 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 		// Handle errors
 		err := resp.Render(w)
 		if err != nil {
-			err := response.InternalError(err).Render(w)
+			writeErr := response.InternalError(err).Render(w)
 			if err != nil {
-				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "error": err})
+				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "error": err, "writeErr": writeErr})
 			}
 		}
 	})

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2777,7 +2777,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 			// Stop the instance if needed.
 			isRunning := inst.IsRunning()
 			if isRunning && !(migrate && live) {
-				metadata["evacuation_progress"] = fmt.Sprintf("Stopping %q in project %q", inst.Name(), inst.Project())
+				metadata["evacuation_progress"] = fmt.Sprintf("Stopping %q in project %q", inst.Name(), inst.Project().Name)
 				_ = op.UpdateMetadata(metadata)
 
 				// Get the shutdown timeout for the instance.
@@ -2834,12 +2834,12 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 
 			// Skip migration if no target available.
 			if targetNodeName == "" {
-				logger.Warn("No migration target available for instance", logger.Ctx{"name": inst.Name(), "project": inst.Project()})
+				logger.Warn("No migration target available for instance", logger.Ctx{"name": inst.Name(), "project": inst.Project().Name})
 				continue
 			}
 
 			// Start migrating the instance.
-			metadata["evacuation_progress"] = fmt.Sprintf("Migrating %q in project %q to %q", inst.Name(), inst.Project(), targetNodeName)
+			metadata["evacuation_progress"] = fmt.Sprintf("Migrating %q in project %q to %q", inst.Name(), inst.Project().Name, targetNodeName)
 			_ = op.UpdateMetadata(metadata)
 
 			// Set origin server (but skip if already set as that suggests more than one server being evacuated).
@@ -2868,9 +2868,9 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 				return fmt.Errorf("Failed to connect to destination: %w", err)
 			}
 
-			dest = dest.UseProject(inst.Project())
+			dest = dest.UseProject(inst.Project().Name)
 
-			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project())
+			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name)
 			_ = op.UpdateMetadata(metadata)
 
 			startOp, err := dest.UpdateInstanceState(inst.Name(), api.InstanceStatePut{Action: "start"}, "")
@@ -2975,7 +2975,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Start the instance.
-			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project())
+			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name)
 			_ = op.UpdateMetadata(metadata)
 
 			err = inst.Start(false)
@@ -2989,7 +2989,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 			// Check if live-migratable.
 			_, live := inst.CanMigrate()
 
-			metadata["evacuation_progress"] = fmt.Sprintf("Migrating %q in project %q from %q", inst.Name(), inst.Project(), inst.Location())
+			metadata["evacuation_progress"] = fmt.Sprintf("Migrating %q in project %q from %q", inst.Name(), inst.Project().Name, inst.Location())
 			_ = op.UpdateMetadata(metadata)
 
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -3009,7 +3009,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 				return fmt.Errorf("Failed to connect to source: %w", err)
 			}
 
-			source = source.UseProject(inst.Project())
+			source = source.UseProject(inst.Project().Name)
 
 			apiInst, _, err := source.GetInstance(inst.Name())
 			if err != nil {
@@ -3018,7 +3018,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 
 			isRunning := apiInst.StatusCode == api.Running
 			if isRunning && !live {
-				metadata["evacuation_progress"] = fmt.Sprintf("Stopping %q in project %q", inst.Name(), inst.Project())
+				metadata["evacuation_progress"] = fmt.Sprintf("Stopping %q in project %q", inst.Name(), inst.Project().Name)
 				_ = op.UpdateMetadata(metadata)
 
 				timeout := inst.ExpandedConfig()["boot.host_shutdown_timeout"]
@@ -3070,7 +3070,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Reload the instance after migration.
-			inst, err := instance.LoadByProjectAndName(s, inst.Project(), inst.Name())
+			inst, err := instance.LoadByProjectAndName(s, inst.Project().Name, inst.Name())
 			if err != nil {
 				return fmt.Errorf("Failed to load instance: %w", err)
 			}
@@ -3085,7 +3085,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 				Devices:      inst.LocalDevices(),
 				Ephemeral:    inst.IsEphemeral(),
 				Profiles:     inst.Profiles(),
-				Project:      inst.Project(),
+				Project:      inst.Project().Name,
 				ExpiryDate:   inst.ExpiryDate(),
 			}
 
@@ -3098,7 +3098,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 				continue
 			}
 
-			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project())
+			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name)
 			_ = op.UpdateMetadata(metadata)
 
 			err = inst.Start(false)

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -189,7 +189,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 				newMetricsLock.Lock()
 				defer newMetricsLock.Unlock()
 
-				newMetrics[inst.Project()].Merge(instanceMetrics)
+				newMetrics[inst.Project().Name].Merge(instanceMetrics)
 			}(inst)
 		}
 	}

--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -13,11 +13,12 @@ import (
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // Internal copy of the instance interface.
 type instance interface {
-	Project() string
+	Project() api.Project
 	Name() string
 	ExpandedConfig() map[string]string
 	Type() instancetype.Type
@@ -29,7 +30,7 @@ type instance interface {
 // InstanceProfileName returns the instance's AppArmor profile name.
 func InstanceProfileName(inst instance) string {
 	path := shared.VarPath("")
-	name := fmt.Sprintf("%s_<%s>", project.Instance(inst.Project(), inst.Name()), path)
+	name := fmt.Sprintf("%s_<%s>", project.Instance(inst.Project().Name, inst.Name()), path)
 	return profileName("", name)
 }
 
@@ -37,13 +38,13 @@ func InstanceProfileName(inst instance) string {
 func InstanceNamespaceName(inst instance) string {
 	// Unlike in profile names, / isn't an allowed character so replace with a -.
 	path := strings.Replace(strings.Trim(shared.VarPath(""), "/"), "/", "-", -1)
-	name := fmt.Sprintf("%s_<%s>", project.Instance(inst.Project(), inst.Name()), path)
+	name := fmt.Sprintf("%s_<%s>", project.Instance(inst.Project().Name, inst.Name()), path)
 	return profileName("", name)
 }
 
 // instanceProfileFilename returns the name of the on-disk profile name.
 func instanceProfileFilename(inst instance) string {
-	name := project.Instance(inst.Project(), inst.Name())
+	name := project.Instance(inst.Project().Name, inst.Name())
 	return profileName("", name)
 }
 

--- a/lxd/apparmor/instance_forkproxy.go
+++ b/lxd/apparmor/instance_forkproxy.go
@@ -171,13 +171,13 @@ func forkproxyProfile(sysOS *sys.OS, inst instance, dev device) (string, error) 
 // ForkproxyProfileName returns the AppArmor profile name.
 func ForkproxyProfileName(inst instance, dev device) string {
 	path := shared.VarPath("")
-	name := fmt.Sprintf("%s_%s_<%s>", dev.Name(), project.Instance(inst.Project(), inst.Name()), path)
+	name := fmt.Sprintf("%s_%s_<%s>", dev.Name(), project.Instance(inst.Project().Name, inst.Name()), path)
 	return profileName("forkproxy", name)
 }
 
 // forkproxyProfileFilename returns the name of the on-disk profile name.
 func forkproxyProfileFilename(inst instance, dev device) string {
-	name := fmt.Sprintf("%s_%s", dev.Name(), project.Instance(inst.Project(), inst.Name()))
+	name := fmt.Sprintf("%s_%s", dev.Name(), project.Instance(inst.Project().Name, inst.Name()))
 	return profileName("forkproxy", name)
 }
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -699,9 +699,9 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		// Handle errors
 		err = resp.Render(w)
 		if err != nil {
-			err := response.InternalError(err).Render(w)
+			writeErr := response.InternalError(err).Render(w)
 			if err != nil {
-				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err})
+				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err, "writeErr": writeErr})
 			}
 		}
 	})

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -695,26 +695,6 @@ func networkFillType(network *api.Network, netType NetworkType) {
 	}
 }
 
-// NetworkNodes returns the nodes keyed by node ID that the given network is defined on.
-func (c *Cluster) NetworkNodes(networkID int64) (map[int64]NetworkNode, error) {
-	var nodes map[int64]NetworkNode
-	var err error
-
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		nodes, err = tx.NetworkNodes(networkID)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return nodes, nil
-}
-
 // GetNetworkWithInterface returns the network associated with the interface with the given name.
 func (c *Cluster) GetNetworkWithInterface(devName string) (int64, *api.Network, error) {
 	id := int64(-1)

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -647,26 +647,6 @@ func StoragePoolStateToAPIStatus(state StoragePoolState) string {
 	}
 }
 
-// StoragePoolNodes returns the nodes keyed by node ID that the given storage pool is defined on.
-func (c *Cluster) StoragePoolNodes(poolID int64) (map[int64]StoragePoolNode, error) {
-	var nodes map[int64]StoragePoolNode
-	var err error
-
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		nodes, err = tx.storagePoolNodes(poolID)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return nodes, nil
-}
-
 // getStoragePoolConfig populates the config map of the Storage pool with the given ID.
 func (c *Cluster) getStoragePoolConfig(tx *ClusterTx, poolID int64, pool *api.StoragePool) error {
 	q := "SELECT key, value FROM storage_pools_config WHERE storage_pool_id=? AND (node_id=? OR node_id IS NULL)"

--- a/lxd/device/device_load.go
+++ b/lxd/device/device_load.go
@@ -111,7 +111,7 @@ func load(inst instance.Instance, state *state.State, projectName string, name s
 // not compatible with the instance type then an ErrUnsupportedDevType error is returned.
 // Note: The supplied config may be modified during validation to enrich. If this is not desired, supply a copy.
 func New(inst instance.Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
-	dev, err := load(inst, state, inst.Project(), name, conf, volatileGet, volatileSet)
+	dev, err := load(inst, state, inst.Project().Name, name, conf, volatileGet, volatileSet)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func Validate(instConfig instance.ConfigReader, state *state.State, name string,
 		return err
 	}
 
-	dev, err := load(nil, state, instConfig.Project(), name, conf, nil, nil)
+	dev, err := load(nil, state, instConfig.Project().Name, name, conf, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -89,7 +89,7 @@ func networkRemoveInterfaceIfNeeded(state *state.State, nic string, current inst
 	}
 
 	for _, inst := range instances {
-		if inst.Name() == current.Name() && inst.Project() == current.Project() {
+		if inst.Name() == current.Name() && inst.Project().Name == current.Project().Name {
 			continue
 		}
 

--- a/lxd/device/device_utils_unix_events.go
+++ b/lxd/device/device_utils_unix_events.go
@@ -41,7 +41,7 @@ func unixRegisterHandler(s *state.State, inst instance.Instance, deviceName, pat
 	defer unixMutex.Unlock()
 
 	// Null delimited string of project name, instance name and device name.
-	key := fmt.Sprintf("%s\000%s\000%s", inst.Project(), inst.Name(), deviceName)
+	key := fmt.Sprintf("%s\000%s\000%s", inst.Project().Name, inst.Name(), deviceName)
 	unixHandlers[key] = UnixSubscription{
 		Path:    path,
 		Handler: handler,
@@ -69,7 +69,7 @@ func unixUnregisterHandler(s *state.State, inst instance.Instance, deviceName st
 	defer unixMutex.Unlock()
 
 	// Null delimited string of project name, instance name and device name.
-	key := fmt.Sprintf("%s\000%s\000%s", inst.Project(), inst.Name(), deviceName)
+	key := fmt.Sprintf("%s\000%s\000%s", inst.Project().Name, inst.Name(), deviceName)
 
 	sub, exists := unixHandlers[key]
 	if !exists {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1475,7 +1475,7 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 		if shared.IsFalseOrEmpty(poolVolumePut.Config["security.shifted"]) {
 			volumeUsedBy := []instance.Instance{}
 			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-				inst, err := instance.Load(d.state, dbInst, nil)
+				inst, err := instance.Load(d.state, dbInst)
 				if err != nil {
 					return err
 				}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1475,7 +1475,7 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 		if shared.IsFalseOrEmpty(poolVolumePut.Config["security.shifted"]) {
 			volumeUsedBy := []instance.Instance{}
 			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-				inst, err := instance.Load(d.state, dbInst)
+				inst, err := instance.Load(d.state, dbInst, project)
 				if err != nil {
 					return err
 				}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -549,7 +549,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	// missing.
 	bridgeNet, ok := d.network.(bridgeNetwork)
 	if ok && d.network.IsManaged() && bridgeNet.UsesDNSMasq() {
-		deviceStaticFileName := dnsmasq.DHCPStaticAllocationPath(d.network.Name(), dnsmasq.StaticAllocationFileName(d.inst.Project(), d.inst.Name(), d.Name()))
+		deviceStaticFileName := dnsmasq.DHCPStaticAllocationPath(d.network.Name(), dnsmasq.StaticAllocationFileName(d.inst.Project().Name, d.inst.Name(), d.Name()))
 		if !shared.PathExists(deviceStaticFileName) {
 			err = d.rebuildDnsmasqEntry()
 			if err != nil {
@@ -876,7 +876,7 @@ func (d *nicBridged) Remove() error {
 		}
 
 		// Remove dnsmasq config if it exists (doesn't return error if file is missing).
-		err := dnsmasq.RemoveStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name(), d.Name())
+		err := dnsmasq.RemoveStaticEntry(d.config["parent"], d.inst.Project().Name, d.inst.Name(), d.Name())
 		if err != nil {
 			return err
 		}
@@ -917,7 +917,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	// If IP filtering is enabled, and no static IP in config, check if there is already a
 	// dynamically assigned static IP in dnsmasq config and write that back out in new config.
 	if (shared.IsTrue(d.config["security.ipv4_filtering"]) && ipv4Address == "") || (shared.IsTrue(d.config["security.ipv6_filtering"]) && ipv6Address == "") {
-		deviceStaticFileName := dnsmasq.StaticAllocationFileName(d.inst.Project(), d.inst.Name(), d.Name())
+		deviceStaticFileName := dnsmasq.StaticAllocationFileName(d.inst.Project().Name, d.inst.Name(), d.Name())
 		_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d.config["parent"], deviceStaticFileName)
 		if err != nil && !os.IsNotExist(err) {
 			return err
@@ -932,7 +932,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 		}
 	}
 
-	err := dnsmasq.UpdateStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name(), d.Name(), d.network.Config(), d.config["hwaddr"], ipv4Address, ipv6Address)
+	err := dnsmasq.UpdateStaticEntry(d.config["parent"], d.inst.Project().Name, d.inst.Name(), d.Name(), d.network.Config(), d.config["hwaddr"], ipv4Address, ipv6Address)
 	if err != nil {
 		return err
 	}
@@ -1002,7 +1002,7 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) {
 	// Remove filters for static MAC and IPs (if specified above).
 	// This covers the case when filtering is used with an unmanaged bridge.
 	d.logger.Debug("Clearing instance firewall static filters", logger.Ctx{"parent": m["parent"], "host_name": m["host_name"], "hwaddr": m["hwaddr"], "IPv4Nets": IPv4Nets, "IPv6Nets": IPv6Nets})
-	err = d.state.Firewall.InstanceClearBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, m["parent"], m["host_name"], m["hwaddr"], IPv4Nets, IPv6Nets)
+	err = d.state.Firewall.InstanceClearBridgeFilter(d.inst.Project().Name, d.inst.Name(), d.name, m["parent"], m["host_name"], m["hwaddr"], IPv4Nets, IPv6Nets)
 	if err != nil {
 		d.logger.Error("Failed to remove static IP network filters", logger.Ctx{"err": err})
 	}
@@ -1010,14 +1010,14 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) {
 	// If allowedIPNets returned nil for IPv4 or IPv6, it is possible that total protocol blocking was set up
 	// because the device has a managed parent network with DHCP disabled. Pass in empty slices to catch this case.
 	d.logger.Debug("Clearing instance total protocol filters", logger.Ctx{"parent": m["parent"], "host_name": m["host_name"], "hwaddr": m["hwaddr"], "IPv4Nets": IPv4Nets, "IPv6Nets": IPv6Nets})
-	err = d.state.Firewall.InstanceClearBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, m["parent"], m["host_name"], m["hwaddr"], make([]*net.IPNet, 0), make([]*net.IPNet, 0))
+	err = d.state.Firewall.InstanceClearBridgeFilter(d.inst.Project().Name, d.inst.Name(), d.name, m["parent"], m["host_name"], m["hwaddr"], make([]*net.IPNet, 0), make([]*net.IPNet, 0))
 	if err != nil {
 		d.logger.Error("Failed to remove total protocol network filters", logger.Ctx{"err": err})
 	}
 
 	// Read current static DHCP IP allocation configured from dnsmasq host config (if exists).
 	// This covers the case when IPs are not defined in config, but have been assigned in managed DHCP.
-	deviceStaticFileName := dnsmasq.StaticAllocationFileName(d.inst.Project(), d.inst.Name(), d.Name())
+	deviceStaticFileName := dnsmasq.StaticAllocationFileName(d.inst.Project().Name, d.inst.Name(), d.Name())
 	_, IPv4Alloc, IPv6Alloc, err := dnsmasq.DHCPStaticAllocation(m["parent"], deviceStaticFileName)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1050,7 +1050,7 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) {
 	}
 
 	d.logger.Debug("Clearing instance firewall dynamic filters", logger.Ctx{"parent": m["parent"], "host_name": m["host_name"], "hwaddr": m["hwaddr"], "ipv4": IPv4Alloc.IP, "ipv6": IPv6Alloc.IP})
-	err = d.state.Firewall.InstanceClearBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, m["parent"], m["host_name"], m["hwaddr"], IPv4AllocNets, IPv6AllocNets)
+	err = d.state.Firewall.InstanceClearBridgeFilter(d.inst.Project().Name, d.inst.Name(), d.name, m["parent"], m["host_name"], m["hwaddr"], IPv4AllocNets, IPv6AllocNets)
 	if err != nil {
 		logger.Errorf("Failed to remove DHCP network assigned filters  for %q: %v", d.name, err)
 	}
@@ -1098,7 +1098,7 @@ func (d *nicBridged) setFilters() (err error) {
 	// If parent bridge is managed, allocate the static IPs (if needed).
 	if d.network != nil && (IPv4 == nil || IPv6 == nil) {
 		opts := &dhcpalloc.Options{
-			ProjectName: d.inst.Project(),
+			ProjectName: d.inst.Project().Name,
 			HostName:    d.inst.Name(),
 			DeviceName:  d.Name(),
 			HostMAC:     mac,
@@ -1147,7 +1147,7 @@ func (d *nicBridged) setFilters() (err error) {
 		return err
 	}
 
-	err = d.state.Firewall.InstanceSetupBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, d.config["parent"], d.config["host_name"], d.config["hwaddr"], IPv4Nets, IPv6Nets, d.network != nil)
+	err = d.state.Firewall.InstanceSetupBridgeFilter(d.inst.Project().Name, d.inst.Name(), d.name, d.config["parent"], d.config["host_name"], d.config["hwaddr"], IPv4Nets, IPv6Nets, d.network != nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -89,7 +89,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	// The NIC's network may be a non-default project, so lookup project and get network's project name.
-	networkProjectName, _, err := project.NetworkProject(d.state.DB.Cluster, instConf.Project())
+	networkProjectName, _, err := project.NetworkProject(d.state.DB.Cluster, instConf.Project().Name)
 	if err != nil {
 		return fmt.Errorf("Failed loading network project name: %w", err)
 	}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -363,7 +363,7 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Apply firewall rules for reverse path filtering of IPv4 and IPv6.
-	err = d.state.Firewall.InstanceSetupRPFilter(d.inst.Project(), d.inst.Name(), d.name, saveData["host_name"])
+	err = d.state.Firewall.InstanceSetupRPFilter(d.inst.Project().Name, d.inst.Name(), d.name, saveData["host_name"])
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up reverse path filter: %w", err)
 	}
@@ -646,7 +646,7 @@ func (d *nicRouted) postStop() error {
 	}
 
 	// Remove reverse path filters.
-	err := d.state.Firewall.InstanceClearRPFilter(d.inst.Project(), d.inst.Name(), d.name)
+	err := d.state.Firewall.InstanceClearRPFilter(d.inst.Project().Name, d.inst.Name(), d.name)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -215,7 +215,7 @@ var devlxdAPIHandler = devLxdHandler{"/1.0", func(d *Daemon, c instance.Instance
 		}
 
 		if state == api.Ready {
-			d.events.SendLifecycle(c.Project(), lifecycle.InstanceReady.Event(c, nil))
+			d.events.SendLifecycle(c.Project().Name, lifecycle.InstanceReady.Event(c, nil))
 		}
 
 		return response.DevLxdResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -383,7 +383,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	info.Properties = meta.Properties
 
 	// Create the database entry
-	err = d.db.Cluster.CreateImage(c.Project(), info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
+	err = d.db.Cluster.CreateImage(c.Project().Name, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -403,7 +403,7 @@ func instanceLoadNodeProjectAll(s *state.State, project string, instanceType ins
 	}
 
 	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
-		inst, err := instance.Load(s, dbInst, nil)
+		inst, err := instance.Load(s, dbInst)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
 		}
@@ -466,7 +466,7 @@ func autoCreateInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		// Figure out which need snapshotting (if any).
 		instances := make([]instance.Instance, 0)
 		for _, instArg := range instanceArgs {
-			inst, err := instance.Load(s, instArg, nil)
+			inst, err := instance.Load(s, instArg)
 			if err != nil {
 				logger.Error("Failed loading instance for snapshot task", logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
 				continue
@@ -610,7 +610,7 @@ func pruneExpiredInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 			expiredSnapshotInstances = make([]instance.Instance, 0)
 			for _, snapshotArg := range snapshotArgs {
-				inst, err := instance.Load(s, snapshotArg, nil)
+				inst, err := instance.Load(s, snapshotArg)
 				if err != nil {
 					logger.Error("Failed loading instance for snapshot prune task", logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
 					continue

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -172,8 +172,8 @@ func (d *common) Profiles() []api.Profile {
 }
 
 // Project returns instance's project.
-func (d *common) Project() string {
-	return d.project.Name
+func (d *common) Project() api.Project {
+	return d.project
 }
 
 // IsSnapshot returns whether instance is snapshot or not.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -482,7 +482,7 @@ func (d *common) expandConfig() error {
 // restartCommon handles the common part of instance restarts.
 func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) error {
 	// Setup a new operation for the stop/shutdown phase.
-	op, err := operationlock.Create(d.Project(), d.Name(), operationlock.ActionRestart, true, true)
+	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestart, true, true)
 	if err != nil {
 		return fmt.Errorf("Create restart operation: %w", err)
 	}
@@ -498,7 +498,7 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 			Devices:      inst.LocalDevices(),
 			Ephemeral:    false,
 			Profiles:     inst.Profiles(),
-			Project:      inst.Project(),
+			Project:      inst.Project().Name,
 			Type:         inst.Type(),
 			Snapshot:     inst.IsSnapshot(),
 		}
@@ -536,7 +536,7 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 	}
 
 	// Setup a new operation for the start phase.
-	op, err = operationlock.Create(d.Project(), d.Name(), operationlock.ActionRestart, true, true)
+	op, err = operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestart, true, true)
 	if err != nil {
 		return fmt.Errorf("Create restart (for start) operation: %w", err)
 	}
@@ -570,7 +570,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 
 	// Setup the arguments.
 	args := db.InstanceArgs{
-		Project:      inst.Project(),
+		Project:      inst.Project().Name,
 		Architecture: inst.Architecture(),
 		Config:       inst.LocalConfig(),
 		Type:         inst.Type(),
@@ -884,7 +884,7 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 	// Pick up the existing stop operation lock created in Stop() function.
 	// If there is another ongoing operation (such as start), wait until that has finished before proceeding
 	// to run the hook (this should be quick as it will fail showing instance is already running).
-	op := operationlock.Get(d.Project(), d.Name())
+	op := operationlock.Get(d.Project().Name, d.Name())
 	if op != nil && !op.ActionMatch(operationlock.ActionStop, operationlock.ActionRestart, operationlock.ActionRestore) {
 		d.logger.Debug("Waiting for existing operation lock to finish before running hook", logger.Ctx{"action": op.Action()})
 		_ = op.Wait()
@@ -902,7 +902,7 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 			action = operationlock.ActionRestart
 		}
 
-		op, err = operationlock.Create(d.Project(), d.Name(), action, false, false)
+		op, err = operationlock.Create(d.Project().Name, d.Name(), action, false, false)
 		if err != nil {
 			return nil, false, fmt.Errorf("Failed creating %q operation: %w", action, err)
 		}
@@ -1115,7 +1115,7 @@ func (d *common) getStoragePool() (storagePools.Pool, error) {
 		return d.storagePool, nil
 	}
 
-	poolName, err := d.state.DB.Cluster.GetInstancePool(d.Project(), d.Name())
+	poolName, err := d.state.DB.Cluster.GetInstancePool(d.Project().Name, d.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -278,7 +278,7 @@ func (d *common) Snapshots() ([]instance.Instance, error) {
 		// Populate profile info that was already loaded.
 		snapshotArg.Profiles = d.profiles
 
-		snapInst, err := instance.Load(d.state, snapshotArg, nil)
+		snapInst, err := instance.Load(d.state, snapshotArg)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -472,13 +472,9 @@ func (d *common) deviceVolatileSetFunc(devName string) func(save map[string]stri
 }
 
 // expandConfig applies the config of each profile in order, followed by the local config.
-func (d *common) expandConfig(profiles []api.Profile) error {
-	if profiles == nil && len(d.profiles) > 0 {
-		profiles = d.profiles
-	}
-
-	d.expandedConfig = db.ExpandInstanceConfig(d.localConfig, profiles)
-	d.expandedDevices = db.ExpandInstanceDevices(d.localDevices, profiles)
+func (d *common) expandConfig() error {
+	d.expandedConfig = db.ExpandInstanceConfig(d.localConfig, d.profiles)
+	d.expandedDevices = db.ExpandInstanceDevices(d.localDevices, d.profiles)
 
 	return nil
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -626,7 +626,7 @@ func (d *lxc) initLXC(config bool) error {
 	}
 
 	// Load the go-lxc struct
-	cname := project.Instance(d.Project(), d.Name())
+	cname := project.Instance(d.Project().Name, d.Name())
 	cc, err := liblxc.NewContainer(cname, d.state.OS.LxcPath)
 	if err != nil {
 		return err
@@ -889,19 +889,19 @@ func (d *lxc) initLXC(config bool) error {
 	}
 
 	// Call the onstart hook on start.
-	err = lxcSetConfigItem(cc, "lxc.hook.pre-start", fmt.Sprintf("/proc/%d/exe callhook %s %s %s start", os.Getpid(), shared.VarPath(""), strconv.Quote(d.Project()), strconv.Quote(d.Name())))
+	err = lxcSetConfigItem(cc, "lxc.hook.pre-start", fmt.Sprintf("/proc/%d/exe callhook %s %s %s start", os.Getpid(), shared.VarPath(""), strconv.Quote(d.Project().Name), strconv.Quote(d.Name())))
 	if err != nil {
 		return err
 	}
 
 	// Call the onstopns hook on stop but before namespaces are unmounted.
-	err = lxcSetConfigItem(cc, "lxc.hook.stop", fmt.Sprintf("%s callhook %s %s %s stopns", d.state.OS.ExecPath, shared.VarPath(""), strconv.Quote(d.Project()), strconv.Quote(d.Name())))
+	err = lxcSetConfigItem(cc, "lxc.hook.stop", fmt.Sprintf("%s callhook %s %s %s stopns", d.state.OS.ExecPath, shared.VarPath(""), strconv.Quote(d.Project().Name), strconv.Quote(d.Name())))
 	if err != nil {
 		return err
 	}
 
 	// Call the onstop hook on stop.
-	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %s %s stop", d.state.OS.ExecPath, shared.VarPath(""), strconv.Quote(d.Project()), strconv.Quote(d.Name())))
+	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %s %s stop", d.state.OS.ExecPath, shared.VarPath(""), strconv.Quote(d.Project().Name), strconv.Quote(d.Name())))
 	if err != nil {
 		return err
 	}
@@ -1558,7 +1558,7 @@ func (d *lxc) deviceDetachNIC(configCopy map[string]string, netIF []deviceConfig
 	// If container is running, perform live detach of interface back to host.
 	if instanceRunning {
 		// For some reason, having network config confuses detach, so get our own go-lxc struct.
-		cname := project.Instance(d.Project(), d.Name())
+		cname := project.Instance(d.Project().Name, d.Name())
 		cc, err := liblxc.NewContainer(cname, d.state.OS.LxcPath)
 		if err != nil {
 			return err
@@ -2275,7 +2275,7 @@ func (d *lxc) Start(stateful bool) error {
 	var ctxMap logger.Ctx
 
 	// Setup a new operation
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
 		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
 			// An existing matching operation has now succeeded, return.
@@ -2386,7 +2386,7 @@ func (d *lxc) Start(stateful bool) error {
 		return err
 	}
 
-	name := project.Instance(d.Project(), d.name)
+	name := project.Instance(d.Project().Name, d.name)
 
 	// Start the LXC container
 	_, err = shared.RunCommand(
@@ -2532,7 +2532,7 @@ func (d *lxc) Stop(stateful bool) error {
 	}
 
 	// Setup a new operation
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, true)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, true)
 	if err != nil {
 		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
 			// An existing matching operation has now succeeded, return.
@@ -2702,7 +2702,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 	}
 
 	// Setup a new operation
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart}, true, true)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart}, true, true)
 	if err != nil {
 		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
 			// An existing matching operation has now succeeded, return.
@@ -3375,7 +3375,7 @@ func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
 func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 	var ctxMap logger.Ctx
 
-	op, err := operationlock.Create(d.Project(), d.Name(), operationlock.ActionRestore, false, false)
+	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestore, false, false)
 	if err != nil {
 		return fmt.Errorf("Failed to create instance restore operation: %w", err)
 	}
@@ -3397,7 +3397,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 				Devices:      d.LocalDevices(),
 				Ephemeral:    false,
 				Profiles:     d.Profiles(),
-				Project:      d.Project(),
+				Project:      d.Project().Name,
 				Type:         d.Type(),
 				Snapshot:     d.IsSnapshot(),
 			}
@@ -3423,7 +3423,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		}
 
 		// Refresh the operation as that one is now complete.
-		op, err = operationlock.Create(d.Project(), d.Name(), operationlock.ActionRestore, false, false)
+		op, err = operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestore, false, false)
 		if err != nil {
 			return fmt.Errorf("Failed to create instance restore operation: %w", err)
 		}
@@ -3491,7 +3491,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		Devices:      sourceContainer.LocalDevices(),
 		Ephemeral:    sourceContainer.IsEphemeral(),
 		Profiles:     sourceContainer.Profiles(),
-		Project:      sourceContainer.Project(),
+		Project:      sourceContainer.Project().Name,
 		Type:         sourceContainer.Type(),
 		Snapshot:     sourceContainer.IsSnapshot(),
 	}
@@ -3785,7 +3785,7 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 	}
 
 	// Rename the logging path.
-	newFullName := project.Instance(d.Project(), d.Name())
+	newFullName := project.Instance(d.Project().Name, d.Name())
 	_ = os.RemoveAll(shared.LogPath(newFullName))
 	if shared.PathExists(d.LogPath()) {
 		err := os.Rename(d.LogPath(), shared.LogPath(newFullName))
@@ -3890,7 +3890,7 @@ func (d *lxc) CGroupSet(key string, value string) error {
 // Update applies updated config.
 func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	// Setup a new operation
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionUpdate, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionUpdate, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
 		return fmt.Errorf("Failed to create instance update operation: %w", err)
 	}
@@ -4067,12 +4067,12 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		// between oldDevice and newDevice. The result of this is that as long as the
 		// devices are otherwise identical except for the fields returned here, then the
 		// device is considered to be being "updated" rather than "added & removed".
-		oldDevType, err := device.LoadByType(d.state, d.Project(), oldDevice)
+		oldDevType, err := device.LoadByType(d.state, d.Project().Name, oldDevice)
 		if err != nil {
 			return []string{} // Couldn't create Device, so this cannot be an update.
 		}
 
-		newDevType, err := device.LoadByType(d.state, d.Project(), newDevice)
+		newDevType, err := device.LoadByType(d.state, d.Project().Name, newDevice)
 		if err != nil {
 			return []string{} // Couldn't create Device, so this cannot be an update.
 		}
@@ -5351,7 +5351,7 @@ func (d *lxc) FileSFTPConn() (net.Conn, error) {
 	// to complete before continuing as it is possible that a disk device is being removed that requires SFTP
 	// to clean up the path inside the container. Also it is not possible to be shifting/replacing the root
 	// volume when the instance is running, so there should be no reason to wait for the operation to finish.
-	op := operationlock.Get(d.Project(), d.Name())
+	op := operationlock.Get(d.Project().Name, d.Name())
 	if op.Action() != operationlock.ActionUpdate || !d.IsRunning() {
 		_ = op.Wait()
 	}
@@ -5575,7 +5575,7 @@ func (d *lxc) Console(protocol string) (*os.File, chan error, error) {
 	args := []string{
 		d.state.OS.ExecPath,
 		"forkconsole",
-		project.Instance(d.Project(), d.Name()),
+		project.Instance(d.Project().Name, d.Name()),
 		d.state.OS.LxcPath,
 		filepath.Join(d.LogPath(), "lxc.conf"),
 		"tty=0",
@@ -5666,7 +5666,7 @@ func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 	defer func() { _ = logFile.Close() }()
 
 	// Prepare the subcommand
-	cname := project.Instance(d.Project(), d.Name())
+	cname := project.Instance(d.Project().Name, d.Name())
 	args := []string{
 		d.state.OS.ExecPath,
 		"forkexec",
@@ -5806,7 +5806,7 @@ func (d *lxc) diskState() map[string]api.InstanceStateDisk {
 				continue
 			}
 
-			usage, err = pool.GetCustomVolumeUsage(d.Project(), dev.Config["source"])
+			usage, err = pool.GetCustomVolumeUsage(d.Project().Name, dev.Config["source"])
 			if err != nil {
 				if !errors.Is(err, storageDrivers.ErrNotSupported) {
 					d.logger.Error("Error getting volume usage", logger.Ctx{"volume": dev.Config["source"], "err": err})
@@ -6161,7 +6161,7 @@ func (d *lxc) insertMountLXD(source, target, fstype string, flags int, mntnsPID 
 }
 
 func (d *lxc) insertMountLXC(source, target, fstype string, flags int) error {
-	cname := project.Instance(d.Project(), d.Name())
+	cname := project.Instance(d.Project().Name, d.Name())
 	configPath := filepath.Join(d.LogPath(), "lxc.conf")
 	if fstype == "" {
 		fstype = "none"
@@ -6208,7 +6208,7 @@ func (d *lxc) removeMount(mount string) error {
 
 	if d.state.OS.LXCFeatures["mount_injection_file"] {
 		configPath := filepath.Join(d.LogPath(), "lxc.conf")
-		cname := project.Instance(d.Project(), d.Name())
+		cname := project.Instance(d.Project().Name, d.Name())
 
 		if !strings.HasPrefix(mount, "/") {
 			mount = "/" + mount
@@ -6374,7 +6374,7 @@ func (d *lxc) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfi
 		}
 
 		// Attempt to include all existing interfaces
-		cname := project.Instance(d.Project(), d.Name())
+		cname := project.Instance(d.Project().Name, d.Name())
 		cc, err := liblxc.NewContainer(cname, d.state.OS.LxcPath)
 		if err == nil {
 			defer func() { _ = cc.Release() }()
@@ -6409,7 +6409,7 @@ func (d *lxc) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfi
 		}
 	}
 
-	nicType, err := nictype.NICType(d.state, d.Project(), m)
+	nicType, err := nictype.NICType(d.state, d.Project().Name, m)
 	if err != nil {
 		return nil, err
 	}
@@ -6616,7 +6616,7 @@ func (d *lxc) LockExclusive() (*operationlock.InstanceOperation, error) {
 	defer revert.Fail()
 
 	// Prevent concurrent operations the instance.
-	op, err := operationlock.Create(d.Project(), d.Name(), operationlock.ActionCreate, false, false)
+	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionCreate, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -148,7 +148,7 @@ func lxcStatusCode(state liblxc.State) api.StatusCode {
 
 // lxcCreate creates the DB storage records and sets up instance devices.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
-func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.Hook, error) {
+func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -171,7 +171,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 			name:         args.Name,
 			node:         args.Node,
 			profiles:     args.Profiles,
-			project:      args.Project,
+			project:      p,
 			snapshot:     args.Snapshot,
 			stateful:     args.Stateful,
 		},
@@ -204,7 +204,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 		return nil, nil, fmt.Errorf("Invalid config: %w", err)
 	}
 
-	err = instance.ValidDevices(s, d.Project(), d.Type(), d.expandedDevices, true)
+	err = instance.ValidDevices(s, d.project, d.Type(), d.expandedDevices, true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Invalid devices: %w", err)
 	}
@@ -307,9 +307,9 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 
 	d.logger.Info("Created container", logger.Ctx{"ephemeral": d.ephemeral})
 	if d.snapshot {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotCreated.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotCreated.Event(d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceCreated.Event(d, map[string]any{
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
 			"type":         api.InstanceTypeContainer,
 			"storage-pool": d.storagePool.Name(),
 		}))
@@ -320,9 +320,9 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 	return d, cleanup, err
 }
 
-func lxcLoad(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
+func lxcLoad(s *state.State, args db.InstanceArgs, p api.Project) (instance.Instance, error) {
 	// Create the container struct
-	d := lxcInstantiate(s, args, nil)
+	d := lxcInstantiate(s, args, nil, p)
 
 	// Setup finalizer
 	runtime.SetFinalizer(d, lxcUnload)
@@ -351,7 +351,7 @@ func (d *lxc) release() {
 }
 
 // Create a container struct without initializing it.
-func lxcInstantiate(s *state.State, args db.InstanceArgs, expandedDevices deviceConfig.Devices) instance.Instance {
+func lxcInstantiate(s *state.State, args db.InstanceArgs, expandedDevices deviceConfig.Devices, p api.Project) instance.Instance {
 	d := &lxc{
 		common: common{
 			state: s,
@@ -370,7 +370,7 @@ func lxcInstantiate(s *state.State, args db.InstanceArgs, expandedDevices device
 			name:         args.Name,
 			node:         args.Node,
 			profiles:     args.Profiles,
-			project:      args.Project,
+			project:      p,
 			snapshot:     args.Snapshot,
 			stateful:     args.Stateful,
 		},
@@ -2357,7 +2357,7 @@ func (d *lxc) Start(stateful bool) error {
 
 		if op.Action() == "start" {
 			d.logger.Info("Started container", ctxMap)
-			d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStarted.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStarted.Event(d, nil))
 		}
 
 		return nil
@@ -2443,7 +2443,7 @@ func (d *lxc) Start(stateful bool) error {
 
 	if op.Action() == "start" {
 		d.logger.Info("Started container", ctxMap)
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStarted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStarted.Event(d, nil))
 	}
 
 	return nil
@@ -2595,7 +2595,7 @@ func (d *lxc) Stop(stateful bool) error {
 		}
 
 		d.logger.Info("Stopped container", ctxMap)
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStopped.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(d, nil))
 
 		return nil
 	} else if shared.PathExists(d.StatePath()) {
@@ -2675,7 +2675,7 @@ func (d *lxc) Stop(stateful bool) error {
 		return errPrefix
 	} else if op.Action() == "stop" {
 		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStopped.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(d, nil))
 	}
 
 	// Now handle errors from stop sequence and return to caller if wasn't completed cleanly.
@@ -2802,7 +2802,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 		return errPrefix
 	} else if op.Action() == "stop" {
 		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceShutdown.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(d, nil))
 	}
 
 	// Now handle errors from shutdown sequence and return to caller if wasn't completed cleanly.
@@ -2830,7 +2830,7 @@ func (d *lxc) Restart(timeout time.Duration) error {
 	}
 
 	d.logger.Info("Restarted container", ctxMap)
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestarted.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
 
 	return nil
 }
@@ -2962,7 +2962,7 @@ func (d *lxc) onStop(args map[string]string) error {
 			}
 
 			d.logger.Info("Shut down container", ctxMap)
-			d.state.Events.SendLifecycle(d.project, lifecycle.InstanceShutdown.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(d, nil))
 		}
 
 		// Reboot the container
@@ -2974,7 +2974,7 @@ func (d *lxc) onStop(args map[string]string) error {
 				return
 			}
 
-			d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestarted.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
 
 			return
 		}
@@ -3071,7 +3071,7 @@ func (d *lxc) Freeze() error {
 	}
 
 	d.logger.Info("Froze container", ctxMap)
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstancePaused.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstancePaused.Event(d, nil))
 
 	return err
 }
@@ -3119,7 +3119,7 @@ func (d *lxc) Unfreeze() error {
 	}
 
 	d.logger.Info("Unfroze container", ctxMap)
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceResumed.Event(d, nil))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceResumed.Event(d, nil))
 
 	return err
 }
@@ -3218,7 +3218,7 @@ func (d *lxc) Render(options ...func(response any) error) (any, any, error) {
 	instState.LastUsedAt = d.lastUsedDate
 	instState.Profiles = profileNames
 	instState.Stateful = d.stateful
-	instState.Project = d.project
+	instState.Project = d.project.Name
 
 	for _, option := range options {
 		err := option(&instState)
@@ -3559,7 +3559,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		}
 	}
 
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRestored.Event(d, map[string]any{"snapshot": sourceContainer.Name()}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestored.Event(d, map[string]any{"snapshot": sourceContainer.Name()}))
 	d.logger.Info("Restored container", ctxMap)
 
 	return nil
@@ -3665,7 +3665,7 @@ func (d *lxc) Delete(force bool) error {
 	}
 
 	// Remove the database record of the instance or snapshot instance.
-	err = d.state.DB.Cluster.DeleteInstance(d.project, d.Name())
+	err = d.state.DB.Cluster.DeleteInstance(d.project.Name, d.Name())
 	if err != nil {
 		d.logger.Error("Failed deleting container entry", logger.Ctx{"err": err})
 		return err
@@ -3676,7 +3676,7 @@ func (d *lxc) Delete(force bool) error {
 		parentName, _, _ := api.GetParentAndSnapshotName(d.name)
 
 		// Load the parent.
-		parent, err := instance.LoadByProjectAndName(d.state, d.project, parentName)
+		parent, err := instance.LoadByProjectAndName(d.state, d.project.Name, parentName)
 		if err != nil {
 			return fmt.Errorf("Invalid parent: %w", err)
 		}
@@ -3690,9 +3690,9 @@ func (d *lxc) Delete(force bool) error {
 
 	d.logger.Info("Deleted container", ctxMap)
 	if d.snapshot {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotDeleted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotDeleted.Event(d, nil))
 	} else {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceDeleted.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceDeleted.Event(d, nil))
 	}
 
 	return nil
@@ -3749,7 +3749,7 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 
 	if !d.IsSnapshot() {
 		// Rename all the instance snapshot database entries.
-		results, err := d.state.DB.Cluster.GetInstanceSnapshotsNames(d.project, oldName)
+		results, err := d.state.DB.Cluster.GetInstanceSnapshotsNames(d.project.Name, oldName)
 		if err != nil {
 			d.logger.Error("Failed to get container snapshots", ctxMap)
 			return fmt.Errorf("Failed to get container snapshots: %w", err)
@@ -3760,7 +3760,7 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 			oldSnapName := strings.SplitN(sname, shared.SnapshotDelimiter, 2)[1]
 			baseSnapName := filepath.Base(sname)
 			err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				return cluster.RenameInstanceSnapshot(ctx, tx.Tx(), d.project, oldName, oldSnapName, baseSnapName)
+				return cluster.RenameInstanceSnapshot(ctx, tx.Tx(), d.project.Name, oldName, oldSnapName, baseSnapName)
 			})
 			if err != nil {
 				d.logger.Error("Failed renaming snapshot", ctxMap)
@@ -3774,10 +3774,10 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 		if d.IsSnapshot() {
 			oldParts := strings.SplitN(oldName, shared.SnapshotDelimiter, 2)
 			newParts := strings.SplitN(newName, shared.SnapshotDelimiter, 2)
-			return cluster.RenameInstanceSnapshot(ctx, tx.Tx(), d.project, oldParts[0], oldParts[1], newParts[1])
+			return cluster.RenameInstanceSnapshot(ctx, tx.Tx(), d.project.Name, oldParts[0], oldParts[1], newParts[1])
 		}
 
-		return cluster.RenameInstance(ctx, tx.Tx(), d.project, oldName, newName)
+		return cluster.RenameInstance(ctx, tx.Tx(), d.project.Name, oldName, newName)
 	})
 	if err != nil {
 		d.logger.Error("Failed renaming container", ctxMap)
@@ -3857,9 +3857,9 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 
 	d.logger.Info("Renamed container", ctxMap)
 	if d.snapshot {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
 	} else {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
 	}
 
 	revert.Success()
@@ -3926,7 +3926,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Validate the new devices without using expanded devices validation (expensive checks disabled).
-		err = instance.ValidDevices(d.state, d.Project(), d.Type(), args.Devices, false)
+		err = instance.ValidDevices(d.state, d.project, d.Type(), args.Devices, false)
 		if err != nil {
 			return fmt.Errorf("Invalid devices: %w", err)
 		}
@@ -4107,7 +4107,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Do full expanded validation of the devices diff.
-		err = instance.ValidDevices(d.state, d.Project(), d.Type(), d.expandedDevices, true)
+		err = instance.ValidDevices(d.state, d.project, d.Type(), d.expandedDevices, true)
 		if err != nil {
 			return fmt.Errorf("Invalid expanded devices: %w", err)
 		}
@@ -4545,7 +4545,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 			return tx.UpdateInstanceSnapshot(d.id, d.description, d.expiryDate)
 		}
 
-		object, err := cluster.GetInstance(ctx, tx.Tx(), d.project, d.name)
+		object, err := cluster.GetInstance(ctx, tx.Tx(), d.project.Name, d.name)
 		if err != nil {
 			return err
 		}
@@ -4555,7 +4555,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		object.Ephemeral = d.ephemeral
 		object.ExpiryDate = sql.NullTime{Time: d.expiryDate, Valid: true}
 
-		err = cluster.UpdateInstance(ctx, tx.Tx(), d.project, d.name, *object)
+		err = cluster.UpdateInstance(ctx, tx.Tx(), d.project.Name, d.name, *object)
 		if err != nil {
 			return err
 		}
@@ -4657,9 +4657,9 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 
 	if userRequested {
 		if d.snapshot {
-			d.state.Events.SendLifecycle(d.project, lifecycle.InstanceSnapshotUpdated.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotUpdated.Event(d, nil))
 		} else {
-			d.state.Events.SendLifecycle(d.project, lifecycle.InstanceUpdated.Event(d, nil))
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceUpdated.Event(d, nil))
 		}
 	}
 
@@ -4737,7 +4737,7 @@ func (d *lxc) Export(w io.Writer, properties map[string]string, expiration time.
 		var arch string
 		if d.IsSnapshot() {
 			parentName, _, _ := api.GetParentAndSnapshotName(d.name)
-			parent, err := instance.LoadByProjectAndName(d.state, d.project, parentName)
+			parent, err := instance.LoadByProjectAndName(d.state, d.project.Name, parentName)
 			if err != nil {
 				_ = tarWriter.Close()
 				d.logger.Error("Failed exporting instance", ctxMap)
@@ -5626,7 +5626,7 @@ func (d *lxc) Console(protocol string) (*os.File, chan error, error) {
 		_ = cmd.Process.Kill()
 	}()
 
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceConsole.Event(d, logger.Ctx{"type": instance.ConsoleTypeConsole}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsole.Event(d, logger.Ctx{"type": instance.ConsoleTypeConsole}))
 
 	return ptx, chDisconnect, nil
 }
@@ -5639,9 +5639,9 @@ func (d *lxc) ConsoleLog(opts liblxc.ConsoleLogOptions) (string, error) {
 	}
 
 	if opts.ClearLog {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceConsoleReset.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsoleReset.Event(d, nil))
 	} else if opts.ReadLog && opts.WriteToLogFile {
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceConsoleRetrieved.Event(d, nil))
+		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceConsoleRetrieved.Event(d, nil))
 	}
 
 	return string(msg), nil
@@ -5740,7 +5740,7 @@ func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 
 	d.logger.Debug("Retrieved PID of executing child process", logger.Ctx{"attachedPid": attachedPid})
 
-	d.state.Events.SendLifecycle(d.project, lifecycle.InstanceExec.Event(d, logger.Ctx{"command": req.Command}))
+	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceExec.Event(d, logger.Ctx{"command": req.Command}))
 
 	instCmd := &lxcCmd{
 		cmd:              &cmd,
@@ -6823,7 +6823,7 @@ func (d *lxc) Info() instance.Info {
 }
 
 func (d *lxc) Metrics() (*metrics.MetricSet, error) {
-	out := metrics.NewMetricSet(map[string]string{"project": d.project, "name": d.name, "type": instancetype.Container.String()})
+	out := metrics.NewMetricSet(map[string]string{"project": d.project.Name, "name": d.name, "type": instancetype.Container.String()})
 
 	// Load cgroup abstraction
 	cg, err := d.cgroup(nil)
@@ -6988,7 +6988,7 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 		FSType     string
 	}
 
-	out := metrics.NewMetricSet(map[string]string{"project": d.project, "name": d.name})
+	out := metrics.NewMetricSet(map[string]string{"project": d.project.Name, "name": d.name})
 
 	mounts, err := ioutil.ReadFile("/proc/mounts")
 	if err != nil {
@@ -7019,10 +7019,10 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 			var volName string
 			var volType storageDrivers.VolumeType
 			if dev["source"] != "" {
-				volName = project.StorageVolume(d.project, dev["source"])
+				volName = project.StorageVolume(d.project.Name, dev["source"])
 				volType = storageDrivers.VolumeTypeCustom
 			} else {
-				volName = project.Instance(d.project, d.name)
+				volName = project.Instance(d.project.Name, d.name)
 				volType = storageDrivers.VolumeTypeContainer
 			}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -320,7 +320,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 	return d, cleanup, err
 }
 
-func lxcLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instance.Instance, error) {
+func lxcLoad(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	// Create the container struct
 	d := lxcInstantiate(s, args, nil)
 
@@ -328,7 +328,7 @@ func lxcLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (inst
 	runtime.SetFinalizer(d, lxcUnload)
 
 	// Expand config and devices
-	err := d.(*lxc).expandConfig(profiles)
+	err := d.(*lxc).expandConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -599,7 +599,7 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 
 func (d *lxc) init() error {
 	// Compute the expanded config and device list
-	err := d.expandConfig(nil)
+	err := d.expandConfig()
 	if err != nil {
 		return err
 	}
@@ -4038,7 +4038,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	d.expiryDate = args.ExpiryDate
 
 	// Expand the config and refresh the LXC config
-	err = d.expandConfig(nil)
+	err = d.expandConfig()
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -348,7 +348,7 @@ func (d *qemu) getAgentClient() (*http.Client, error) {
 func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) {
 	// Create local variables from instance properties we need so as not to keep references to instance around
 	// after we have returned the callback function.
-	projectName := d.Project()
+	instProject := d.Project()
 	instanceName := d.Name()
 	state := d.state
 
@@ -359,14 +359,14 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) 
 
 		var d *qemu // Redefine d as local variable inside callback to avoid keeping references around.
 
-		inst, err := instance.LoadByProjectAndName(state, projectName, instanceName)
+		inst, err := instance.LoadByProjectAndName(state, instProject.Name, instanceName)
 		if err != nil {
-			l := logger.AddContext(logger.Log, logger.Ctx{"project": projectName, "instance": instanceName})
+			l := logger.AddContext(logger.Log, logger.Ctx{"project": instProject.Name, "instance": instanceName})
 			// If DB not available, try loading from backup file.
 			l.Warn("Failed loading instance from database to handle monitor event, trying backup file", logger.Ctx{"err": err})
 
-			instancePath := filepath.Join(shared.VarPath("virtual-machines"), project.Instance(projectName, instanceName))
-			inst, err = instance.LoadFromBackup(state, projectName, instancePath, false)
+			instancePath := filepath.Join(shared.VarPath("virtual-machines"), project.Instance(instProject.Name, instanceName))
+			inst, err = instance.LoadFromBackup(state, instProject.Name, instancePath, false)
 			if err != nil {
 				l.Error("Failed loading instance to handle monitor event", logger.Ctx{"err": err})
 				return
@@ -674,7 +674,7 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 	// Allow reuse when creating a new stop operation. This allows the Stop() function to inherit operation.
 	// Allow reuse of a reusable ongoing stop operation as Shutdown() may be called earlier, which allows reuse
 	// of its operations. This allow for multiple Shutdown() attempts.
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart}, true, true)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart}, true, true)
 	if err != nil {
 		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
 			// An existing matching operation has now succeeded, return.
@@ -1003,7 +1003,7 @@ func (d *qemu) Start(stateful bool) error {
 	}
 
 	// Setup a new operation.
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
 		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
 			// An existing matching operation has now succeeded, return.
@@ -3850,7 +3850,7 @@ func (d *qemu) Stop(stateful bool) error {
 	// Don't allow reuse when creating a new stop operation. This prevents other operations from intefering.
 	// Allow reuse of a reusable ongoing stop operation as Shutdown() may be called first, which allows reuse
 	// of its operations. This allow for Stop() to inherit from Shutdown() where instance is stuck.
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, true)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, true)
 	if err != nil {
 		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
 			// An existing matching operation has now succeeded, return.
@@ -4026,7 +4026,7 @@ func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
 
 // Restore restores an instance snapshot.
 func (d *qemu) Restore(source instance.Instance, stateful bool) error {
-	op, err := operationlock.Create(d.Project(), d.Name(), operationlock.ActionRestore, false, false)
+	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestore, false, false)
 	if err != nil {
 		return fmt.Errorf("Failed to create instance restore operation: %w", err)
 	}
@@ -4050,7 +4050,7 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 				Devices:      d.LocalDevices(),
 				Ephemeral:    false,
 				Profiles:     d.Profiles(),
-				Project:      d.Project(),
+				Project:      d.Project().Name,
 				Type:         d.Type(),
 				Snapshot:     d.IsSnapshot(),
 			}
@@ -4076,7 +4076,7 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 		}
 
 		// Refresh the operation as that one is now complete.
-		op, err = operationlock.Create(d.Project(), d.Name(), operationlock.ActionRestore, false, false)
+		op, err = operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionRestore, false, false)
 		if err != nil {
 			return fmt.Errorf("Failed to create instance restore operation: %w", err)
 		}
@@ -4114,7 +4114,7 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 		Devices:      source.LocalDevices(),
 		Ephemeral:    source.IsEphemeral(),
 		Profiles:     source.Profiles(),
-		Project:      source.Project(),
+		Project:      source.Project().Name,
 		Type:         source.Type(),
 		Snapshot:     source.IsSnapshot(),
 	}
@@ -4231,7 +4231,7 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 	}
 
 	// Rename the logging path.
-	newFullName := project.Instance(d.Project(), d.Name())
+	newFullName := project.Instance(d.Project().Name, d.Name())
 	_ = os.RemoveAll(shared.LogPath(newFullName))
 	if shared.PathExists(d.LogPath()) {
 		err := os.Rename(d.LogPath(), shared.LogPath(newFullName))
@@ -4311,7 +4311,7 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 // Update the instance config.
 func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	// Setup a new operation.
-	op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), operationlock.ActionUpdate, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionUpdate, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
 		return fmt.Errorf("Failed to create instance update operation: %w", err)
 	}
@@ -4482,12 +4482,12 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		// between oldDevice and newDevice. The result of this is that as long as the
 		// devices are otherwise identical except for the fields returned here, then the
 		// device is considered to be being "updated" rather than "added & removed".
-		oldDevType, err := device.LoadByType(d.state, d.Project(), oldDevice)
+		oldDevType, err := device.LoadByType(d.state, d.Project().Name, oldDevice)
 		if err != nil {
 			return []string{} // Couldn't create Device, so this cannot be an update.
 		}
 
-		newDevType, err := device.LoadByType(d.state, d.Project(), newDevice)
+		newDevType, err := device.LoadByType(d.state, d.Project().Name, newDevice)
 		if err != nil {
 			return []string{} // Couldn't create Device, so this cannot be an update.
 		}
@@ -5002,9 +5002,9 @@ func (d *qemu) Delete(force bool) error {
 	}
 
 	// Remove the database record of the instance or snapshot instance.
-	err = d.state.DB.Cluster.DeleteInstance(d.Project(), d.Name())
+	err = d.state.DB.Cluster.DeleteInstance(d.Project().Name, d.Name())
 	if err != nil {
-		d.logger.Error("Failed deleting instance entry", logger.Ctx{"project": d.Project()})
+		d.logger.Error("Failed deleting instance entry", logger.Ctx{"project": d.Project().Name})
 		return err
 	}
 
@@ -5788,7 +5788,7 @@ func (d *qemu) LockExclusive() (*operationlock.InstanceOperation, error) {
 	}
 
 	// Prevent concurrent operations the instance.
-	op, err := operationlock.Create(d.Project(), d.Name(), operationlock.ActionCreate, false, false)
+	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionCreate, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -5870,7 +5870,7 @@ func (d *qemu) InitPID() int {
 
 func (d *qemu) statusCode() api.StatusCode {
 	// Shortcut to avoid spamming QMP during ongoing operations.
-	op := operationlock.Get(d.Project(), d.Name())
+	op := operationlock.Get(d.Project().Name, d.Name())
 	if op != nil {
 		if op.Action() == "start" {
 			return api.Stopped
@@ -5954,7 +5954,7 @@ func (d *qemu) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConf
 
 	newDevice := m.Clone()
 
-	nicType, err := nictype.NICType(d.state, d.Project(), m)
+	nicType, err := nictype.NICType(d.state, d.Project().Name, m)
 	if err != nil {
 		return nil, err
 	}
@@ -6288,7 +6288,7 @@ func (d *qemu) getAgentMetrics() (*metrics.MetricSet, error) {
 
 	agent, err := lxd.ConnectLXDHTTP(nil, client)
 	if err != nil {
-		d.logger.Error("Failed to connect to lxd-agent", logger.Ctx{"project": d.Project(), "instance": d.Name(), "err": err})
+		d.logger.Error("Failed to connect to lxd-agent", logger.Ctx{"project": d.Project().Name, "instance": d.Name(), "err": err})
 		return nil, fmt.Errorf("Failed to connect to lxd-agent")
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -100,12 +100,12 @@ var errQemuAgentOffline = fmt.Errorf("LXD VM agent isn't currently running")
 type monitorHook func(m *qmp.Monitor) error
 
 // qemuLoad creates a Qemu instance from the supplied InstanceArgs.
-func qemuLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instance.Instance, error) {
+func qemuLoad(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	// Create the instance struct.
 	d := qemuInstantiate(s, args, nil)
 
 	// Expand config and devices.
-	err := d.expandConfig(profiles)
+	err := d.expandConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -4453,7 +4453,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	d.expiryDate = args.ExpiryDate
 
 	// Expand the config.
-	err = d.expandConfig(nil)
+	err = d.expandConfig()
 	if err != nil {
 		return err
 	}
@@ -4917,7 +4917,7 @@ func (d *qemu) cleanupDevices() {
 
 func (d *qemu) init() error {
 	// Compute the expanded config and device list.
-	err := d.expandConfig(nil)
+	err := d.expandConfig()
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu_metrics.go
+++ b/lxd/instance/drivers/driver_qemu_metrics.go
@@ -67,7 +67,7 @@ func (d *qemu) getQemuMetrics() (*metrics.MetricSet, error) {
 		}
 	}
 
-	metricSet, err := metrics.MetricSetFromAPI(&out, map[string]string{"project": d.project, "name": d.name, "type": instancetype.VM.String()})
+	metricSet, err := metrics.MetricSetFromAPI(&out, map[string]string{"project": d.project.Name, "name": d.name, "type": instancetype.VM.String()})
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
-	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -47,14 +46,14 @@ func init() {
 }
 
 // load creates the underlying instance type struct and returns it as an Instance.
-func load(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instance.Instance, error) {
+func load(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	var inst instance.Instance
 	var err error
 
 	if args.Type == instancetype.Container {
-		inst, err = lxcLoad(s, args, profiles)
+		inst, err = lxcLoad(s, args)
 	} else if args.Type == instancetype.VM {
-		inst, err = qemuLoad(s, args, profiles)
+		inst, err = qemuLoad(s, args)
 	} else {
 		return nil, fmt.Errorf("Invalid instance type for instance %s", args.Name)
 	}

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -51,7 +51,7 @@ const TemplateTriggerRename TemplateTrigger = "rename"
 
 // ConfigReader is used to read instance config.
 type ConfigReader interface {
-	Project() string
+	Project() api.Project
 	Type() instancetype.Type
 	Architecture() int
 	ExpandedConfig() map[string]string

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -1137,7 +1137,7 @@ func NextSnapshotName(s *state.State, inst Instance, defaultPattern string) (str
 	if count > 1 {
 		return "", fmt.Errorf("Snapshot pattern may contain '%%d' only once")
 	} else if count == 1 {
-		i := s.DB.Cluster.GetNextInstanceSnapshotIndex(inst.Project(), inst.Name(), pattern)
+		i := s.DB.Cluster.GetNextInstanceSnapshotIndex(inst.Project().Name, inst.Name(), pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 
@@ -1159,7 +1159,7 @@ func NextSnapshotName(s *state.State, inst Instance, defaultPattern string) (str
 	// Append '-0', '-1', etc. if the actual pattern/snapshot name already exists
 	if snapshotExists {
 		pattern = fmt.Sprintf("%s-%%d", pattern)
-		i := s.DB.Cluster.GetNextInstanceSnapshotIndex(inst.Project(), inst.Name(), pattern)
+		i := s.DB.Cluster.GetNextInstanceSnapshotIndex(inst.Project().Name, inst.Name(), pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 
@@ -1187,7 +1187,7 @@ func MoveTemporaryName(inst Instance) (string, error) {
 // if they have the same volatile.uuid values.
 func IsSameLogicalInstance(inst Instance, dbInst *db.InstanceArgs) bool {
 	// Instance name is unique within a project.
-	if dbInst.Project == inst.Project() && dbInst.Name == inst.Name() {
+	if dbInst.Project == inst.Project().Name && dbInst.Name == inst.Name() {
 		return true
 	}
 

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -42,7 +42,7 @@ import (
 var ValidDevices func(state *state.State, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error
 
 // Load is linked from instance/drivers.load to allow different instance types to be loaded.
-var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error)
+var Load func(s *state.State, args db.InstanceArgs) (Instance, error)
 
 // Create is linked from instance/drivers.create to allow difference instance types to be created.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
@@ -437,7 +437,7 @@ func LoadByProjectAndName(s *state.State, project, name string) (Instance, error
 		return nil, err
 	}
 
-	inst, err := Load(s, args, nil)
+	inst, err := Load(s, args)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load instance: %w", err)
 	}
@@ -456,7 +456,7 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 	}
 
 	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
-		inst, err := Load(s, dbInst, dbInst.Profiles)
+		inst, err := Load(s, dbInst)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
 		}
@@ -497,7 +497,7 @@ func LoadFromBackup(s *state.State, projectName string, instancePath string, app
 		instDBArgs.Devices = deviceConfig.NewDevices(backupConf.Container.ExpandedDevices)
 	}
 
-	inst, err = Load(s, *instDBArgs, nil)
+	inst, err = Load(s, *instDBArgs)
 	if err != nil {
 		return nil, fmt.Errorf("Failed loading instance from backup file %q: %w", backupYamlPath, err)
 	}

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -209,7 +209,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 			cleanup.Fail()
 		}
 
-		s.Events.SendLifecycle(inst.Project(), lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
 		return response.FileResponse(r, files, headers)
 	} else if fileType == "symlink" {
 		// Find symlink target.
@@ -240,7 +240,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 		files[0].FileModified = time.Now()
 		files[0].FileSize = int64(len(target))
 
-		s.Events.SendLifecycle(inst.Project(), lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
 		return response.FileResponse(r, files, headers)
 	} else if fileType == "directory" {
 		dirEnts := []string{}
@@ -255,7 +255,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 			dirEnts = append(dirEnts, entry.Name())
 		}
 
-		s.Events.SendLifecycle(inst.Project(), lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
 		return response.SyncResponseHeaders(true, dirEnts, headers)
 	} else {
 		return response.InternalError(fmt.Errorf("Bad file type: %s", fileType))
@@ -492,7 +492,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 			}
 		}
 
-		s.Events.SendLifecycle(inst.Project(), lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
 	} else if type_ == "symlink" {
 		// Figure out target.
@@ -513,7 +513,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 			return response.SmartError(err)
 		}
 
-		s.Events.SendLifecycle(inst.Project(), lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
 	} else if type_ == "directory" {
 		// Check if it already exists.
@@ -546,7 +546,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 			}
 		}
 
-		s.Events.SendLifecycle(inst.Project(), lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
+		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
 	} else {
 		return response.BadRequest(fmt.Errorf("Bad file type: %s", type_))
@@ -599,6 +599,6 @@ func instanceFileDelete(s *state.State, inst instance.Instance, path string, r *
 		return response.SmartError(err)
 	}
 
-	s.Events.SendLifecycle(inst.Project(), lifecycle.InstanceFileDeleted.Event(inst, logger.Ctx{"path": path}))
+	s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileDeleted.Event(inst, logger.Ctx{"path": path}))
 	return response.EmptySyncResponse
 }

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -362,7 +362,7 @@ func doInstanceMetadataUpdate(d *Daemon, inst instance.Instance, metadata api.Im
 		return response.InternalError(err)
 	}
 
-	d.State().Events.SendLifecycle(inst.Project(), lifecycle.InstanceMetadataUpdated.Event(inst, request.CreateRequestor(r), nil))
+	d.State().Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceMetadataUpdated.Event(inst, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -502,7 +502,7 @@ func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name st
 				Devices:      snapInst.LocalDevices(),
 				Ephemeral:    snapInst.IsEphemeral(),
 				Profiles:     snapInst.Profiles(),
-				Project:      snapInst.Project(),
+				Project:      snapInst.Project().Name,
 				ExpiryDate:   configRaw.ExpiresAt,
 				Type:         snapInst.Type(),
 				Snapshot:     snapInst.IsSnapshot(),
@@ -526,7 +526,7 @@ func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name st
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
+	op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -691,7 +691,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 				return response.InternalError(err)
 			}
 
-			op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, operationtype.SnapshotTransfer, resources, nil, run, nil, nil, r)
+			op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotTransfer, resources, nil, run, nil, nil, r)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -700,7 +700,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		}
 
 		// Pull mode
-		op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassWebsocket, operationtype.SnapshotTransfer, resources, ws.Metadata(), run, nil, ws.Connect, r)
+		op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassWebsocket, operationtype.SnapshotTransfer, resources, ws.Metadata(), run, nil, ws.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -722,7 +722,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 	fullName := containerName + shared.SnapshotDelimiter + newName
 
 	// Check that the name isn't already in use
-	id, _ := d.db.Cluster.GetInstanceSnapshotID(snapInst.Project(), containerName, newName)
+	id, _ := d.db.Cluster.GetInstanceSnapshotID(snapInst.Project().Name, containerName, newName)
 	if id > 0 {
 		return response.Conflict(fmt.Errorf("Name '%s' already in use", fullName))
 	}
@@ -738,7 +738,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, operationtype.SnapshotRename, resources, nil, rename, nil, nil, r)
+	op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotRename, resources, nil, rename, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -784,7 +784,7 @@ func snapshotDelete(s *state.State, r *http.Request, snapInst instance.Instance,
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(s, snapInst.Project(), operations.OperationClassTask, operationtype.SnapshotDelete, resources, nil, remove, nil, nil, r)
+	op, err := operations.OperationCreate(s, snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotDelete, resources, nil, remove, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -165,7 +165,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	pool, err := storagePools.LoadByName(state, poolName)
 	suite.Req.Nil(err)
 
-	_, err = state.DB.Cluster.CreateStoragePoolVolume(c.Project(), c.Name(), "", db.StoragePoolVolumeContentTypeFS, pool.ID(), nil, db.StoragePoolVolumeContentTypeFS)
+	_, err = state.DB.Cluster.CreateStoragePoolVolume(c.Project().Name, c.Name(), "", db.StoragePoolVolumeContentTypeFS, pool.ID(), nil, db.StoragePoolVolumeContentTypeFS)
 	suite.Req.Nil(err)
 
 	// Load the container and trigger initLXC()

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -377,7 +377,7 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 					Config:  make(map[string]string),
 				}
 
-				inst, err = instance.Load(s, *instDBArgs, nil)
+				inst, err = instance.Load(s, *instDBArgs)
 				if err != nil {
 					logger.Warn("Failed loading instance", logger.Ctx{"project": projectName, "instance": instanceName, "err": err})
 					continue

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -254,7 +254,7 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 			continue
 		}
 
-		instLogger := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+		instLogger := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 
 		// Try to start the instance.
 		var attempt = 0
@@ -270,7 +270,7 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 
 				if attempt >= maxAttempts {
 					// If unable to start after 3 tries, record a warning.
-					warnErr := s.DB.Cluster.UpsertWarningLocalNode(inst.Project(), cluster.TypeInstance, inst.ID(), warningtype.InstanceAutostartFailure, fmt.Sprintf("%v", err))
+					warnErr := s.DB.Cluster.UpsertWarningLocalNode(inst.Project().Name, cluster.TypeInstance, inst.ID(), warningtype.InstanceAutostartFailure, fmt.Sprintf("%v", err))
 					if warnErr != nil {
 						instLogger.Warn("Failed to create instance autostart failure warning", logger.Ctx{"err": warnErr})
 					}
@@ -286,7 +286,7 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 			}
 
 			// Resolve any previous warning.
-			warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(s.DB.Cluster, inst.Project(), warningtype.InstanceAutostartFailure, cluster.TypeInstance, inst.ID())
+			warnErr := warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(s.DB.Cluster, inst.Project().Name, warningtype.InstanceAutostartFailure, cluster.TypeInstance, inst.ID())
 			if warnErr != nil {
 				instLogger.Warn("Failed to resolve instance autostart failure warning", logger.Ctx{"err": warnErr})
 			}
@@ -430,10 +430,10 @@ func instancesShutdown(s *state.State, instances []instance.Instance) {
 
 				err := inst.Shutdown(time.Second * time.Duration(timeoutSeconds))
 				if err != nil {
-					logger.Warn("Failed shutting down instance, forcefully stopping", logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "err": err})
+					logger.Warn("Failed shutting down instance, forcefully stopping", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "err": err})
 					err = inst.Stop(false)
 					if err != nil {
-						logger.Warn("Failed forcefully stopping instance", logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "err": err})
+						logger.Warn("Failed forcefully stopping instance", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "err": err})
 					}
 				}
 

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -377,7 +377,11 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 					Config:  make(map[string]string),
 				}
 
-				inst, err = instance.Load(s, *instDBArgs)
+				emptyProject := api.Project{
+					Name: projectName,
+				}
+
+				inst, err = instance.Load(s, *instDBArgs, emptyProject)
 				if err != nil {
 					logger.Warn("Failed loading instance", logger.Ctx{"project": projectName, "instance": instanceName, "err": err})
 					continue

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -327,7 +327,7 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 			}
 
 			for _, inst := range insts {
-				nodeInstances[[2]string{inst.Project(), inst.Name()}] = inst
+				nodeInstances[[2]string{inst.Project().Name, inst.Name()}] = inst
 			}
 		}
 	}
@@ -477,7 +477,7 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 
 						c, _, err := inst.RenderFull()
 						if err != nil {
-							logger.Error("Unable to list instance", logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "err": err})
+							logger.Error("Unable to list instance", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "err": err})
 							resultFullListAppend(projectInstance, api.InstanceFull{}, err)
 						} else {
 							resultFullListAppend(projectInstance, *c, err)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1246,7 +1246,7 @@ func clusterCopyContainerInternal(d *Daemon, r *http.Request, source instance.In
 		return response.SmartError(err)
 	}
 
-	client = client.UseProject(source.Project())
+	client = client.UseProject(source.Project().Name)
 
 	// Setup websockets
 	var opAPI api.Operation

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -96,7 +96,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 	var names []string
 	var instances []instance.Instance
 	for _, inst := range c {
-		if inst.Project() != projectName {
+		if inst.Project().Name != projectName {
 			continue
 		}
 

--- a/lxd/lifecycle/instance.go
+++ b/lxd/lifecycle/instance.go
@@ -9,7 +9,7 @@ import (
 // Internal copy of the instance interface.
 type instance interface {
 	Name() string
-	Project() string
+	Project() api.Project
 	Operation() *operations.Operation
 }
 
@@ -41,7 +41,7 @@ const (
 
 // Event creates the lifecycle event for an action on an instance.
 func (a InstanceAction) Event(inst instance, ctx map[string]any) api.EventLifecycle {
-	url := api.NewURL().Path(version.APIVersion, "instances", inst.Name()).Project(inst.Project())
+	url := api.NewURL().Path(version.APIVersion, "instances", inst.Name()).Project(inst.Project().Name)
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {

--- a/lxd/lifecycle/instance_backup.go
+++ b/lxd/lifecycle/instance_backup.go
@@ -20,7 +20,7 @@ const (
 func (a InstanceBackupAction) Event(fullBackupName string, inst instance, ctx map[string]any) api.EventLifecycle {
 	_, backupName, _ := api.GetParentAndSnapshotName(fullBackupName)
 
-	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "backups", backupName).Project(inst.Project())
+	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "backups", backupName).Project(inst.Project().Name)
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {

--- a/lxd/lifecycle/instance_log.go
+++ b/lxd/lifecycle/instance_log.go
@@ -16,7 +16,7 @@ const (
 
 // Event creates the lifecycle event for an action on an instance log.
 func (a InstanceLogAction) Event(file string, inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
-	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "backups", file).Project(inst.Project())
+	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "backups", file).Project(inst.Project().Name)
 
 	return api.EventLifecycle{
 		Action:    string(a),

--- a/lxd/lifecycle/instance_metadata.go
+++ b/lxd/lifecycle/instance_metadata.go
@@ -16,7 +16,7 @@ const (
 
 // Event creates the lifecycle event for an action on instance metadata.
 func (a InstanceMetadataAction) Event(inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
-	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "metadata").Project(inst.Project())
+	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "metadata").Project(inst.Project().Name)
 
 	return api.EventLifecycle{
 		Action:    string(a),

--- a/lxd/lifecycle/instance_metadata_template.go
+++ b/lxd/lifecycle/instance_metadata_template.go
@@ -17,7 +17,7 @@ const (
 
 // Event creates the lifecycle event for an action on instance metadata templates.
 func (a InstanceMetadataTemplateAction) Event(inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
-	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "metadata", "templates").Project(inst.Project())
+	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "metadata", "templates").Project(inst.Project().Name)
 
 	return api.EventLifecycle{
 		Action:    string(a),

--- a/lxd/lifecycle/instance_snapshot.go
+++ b/lxd/lifecycle/instance_snapshot.go
@@ -20,7 +20,7 @@ const (
 func (a InstanceSnapshotAction) Event(inst instance, ctx map[string]any) api.EventLifecycle {
 	parentName, snapName, _ := api.GetParentAndSnapshotName(inst.Name())
 
-	u := api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(inst.Project())
+	u := api.NewURL().Path(version.APIVersion, "instances", parentName, "snapshots", snapName).Project(inst.Project().Name)
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -61,7 +61,7 @@ func expireLogs(ctx context.Context, state *state.State) error {
 	// Build the expected names.
 	names := []string{}
 	for _, inst := range instances {
-		names = append(names, project.Instance(inst.Project(), inst.Name()))
+		names = append(names, project.Instance(inst.Project().Name, inst.Name()))
 	}
 
 	newestFile := func(path string, dir os.FileInfo) time.Time {

--- a/lxd/maas/controller.go
+++ b/lxd/maas/controller.go
@@ -8,13 +8,14 @@ import (
 	"github.com/juju/gomaasapi"
 
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // Instance is a MAAS specific instance interface.
 // This is used rather than instance.Instance to avoid import loops.
 type Instance interface {
 	Name() string
-	Project() string
+	Project() api.Project
 }
 
 // Controller represents a MAAS server's machine functions.
@@ -115,7 +116,7 @@ func (c *Controller) getDomain(inst Instance) string {
 	fields := strings.Split(c.machine.FQDN(), ".")
 	domain := strings.Join(fields[1:], ".")
 
-	if inst.Project() == project.Default {
+	if inst.Project().Name == project.Default {
 		return domain
 	}
 

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -583,7 +583,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 
 			actionScriptOp, err := operations.OperationCreate(
 				state,
-				s.instance.Project(),
+				s.instance.Project().Name,
 				operations.OperationClassWebsocket,
 				operationtype.InstanceLiveMigrate,
 				nil,

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -825,7 +825,7 @@ func OVNPortGroupDeleteIfUnused(s *state.State, l logger.Logger, client *openvsw
 			// If an ignore instance was provided, then skip the device that the ACLs were just removed
 			// from. In case DB record is not updated until the update process has completed otherwise
 			// we would still consider it using the ACL.
-			if isIgnoreInst && ignoreInst.Name() == u.Name && ignoreInst.Project() == u.Project && ignoreUsageNicName == nicName {
+			if isIgnoreInst && ignoreInst.Name() == u.Name && ignoreInst.Project().Name == u.Project && ignoreUsageNicName == nicName {
 				return nil
 			}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3197,7 +3197,7 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 				}
 			} else {
 				// Skip our own NIC device.
-				if externalSubnetUser.instanceProject == deviceInstance.Project() && externalSubnetUser.instanceName == deviceInstance.Name() && externalSubnetUser.instanceDevice == deviceName {
+				if externalSubnetUser.instanceProject == deviceInstance.Project().Name && externalSubnetUser.instanceName == deviceInstance.Name() && externalSubnetUser.instanceDevice == deviceName {
 					continue
 				}
 			}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -376,7 +376,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 				continue
 			}
 
-			nicType, err := nictype.NICType(s, inst.Project(), d)
+			nicType, err := nictype.NICType(s, inst.Project().Name, d)
 			if err != nil || nicType != "bridged" {
 				continue
 			}
@@ -404,7 +404,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			}
 
 			if (shared.IsTrue(d["security.ipv4_filtering"]) && d["ipv4.address"] == "") || (shared.IsTrue(d["security.ipv6_filtering"]) && d["ipv6.address"] == "") {
-				deviceStaticFileName := dnsmasq.StaticAllocationFileName(inst.Project(), inst.Name(), deviceName)
+				deviceStaticFileName := dnsmasq.StaticAllocationFileName(inst.Project().Name, inst.Name(), deviceName)
 				_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d["parent"], deviceStaticFileName)
 				if err != nil && !os.IsNotExist(err) {
 					return err
@@ -419,7 +419,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 				}
 			}
 
-			entries[d["parent"]] = append(entries[d["parent"]], []string{d["hwaddr"], inst.Project(), inst.Name(), d["ipv4.address"], d["ipv6.address"], deviceName})
+			entries[d["parent"]] = append(entries[d["parent"]], []string{d["hwaddr"], inst.Project().Name, inst.Name(), d["ipv4.address"], d["ipv6.address"], deviceName})
 		}
 	}
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -267,7 +267,7 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networksPost(d *Daemon, r *http.Request) response.Response {
-	projectName, projectConfig, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -316,8 +316,8 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if project has limits.network and if so check we are allowed to create another network.
-	if projectName != project.Default && projectConfig != nil && projectConfig["limits.networks"] != "" {
-		networksLimit, err := strconv.Atoi(projectConfig["limits.networks"])
+	if projectName != project.Default && reqProject.Config != nil && reqProject.Config["limits.networks"] != "" {
+		networksLimit, err := strconv.Atoi(reqProject.Config["limits.networks"])
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Invalid project limits.network value: %w", err))
 		}

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -62,7 +62,9 @@ func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter) error {
 
 	// Make sure both sides are closed.
 	_ = r.source.Close()
-	return target.Close()
+	_ = target.Close()
+
+	return nil
 }
 
 func (r *forwardedOperationWebSocket) String() string {

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -225,7 +225,7 @@ func doProfileUpdateInstance(d *Daemon, args db.InstanceArgs, p api.Project) err
 		Devices:      inst.LocalDevices(),
 		Ephemeral:    inst.IsEphemeral(),
 		Profiles:     profiles, // Supply with new profile config.
-		Project:      inst.Project(),
+		Project:      inst.Project().Name,
 		Type:         inst.Type(),
 		Snapshot:     inst.IsSnapshot(),
 	}, true)

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -105,7 +105,7 @@ func doProfileUpdate(d *Daemon, p api.Project, profileName string, id int64, pro
 
 		err = cluster.UpdateProfileDevices(ctx, tx.Tx(), id, devices)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		newProfiles, err := cluster.GetProfilesIfEnabled(ctx, tx.Tx(), p.Name, []string{profileName})

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1502,14 +1502,9 @@ func AllowBackupCreation(tx *db.ClusterTx, projectName string) error {
 
 // AllowSnapshotCreation returns an error if any project-specific restriction is violated
 // when creating a new snapshot in a project.
-func AllowSnapshotCreation(tx *db.ClusterTx, dbProject *cluster.Project) error {
-	project, err := dbProject.ToAPI(context.Background(), tx.Tx())
-	if err != nil {
-		return err
-	}
-
-	if projectHasRestriction(project, "restricted.snapshots", "block") {
-		return fmt.Errorf("Project %s doesn't allow for snapshot creation", project.Name)
+func AllowSnapshotCreation(p *api.Project) error {
+	if projectHasRestriction(p, "restricted.snapshots", "block") {
+		return fmt.Errorf("Project %s doesn't allow for snapshot creation", p.Name)
 	}
 
 	return nil

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -208,33 +208,43 @@ func NetworkProjectFromRecord(p *api.Project) string {
 	return Default
 }
 
-// ProfileProject returns the project name to use for the profile based on the requested project.
-// If the project specified has the "features.profiles" flag enabled then the project name is returned,
-// otherwise the default project name is returned. The second return value is the project's config if non-default
-// project is being returned, nil if not.
-func ProfileProject(c *db.Cluster, projectName string) (string, map[string]string, error) {
-	var project *api.Project
+// ProfileProject returns the effective project to use for the profile based on the requested project.
+// If the requested project has the "features.profiles" flag enabled then the requested project's info is returned,
+// otherwise the default project's info is returned.
+func ProfileProject(c *db.Cluster, projectName string) (*api.Project, error) {
+	var p *api.Project
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed loading project %q: %w", projectName, err)
 		}
 
-		project, err = dbProject.ToAPI(ctx, tx.Tx())
+		p, err = dbProject.ToAPI(ctx, tx.Tx())
+		if err != nil {
+			return fmt.Errorf("Failed loading config for project %q: %w", projectName, err)
+		}
 
-		return err
+		effectiveProjectName := ProfileProjectFromRecord(p)
+
+		if effectiveProjectName == Default {
+			dbProject, err = cluster.GetProject(ctx, tx.Tx(), effectiveProjectName)
+			if err != nil {
+				return fmt.Errorf("Failed loading project %q: %w", effectiveProjectName, err)
+			}
+		}
+
+		p, err = dbProject.ToAPI(ctx, tx.Tx())
+		if err != nil {
+			return fmt.Errorf("Failed loading config for project %q: %w", dbProject.Name, err)
+		}
+
+		return nil
 	})
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed to load project %q: %w", projectName, err)
+		return nil, err
 	}
 
-	projectName = ProfileProjectFromRecord(project)
-
-	if projectName != Default {
-		return projectName, project.Config, nil
-	}
-
-	return Default, nil, nil
+	return p, nil
 }
 
 // ProfileProjectFromRecord returns the project name to use for the profile based on the supplied project.

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -166,19 +166,18 @@ func StorageBucketProjectFromRecord(p *api.Project) string {
 	return Default
 }
 
-// NetworkProject returns the project name to use for the network based on the requested project.
-// If the project specified has the "features.networks" flag enabled then the project name is returned,
-// otherwise the default project name is returned. The second return value is the project's config if non-default
-// project is being returned, nil if not.
-func NetworkProject(c *db.Cluster, projectName string) (string, map[string]string, error) {
-	var project *api.Project
+// NetworkProject returns the effective project name to use for the network based on the requested project.
+// If the requested project has the "features.networks" flag enabled then the requested project's info is returned,
+// otherwise the default project name is returned. The second return value is always the requested project's info.
+func NetworkProject(c *db.Cluster, projectName string) (string, *api.Project, error) {
+	var p *api.Project
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
 		if err != nil {
 			return err
 		}
 
-		project, err = dbProject.ToAPI(ctx, tx.Tx())
+		p, err = dbProject.ToAPI(ctx, tx.Tx())
 
 		return err
 	})
@@ -186,13 +185,9 @@ func NetworkProject(c *db.Cluster, projectName string) (string, map[string]strin
 		return "", nil, fmt.Errorf("Failed to load project %q: %w", projectName, err)
 	}
 
-	projectName = NetworkProjectFromRecord(project)
+	effectiveProjectName := NetworkProjectFromRecord(p)
 
-	if projectName != Default {
-		return projectName, project.Config, nil
-	}
-
-	return Default, nil, nil
+	return effectiveProjectName, p, nil
 }
 
 // NetworkProjectFromRecord returns the project name to use for the network based on the supplied project.

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lxc/lxd/lxd/ucred"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/netutils"
@@ -606,7 +607,7 @@ stub_x32_execveat errno 38
 // This is used rather than instance.Instance to avoid import loops.
 type Instance interface {
 	Name() string
-	Project() string
+	Project() api.Project
 	ExpandedConfig() map[string]string
 	IsPrivileged() bool
 	Architecture() int
@@ -622,7 +623,7 @@ var seccompPath = shared.VarPath("security", "seccomp")
 
 // ProfilePath returns the seccomp path for the instance.
 func ProfilePath(c Instance) string {
-	return path.Join(seccompPath, project.Instance(c.Project(), c.Name()))
+	return path.Join(seccompPath, project.Instance(c.Project().Name, c.Name()))
 }
 
 // InstanceNeedsPolicy returns whether the instance needs a policy or not.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -604,7 +604,7 @@ func (b *lxdBackend) applyInstanceRootDiskOverrides(inst instance.Instance, vol 
 
 // CreateInstance creates an empty instance.
 func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CreateInstance started")
 	defer l.Debug("CreateInstance finished")
 
@@ -625,15 +625,15 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 
 	// Validate config and create database entry for new storage volume.
 	volumeConfig := make(map[string]string)
-	err = VolumeDBCreate(b, inst.Project(), inst.Name(), "", volType, false, volumeConfig, time.Time{}, contentType, false)
+	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", volType, false, volumeConfig, time.Time{}, contentType, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), inst.Name(), volType) })
+	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -647,7 +647,7 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 
 	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
 
-	err = b.ensureInstanceSymlink(inst.Type(), inst.Project(), inst.Name(), vol.MountPath())
+	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
 		return err
 	}
@@ -758,12 +758,12 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-		err = VolumeDBCreate(b, inst.Project(), inst.Name(), volumeDescription, volType, false, volumeConfig, time.Time{}, contentType, true)
+		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), volumeDescription, volType, false, volumeConfig, time.Time{}, contentType, true)
 		if err != nil {
 			return err
 		}
 
-		postHookRevert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), inst.Name(), volType) })
+		postHookRevert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
 
 		// If the backup restore interface provides volume snapshot config use it, otherwise use default
 		// volume config for the storage pool.
@@ -786,16 +786,16 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 			// Validate config and create database entry for new storage volume.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-			err = VolumeDBCreate(b, inst.Project(), newSnapshotName, volumeSnapDescription, volType, true, volumeSnapConfig, volumeSnapExpiryDate, contentType, true)
+			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, volumeSnapDescription, volType, true, volumeSnapConfig, volumeSnapExpiryDate, contentType, true)
 			if err != nil {
 				return err
 			}
 
-			postHookRevert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), newSnapshotName, volType) })
+			postHookRevert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, volType) })
 		}
 
 		// Generate the effective root device volume for instance.
-		volStorageName := project.Instance(inst.Project(), inst.Name())
+		volStorageName := project.Instance(inst.Project().Name, inst.Name())
 		vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
 		err = b.applyInstanceRootDiskOverrides(inst, &vol)
 		if err != nil {
@@ -883,7 +883,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 // CreateInstanceFromCopy copies an instance volume and optionally its snapshots to new volume(s).
 func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, allowInconsistent bool, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "src": src.Name(), "snapshots": snapshots})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name(), "snapshots": snapshots})
 	l.Debug("CreateInstanceFromCopy started")
 	defer l.Debug("CreateInstanceFromCopy finished")
 
@@ -928,7 +928,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		}
 	}
 
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, srcConfig.Volume.Config)
 
 	if b.driver.HasVolume(vol) {
@@ -958,16 +958,16 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		l.Debug("CreateInstanceFromCopy same-pool mode detected")
 
 		// Get the src volume name on storage.
-		srcVolStorageName := project.Instance(src.Project(), src.Name())
+		srcVolStorageName := project.Instance(src.Project().Name, src.Name())
 		srcVol := b.GetVolume(volType, contentType, srcVolStorageName, srcConfig.Volume.Config)
 
 		// Validate config and create database entry for new storage volume.
-		err = VolumeDBCreate(b, inst.Project(), inst.Name(), "", vol.Type(), false, vol.Config(), time.Time{}, contentType, false)
+		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", vol.Type(), false, vol.Config(), time.Time{}, contentType, false)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), inst.Name(), volType) })
+		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
 
 		// Create database entries for new storage volume snapshots.
 		for i, snapName := range snapshotNames {
@@ -978,12 +978,12 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 			}
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, inst.Project(), newSnapshotName, srcConfig.VolumeSnapshots[i].Description, vol.Type(), true, srcConfig.VolumeSnapshots[i].Config, volumeSnapExpiryDate, vol.ContentType(), false)
+			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, vol.Type(), true, srcConfig.VolumeSnapshots[i].Config, volumeSnapExpiryDate, vol.ContentType(), false)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), newSnapshotName, vol.Type()) })
+			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, vol.Type()) })
 		}
 
 		// Generate the effective root device volume for instance.
@@ -1084,13 +1084,13 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 	}
 
 	// Setup the symlinks.
-	err = b.ensureInstanceSymlink(inst.Type(), inst.Project(), inst.Name(), vol.MountPath())
+	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
 		return err
 	}
 
 	if len(snapshotNames) > 0 {
-		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project(), inst.Name())
+		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project().Name, inst.Name())
 		if err != nil {
 			return err
 		}
@@ -1378,7 +1378,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 // Snapshots that are not present in the source but are in the destination are removed from the
 // destination if snapshots are included in the synchronisation.
 func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "src": src.Name(), "srcSnapshots": len(srcSnapshots)})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name(), "srcSnapshots": len(srcSnapshots)})
 	l.Debug("RefreshInstance started")
 	defer l.Debug("RefreshInstance finished")
 
@@ -1394,13 +1394,13 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -1438,7 +1438,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	}
 
 	// Get source volume construct.
-	srcVolStorageName := project.Instance(src.Project(), src.Name())
+	srcVolStorageName := project.Instance(src.Project().Name, src.Name())
 	srcVol := b.GetVolume(volType, contentType, srcVolStorageName, srcConfig.Volume.Config)
 
 	// Get source snapshot volume constructs.
@@ -1446,7 +1446,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	snapshotNames := make([]string, 0, len(srcConfig.VolumeSnapshots))
 	for i := range srcConfig.VolumeSnapshots {
 		newSnapshotName := drivers.GetSnapshotVolumeName(src.Name(), srcConfig.VolumeSnapshots[i].Name)
-		snapVolStorageName := project.Instance(src.Project(), newSnapshotName)
+		snapVolStorageName := project.Instance(src.Project().Name, newSnapshotName)
 		srcSnapVol := srcPool.GetVolume(volType, contentType, snapVolStorageName, srcConfig.VolumeSnapshots[i].Config)
 		srcSnapVols = append(srcSnapVols, srcSnapVol)
 		snapshotNames = append(snapshotNames, srcConfig.VolumeSnapshots[i].Name)
@@ -1468,12 +1468,12 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 			}
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, inst.Project(), newSnapshotName, srcConfig.VolumeSnapshots[i].Description, volType, true, srcConfig.VolumeSnapshots[i].Config, volumeSnapExpiryDate, contentType, false)
+			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, volType, true, srcConfig.VolumeSnapshots[i].Config, volumeSnapExpiryDate, contentType, false)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), newSnapshotName, volType) })
+			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, volType) })
 		}
 
 		err = b.driver.RefreshVolume(vol, srcVol, srcSnapVols, allowInconsistent, op)
@@ -1556,7 +1556,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		}
 	}
 
-	err = b.ensureInstanceSymlink(inst.Type(), inst.Project(), inst.Name(), vol.MountPath())
+	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
 		return err
 	}
@@ -1593,7 +1593,7 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) f
 // CreateInstanceFromImage creates a new volume for an instance populated with the image requested.
 // On failure caller is expected to call DeleteInstance() to clean up.
 func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("CreateInstanceFromImage started")
 	defer l.Debug("CreateInstanceFromImage finished")
 
@@ -1614,15 +1614,15 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 	// Validate config and create database entry for new storage volume.
 	volumeConfig := make(map[string]string) // Capture any default config generated by VolumeDBCreate.
-	err = VolumeDBCreate(b, inst.Project(), inst.Name(), "", volType, false, volumeConfig, time.Time{}, contentType, false)
+	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", volType, false, volumeConfig, time.Time{}, contentType, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), inst.Name(), volType) })
+	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -1698,7 +1698,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 		}
 	}
 
-	err = b.ensureInstanceSymlink(inst.Type(), inst.Project(), inst.Name(), vol.MountPath())
+	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
 		return err
 	}
@@ -1715,7 +1715,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 // CreateInstanceFromMigration receives an instance being migrated.
 // The args.Name and args.Config fields are ignored and, instance properties are used instead.
 func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("CreateInstanceFromMigration started")
 	defer l.Debug("CreateInstanceFromMigration finished")
 
@@ -1747,7 +1747,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	var volumeConfig map[string]string
 
 	// Check if the volume exists in database
-	dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -1765,7 +1765,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	}
 
 	// Check if the volume exists on storage.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
 	volExists := b.driver.HasVolume(vol)
 
@@ -1793,12 +1793,12 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	if !args.Refresh {
 		// Validate config and create database entry for new storage volume if not refreshing.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-		err = VolumeDBCreate(b, inst.Project(), inst.Name(), volumeDescription, volType, false, volumeConfig, time.Time{}, contentType, true)
+		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), volumeDescription, volType, false, volumeConfig, time.Time{}, contentType, true)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), inst.Name(), volType) })
+		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
 	}
 
 	for _, snapName := range args.Snapshots {
@@ -1828,12 +1828,12 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 			}
 		}
 
-		err = VolumeDBCreate(b, inst.Project(), newSnapshotName, snapDescription, volType, true, snapConfig, snapExpiryDate, contentType, true)
+		err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, snapDescription, volType, true, snapConfig, snapExpiryDate, contentType, true)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), newSnapshotName, volType) })
+		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, volType) })
 	}
 
 	// Generate the effective root device volume for instance.
@@ -1846,7 +1846,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	args.Config = vol.Config()
 	args.Name = inst.Name()
 
-	projectName := inst.Project()
+	projectName := inst.Project().Name
 
 	// If migration header supplies a volume size, then use that as block volume size instead of pool default.
 	// This way if the volume being received is larger than the pool default size, the block volume created
@@ -1908,13 +1908,13 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 	revert.Add(func() { _ = b.DeleteInstance(inst, op) })
 
-	err = b.ensureInstanceSymlink(inst.Type(), inst.Project(), inst.Name(), vol.MountPath())
+	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
 		return err
 	}
 
 	if len(args.Snapshots) > 0 {
-		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project(), inst.Name())
+		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project().Name, inst.Name())
 		if err != nil {
 			return err
 		}
@@ -1926,7 +1926,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 // RenameInstance renames the instance's root volume and any snapshot volumes.
 func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "newName": newName})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newName": newName})
 	l.Debug("RenameInstance started")
 	defer l.Debug("RenameInstance finished")
 
@@ -1953,15 +1953,15 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 	defer revert.Fail()
 
 	// Get any snapshots the instance has in the format <instance name>/<snapshot name>.
-	snapshots, err := b.state.DB.Cluster.GetInstanceSnapshotsNames(inst.Project(), inst.Name())
+	snapshots, err := b.state.DB.Cluster.GetInstanceSnapshotsNames(inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
 
 	if len(snapshots) > 0 {
 		revert.Add(func() {
-			_ = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project(), newName)
-			_ = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project(), inst.Name())
+			_ = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project().Name, newName)
+			_ = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project().Name, inst.Name())
 		})
 	}
 
@@ -1969,29 +1969,29 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 	for _, srcSnapshot := range snapshots {
 		_, snapName, _ := api.GetParentAndSnapshotName(srcSnapshot)
 		newSnapVolName := drivers.GetSnapshotVolumeName(newName, snapName)
-		err = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project(), srcSnapshot, newSnapVolName, volDBType, b.ID())
+		err = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project().Name, srcSnapshot, newSnapVolName, volDBType, b.ID())
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project(), newSnapVolName, srcSnapshot, volDBType, b.ID())
+			_ = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project().Name, newSnapVolName, srcSnapshot, volDBType, b.ID())
 		})
 	}
 
 	// Rename the parent volume DB record.
-	err = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project(), inst.Name(), newName, volDBType, b.ID())
+	err = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project().Name, inst.Name(), newName, volDBType, b.ID())
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
-		_ = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project(), newName, inst.Name(), volDBType, b.ID())
+		_ = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project().Name, newName, inst.Name(), volDBType, b.ID())
 	})
 
 	// Rename the volume and its snapshots on the storage device.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
-	newVolStorageName := project.Instance(inst.Project(), newName)
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
+	newVolStorageName := project.Instance(inst.Project().Name, newName)
 	contentType := InstanceContentType(inst)
 
 	// There's no need to pass config as it's not needed when renaming a volume.
@@ -2009,32 +2009,32 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 	})
 
 	// Remove old instance symlink and create new one.
-	err = b.removeInstanceSymlink(inst.Type(), inst.Project(), inst.Name())
+	err = b.removeInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
-		_ = b.ensureInstanceSymlink(inst.Type(), inst.Project(), inst.Name(), drivers.GetVolumeMountPath(b.name, volType, volStorageName))
+		_ = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), drivers.GetVolumeMountPath(b.name, volType, volStorageName))
 	})
 
-	err = b.ensureInstanceSymlink(inst.Type(), inst.Project(), newName, drivers.GetVolumeMountPath(b.name, volType, newVolStorageName))
+	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, newName, drivers.GetVolumeMountPath(b.name, volType, newVolStorageName))
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
-		_ = b.removeInstanceSymlink(inst.Type(), inst.Project(), newName)
+		_ = b.removeInstanceSymlink(inst.Type(), inst.Project().Name, newName)
 	})
 
 	// Remove old instance snapshot symlink and create a new one if needed.
-	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project(), inst.Name())
+	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
 
 	if len(snapshots) > 0 {
-		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project(), newName)
+		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project().Name, newName)
 		if err != nil {
 			return err
 		}
@@ -2046,7 +2046,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 
 // DeleteInstance removes the instance's root volume (all snapshots need to be removed first).
 func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstance started")
 	defer l.Debug("DeleteInstance finished")
 
@@ -2061,7 +2061,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	// Get any snapshots the instance has in the format <instance name>/<snapshot name>.
-	snapshots, err := b.state.DB.Cluster.GetInstanceSnapshotsNames(inst.Project(), inst.Name())
+	snapshots, err := b.state.DB.Cluster.GetInstanceSnapshotsNames(inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
@@ -2072,7 +2072,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	// Get the volume name on storage.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	contentType := InstanceContentType(inst)
 
 	// There's no need to pass config as it's not needed when deleting a volume.
@@ -2090,18 +2090,18 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	// Remove symlinks.
-	err = b.removeInstanceSymlink(inst.Type(), inst.Project(), inst.Name())
+	err = b.removeInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
 
-	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project(), inst.Name())
+	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
 
 	// Remove the volume record from the database.
-	err = VolumeDBDelete(b, inst.Project(), inst.Name(), vol.Type())
+	err = VolumeDBDelete(b, inst.Project().Name, inst.Name(), vol.Type())
 	if err != nil {
 		return err
 	}
@@ -2111,7 +2111,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 
 // UpdateInstance updates an instance volume's config.
 func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateInstance started")
 	defer l.Debug("UpdateInstance finished")
 
@@ -2130,7 +2130,7 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 		return err
 	}
 
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	contentType := InstanceContentType(inst)
 
 	// Validate config.
@@ -2141,10 +2141,10 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 	}
 
 	// Get current config to compare what has changed.
-	_, curVol, err := b.state.DB.Cluster.GetLocalStoragePoolVolume(inst.Project(), inst.Name(), volDBType, b.ID())
+	_, curVol, err := b.state.DB.Cluster.GetLocalStoragePoolVolume(inst.Project().Name, inst.Name(), volDBType, b.ID())
 	if err != nil {
 		if response.IsNotFoundError(err) {
-			return fmt.Errorf("Volume doesn't exist for %q on pool %q: %w", project.Instance(inst.Project(), inst.Name()), b.Name(), err)
+			return fmt.Errorf("Volume doesn't exist for %q on pool %q: %w", project.Instance(inst.Project().Name, inst.Name()), b.Name(), err)
 		}
 
 		return err
@@ -2169,13 +2169,13 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 		}
 
 		// Load storage volume from database.
-		dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+		dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 		if err != nil {
 			return err
 		}
 
 		// Generate the effective root device volume for instance.
-		volStorageName := project.Instance(inst.Project(), inst.Name())
+		volStorageName := project.Instance(inst.Project().Name, inst.Name())
 		curVol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 		err = b.applyInstanceRootDiskOverrides(inst, &curVol)
 		if err != nil {
@@ -2192,13 +2192,13 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 
 	// Update the database if something changed.
 	if len(changedConfig) != 0 || newDesc != curVol.Description {
-		err = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project(), inst.Name(), volDBType, b.ID(), newDesc, newConfig)
+		err = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project().Name, inst.Name(), volDBType, b.ID(), newDesc, newConfig)
 		if err != nil {
 			return err
 		}
 	}
 
-	b.state.Events.SendLifecycle(inst.Project(), lifecycle.StorageVolumeUpdated.Event(newVol, string(newVol.Type()), inst.Project(), op, nil))
+	b.state.Events.SendLifecycle(inst.Project().Name, lifecycle.StorageVolumeUpdated.Event(newVol, string(newVol.Type()), inst.Project().Name, op, nil))
 
 	return nil
 }
@@ -2206,7 +2206,7 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 // UpdateInstanceSnapshot updates an instance snapshot volume's description.
 // Volume config is not allowed to be updated and will return an error.
 func (b *lxdBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newDesc": newDesc, "newConfig": newConfig})
 	l.Debug("UpdateInstanceSnapshot started")
 	defer l.Debug("UpdateInstanceSnapshot finished")
 
@@ -2225,13 +2225,13 @@ func (b *lxdBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc stri
 		return err
 	}
 
-	return b.updateVolumeDescriptionOnly(inst.Project(), inst.Name(), volDBType, newDesc, newConfig, op)
+	return b.updateVolumeDescriptionOnly(inst.Project().Name, inst.Name(), volDBType, newDesc, newConfig, op)
 }
 
 // MigrateInstance sends an instance volume for migration.
 // The args.Name field is ignored and the name of the instance is used instead.
 func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "args": fmt.Sprintf("%+v", args)})
 	l.Debug("MigrateInstance started")
 	defer l.Debug("MigrateInstance finished")
 
@@ -2264,13 +2264,13 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 	}
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -2315,7 +2315,7 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 
 // BackupInstance creates an instance backup.
 func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "optimized": optimized, "snapshots": snapshots})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "optimized": optimized, "snapshots": snapshots})
 	l.Debug("BackupInstance started")
 	defer l.Debug("BackupInstance finished")
 
@@ -2327,13 +2327,13 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -2371,7 +2371,7 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 
 // GetInstanceUsage returns the disk usage of the instance's root volume.
 func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (int64, error) {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("GetInstanceUsage started")
 	defer l.Debug("GetInstanceUsage finished")
 
@@ -2383,7 +2383,7 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (int64, error) {
 	contentType := InstanceContentType(inst)
 
 	// There's no need to pass config as it's not needed when retrieving the volume usage.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, nil)
 
 	return b.driver.GetVolumeUsage(vol)
@@ -2392,7 +2392,7 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (int64, error) {
 // SetInstanceQuota sets the quota on the instance's root volume.
 // Returns ErrInUse if the instance is running and the storage driver doesn't support online resizing.
 func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "size": size, "vm_state_size": vmStateSize})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "size": size, "vm_state_size": vmStateSize})
 	l.Debug("SetInstanceQuota started")
 	defer l.Debug("SetInstanceQuota finished")
 
@@ -2403,7 +2403,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 	}
 
 	contentVolume := InstanceContentType(inst)
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Apply the main volume quota.
 	// There's no need to pass config as it's not needed when setting quotas.
@@ -2435,7 +2435,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 
 // MountInstance mounts the instance's root volume.
 func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("MountInstance started")
 	defer l.Debug("MountInstance finished")
 
@@ -2457,11 +2457,11 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 
 	// Get the volume.
 	var vol drivers.Volume
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	if inst.ID() > -1 {
 		// Load storage volume from database.
-		dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+		dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 		if err != nil {
 			return nil, err
 		}
@@ -2499,7 +2499,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 
 // UnmountInstance unmounts the instance's root volume.
 func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UnmountInstance started")
 	defer l.Debug("UnmountInstance finished")
 
@@ -2513,11 +2513,11 @@ func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Oper
 
 	// Get the volume.
 	var vol drivers.Volume
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	if inst.ID() > -1 {
 		// Load storage volume from database.
-		dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+		dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 		if err != nil {
 			return err
 		}
@@ -2550,7 +2550,7 @@ func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 	}
 
 	contentType := InstanceContentType(inst)
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Get the volume.
 	// There's no need to pass config as it's not needed when getting the
@@ -2568,7 +2568,7 @@ func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 
 // CreateInstanceSnapshot creates a snaphot of an instance volume.
 func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "src": src.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
 	l.Debug("CreateInstanceSnapshot started")
 	defer l.Debug("CreateInstanceSnapshot finished")
 
@@ -2593,7 +2593,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	srcDBVol, err := VolumeDBGet(b, src.Project(), src.Name(), volType)
+	srcDBVol, err := VolumeDBGet(b, src.Project().Name, src.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -2602,12 +2602,12 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 	defer revert.Fail()
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, inst.Project(), inst.Name(), srcDBVol.Description, volType, true, srcDBVol.Config, time.Time{}, contentType, false)
+	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), srcDBVol.Description, volType, true, srcDBVol.Config, time.Time{}, contentType, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), inst.Name(), volType) })
+	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
 
 	// Some driver backing stores require that running instances be frozen during snapshot.
 	if b.driver.Info().RunningCopyFreeze && src.IsRunning() && !src.IsFrozen() {
@@ -2623,7 +2623,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 		_ = filesystem.SyncFS(src.RootfsPath())
 	}
 
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Get the volume.
 	// There's no need to pass config as it's not needed when creating volume snapshots.
@@ -2639,7 +2639,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 		return err
 	}
 
-	err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project(), inst.Name())
+	err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
@@ -2650,7 +2650,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 
 // RenameInstanceSnapshot renames an instance snapshot.
 func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "newName": newName})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "newName": newName})
 	l.Debug("RenameInstanceSnapshot started")
 	defer l.Debug("RenameInstanceSnapshot finished")
 
@@ -2682,7 +2682,7 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 	}
 
 	contentType := InstanceContentType(inst)
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Rename storage volume snapshot. No need to pass config as it's not needed when renaming a volume.
 	snapVol := b.GetVolume(volType, contentType, volStorageName, nil)
@@ -2695,19 +2695,19 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 
 	revert.Add(func() {
 		// Revert rename. No need to pass config as it's not needed when renaming a volume.
-		newSnapVol := b.GetVolume(volType, contentType, project.Instance(inst.Project(), newVolName), nil)
+		newSnapVol := b.GetVolume(volType, contentType, project.Instance(inst.Project().Name, newVolName), nil)
 		_ = b.driver.RenameVolumeSnapshot(newSnapVol, oldSnapshotName, op)
 	})
 
 	// Rename DB volume record.
-	err = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project(), inst.Name(), newVolName, volDBType, b.ID())
+	err = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project().Name, inst.Name(), newVolName, volDBType, b.ID())
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
 		// Rename DB volume record back.
-		_ = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project(), newVolName, inst.Name(), volDBType, b.ID())
+		_ = b.state.DB.Cluster.RenameStoragePoolVolume(inst.Project().Name, newVolName, inst.Name(), volDBType, b.ID())
 	})
 
 	// Ensure the backup file reflects current config.
@@ -2722,7 +2722,7 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 
 // DeleteInstanceSnapshot removes the snapshot volume for the supplied snapshot instance.
 func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("DeleteInstanceSnapshot started")
 	defer l.Debug("DeleteInstanceSnapshot finished")
 
@@ -2740,7 +2740,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 	contentType := InstanceContentType(inst)
 
 	// Get the parent volume name on storage.
-	parentStorageName := project.Instance(inst.Project(), parentName)
+	parentStorageName := project.Instance(inst.Project().Name, parentName)
 
 	// Delete the snapshot from the storage device.
 	// Must come before DB VolumeDBDelete so that the volume ID is still available.
@@ -2759,13 +2759,13 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 	}
 
 	// Delete symlink if needed.
-	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project(), inst.Name())
+	err = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
 
 	// Remove the snapshot volume record from the database if exists.
-	err = VolumeDBDelete(b, inst.Project(), inst.Name(), vol.Type())
+	err = VolumeDBDelete(b, inst.Project().Name, inst.Name(), vol.Type())
 	if err != nil {
 		return err
 	}
@@ -2775,7 +2775,7 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 
 // RestoreInstanceSnapshot restores an instance snapshot.
 func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "src": src.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
 	l.Debug("RestoreInstanceSnapshot started")
 	defer l.Debug("RestoreInstanceSnapshot finished")
 
@@ -2808,13 +2808,13 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -2826,7 +2826,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 		return fmt.Errorf("Volume name must be a snapshot")
 	}
 
-	srcDBVol, err := VolumeDBGet(b, src.Project(), src.Name(), volType)
+	srcDBVol, err := VolumeDBGet(b, src.Project().Name, src.Name(), volType)
 	if err != nil {
 		return err
 	}
@@ -2839,13 +2839,13 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 			return err
 		}
 
-		err = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project(), inst.Name(), volDBType, b.ID(), srcDBVol.Description, srcDBVol.Config)
+		err = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project().Name, inst.Name(), volDBType, b.ID(), srcDBVol.Description, srcDBVol.Config)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project(), inst.Name(), volDBType, b.ID(), dbVol.Description, dbVol.Config)
+			_ = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project().Name, inst.Name(), volDBType, b.ID(), dbVol.Description, dbVol.Config)
 		})
 	}
 
@@ -2892,7 +2892,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 // MountInstanceSnapshot mounts an instance snapshot. It is mounted as read only so that the
 // snapshot cannot be modified.
 func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("MountInstanceSnapshot started")
 	defer l.Debug("MountInstanceSnapshot finished")
 
@@ -2907,7 +2907,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	}
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return nil, err
 	}
@@ -2915,7 +2915,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	contentType := InstanceContentType(inst)
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -2941,7 +2941,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 
 // UnmountInstanceSnapshot unmounts an instance snapshot.
 func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UnmountInstanceSnapshot started")
 	defer l.Debug("UnmountInstanceSnapshot finished")
 
@@ -2958,13 +2958,13 @@ func (b *lxdBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operati
 	contentType := InstanceContentType(inst)
 
 	// Load storage volume from database.
-	dbVol, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return err
 	}
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -5026,7 +5026,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		return nil, err
 	}
 
-	volume, err := VolumeDBGet(b, inst.Project(), inst.Name(), volType)
+	volume, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 	if err != nil {
 		return nil, err
 	}
@@ -5056,7 +5056,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 				config.Snapshots = append(config.Snapshots, si.(*api.InstanceSnapshot))
 			}
 
-			dbVolSnaps, err := VolumeDBSnapshotsGet(b, inst.Project(), inst.Name(), volType)
+			dbVolSnaps, err := VolumeDBSnapshotsGet(b, inst.Project().Name, inst.Name(), volType)
 			if err != nil {
 				return nil, err
 			}
@@ -5099,7 +5099,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 
 // UpdateInstanceBackupFile writes the instance's config to the backup.yaml file on the storage device.
 func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UpdateInstanceBackupFile started")
 	defer l.Debug("UpdateInstanceBackupFile finished")
 
@@ -5119,7 +5119,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, op *operat
 	}
 
 	// Get the volume name on storage.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	volType, err := InstanceTypeToVolumeType(inst.Type())
 	if err != nil {
 		return err
@@ -5568,7 +5568,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 // If the instance exists on the local cluster member then the local mount status is restored as needed.
 // If the optional poolVol argument is provided then it is used to create the storage volume database records.
 func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) error {
-	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("ImportInstance started")
 	defer l.Debug("ImportInstance finished")
 
@@ -5578,7 +5578,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 	}
 
 	// Get any snapshots the instance has in the format <instance name>/<snapshot name>.
-	snapshots, err := b.state.DB.Cluster.GetInstanceSnapshotsNames(inst.Project(), inst.Name())
+	snapshots, err := b.state.DB.Cluster.GetInstanceSnapshotsNames(inst.Project().Name, inst.Name())
 	if err != nil {
 		return err
 	}
@@ -5602,12 +5602,12 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 		}
 
 		// Validate config and create database entry for recovered storage volume.
-		err = VolumeDBCreate(b, inst.Project(), poolVol.Volume.Name, "", volType, false, volumeConfig, time.Time{}, contentType, false)
+		err = VolumeDBCreate(b, inst.Project().Name, poolVol.Volume.Name, "", volType, false, volumeConfig, time.Time{}, contentType, false)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), poolVol.Volume.Name, volType) })
+		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, poolVol.Volume.Name, volType) })
 
 		if len(snapshots) > 0 && len(poolVol.VolumeSnapshots) > 0 {
 			// Create storage volume snapshot DB records from the entries in the backup file config.
@@ -5622,12 +5622,12 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 				}
 
 				// Validate config and create database entry for recovered storage volume.
-				err = VolumeDBCreate(b, inst.Project(), fullSnapName, poolVolSnap.Description, volType, true, snapVolumeConfig, time.Time{}, contentType, false)
+				err = VolumeDBCreate(b, inst.Project().Name, fullSnapName, poolVolSnap.Description, volType, true, snapVolumeConfig, time.Time{}, contentType, false)
 				if err != nil {
 					return err
 				}
 
-				revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), fullSnapName, volType) })
+				revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, fullSnapName, volType) })
 			}
 		} else {
 			b.logger.Warn("Missing volume snapshot info in backup config, using parent volume config")
@@ -5641,18 +5641,18 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 
 				// Validate config and create database entry for new storage volume.
 				// Use parent volume config.
-				err = VolumeDBCreate(b, inst.Project(), fullSnapName, "", volType, true, volumeConfig, time.Time{}, contentType, false)
+				err = VolumeDBCreate(b, inst.Project().Name, fullSnapName, "", volType, true, volumeConfig, time.Time{}, contentType, false)
 				if err != nil {
 					return err
 				}
 
-				revert.Add(func() { _ = VolumeDBDelete(b, inst.Project(), fullSnapName, volType) })
+				revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, fullSnapName, volType) })
 			}
 		}
 	}
 
 	// Generate the effective root device volume for instance.
-	volStorageName := project.Instance(inst.Project(), inst.Name())
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
 	err = b.applyInstanceRootDiskOverrides(inst, &vol)
 	if err != nil {
@@ -5690,15 +5690,15 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 	}
 
 	// Create symlink.
-	err = b.ensureInstanceSymlink(inst.Type(), inst.Project(), inst.Name(), vol.MountPath())
+	err = b.ensureInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name(), vol.MountPath())
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
 		// Remove symlinks.
-		_ = b.removeInstanceSymlink(inst.Type(), inst.Project(), inst.Name())
-		_ = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project(), inst.Name())
+		_ = b.removeInstanceSymlink(inst.Type(), inst.Project().Name, inst.Name())
+		_ = b.removeInstanceSnapshotSymlinkIfUnused(inst.Type(), inst.Project().Name, inst.Name())
 	})
 
 	// Create snapshot mount paths and snapshot symlink if needed.
@@ -5718,7 +5718,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 			}
 		}
 
-		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project(), inst.Name())
+		err = b.ensureInstanceSnapshotSymlink(inst.Type(), inst.Project().Name, inst.Name())
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4362,7 +4362,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 		// Check for config changing that is not allowed when running instances are using it.
 		if changedConfig["security.shifted"] != "" {
 			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-				inst, err := instance.Load(b.state, dbInst, nil)
+				inst, err := instance.Load(b.state, dbInst)
 				if err != nil {
 					return err
 				}
@@ -4890,7 +4890,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 
 	// Check that the volume isn't in use by running instances.
 	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(b.state, dbInst, nil)
+		inst, err := instance.Load(b.state, dbInst)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4362,7 +4362,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 		// Check for config changing that is not allowed when running instances are using it.
 		if changedConfig["security.shifted"] != "" {
 			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-				inst, err := instance.Load(b.state, dbInst)
+				inst, err := instance.Load(b.state, dbInst, project)
 				if err != nil {
 					return err
 				}
@@ -4890,7 +4890,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 
 	// Check that the volume isn't in use by running instances.
 	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(b.state, dbInst)
+		inst, err := instance.Load(b.state, dbInst, project)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -672,14 +672,13 @@ func InstanceContentType(inst instance.Instance) drivers.ContentType {
 // VolumeUsedByProfileDevices finds profiles using a volume and passes them to profileFunc for evaluation.
 // The profileFunc is provided with a profile config, project config and a list of device names that are using
 // the volume.
-func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, profileFunc func(profileID int64, profile api.Profile, project cluster.Project, usedByDevices []string) error) error {
+func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, profileFunc func(profileID int64, profile api.Profile, project api.Project, usedByDevices []string) error) error {
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := VolumeTypeNameToDBType(vol.Type)
 	if err != nil {
 		return err
 	}
 
-	projectMap := map[string]cluster.Project{}
 	var profiles []api.Profile
 	var profileIDs []int64
 	var profileProjects []*api.Project
@@ -691,8 +690,12 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 		}
 
 		// Index of all projects by name.
-		for i, project := range projects {
-			projectMap[project.Name] = projects[i]
+		projectMap := make(map[string]*api.Project, len(projects))
+		for _, project := range projects {
+			projectMap[project.Name], err = project.ToAPI(ctx, tx.Tx())
+			if err != nil {
+				return fmt.Errorf("Failed loading config for projec %q: %w", project.Name, err)
+			}
 		}
 
 		dbProfiles, err := cluster.GetProfiles(ctx, tx.Tx())
@@ -712,11 +715,7 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 
 		profileProjects = make([]*api.Project, len(dbProfiles))
 		for i, p := range dbProfiles {
-			project := projectMap[p.Project]
-			profileProjects[i], err = project.ToAPI(ctx, tx.Tx())
-			if err != nil {
-				return err
-			}
+			profileProjects[i] = projectMap[p.Project]
 		}
 
 		return nil
@@ -759,7 +758,7 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 		}
 
 		if len(usedByDevices) > 0 {
-			err = profileFunc(profileIDs[i], profile, projectMap[profileProjects[i].Name], usedByDevices)
+			err = profileFunc(profileIDs[i], profile, *profileProjects[i], usedByDevices)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -149,7 +149,7 @@ var storagePoolBucketKeyCmd = APIEndpoint{
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 	requestProjectName := projectParam(r)
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, requestProjectName)
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, requestProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -267,7 +267,7 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -349,7 +349,7 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -488,7 +488,7 @@ func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -583,7 +583,7 @@ func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -708,7 +708,7 @@ func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeysGet(d *Daemon, r *http.Request) response.Response {
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -813,7 +813,7 @@ func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -886,7 +886,7 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -967,7 +967,7 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1065,7 +1065,7 @@ func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, _, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -28,7 +28,7 @@ func snapshotProtobufToInstanceArgs(s *state.State, inst instance.Instance, snap
 		devices[ent.GetName()] = props
 	}
 
-	profiles, err := s.DB.Cluster.GetProfiles(inst.Project(), snap.Profiles)
+	profiles, err := s.DB.Cluster.GetProfiles(inst.Project().Name, snap.Profiles)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func snapshotProtobufToInstanceArgs(s *state.State, inst instance.Instance, snap
 		Name:         inst.Name() + shared.SnapshotDelimiter + snap.GetName(),
 		Profiles:     profiles,
 		Stateful:     snap.GetStateful(),
-		Project:      inst.Project(),
+		Project:      inst.Project().Name,
 	}
 
 	if snap.GetCreationDate() != 0 {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1080,7 +1080,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// Check if a running instance is using it.
 	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(d.State(), dbInst)
+		inst, err := instance.Load(d.State(), dbInst, project)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1080,7 +1080,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// Check if a running instance is using it.
 	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(d.State(), dbInst, nil)
+		inst, err := instance.Load(d.State(), dbInst)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -41,7 +41,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 			Devices:      localDevices,
 			Ephemeral:    inst.IsEphemeral(),
 			Profiles:     inst.Profiles(),
-			Project:      inst.Project(),
+			Project:      inst.Project().Name,
 			Type:         inst.Type(),
 			Snapshot:     inst.IsSnapshot(),
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -21,7 +21,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 
 	// Update all instances that are using the volume with a local (non-expanded) device.
 	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(s, dbInst, nil)
+		inst, err := instance.Load(s, dbInst)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Embeds an `api.Project` struct inside a loaded instance `driver.Common` struct (like we do with profiles) so that the project's config is available to devices during validation and operation. This allows us to avoid additional queries when using devices.
- Modifies `ProfileProject()` project helper function to return the effective project as an `api.Project` so it can be used for profile device validation. This will be useful for the forthcoming `restricted.networks.access` project feature.
- Modifies `NetworkProject()` project helper function to return the requested project as an `api.Project` as well as the effective project name. This will be useful for the forthcoming `restricted.networks.access` project feature as it will allow checking access for a particular network even if the project itself doesn't have its own networks.
- Updates `instance.Project()` function to return an `api.Project` struct.