### PR TITLE
GetAllXattr: handle overlay filtering

### DIFF
--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -125,6 +125,9 @@ func GetAllXattr(path string) (xattrs map[string]string, err error) {
 
 	if post > pre {
 		return nil, fmt.Errorf("Extended attribute list size increased from %d to %d during retrieval", pre, post)
+	} else if post == 0 {
+		// fs may have filtered out all xattrs during the second call
+		return nil, nil
 	}
 
 	split := strings.Split(string(dest), "\x00")


### PR DESCRIPTION
When calling listxattr with sz 0, overlay does not filter the results.  When subsequently calling it with non-zero sz, it will filter out some xattrs.  If all xattrs were filtered out, then the next result will be 0.  In this case, we were continuing on to call getxattr on xattr=="", and getting back an ERANGE, after which we returned ERANGE for the whole ShiftFile operation.

So if listxattr returns 0 on our second call, simply return with no error.

Signed-off-by: Serge Hallyn <serge@hallyn.com>