### PR TITLE
lxd-generate: Create filtered statements from pre-existing "objects" statement.

### DIFF
--- a/lxd/db/cluster/certificate_projects.go
+++ b/lxd/db/cluster/certificate_projects.go
@@ -7,6 +7,7 @@ package cluster
 //go:generate -command mapper lxd-generate db mapper -t certificate_projects.mapper.go
 //go:generate mapper reset -i -b "//go:build linux && cgo && !agent"
 //
+//go:generate mapper stmt -e certificate_project objects
 //go:generate mapper stmt -e certificate_project objects-by-CertificateID
 //go:generate mapper stmt -e certificate_project create struct=CertificateProject
 //go:generate mapper stmt -e certificate_project delete-by-CertificateID

--- a/lxd/db/cluster/certificate_projects.mapper.go
+++ b/lxd/db/cluster/certificate_projects.mapper.go
@@ -15,10 +15,17 @@ import (
 
 var _ = api.ServerEnvironment{}
 
+var certificateProjectObjects = RegisterStmt(`
+SELECT certificates_projects.certificate_id, certificates_projects.project_id
+  FROM certificates_projects
+  ORDER BY certificates_projects.certificate_id
+`)
+
 var certificateProjectObjectsByCertificateID = RegisterStmt(`
 SELECT certificates_projects.certificate_id, certificates_projects.project_id
   FROM certificates_projects
-  WHERE ( certificates_projects.certificate_id = ? ) ORDER BY certificates_projects.certificate_id
+  WHERE ( certificates_projects.certificate_id = ? )
+  ORDER BY certificates_projects.certificate_id
 `)
 
 var certificateProjectCreate = RegisterStmt(`

--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -26,13 +26,15 @@ SELECT certificates.id, certificates.fingerprint, certificates.type, certificate
 var certificateObjectsByID = RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
-  WHERE ( certificates.id = ? ) ORDER BY certificates.fingerprint
+  WHERE ( certificates.id = ? )
+  ORDER BY certificates.fingerprint
 `)
 
 var certificateObjectsByFingerprint = RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
-  WHERE ( certificates.fingerprint = ? ) ORDER BY certificates.fingerprint
+  WHERE ( certificates.fingerprint = ? )
+  ORDER BY certificates.fingerprint
 `)
 
 var certificateID = RegisterStmt(`

--- a/lxd/db/cluster/cluster_groups.mapper.go
+++ b/lxd/db/cluster/cluster_groups.mapper.go
@@ -26,7 +26,8 @@ SELECT cluster_groups.id, cluster_groups.name, coalesce(cluster_groups.descripti
 var clusterGroupObjectsByName = RegisterStmt(`
 SELECT cluster_groups.id, cluster_groups.name, coalesce(cluster_groups.description, '')
   FROM cluster_groups
-  WHERE ( cluster_groups.name = ? ) ORDER BY cluster_groups.name
+  WHERE ( cluster_groups.name = ? )
+  ORDER BY cluster_groups.name
 `)
 
 var clusterGroupID = RegisterStmt(`

--- a/lxd/db/cluster/images.mapper.go
+++ b/lxd/db/cluster/images.mapper.go
@@ -26,43 +26,50 @@ SELECT images.id, projects.name AS project, images.fingerprint, images.type, ima
 var imageObjectsByID = RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
-  WHERE ( images.id = ? ) ORDER BY projects.id, images.fingerprint
+  WHERE ( images.id = ? )
+  ORDER BY projects.id, images.fingerprint
 `)
 
 var imageObjectsByProject = RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
-  WHERE ( project = ? ) ORDER BY projects.id, images.fingerprint
+  WHERE ( project = ? )
+  ORDER BY projects.id, images.fingerprint
 `)
 
 var imageObjectsByProjectAndCached = RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
-  WHERE ( project = ? AND images.cached = ? ) ORDER BY projects.id, images.fingerprint
+  WHERE ( project = ? AND images.cached = ? )
+  ORDER BY projects.id, images.fingerprint
 `)
 
 var imageObjectsByProjectAndPublic = RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
-  WHERE ( project = ? AND images.public = ? ) ORDER BY projects.id, images.fingerprint
+  WHERE ( project = ? AND images.public = ? )
+  ORDER BY projects.id, images.fingerprint
 `)
 
 var imageObjectsByFingerprint = RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
-  WHERE ( images.fingerprint = ? ) ORDER BY projects.id, images.fingerprint
+  WHERE ( images.fingerprint = ? )
+  ORDER BY projects.id, images.fingerprint
 `)
 
 var imageObjectsByCached = RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
-  WHERE ( images.cached = ? ) ORDER BY projects.id, images.fingerprint
+  WHERE ( images.cached = ? )
+  ORDER BY projects.id, images.fingerprint
 `)
 
 var imageObjectsByAutoUpdate = RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
-  WHERE ( images.auto_update = ? ) ORDER BY projects.id, images.fingerprint
+  WHERE ( images.auto_update = ? )
+  ORDER BY projects.id, images.fingerprint
 `)
 
 // GetImages returns all available images.

--- a/lxd/db/cluster/instance_profiles.go
+++ b/lxd/db/cluster/instance_profiles.go
@@ -13,6 +13,7 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t instance_profiles.mapper.go
 //go:generate mapper reset -i -b "//go:build linux && cgo && !agent"
 //
+//go:generate mapper stmt -e instance_profile objects
 //go:generate mapper stmt -e instance_profile objects-by-ProfileID
 //go:generate mapper stmt -e instance_profile objects-by-InstanceID
 //go:generate mapper stmt -e instance_profile create

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -15,16 +15,24 @@ import (
 
 var _ = api.ServerEnvironment{}
 
+var instanceProfileObjects = RegisterStmt(`
+SELECT instances_profiles.instance_id, instances_profiles.profile_id, instances_profiles.apply_order
+  FROM instances_profiles
+  ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
+`)
+
 var instanceProfileObjectsByProfileID = RegisterStmt(`
 SELECT instances_profiles.instance_id, instances_profiles.profile_id, instances_profiles.apply_order
   FROM instances_profiles
-  WHERE ( instances_profiles.profile_id = ? ) ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
+  WHERE ( instances_profiles.profile_id = ? )
+  ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
 `)
 
 var instanceProfileObjectsByInstanceID = RegisterStmt(`
 SELECT instances_profiles.instance_id, instances_profiles.profile_id, instances_profiles.apply_order
   FROM instances_profiles
-  WHERE ( instances_profiles.instance_id = ? ) ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
+  WHERE ( instances_profiles.instance_id = ? )
+  ORDER BY instances_profiles.instance_id, instances_profiles.apply_order
 `)
 
 var instanceProfileCreate = RegisterStmt(`

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -26,97 +26,113 @@ SELECT instances.id, projects.name AS project, instances.name, nodes.name AS nod
 var instanceObjectsByID = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( instances.id = ? ) ORDER BY projects.id, instances.name
+  WHERE ( instances.id = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProject = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndType = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? AND instances.type = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndTypeAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? AND instances.type = ? AND node = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? AND node = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndTypeAndNodeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? AND instances.type = ? AND node = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? AND node = ? AND instances.name = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndTypeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? AND instances.type = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.type = ? AND instances.name = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.name = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndNameAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? AND instances.name = ? AND node = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND instances.name = ? AND node = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByProjectAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( project = ? AND node = ? ) ORDER BY projects.id, instances.name
+  WHERE ( project = ? AND node = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByType = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( instances.type = ? ) ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByTypeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( instances.type = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? AND instances.name = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByTypeAndNameAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( instances.type = ? AND instances.name = ? AND node = ? ) ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? AND instances.name = ? AND node = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByTypeAndNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( instances.type = ? AND node = ? ) ORDER BY projects.id, instances.name
+  WHERE ( instances.type = ? AND node = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByNode = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( node = ? ) ORDER BY projects.id, instances.name
+  WHERE ( node = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByNodeAndName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( node = ? AND instances.name = ? ) ORDER BY projects.id, instances.name
+  WHERE ( node = ? AND instances.name = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceObjectsByName = RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE ( instances.name = ? ) ORDER BY projects.id, instances.name
+  WHERE ( instances.name = ? )
+  ORDER BY projects.id, instances.name
 `)
 
 var instanceID = RegisterStmt(`

--- a/lxd/db/cluster/nodes_cluster_groups.mapper.go
+++ b/lxd/db/cluster/nodes_cluster_groups.mapper.go
@@ -26,7 +26,8 @@ SELECT nodes_cluster_groups.group_id, nodes.name AS node
 var nodeClusterGroupObjectsByGroupID = RegisterStmt(`
 SELECT nodes_cluster_groups.group_id, nodes.name AS node
   FROM nodes_cluster_groups JOIN nodes ON nodes_cluster_groups.node_id = nodes.id
-  WHERE ( nodes_cluster_groups.group_id = ? ) ORDER BY nodes_cluster_groups.group_id
+  WHERE ( nodes_cluster_groups.group_id = ? )
+  ORDER BY nodes_cluster_groups.group_id
 `)
 
 var nodeClusterGroupID = RegisterStmt(`

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -26,19 +26,22 @@ SELECT operations.id, operations.uuid, nodes.address AS node_address, operations
 var operationObjectsByNodeID = RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
-  WHERE ( operations.node_id = ? ) ORDER BY operations.id, operations.uuid
+  WHERE ( operations.node_id = ? )
+  ORDER BY operations.id, operations.uuid
 `)
 
 var operationObjectsByID = RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
-  WHERE ( operations.id = ? ) ORDER BY operations.id, operations.uuid
+  WHERE ( operations.id = ? )
+  ORDER BY operations.id, operations.uuid
 `)
 
 var operationObjectsByUUID = RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
-  WHERE ( operations.uuid = ? ) ORDER BY operations.id, operations.uuid
+  WHERE ( operations.uuid = ? )
+  ORDER BY operations.id, operations.uuid
 `)
 
 var operationCreateOrReplace = RegisterStmt(`

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -26,25 +26,29 @@ SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name
 var profileObjectsByID = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE ( profiles.id = ? ) ORDER BY projects.id, profiles.name
+  WHERE ( profiles.id = ? )
+  ORDER BY projects.id, profiles.name
 `)
 
 var profileObjectsByName = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE ( profiles.name = ? ) ORDER BY projects.id, profiles.name
+  WHERE ( profiles.name = ? )
+  ORDER BY projects.id, profiles.name
 `)
 
 var profileObjectsByProject = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE ( project = ? ) ORDER BY projects.id, profiles.name
+  WHERE ( project = ? )
+  ORDER BY projects.id, profiles.name
 `)
 
 var profileObjectsByProjectAndName = RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE ( project = ? AND profiles.name = ? ) ORDER BY projects.id, profiles.name
+  WHERE ( project = ? AND profiles.name = ? )
+  ORDER BY projects.id, profiles.name
 `)
 
 var profileID = RegisterStmt(`

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -26,13 +26,15 @@ SELECT projects.id, projects.description, projects.name
 var projectObjectsByName = RegisterStmt(`
 SELECT projects.id, projects.description, projects.name
   FROM projects
-  WHERE ( projects.name = ? ) ORDER BY projects.name
+  WHERE ( projects.name = ? )
+  ORDER BY projects.name
 `)
 
 var projectObjectsByID = RegisterStmt(`
 SELECT projects.id, projects.description, projects.name
   FROM projects
-  WHERE ( projects.id = ? ) ORDER BY projects.name
+  WHERE ( projects.id = ? )
+  ORDER BY projects.name
 `)
 
 var projectCreate = RegisterStmt(`

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -26,19 +26,22 @@ SELECT instances_snapshots.id, projects.name AS project, instances.name AS insta
 var instanceSnapshotObjectsByID = RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
-  WHERE ( instances_snapshots.id = ? ) ORDER BY projects.id, instances.id, instances_snapshots.name
+  WHERE ( instances_snapshots.id = ? )
+  ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
 
 var instanceSnapshotObjectsByProjectAndInstance = RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
-  WHERE ( project = ? AND instance = ? ) ORDER BY projects.id, instances.id, instances_snapshots.name
+  WHERE ( project = ? AND instance = ? )
+  ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
 
 var instanceSnapshotObjectsByProjectAndInstanceAndName = RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
-  WHERE ( project = ? AND instance = ? AND instances_snapshots.name = ? ) ORDER BY projects.id, instances.id, instances_snapshots.name
+  WHERE ( project = ? AND instance = ? AND instances_snapshots.name = ? )
+  ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
 
 var instanceSnapshotID = RegisterStmt(`

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -26,37 +26,43 @@ SELECT warnings.id, coalesce(nodes.name, '') AS node, coalesce(projects.name, ''
 var warningObjectsByUUID = RegisterStmt(`
 SELECT warnings.id, coalesce(nodes.name, '') AS node, coalesce(projects.name, '') AS project, coalesce(warnings.entity_type_code, -1), coalesce(warnings.entity_id, -1), warnings.uuid, warnings.type_code, warnings.status, warnings.first_seen_date, warnings.last_seen_date, warnings.updated_date, warnings.last_message, warnings.count
   FROM warnings LEFT JOIN nodes ON warnings.node_id = nodes.id LEFT JOIN projects ON warnings.project_id = projects.id
-  WHERE ( warnings.uuid = ? ) ORDER BY warnings.uuid
+  WHERE ( warnings.uuid = ? )
+  ORDER BY warnings.uuid
 `)
 
 var warningObjectsByProject = RegisterStmt(`
 SELECT warnings.id, coalesce(nodes.name, '') AS node, coalesce(projects.name, '') AS project, coalesce(warnings.entity_type_code, -1), coalesce(warnings.entity_id, -1), warnings.uuid, warnings.type_code, warnings.status, warnings.first_seen_date, warnings.last_seen_date, warnings.updated_date, warnings.last_message, warnings.count
   FROM warnings LEFT JOIN nodes ON warnings.node_id = nodes.id LEFT JOIN projects ON warnings.project_id = projects.id
-  WHERE ( coalesce(project, '') = ? ) ORDER BY warnings.uuid
+  WHERE ( coalesce(project, '') = ? )
+  ORDER BY warnings.uuid
 `)
 
 var warningObjectsByStatus = RegisterStmt(`
 SELECT warnings.id, coalesce(nodes.name, '') AS node, coalesce(projects.name, '') AS project, coalesce(warnings.entity_type_code, -1), coalesce(warnings.entity_id, -1), warnings.uuid, warnings.type_code, warnings.status, warnings.first_seen_date, warnings.last_seen_date, warnings.updated_date, warnings.last_message, warnings.count
   FROM warnings LEFT JOIN nodes ON warnings.node_id = nodes.id LEFT JOIN projects ON warnings.project_id = projects.id
-  WHERE ( warnings.status = ? ) ORDER BY warnings.uuid
+  WHERE ( warnings.status = ? )
+  ORDER BY warnings.uuid
 `)
 
 var warningObjectsByNodeAndTypeCode = RegisterStmt(`
 SELECT warnings.id, coalesce(nodes.name, '') AS node, coalesce(projects.name, '') AS project, coalesce(warnings.entity_type_code, -1), coalesce(warnings.entity_id, -1), warnings.uuid, warnings.type_code, warnings.status, warnings.first_seen_date, warnings.last_seen_date, warnings.updated_date, warnings.last_message, warnings.count
   FROM warnings LEFT JOIN nodes ON warnings.node_id = nodes.id LEFT JOIN projects ON warnings.project_id = projects.id
-  WHERE ( coalesce(node, '') = ? AND warnings.type_code = ? ) ORDER BY warnings.uuid
+  WHERE ( coalesce(node, '') = ? AND warnings.type_code = ? )
+  ORDER BY warnings.uuid
 `)
 
 var warningObjectsByNodeAndTypeCodeAndProject = RegisterStmt(`
 SELECT warnings.id, coalesce(nodes.name, '') AS node, coalesce(projects.name, '') AS project, coalesce(warnings.entity_type_code, -1), coalesce(warnings.entity_id, -1), warnings.uuid, warnings.type_code, warnings.status, warnings.first_seen_date, warnings.last_seen_date, warnings.updated_date, warnings.last_message, warnings.count
   FROM warnings LEFT JOIN nodes ON warnings.node_id = nodes.id LEFT JOIN projects ON warnings.project_id = projects.id
-  WHERE ( coalesce(node, '') = ? AND warnings.type_code = ? AND coalesce(project, '') = ? ) ORDER BY warnings.uuid
+  WHERE ( coalesce(node, '') = ? AND warnings.type_code = ? AND coalesce(project, '') = ? )
+  ORDER BY warnings.uuid
 `)
 
 var warningObjectsByNodeAndTypeCodeAndProjectAndEntityTypeCodeAndEntityID = RegisterStmt(`
 SELECT warnings.id, coalesce(nodes.name, '') AS node, coalesce(projects.name, '') AS project, coalesce(warnings.entity_type_code, -1), coalesce(warnings.entity_id, -1), warnings.uuid, warnings.type_code, warnings.status, warnings.first_seen_date, warnings.last_seen_date, warnings.updated_date, warnings.last_message, warnings.count
   FROM warnings LEFT JOIN nodes ON warnings.node_id = nodes.id LEFT JOIN projects ON warnings.project_id = projects.id
-  WHERE ( coalesce(node, '') = ? AND warnings.type_code = ? AND coalesce(project, '') = ? AND coalesce(warnings.entity_type_code, -1) = ? AND coalesce(warnings.entity_id, -1) = ? ) ORDER BY warnings.uuid
+  WHERE ( coalesce(node, '') = ? AND warnings.type_code = ? AND coalesce(project, '') = ? AND coalesce(warnings.entity_type_code, -1) = ? AND coalesce(warnings.entity_id, -1) = ? )
+  ORDER BY warnings.uuid
 `)
 
 var warningDeleteByUUID = RegisterStmt(`

--- a/lxd/db/generate/README.md
+++ b/lxd/db/generate/README.md
@@ -1,0 +1,217 @@
+# `lxd-generate`
+
+## Introduction
+
+`lxd-generate` is a database statement and associated `go` function generator
+for LXD and related projects. `lxd-generate` utilizes `go`'s code generation
+directives (`//go:generate ...`) alongside go's [ast](https://pkg.go.dev/go/ast)
+package for parsing the syntax tree for go structs and variables. We use
+`lxd-generate` for the majority of our SQL statements and database interactions
+on the `go` side for consistency and predictability.
+
+## Usage
+
+### Initialization
+
+Generally the first thing we will want to do for any newly generated file is to
+establish the command, the target file, and ensure the file has been cleared of
+content:
+
+```go
+//go:generate -command mapper lxd-generate db mapper -t instances.mapper.go
+//go:generate mapper reset -i -b "//go:build linux && cgo && !agent"
+
+```
+
+This will initiate a call to `lxd-generate db mapper -t instances.mapper.go` on
+each call to the go generation directive `mapper`.
+
+### Generation Directive Arguments
+
+* `//go:generate mapper stmt -e instance objects table=table_name`
+
+The `table` key can be used to override the generated table name for a specified one.
+
+
+* `//go:generate mapper method -e instance Create references=Config,Device`
+
+For some tables (defined below under [Additional Information](#Additional-Information) as [EntityTable](#EntityTable), the `references=<ReferenceEntity>` key can be provided with the name of
+a [ReferenceTable](#ReferenceTable) or [MapTable](#MapTable) struct. This directive would produce `CreateInstance` in addition to `CreateInstanceConfig` and `CreateInstanceDevices`
+
+
+* //go:generate mapper method -i -e instance_profile Create struct=Instance
+* //go:generate mapper method -i -e instance_profile Create struct=Profile
+
+For some tables (defined below under [Additional Information](#Additional-Information) as [AssociationTable](#AssociationTable), `method` declarations must
+include a `struct=<Entity>` to indicate the directionality of the function. An invocation can be called for each direction.
+This would produce `CreateInstanceProfiles` and `CreateProfileInstances` respectively.
+
+### SQL Statement Generation
+
+SQL generation supports the following SQL statement types:
+Type                                  | Description
+:---                                  | :----
+`objects`                             | Creates a basic SELECT statement of the form `SELECT <columns> FROM <table> ORDER BY <columns>`.
+`objects-by-<FIELD>-and-<FIELD>...`   | Parses a pre-existing SELECT statement variable declaration of the form produced by`objects`, and appends a `WHERE` clause with the given fields located in the associated struct. Specifically looks for a variable declaration of the form 'var <entity>Objects = RegisterStmt(`SQL String`)'
+`create`                              | Creates a basic INSERT statement of the form `INSERT INTO <table> VALUES`.
+`create-or-replace`                   | Creates a basic INSERT statement of the form `INSERT OR REPLACE INTO <table> VALUES`.
+`delete-by-<FIELD>-and-<FIELD>...`    | Creates a DELETE statement of the form `DELETE FROM <table> WHERE <constraint>` where the constraint is based on the given fields of the associated struct.
+`id`                                  | Creates a basic SELECT statement that returns just the internal ID of the table.
+`rename`                              | Creates an UPDATE statement that updates the primary key of a table: `UPDATE <table> SET <primary key> WHERE <primary key = ?>`.
+`update`                              | Creates an UPDATE statement of the form `UPDATE <table> SET <all columns> WHERE <primary key = ?>`.
+
+#### Examples
+
+```go
+//go:generate mapper stmt -e instance objects
+//go:generate mapper stmt -e instance objects-by-Name-and-Project
+//go:generate mapper stmt -e instance create
+//go:generate mapper stmt -e instance update
+//go:generate mapper stmt -e instance delete-by-Name-and-Project
+```
+
+#### Statement Related Go Tags
+
+There are several tags that can be added to fields of a struct that will be parsed by the `ast` package.
+
+Tag                         | Description
+:--                         | :----
+`coalesce=<value>`          | Generates a SQL coalesce function with the given value `coalesce(<column>, value)`.
+`order=yes`                 | Override the default `ORDER BY` columns with all fields specifying this tag.
+`join=<joinTable.column>`   | Applies a `JOIN` of the form `JOIN <joinTable> ON <table>.<joinTable_id> = <joinTable.id>`.
+`leftjoin=<table.column>`   | Applies a `LEFT JOIN` of the same form as a `JOIN`.
+`joinon=<table>.<column>`   | Overrides the default `JOIN ON` clause with the given table and column, replacing `<table>.<joinTable_id>` above.
+`via=<otherTable>`          | Applies a nested join when included with a `join` tag.
+`primary=yes`               | Assigns column associated with the field to be sufficient for returning a row from the table. Will default to `Name` if unspecified. Fields with this key will be included in the default 'ORDER BY' clause.
+`omit=<Stmt Types>`         | Omits a given field from consideration for the comma separated list of statement types (`create`, `objects-by-Name`, `update`).
+`ignore=yes`                | Outright ignore the struct field as though it does not exist.
+
+### Go Function Generation
+
+Go function generation supports the following types:
+Type                                | Description
+:---                                | :----
+`GetMany`                           | Return a slice of structs for all rows in a table matching the filter.
+`GetOne`                            | Return a single struct corresponding to a row with the given primary keys. Depends on `GetMany`.
+`ID`                                | Return the ID column from the table corresponding to the given primary keys.
+`Exists`                            | Returns whether there is an row in the table with the given primary keys. Depends on `ID.`
+`Create`                            | Insert a row from the given struct into the table if not already present. Depends on `Exists`
+`CreateOrReplace`                   | Insert a row from the given struct into the table, regardless of if an entry already exists.
+`Rename`                            | Update the primary key for a table row.
+`Update`                            | Update the columns at a given row, specified by primary key.
+`DeleteOne`                         | Delete exactly one row from the table.
+`DeleteMany`                        | Delete one or more rows from the table.
+
+
+```go
+//go:generate mapper method -i -e instance GetMany
+//go:generate mapper method -i -e instance GetOne
+//go:generate mapper method -i -e instance ID
+//go:generate mapper method -i -e instance Exist
+//go:generate mapper method -i -e instance Create
+//go:generate mapper method -i -e instance Update
+//go:generate mapper method -i -e instance DeleteOne-by-Project-and-Name
+//go:generate mapper method -i -e instance DeleteMany-by-Name
+```
+
+### Additional Information
+
+All structs should have an `ID` field, as well as an additional `Filter` struct prefixed with the original struct name.
+This should include any fields that should be considered for filtering in `WHERE` clauses.
+These fields should be pointers to facilitate omission and inclusion without setting default values.
+
+Example:
+
+```go
+type Instance struct {
+  ID int
+  Name string
+  Project string
+}
+
+type InstanceFilter struct {
+  Name *string
+  Project *string
+}
+```
+
+`lxd-generate` will handle parsing of structs differently based on the composition of the struct in four different ways.
+
+Non-`EntityType` structs will only support `GetMany`, `Create`, `Update`, and `Delete` functions.
+
+### EntityTable
+
+Most structs will get treated this way, and represent a normal table.
+
+* If a table has an associated table for which a `ReferenceTable` or `MapTable` as defined below is applicable, functions specific to this entity can be generated by
+including a comma separated list to `references=<OtherEntity>` in the code generation directive for `GetMany`, `Create`, or `Update` directives.
+
+* The `Create` method directive for `EntityTable` will expect on the `ID` and `Exist` method directives to be present.
+
+### ReferenceTable
+
+A struct that contains a field named `ReferenceID` will be parsed this way.
+`lxd-generate` will use this struct to generate more abstract SQL statements and functions of the form `<parent_table>_<this_table>`.
+
+Real world invocation of these statements and functions should be done through an `EntityTable` `method` call with the tag `references=<ThisStruct>`. This `EntityTable` will replace the `<parent_table>` above.
+
+Example:
+
+```go
+//go:generate mapper stmt -e device create
+//go:generate mapper method -e device Create
+
+type Device struct {
+  ID int
+  ReferenceID int
+  Name string
+  Type string
+}
+
+//...
+//go:generate mapper method -e instance Create references=Device
+// This will produce a function called `CreateInstanceDevices`.
+```
+
+### MapTable
+
+This is a special type of `ReferenceTable` with fields named `Key` and `Value`.
+On the SQL side, this is treated exactly like a `ReferenceTable`, but on the `go` side, the return values will be a map.
+
+Example:
+
+```go
+//go:generate mapper stmt -e config create
+//go:generate mapper method -e config Create
+
+type Config struct {
+  ID int
+  ReferenceID int
+  Key string
+  Value string
+}
+
+//...
+//go:generate mapper method -e instance Create references=Config
+// This will produce a function called `CreateInstanceConfig`, which will return a `map[string]string`.
+```
+
+### AssociationTable
+This is a special type of table that contains two fields of the form `<Entity>ID`, where `<Entity>` corresponds to two other structs present in the same package.
+This will generate code for compound tables of the form `<entity1>_<entity2>` that are generally used to associate two tables together by their IDs.
+
+`method` generation declarations for these statements should include a `struct=<Entity>` to indicate the directionality of the function.
+An invocation can be called for each direction.
+
+Example:
+
+```go
+
+//go:generate mapper method -i -e instance_profile Create struct=Instance
+//go:generate mapper method -i -e instance_profile Create struct=Profile
+
+type InstanceProfile struct {
+  InstanceID int
+  ProfileID int
+}
+```


### PR DESCRIPTION
As per our discussions on irc, I've updated `lxd-generate`'s statement generation for all statements of the type `objects-by-FIELD` to first search the package for a variable declaration of the form
```go
var <entity>Objects = RegisterStmt(`SQL String`)
```
And then extract the `SQL String` from the syntax tree, and append a `WHERE` clause with the given filters, and create a new variable declaration of the form
```go
var <entity>ObjectsByField = RegisterStmt(`SQL String with WHERE clause`)
```

This will allow us to specify our own `<entity>Objects` for more complex queries, and still be able to use `lxd-generate` to create filterable statements. 

Additionally, I went ahead and created a `lxd-generate.md` under the `docs` directory with an overview of all the functionality of `lxd-generate` including how to formulate structs and how `lxd-generate` will behave based on that, as well as all of the types of generation and associated tags that `lxd-generate` can use.

I'll send up another PR soon that will add an `sql=<table>.<column>` tag to each field that will let us bypass the generator's automatic generation of table names and column names. 