### PR TITLE
Network: Make dnsmasq start failure a network start failure

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1617,10 +1617,9 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		_, err = p.Wait(ctx)
 		if !errors.Is(err, context.DeadlineExceeded) {
 			stderr, _ := ioutil.ReadFile(dnsmasqLogPath)
+			cancel()
 
-			// Just log an error if dnsmasq has exited, and still proceed with normal setup so we
-			// don't leave the firewall in an inconsistent state.
-			n.logger.Error("The dnsmasq process exited prematurely", logger.Ctx{"err": err, "stderr": strings.TrimSpace(string(stderr))})
+			return fmt.Errorf("The DNS and DHCP service exited prematurely: %w (%q)", err, strings.TrimSpace(string(stderr)))
 		}
 
 		cancel()

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -260,7 +260,8 @@ func warningGet(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		resp := dbWarning.ToAPI()
+		resp = dbWarning.ToAPI()
+
 		resp.EntityURL, err = getWarningEntityURL(ctx, tx.Tx(), dbWarning)
 		if err != nil {
 			return err

--- a/test/suites/warnings.sh
+++ b/test/suites/warnings.sh
@@ -46,8 +46,8 @@ test_warnings() {
     count=$(curl -G --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0/warnings" --data-urlencode "recursion=0" --data-urlencode "filter=status eq resolved" | jq ".metadata | length")
     [ "${count}" -eq 0 ] || false
 
-    # Acknowledge first warning warning
-    uuid=$(lxc warning list --format json | jq -r '.[0].uuid')
+    # Acknowledge a warning
+    uuid=$(lxc warning list --format json | jq -r '.[] | select(.last_message=="global warning 2") | .uuid')
     lxc warning ack "${uuid}"
 
     # This should hide the acknowledged
@@ -58,7 +58,10 @@ test_warnings() {
     count=$(lxc warning list --all --format json | jq 'length')
     [ "${count}" -eq 3 ] || false
 
+    lxc warning show "${uuid}" | grep "global warning 2"
+
     # Delete warning
     lxc warning rm "${uuid}"
     ! lxc warning list | grep -q "${uuid}" || false
+    ! lxc warning show "${uuid}" || false
 }


### PR DESCRIPTION
- This will trigger network start retry functionality.
- This will cause a warning to be shown in `lxc warning list`.
- Also fixes `lxc warning show` breakage and adds tests to catch any future regressions.

Fixes #10874