### PR TITLE
Migration cleanup

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -4,30 +4,13 @@ discourse: 8767
 
 # Containers
 
-## Introduction
-
 Containers are the default type for LXD and currently the most
 complete implementation of LXD instances, providing the most features.
 
 They are implemented through the use of `liblxc` (LXC).
 
+There is limited support for {ref}`live-migration`.
+
 ## Configuration
 
 See [instance configuration](instances.md) for valid configuration options.
-
-## Live migration
-
-LXD supports live migration of containers using [CRIU](https://criu.org). In
-order to optimize the memory transfer for a container LXD can be instructed to
-make use of the pre-copy features in CRIU by setting the
-`migration.incremental.memory` property to `true`. This means LXD will request
-CRIU to perform a series of memory dumps for the container. After each dump LXD
-will send the memory dump to the specified remote. In an ideal scenario each
-memory dump will decrease the delta to the previous memory dump thereby
-increasing the percentage of memory that is already synced. When the percentage
-of synced memory is equal to or greater than the threshold specified via
-`migration.incremental.memory.goal` LXD will request CRIU to perform a final
-memory dump and transfer it. If the threshold is not reached after the maximum
-number of allowed iterations specified via
-`migration.incremental.memory.iterations` LXD will request a final memory dump
-from CRIU and migrate the container.

--- a/doc/howto/move_instances.md
+++ b/doc/howto/move_instances.md
@@ -43,3 +43,9 @@ If you are using the snap, use the following commands to enable CRIU:
     systemctl reload snap.lxd.daemon
 
 Otherwise, make sure you have CRIU installed on both systems.
+
+To optimize the memory transfer for a container, set the [`migration.incremental.memory`](instance-configuration) property to `true` to make use of the pre-copy features in CRIU.
+With this configuration, LXD instructs CRIU to perform a series of memory dumps for the container.
+After each dump, LXD sends the memory dump to the specified remote.
+In an ideal scenario, each memory dump will decrease the delta to the previous memory dump, thereby increasing the percentage of memory that is already synced.
+When the percentage of synced memory is equal to or greater than the threshold specified via [`migration.incremental.memory.goal`](instance-configuration), or the maximum number of allowed iterations specified via [`migration.incremental.memory.iterations`](instance-configuration) is reached, LXD instructs CRIU to perform a final memory dump and transfers it.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -47,6 +47,7 @@ The currently supported keys are:
 ```{rst-class} dec-font-size break-col-1 min-width-1-15
 ```
 
+(instance-configuration)=
 Key                                             | Type      | Default           | Live update   | Condition                 | Description
 :--                                             | :---      | :------           | :----------   | :----------               | :----------
 `agent.nic_config`                              | bool      | `false`           | n/a           | virtual machine           | Set the name and MTU of the default network interfaces to be the same as the instance devices (this is automatic for containers).

--- a/doc/virtual-machines.md
+++ b/doc/virtual-machines.md
@@ -4,9 +4,7 @@ discourse: 7519,9281,9223
 
 # Virtual Machines
 
-## Introduction
-
-Virtual machines are a new instance type supported by LXD alongside containers.
+Virtual machines are an instance type supported by LXD alongside containers.
 
 They are implemented through the use of `qemu`.
 


### PR DESCRIPTION
A small follow-up to the migration docs - move the live migration content from the container page to the new page that covers live migration.