### PR TITLE
lxd/db/generate/db/mapping: Use 'join' tag to deduce column name

### DIFF
--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -440,15 +440,15 @@ func (f *Field) InsertColumn(pkg *ast.Package, dbPkg *ast.Package, mapping *Mapp
 			}
 		}
 
-		if columnName != "" {
-			column = columnName
-		} else {
-			column = lex.Snake(f.Name) + "_id"
-		}
-
 		table, _, ok := strings.Cut(f.JoinConfig(), ".")
 		if !ok {
 			return "", "", fmt.Errorf("'join' tag of field %q of struct %q must be of form <table>.<column>", f.Name, mapping.Name)
+		}
+
+		if columnName != "" {
+			column = columnName
+		} else {
+			column = lex.Singular(table) + "_id"
 		}
 
 		varName := stmtCodeVar(lex.Singular(table), "ID")


### PR DESCRIPTION
We should avoid trying to translate from the struct's field names as much as we can, so rather than relying on translating the struct field name, we should use the 'join' tag's table name to formulate the ID column '<joinTable>_id'.

This can still be overridden by the `joinon` tag, but this way that tag should be needed less often.

Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>