### PR TITLE
Instance: Remove duplicate profiles argument from `instance.Load()`

### DIFF
--- a/lxd-agent/server.go
+++ b/lxd-agent/server.go
@@ -94,9 +94,9 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 		// Handle errors
 		err := resp.Render(w)
 		if err != nil {
-			err := response.InternalError(err).Render(w)
+			writeErr := response.InternalError(err).Render(w)
 			if err != nil {
-				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "error": err})
+				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "error": err, "writeErr": writeErr})
 			}
 		}
 	})

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -699,9 +699,9 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		// Handle errors
 		err = resp.Render(w)
 		if err != nil {
-			err := response.InternalError(err).Render(w)
+			writeErr := response.InternalError(err).Render(w)
 			if err != nil {
-				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err})
+				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err, "writeErr": writeErr})
 			}
 		}
 	})

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -695,26 +695,6 @@ func networkFillType(network *api.Network, netType NetworkType) {
 	}
 }
 
-// NetworkNodes returns the nodes keyed by node ID that the given network is defined on.
-func (c *Cluster) NetworkNodes(networkID int64) (map[int64]NetworkNode, error) {
-	var nodes map[int64]NetworkNode
-	var err error
-
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		nodes, err = tx.NetworkNodes(networkID)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return nodes, nil
-}
-
 // GetNetworkWithInterface returns the network associated with the interface with the given name.
 func (c *Cluster) GetNetworkWithInterface(devName string) (int64, *api.Network, error) {
 	id := int64(-1)

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -647,26 +647,6 @@ func StoragePoolStateToAPIStatus(state StoragePoolState) string {
 	}
 }
 
-// StoragePoolNodes returns the nodes keyed by node ID that the given storage pool is defined on.
-func (c *Cluster) StoragePoolNodes(poolID int64) (map[int64]StoragePoolNode, error) {
-	var nodes map[int64]StoragePoolNode
-	var err error
-
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		nodes, err = tx.storagePoolNodes(poolID)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return nodes, nil
-}
-
 // getStoragePoolConfig populates the config map of the Storage pool with the given ID.
 func (c *Cluster) getStoragePoolConfig(tx *ClusterTx, poolID int64, pool *api.StoragePool) error {
 	q := "SELECT key, value FROM storage_pools_config WHERE storage_pool_id=? AND (node_id=? OR node_id IS NULL)"

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1475,7 +1475,7 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 		if shared.IsFalseOrEmpty(poolVolumePut.Config["security.shifted"]) {
 			volumeUsedBy := []instance.Instance{}
 			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-				inst, err := instance.Load(d.state, dbInst, nil)
+				inst, err := instance.Load(d.state, dbInst)
 				if err != nil {
 					return err
 				}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -403,7 +403,7 @@ func instanceLoadNodeProjectAll(s *state.State, project string, instanceType ins
 	}
 
 	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
-		inst, err := instance.Load(s, dbInst, nil)
+		inst, err := instance.Load(s, dbInst)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
 		}
@@ -466,7 +466,7 @@ func autoCreateInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		// Figure out which need snapshotting (if any).
 		instances := make([]instance.Instance, 0)
 		for _, instArg := range instanceArgs {
-			inst, err := instance.Load(s, instArg, nil)
+			inst, err := instance.Load(s, instArg)
 			if err != nil {
 				logger.Error("Failed loading instance for snapshot task", logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
 				continue
@@ -610,7 +610,7 @@ func pruneExpiredInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 			expiredSnapshotInstances = make([]instance.Instance, 0)
 			for _, snapshotArg := range snapshotArgs {
-				inst, err := instance.Load(s, snapshotArg, nil)
+				inst, err := instance.Load(s, snapshotArg)
 				if err != nil {
 					logger.Error("Failed loading instance for snapshot prune task", logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
 					continue

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -278,7 +278,7 @@ func (d *common) Snapshots() ([]instance.Instance, error) {
 		// Populate profile info that was already loaded.
 		snapshotArg.Profiles = d.profiles
 
-		snapInst, err := instance.Load(d.state, snapshotArg, nil)
+		snapInst, err := instance.Load(d.state, snapshotArg)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -472,13 +472,9 @@ func (d *common) deviceVolatileSetFunc(devName string) func(save map[string]stri
 }
 
 // expandConfig applies the config of each profile in order, followed by the local config.
-func (d *common) expandConfig(profiles []api.Profile) error {
-	if profiles == nil && len(d.profiles) > 0 {
-		profiles = d.profiles
-	}
-
-	d.expandedConfig = db.ExpandInstanceConfig(d.localConfig, profiles)
-	d.expandedDevices = db.ExpandInstanceDevices(d.localDevices, profiles)
+func (d *common) expandConfig() error {
+	d.expandedConfig = db.ExpandInstanceConfig(d.localConfig, d.profiles)
+	d.expandedDevices = db.ExpandInstanceDevices(d.localDevices, d.profiles)
 
 	return nil
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -320,7 +320,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, revert.
 	return d, cleanup, err
 }
 
-func lxcLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instance.Instance, error) {
+func lxcLoad(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	// Create the container struct
 	d := lxcInstantiate(s, args, nil)
 
@@ -328,7 +328,7 @@ func lxcLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (inst
 	runtime.SetFinalizer(d, lxcUnload)
 
 	// Expand config and devices
-	err := d.(*lxc).expandConfig(profiles)
+	err := d.(*lxc).expandConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -599,7 +599,7 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 
 func (d *lxc) init() error {
 	// Compute the expanded config and device list
-	err := d.expandConfig(nil)
+	err := d.expandConfig()
 	if err != nil {
 		return err
 	}
@@ -4038,7 +4038,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	d.expiryDate = args.ExpiryDate
 
 	// Expand the config and refresh the LXC config
-	err = d.expandConfig(nil)
+	err = d.expandConfig()
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -100,12 +100,12 @@ var errQemuAgentOffline = fmt.Errorf("LXD VM agent isn't currently running")
 type monitorHook func(m *qmp.Monitor) error
 
 // qemuLoad creates a Qemu instance from the supplied InstanceArgs.
-func qemuLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instance.Instance, error) {
+func qemuLoad(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	// Create the instance struct.
 	d := qemuInstantiate(s, args, nil)
 
 	// Expand config and devices.
-	err := d.expandConfig(profiles)
+	err := d.expandConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -4453,7 +4453,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	d.expiryDate = args.ExpiryDate
 
 	// Expand the config.
-	err = d.expandConfig(nil)
+	err = d.expandConfig()
 	if err != nil {
 		return err
 	}
@@ -4917,7 +4917,7 @@ func (d *qemu) cleanupDevices() {
 
 func (d *qemu) init() error {
 	// Compute the expanded config and device list.
-	err := d.expandConfig(nil)
+	err := d.expandConfig()
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
-	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -47,14 +46,14 @@ func init() {
 }
 
 // load creates the underlying instance type struct and returns it as an Instance.
-func load(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instance.Instance, error) {
+func load(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	var inst instance.Instance
 	var err error
 
 	if args.Type == instancetype.Container {
-		inst, err = lxcLoad(s, args, profiles)
+		inst, err = lxcLoad(s, args)
 	} else if args.Type == instancetype.VM {
-		inst, err = qemuLoad(s, args, profiles)
+		inst, err = qemuLoad(s, args)
 	} else {
 		return nil, fmt.Errorf("Invalid instance type for instance %s", args.Name)
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -42,7 +42,7 @@ import (
 var ValidDevices func(state *state.State, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error
 
 // Load is linked from instance/drivers.load to allow different instance types to be loaded.
-var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error)
+var Load func(s *state.State, args db.InstanceArgs) (Instance, error)
 
 // Create is linked from instance/drivers.create to allow difference instance types to be created.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
@@ -437,7 +437,7 @@ func LoadByProjectAndName(s *state.State, project, name string) (Instance, error
 		return nil, err
 	}
 
-	inst, err := Load(s, args, nil)
+	inst, err := Load(s, args)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load instance: %w", err)
 	}
@@ -456,7 +456,7 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 	}
 
 	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
-		inst, err := Load(s, dbInst, dbInst.Profiles)
+		inst, err := Load(s, dbInst)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
 		}
@@ -497,7 +497,7 @@ func LoadFromBackup(s *state.State, projectName string, instancePath string, app
 		instDBArgs.Devices = deviceConfig.NewDevices(backupConf.Container.ExpandedDevices)
 	}
 
-	inst, err = Load(s, *instDBArgs, nil)
+	inst, err = Load(s, *instDBArgs)
 	if err != nil {
 		return nil, fmt.Errorf("Failed loading instance from backup file %q: %w", backupYamlPath, err)
 	}

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -377,7 +377,7 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 					Config:  make(map[string]string),
 				}
 
-				inst, err = instance.Load(s, *instDBArgs, nil)
+				inst, err = instance.Load(s, *instDBArgs)
 				if err != nil {
 					logger.Warn("Failed loading instance", logger.Ctx{"project": projectName, "instance": instanceName, "err": err})
 					continue

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -62,7 +62,9 @@ func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter) error {
 
 	// Make sure both sides are closed.
 	_ = r.source.Close()
-	return target.Close()
+	_ = target.Close()
+
+	return nil
 }
 
 func (r *forwardedOperationWebSocket) String() string {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4362,7 +4362,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 		// Check for config changing that is not allowed when running instances are using it.
 		if changedConfig["security.shifted"] != "" {
 			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-				inst, err := instance.Load(b.state, dbInst, nil)
+				inst, err := instance.Load(b.state, dbInst)
 				if err != nil {
 					return err
 				}
@@ -4890,7 +4890,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 
 	// Check that the volume isn't in use by running instances.
 	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(b.state, dbInst, nil)
+		inst, err := instance.Load(b.state, dbInst)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1080,7 +1080,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// Check if a running instance is using it.
 	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(d.State(), dbInst, nil)
+		inst, err := instance.Load(d.State(), dbInst)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -21,7 +21,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 
 	// Update all instances that are using the volume with a local (non-expanded) device.
 	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		inst, err := instance.Load(s, dbInst, nil)
+		inst, err := instance.Load(s, dbInst)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As part of introducing `restricted.networks.access` feature for projects I intend to make the instance's `api.Project` struct available inside the instance `driver.Common` struct (like we do with profiles), so that the project's config is available during instance device validation without having to load it repeatedly.

As a precursor to this I noticed that the `instance.Load()` function accepted a `profiles` argument that was largely redundant since we started embedding the instance's profiles inside the instance args struct. So this PR removes it.

Whilst doing that I also noticed a few other minor tweaks that improve error logging and reduce logging noise.