### PR TITLE
lxd: Fix calls to inst.Project().Name when used in fmt.Sprintf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,6 @@ build-mo: $(MOFILES)
 
 .PHONY: static-analysis
 static-analysis:
-	SHELLCHECK_VERSION=$(shell shellcheck --version | grep version: | cut -d ' ' -f2)
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 endif
@@ -252,7 +251,7 @@ ifeq ($(shell command -v shellcheck 2> /dev/null),)
 	echo "Please install shellcheck"
 	exit 1
 endif
-ifneq "$(SHELLCHECK_VERSION)" "0.8.0"
+ifneq "$(shell shellcheck --version | grep version: | cut -d ' ' -f2)" "0.8.0"
 	@echo "WARN: shellcheck version is not 0.8.0"
 endif
 ifeq ($(shell command -v flake8 2> /dev/null),)

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ build-mo: $(MOFILES)
 .PHONY: static-analysis
 static-analysis:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 endif
 ifeq ($(shell command -v shellcheck 2> /dev/null),)
 	echo "Please install shellcheck"

--- a/lxd/device/device_utils_unix_hotplug_events.go
+++ b/lxd/device/device_utils_unix_hotplug_events.go
@@ -39,7 +39,7 @@ func unixHotplugRegisterHandler(instance instance.Instance, deviceName string, h
 	defer unixHotplugMutex.Unlock()
 
 	// Null delimited string of project name, instance name and device name.
-	key := fmt.Sprintf("%s\000%s\000%s", instance.Project(), instance.Name(), deviceName)
+	key := fmt.Sprintf("%s\000%s\000%s", instance.Project().Name, instance.Name(), deviceName)
 	unixHotplugHandlers[key] = handler
 }
 
@@ -49,7 +49,7 @@ func unixHotplugUnregisterHandler(instance instance.Instance, deviceName string)
 	defer unixHotplugMutex.Unlock()
 
 	// Null delimited string of project name, instance name and device name.
-	key := fmt.Sprintf("%s\000%s\000%s", instance.Project(), instance.Name(), deviceName)
+	key := fmt.Sprintf("%s\000%s\000%s", instance.Project().Name, instance.Name(), deviceName)
 	delete(unixHotplugHandlers, key)
 }
 

--- a/lxd/device/device_utils_usb_events.go
+++ b/lxd/device/device_utils_usb_events.go
@@ -42,7 +42,7 @@ func usbRegisterHandler(inst instance.Instance, deviceName string, handler func(
 	defer usbMutex.Unlock()
 
 	// Null delimited string of project name, instance name and device name.
-	key := fmt.Sprintf("%s\000%s\000%s", inst.Project(), inst.Name(), deviceName)
+	key := fmt.Sprintf("%s\000%s\000%s", inst.Project().Name, inst.Name(), deviceName)
 	usbHandlers[key] = handler
 }
 
@@ -52,7 +52,7 @@ func usbUnregisterHandler(inst instance.Instance, deviceName string) {
 	defer usbMutex.Unlock()
 
 	// Null delimited string of project name, instance name and device name.
-	key := fmt.Sprintf("%s\000%s\000%s", inst.Project(), inst.Name(), deviceName)
+	key := fmt.Sprintf("%s\000%s\000%s", inst.Project().Name, inst.Name(), deviceName)
 	delete(usbHandlers, key)
 }
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -476,7 +476,7 @@ func autoCreateInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		for _, instArg := range instanceArgs {
 			inst, err := instance.Load(s, instArg, *projects[instArg.Project])
 			if err != nil {
-				logger.Error("Failed loading instance for snapshot task", logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+				logger.Error("Failed loading instance for snapshot task", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 				continue
 			}
 
@@ -636,7 +636,7 @@ func pruneExpiredInstanceSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 				inst, err := instance.Load(s, snapshotArg, *p)
 				if err != nil {
-					logger.Error("Failed loading instance for snapshot prune task", logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+					logger.Error("Failed loading instance for snapshot prune task", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 					continue
 				}
 
@@ -704,7 +704,7 @@ func pruneExpiredInstanceSnapshots(ctx context.Context, d *Daemon, snapshots []i
 		err := snapshot.Delete(true)
 		instSnapshotsPruneRunning.Delete(snapshot.ID())
 		if err != nil {
-			return fmt.Errorf("Failed to delete expired instance snapshot %q in project %q: %w", snapshot.Name(), snapshot.Project(), err)
+			return fmt.Errorf("Failed to delete expired instance snapshot %q in project %q: %w", snapshot.Name(), snapshot.Project().Name, err)
 		}
 
 		logger.Debug("Deleted instance snapshot", logger.Ctx{"project": snapshot.Project(), "snapshot": snapshot.Name()})

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -548,7 +548,7 @@ func createFromCopy(d *Daemon, r *http.Request, projectName string, req *api.Ins
 
 	for key, value := range sourceConfig {
 		if !shared.InstanceIncludeWhenCopying(key, false) {
-			logger.Debug("Skipping key from copy source", logger.Ctx{"key": key, "sourceProject": source.Project(), "sourceInstance": source.Name(), "project": targetProject, "instance": req.Name})
+			logger.Debug("Skipping key from copy source", logger.Ctx{"key": key, "sourceProject": source.Project().Name, "sourceInstance": source.Name(), "project": targetProject, "instance": req.Name})
 			continue
 		}
 

--- a/lxd/maas/controller.go
+++ b/lxd/maas/controller.go
@@ -120,7 +120,7 @@ func (c *Controller) getDomain(inst Instance) string {
 		return domain
 	}
 
-	return fmt.Sprintf("%s.%s", inst.Project(), domain)
+	return fmt.Sprintf("%s.%s", inst.Project().Name, domain)
 }
 
 func (c *Controller) getDevice(name string, domain string) (gomaasapi.Device, error) {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -67,7 +67,7 @@ func resetContainerDiskIdmap(container instance.Container, srcIdmap *idmap.Idmap
 			jsonIdmap = "[]"
 		}
 
-		logger.Debug("Setting new volatile.last_state.idmap from source instance", logger.Ctx{"project": container.Project(), "instance": container.Name(), "sourceIdmap": srcIdmap})
+		logger.Debug("Setting new volatile.last_state.idmap from source instance", logger.Ctx{"project": container.Project().Name, "instance": container.Name(), "sourceIdmap": srcIdmap})
 		err := container.VolatileSet(map[string]string{"volatile.last_state.idmap": jsonIdmap})
 		if err != nil {
 			return err


### PR DESCRIPTION
These were missed during https://github.com/lxc/lxd/pull/10869

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>