### PR TITLE
Shared: Don't modify the global logrus standard logger

### DIFF
--- a/shared/logger/log.go
+++ b/shared/logger/log.go
@@ -13,7 +13,7 @@ import (
 
 // Setup a basic empty logger on init.
 func init() {
-	logger := logrus.StandardLogger()
+	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
 
 	Log = newWrapper(logger)
@@ -21,7 +21,7 @@ func init() {
 
 // InitLogger intializes a full logging instance.
 func InitLogger(filepath string, syslogName string, verbose bool, debug bool, hook logrus.Hook) error {
-	logger := logrus.StandardLogger()
+	logger := logrus.New()
 	logger.Level = logrus.DebugLevel
 	logger.SetOutput(io.Discard)
 


### PR DESCRIPTION
Instead create a new one for LXD's Log variable.

Fixes #10806

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>