### PR TITLE
Add profiles to backup data

### DIFF
--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -9,6 +9,7 @@ type Config struct {
 	Container       *api.Instance                `yaml:"container,omitempty"` // Used by VM backups too.
 	Snapshots       []*api.InstanceSnapshot      `yaml:"snapshots,omitempty"`
 	Pool            *api.StoragePool             `yaml:"pool,omitempty"`
+	Profiles        []*api.Profile               `yaml:"profiles,omitempty"`
 	Volume          *api.StorageVolume           `yaml:"volume,omitempty"`
 	VolumeSnapshots []*api.StorageVolumeSnapshot `yaml:"volume_snapshots,omitempty"`
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5036,6 +5036,32 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		Volume: volume,
 	}
 
+	// Set profiles
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		projectName := inst.Project().Name
+		filter := cluster.ProfileFilter{
+			Project: &projectName,
+		}
+
+		profiles, err := cluster.GetProfiles(ctx, tx.Tx(), filter)
+		if err != nil {
+			return err
+		}
+
+		config.Profiles = make([]*api.Profile, len(profiles))
+		for i, profile := range profiles {
+			config.Profiles[i], err = profile.ToAPI(ctx, tx.Tx())
+			if err != nil {
+				return err
+			}
+		}
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	// Only populate Container field for non-snapshot instances.
 	if !inst.IsSnapshot() {
 		config.Container = ci.(*api.Instance)


### PR DESCRIPTION
This PR adds profiles into `backup.yaml` upon `lxc export`.

Example:
```
pool:
  config:
    size: 7GiB
    source: /var/lib/lxd/disks/default.img
    zfs.pool_name: default
  description: ""
  name: default
  driver: zfs
  used_by: []
  status: Created
  locations:
  - none
profiles:
- config: {}
  description: Default LXD profile
  devices:
    eth0:
      name: eth0
      network: lxdbr0
      type: nic
    root:
      path: /
      pool: default
      type: disk
  name: default
  used_by: []
- config: {}
  description: ""
  devices: {}
  name: p1
  used_by: []
```

Fixes: #10329