### PR TITLE
Upgrade instructions for coexistence with Docker

### DIFF
--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -103,7 +103,7 @@ If that is not an option, use the following command to explicitly allow network 
     iptables -I DOCKER-USER -i <network_bridge> -o <external_interface> -j ACCEPT
     iptables -I DOCKER-USER -i <external_interface> -o <network_bridge> -j ACCEPT
 
-To make it stick across reboots, the above can be added to `/etc/network/interfaces` along the lines of:
+To make the configuration persist across reboots, add the commands to `/etc/network/interfaces`:
 
     post-up iptables -I DOCKER-USER -i <network_bridge> -o <external_interface> -j ACCEPT
     post-up iptables -I DOCKER-USER -i <external_interface> -o <network_bridge> -j ACCEPT

--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -98,6 +98,12 @@ A common reason for these issues is that Docker sets the FORWARD policy to `drop
 See [Docker on a router](https://docs.docker.com/network/iptables/#docker-on-a-router) for detailed information.
 
 The easiest way to prevent such issues is to uninstall Docker from the system that runs LXD.
-If that is not an option, use the following command to explicitly allow network traffic from your network bridge to your external network interface:
+If that is not an option, use the following command to explicitly allow network traffic between your network bridge and your external network interface:
 
     iptables -I DOCKER-USER -i <network_bridge> -o <external_interface> -j ACCEPT
+    iptables -I DOCKER-USER -i <external_interface> -o <network_bridge> -j ACCEPT
+
+To make it stick across reboots, the above can be added to `/etc/network/interfaces` along the lines of:
+
+    post-up iptables -I DOCKER-USER -i <network_bridge> -o <external_interface> -j ACCEPT
+    post-up iptables -I DOCKER-USER -i <external_interface> -o <network_bridge> -j ACCEPT


### PR DESCRIPTION
This PR was requested by @tomponline  on the [linuxcontainers forum](https://discuss.linuxcontainers.org/t/lxd-and-docker-firewall-redux-how-to-deal-with-forward-policy-set-to-drop/9953/12).
