### PR TITLE
Database: Use `QueryContext` in `query.Scan` and `query.SelectObjects` 

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -168,7 +168,7 @@ func storageBucketsServer(d *Daemon) *http.Server {
 			var err error
 			var bucket *db.StorageBucket
 			err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-				bucket, err = tx.GetStoragePoolLocalBucketByAccessKey(accessKey)
+				bucket, err = tx.GetStoragePoolLocalBucketByAccessKey(ctx, accessKey)
 				return err
 			})
 			if err != nil {
@@ -228,7 +228,7 @@ func storageBucketsServer(d *Daemon) *http.Server {
 		// Lookup bucket.
 		var bucket *db.StorageBucket
 		err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			bucket, err = tx.GetStoragePoolLocalBucket(bucketName)
+			bucket, err = tx.GetStoragePoolLocalBucket(ctx, bucketName)
 			return err
 		})
 		if err != nil {

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -552,7 +552,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 	nodeChanged := map[string]string{}
 	var newNodeConfig *node.Config
-	err = d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		newNodeConfig, err = node.ConfigLoad(tx)
 		if err != nil {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -358,7 +358,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 
 	// If there's no cluster.https_address set, but core.https_address is,
 	// let's default to it.
-	err := d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch member configuration: %w", err)
@@ -441,7 +441,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			return response.SmartError(err)
 		}
 
-		err := d.db.Node.Transaction(func(tx *db.NodeTx) error {
+		err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 			config, err := node.ConfigLoad(tx)
 			if err != nil {
 				return fmt.Errorf("Failed to load cluster config: %w", err)
@@ -472,7 +472,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Update the cluster.https_address config key.
-		err := d.db.Node.Transaction(func(tx *db.NodeTx) error {
+		err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 			config, err := node.ConfigLoad(tx)
 			if err != nil {
 				return fmt.Errorf("Failed to load cluster config: %w", err)
@@ -701,7 +701,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		var nodeConfig *node.Config
-		err = d.db.Node.Transaction(func(tx *db.NodeTx) error {
+		err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 			var err error
 			nodeConfig, err = node.ConfigLoad(tx)
 			return err
@@ -1761,7 +1761,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	// Get information about the cluster.
 	var nodes []db.RaftNode
-	err = d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		nodes, err = tx.GetRaftNodes()
 		return err

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1763,7 +1763,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	var nodes []db.RaftNode
 	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		nodes, err = tx.GetRaftNodes()
+		nodes, err = tx.GetRaftNodes(ctx)
 		return err
 	})
 	if err != nil {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -689,7 +689,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// Handle optional service integration on cluster join
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Add the new node to the default cluster group.
-			err := tx.AddNodeToClusterGroup("default", req.ServerName)
+			err := tx.AddNodeToClusterGroup(ctx, "default", req.ServerName)
 			if err != nil {
 				return fmt.Errorf("Failed to add new member to the default cluster group: %w", err)
 			}
@@ -1116,7 +1116,7 @@ func clusterNodesGet(d *Daemon, r *http.Request) response.Response {
 	var nodes []db.NodeInfo
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the nodes.
-		nodes, err = tx.GetNodes()
+		nodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}
@@ -1212,7 +1212,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the nodes.
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}
@@ -1349,7 +1349,7 @@ func clusterNodeGet(d *Daemon, r *http.Request) response.Response {
 	var nodes []db.NodeInfo
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the node.
-		nodes, err = tx.GetNodes()
+		nodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}
@@ -1459,7 +1459,7 @@ func updateClusterNode(d *Daemon, r *http.Request, isPatch bool) response.Respon
 	var node db.NodeInfo
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the node.
-		node, err = tx.GetNodeByName(name)
+		node, err = tx.GetNodeByName(ctx, name)
 		if err != nil {
 			return err
 		}
@@ -1515,7 +1515,7 @@ func updateClusterNode(d *Daemon, r *http.Request, isPatch bool) response.Respon
 
 	// Update the database
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodeInfo, err := tx.GetNodeByName(name)
+		nodeInfo, err := tx.GetNodeByName(ctx, name)
 		if err != nil {
 			return fmt.Errorf("Loading node information: %w", err)
 		}
@@ -1559,13 +1559,13 @@ func updateClusterNode(d *Daemon, r *http.Request, isPatch bool) response.Respon
 			return fmt.Errorf("Update roles: %w", err)
 		}
 
-		err = tx.UpdateNodeFailureDomain(nodeInfo.ID, req.FailureDomain)
+		err = tx.UpdateNodeFailureDomain(ctx, nodeInfo.ID, req.FailureDomain)
 		if err != nil {
 			return fmt.Errorf("Update failure domain: %w", err)
 		}
 
 		// Update the cluster groups.
-		err = tx.UpdateNodeClusterGroups(nodeInfo.ID, req.Groups)
+		err = tx.UpdateNodeClusterGroups(ctx, nodeInfo.ID, req.Groups)
 		if err != nil {
 			return fmt.Errorf("Update cluster groups: %w", err)
 		}
@@ -1743,12 +1743,12 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	var localInfo, leaderInfo db.NodeInfo
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localInfo, err = tx.GetNodeByAddress(localAddress)
+		localInfo, err = tx.GetNodeByAddress(ctx, localAddress)
 		if err != nil {
 			return fmt.Errorf("Failed loading local member info %q: %w", localAddress, err)
 		}
 
-		leaderInfo, err = tx.GetNodeByAddress(leader)
+		leaderInfo, err = tx.GetNodeByAddress(ctx, leader)
 		if err != nil {
 			return fmt.Errorf("Failed loading leader member info %q: %w", leader, err)
 		}
@@ -2268,7 +2268,7 @@ func upgradeNodesWithoutRaftRole(d *Daemon) error {
 	var allNodes []db.NodeInfo
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		allNodes, err = tx.GetNodes()
+		allNodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}
@@ -2666,7 +2666,7 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 func evacuateClusterSetState(d *Daemon, name string, state int) error {
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the node.
-		node, err := tx.GetNodeByName(name)
+		node, err := tx.GetNodeByName(ctx, name)
 		if err != nil {
 			return fmt.Errorf("Failed to get cluster member by name: %w", err)
 		}
@@ -2811,7 +2811,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 
 			// Find the least loaded cluster member which supports the architecture.
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				targetNodeName, err = tx.GetNodeWithLeastInstances([]int{inst.Architecture()}, -1, "", nil)
+				targetNodeName, err = tx.GetNodeWithLeastInstances(ctx, []int{inst.Architecture()}, -1, "", nil)
 				if err != nil {
 					return err
 				}
@@ -2821,7 +2821,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 					return nil
 				}
 
-				targetNode, err = tx.GetNodeByName(targetNodeName)
+				targetNode, err = tx.GetNodeByName(ctx, targetNodeName)
 				if err != nil {
 					return err
 				}
@@ -2993,7 +2993,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 			_ = op.UpdateMetadata(metadata)
 
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				sourceNode, err = tx.GetNodeByName(inst.Location())
+				sourceNode, err = tx.GetNodeByName(ctx, inst.Location())
 				if err != nil {
 					return fmt.Errorf("Failed to get node %q: %w", inst.Location(), err)
 				}
@@ -3616,7 +3616,7 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 				// That is because each member needs to belong to at least one group.
 				if len(groups) > 1 {
 					// Remove member from this group as it belongs to at least one other group.
-					err = tx.RemoveNodeFromClusterGroup(name, oldMember)
+					err = tx.RemoveNodeFromClusterGroup(ctx, name, oldMember)
 					if err != nil {
 						return err
 					}
@@ -3633,7 +3633,7 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Add new members to the group.
-			err = tx.AddNodeToClusterGroup(name, member)
+			err = tx.AddNodeToClusterGroup(ctx, name, member)
 			if err != nil {
 				return err
 			}
@@ -3796,7 +3796,7 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 				}
 
 				// Remove member from this group as it belongs to at least one other group.
-				err = tx.RemoveNodeFromClusterGroup(name, oldMember)
+				err = tx.RemoveNodeFromClusterGroup(ctx, name, oldMember)
 				if err != nil {
 					return err
 				}
@@ -3812,7 +3812,7 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Add new members to the group.
-			err = tx.AddNodeToClusterGroup(name, member)
+			err = tx.AddNodeToClusterGroup(ctx, name, member)
 			if err != nil {
 				return err
 			}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -690,7 +690,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 	// Check if a storage volume entry for the instance already exists.
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(pool.ID(), projectName, instanceDBVolType, backupConf.Container.Name, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, instanceDBVolType, backupConf.Container.Name, true)
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		}
@@ -809,7 +809,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 		// Check if a storage volume entry for the snapshot already exists.
 		var dbVolume *db.StorageVolume
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			dbVolume, err = tx.GetStoragePoolVolume(pool.ID(), projectName, instanceDBVolType, snapInstName, true)
+			dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, instanceDBVolType, snapInstName, true)
 			if err != nil && !response.IsNotFoundError(err) {
 				return err
 			}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -117,7 +117,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 		}
 
 		// Load list of project/network names for validation.
-		projectNetworks, err = tx.GetCreatedNetworks()
+		projectNetworks, err = tx.GetCreatedNetworks(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -218,7 +218,7 @@ func projectUsedBy(ctx context.Context, tx *db.ClusterTx, project *cluster.Proje
 		usedBy = append(usedBy, apiImage.URL(version.APIVersion, project.Name).String())
 	}
 
-	volumes, err := tx.GetStorageVolumeURIs(project.Name)
+	volumes, err := tx.GetStorageVolumeURIs(ctx, project.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -954,7 +954,7 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 
 	// Get current limits and usage.
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		result, err := projecthelpers.GetCurrentAllocations(tx, name)
+		result, err := projecthelpers.GetCurrentAllocations(ctx, tx, name)
 		if err != nil {
 			return err
 		}
@@ -1004,7 +1004,7 @@ func projectIsEmpty(ctx context.Context, project *cluster.Project, tx *db.Cluste
 		return false, nil
 	}
 
-	volumes, err := tx.GetStorageVolumeURIs(project.Name)
+	volumes, err := tx.GetStorageVolumeURIs(ctx, project.Name)
 	if err != nil {
 		return false, err
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -270,7 +270,7 @@ func updateCertificateCacheFromLocal(d *Daemon) error {
 	var err error
 
 	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		dbCerts, err = tx.GetCertificates()
+		dbCerts, err = tx.GetCertificates(ctx)
 		return err
 	})
 	if err != nil {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -245,7 +245,7 @@ func updateCertificateCache(d *Daemon) {
 	}
 
 	// Write out the server certs to the local database to allow the cluster to restart.
-	err = d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		return tx.ReplaceCertificates(localCerts)
 	})
 	if err != nil {
@@ -269,7 +269,7 @@ func updateCertificateCacheFromLocal(d *Daemon) error {
 	var dbCerts []dbCluster.Certificate
 	var err error
 
-	err = d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		dbCerts, err = tx.GetCertificates()
 		return err
 	})

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -123,7 +123,7 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 			return err
 		}
 
-		nodes, err = tx.GetStorageVolumeNodes(poolID, projectName, volumeName, volumeType)
+		nodes, err = tx.GetStorageVolumeNodes(ctx, poolID, projectName, volumeName, volumeType)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 		// GetStoragePoolVolume returns a volume with an empty Location field for remote drivers.
 		var dbVolume *db.StorageVolume
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, volumeType, volumeName, true)
+			dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
 			return err
 		})
 		if err != nil {
@@ -156,7 +156,7 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 		if remoteInstance != nil {
 			var instNode db.NodeInfo
 			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				instNode, err = tx.GetNodeByName(remoteInstance.Node)
+				instNode, err = tx.GetNodeByName(ctx, remoteInstance.Node)
 				return err
 			})
 			if err != nil {

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -227,7 +227,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 		err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
 
-			dbMembers, err = tx.GetNodes()
+			dbMembers, err = tx.GetNodes(ctx)
 			if err != nil {
 				return err
 			}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -668,7 +668,7 @@ func (g *Gateway) LeaderAddress() (string, error) {
 
 	addresses := []string{}
 	err = g.db.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		nodes, err := tx.GetRaftNodes()
+		nodes, err := tx.GetRaftNodes(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -957,7 +957,7 @@ func (g *Gateway) currentRaftNodes() ([]db.RaftNode, error) {
 	// Get the names of the raft nodes from the global database.
 	if g.Cluster != nil {
 		err = g.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			nodes, err := tx.GetNodes()
+			nodes, err := tx.GetNodes(ctx)
 			if err != nil {
 				return fmt.Errorf("Failed loading cluster members: %w", err)
 			}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -601,7 +601,7 @@ func (g *Gateway) Reset(networkCert *shared.CertInfo) error {
 		return err
 	}
 
-	err = g.db.Transaction(func(tx *db.NodeTx) error {
+	err = g.db.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		return tx.ReplaceRaftNodes(nil)
 	})
 	if err != nil {
@@ -667,7 +667,7 @@ func (g *Gateway) LeaderAddress() (string, error) {
 	}
 
 	addresses := []string{}
-	err = g.db.Transaction(func(tx *db.NodeTx) error {
+	err = g.db.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodes, err := tx.GetRaftNodes()
 		if err != nil {
 			return err
@@ -994,7 +994,7 @@ func (g *Gateway) nodeAddress(raftAddress string) (string, error) {
 	}
 
 	var address string
-	err := g.db.Transaction(func(tx *db.NodeTx) error {
+	err := g.db.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		address, err = tx.GetRaftNodeAddress(1)
 		if err != nil {

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -361,7 +361,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	// been elected leader before the former leader had chance to
 	// send us a fresh update through the heartbeat pool.
 	logger.Debug("Heartbeat updating local raft members", logger.Ctx{"members": raftNodes})
-	err = g.db.Transaction(func(tx *db.NodeTx) error {
+	err = g.db.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		return tx.ReplaceRaftNodes(raftNodes)
 	})
 	if err != nil {

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -129,7 +129,7 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 	if len(raftNodeMap) > 0 && hbState.cluster != nil {
 		_ = hbState.cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			for addr, raftNode := range raftNodeMap {
-				_, err := tx.GetPendingNodeByAddress(addr)
+				_, err := tx.GetPendingNodeByAddress(ctx, addr)
 				if err != nil {
 					logger.Errorf("Unaccounted raft node(s) not found in 'nodes' table for heartbeat: %+v", raftNode)
 				}
@@ -328,7 +328,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	var allNodes []db.NodeInfo
 	err = g.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		allNodes, err = tx.GetNodes()
+		allNodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}
@@ -411,7 +411,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		var currentNodes []db.NodeInfo
 		err = g.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			currentNodes, err = tx.GetNodes()
+			currentNodes, err = tx.GetNodes(ctx)
 			if err != nil {
 				return err
 			}

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -39,7 +39,7 @@ func TestHeartbeat(t *testing.T) {
 
 	// Artificially mark all nodes as down
 	err := leaderState.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		require.NoError(t, err)
 		for _, node := range nodes {
 			err := tx.SetNodeHeartbeat(node.Address, time.Now().Add(-time.Minute))
@@ -58,7 +58,7 @@ func TestHeartbeat(t *testing.T) {
 
 	// The heartbeat timestamps of all nodes got updated
 	err = leaderState.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		require.NoError(t, err)
 
 		offlineThreshold, err := tx.GetNodeOfflineThreshold()

--- a/lxd/cluster/info.go
+++ b/lxd/cluster/info.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -15,7 +16,7 @@ import (
 func loadInfo(database *db.Node, cert *shared.CertInfo) (*db.RaftNode, error) {
 	// Figure out if we actually need to act as dqlite node.
 	var info *db.RaftNode
-	err := database.Transaction(func(tx *db.NodeTx) error {
+	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		info, err = node.DetermineRaftNode(tx)
 		return err

--- a/lxd/cluster/info.go
+++ b/lxd/cluster/info.go
@@ -18,7 +18,7 @@ func loadInfo(database *db.Node, cert *shared.CertInfo) (*db.RaftNode, error) {
 	var info *db.RaftNode
 	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		info, err = node.DetermineRaftNode(tx)
+		info, err = node.DetermineRaftNode(ctx, tx)
 		return err
 	})
 	if err != nil {

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -51,7 +51,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 		address = config.ClusterAddress()
 
 		// Make sure node-local database state is in order.
-		err = membershipCheckNodeStateForBootstrapOrJoin(tx, address)
+		err = membershipCheckNodeStateForBootstrapOrJoin(ctx, tx, address)
 		if err != nil {
 			return err
 		}
@@ -318,7 +318,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		address = config.ClusterAddress()
 
 		// Make sure node-local database state is in order.
-		err = membershipCheckNodeStateForBootstrapOrJoin(tx, address)
+		err = membershipCheckNodeStateForBootstrapOrJoin(ctx, tx, address)
 		if err != nil {
 			return err
 		}
@@ -573,7 +573,7 @@ func NotifyHeartbeat(state *state.State, gateway *Gateway) {
 	var raftNodes []db.RaftNode
 	var localAddress string
 	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		raftNodes, err = tx.GetRaftNodes()
+		raftNodes, err = tx.GetRaftNodes(ctx)
 		if err != nil {
 			return err
 		}
@@ -1097,8 +1097,8 @@ func Enabled(node *db.Node) (bool, error) {
 
 // Check that node-related preconditions are met for bootstrapping or joining a
 // cluster.
-func membershipCheckNodeStateForBootstrapOrJoin(tx *db.NodeTx, address string) error {
-	nodes, err := tx.GetRaftNodes()
+func membershipCheckNodeStateForBootstrapOrJoin(ctx context.Context, tx *db.NodeTx, address string) error {
+	nodes, err := tx.GetRaftNodes(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch current raft nodes: %w", err)
 	}

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -41,7 +41,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 
 	var address string
 
-	err = state.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		// Fetch current network address and raft nodes
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
@@ -308,7 +308,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	}
 
 	var address string
-	err := state.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err := state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		// Fetch current network address and raft nodes
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
@@ -572,7 +572,7 @@ func NotifyHeartbeat(state *state.State, gateway *Gateway) {
 	var err error
 	var raftNodes []db.RaftNode
 	var localAddress string
-	err = state.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		raftNodes, err = tx.GetRaftNodes()
 		if err != nil {
 			return err
@@ -721,7 +721,7 @@ func Assign(state *state.State, gateway *Gateway, nodes []db.RaftNode) error {
 
 	// Replace our local list of raft nodes with the given one (which
 	// includes ourselves).
-	err = state.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		err = tx.ReplaceRaftNodes(nodes)
 		if err != nil {
 			return fmt.Errorf("Failed to set raft nodes: %w", err)
@@ -1082,7 +1082,7 @@ func Count(state *state.State) (int, error) {
 // node.
 func Enabled(node *db.Node) (bool, error) {
 	enabled := false
-	err := node.Transaction(func(tx *db.NodeTx) error {
+	err := node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		addresses, err := tx.GetRaftNodeAddresses()
 		if err != nil {
 			return err

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -71,7 +71,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 	// Update our own entry in the nodes table.
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Make sure cluster database state is in order.
-		err := membershipCheckClusterStateForBootstrapOrJoin(tx)
+		err := membershipCheckClusterStateForBootstrapOrJoin(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 	// connection, so new queries will be executed over the new network
 	// connection.
 	err = state.DB.Cluster.ExitExclusive(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		_, err := tx.GetNodes()
+		_, err := tx.GetNodes(ctx)
 		return err
 	})
 	if err != nil {
@@ -230,7 +230,7 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 	var id int64
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Check that the node can be accepted with these parameters.
-		err := membershipCheckClusterStateForAccept(tx, name, address, schema, api)
+		err := membershipCheckClusterStateForAccept(ctx, tx, name, address, schema, api)
 		if err != nil {
 			return err
 		}
@@ -439,7 +439,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	// tables with our local configuration.
 	logger.Info("Migrate local data to cluster database")
 	err = state.DB.Cluster.ExitExclusive(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		node, err := tx.GetPendingNodeByAddress(address)
+		node, err := tx.GetPendingNodeByAddress(ctx, address)
 		if err != nil {
 			return fmt.Errorf("Failed to get ID of joining node: %w", err)
 		}
@@ -448,7 +448,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		tx.NodeID(node.ID)
 
 		// Storage pools.
-		ids, err := tx.GetNonPendingStoragePoolsNamesToIDs()
+		ids, err := tx.GetNonPendingStoragePoolsNamesToIDs(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to get cluster storage pool IDs: %w", err)
 		}
@@ -486,7 +486,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		}
 
 		// Networks.
-		netids, err := tx.GetNonPendingNetworkIDs()
+		netids, err := tx.GetNonPendingNetworkIDs(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to get cluster network IDs: %w", err)
 		}
@@ -594,7 +594,7 @@ func NotifyHeartbeat(state *state.State, gateway *Gateway) {
 
 	var allNodes []db.NodeInfo
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		allNodes, err = tx.GetNodes()
+		allNodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}
@@ -893,14 +893,14 @@ func Leave(state *state.State, gateway *Gateway, name string, force bool) (strin
 	var address string
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the node (if it doesn't exists an error is returned).
-		node, err := tx.GetNodeByName(name)
+		node, err := tx.GetNodeByName(ctx, name)
 		if err != nil {
 			return err
 		}
 
 		// Check that the node is eligeable for leaving.
 		if !force {
-			err := membershipCheckClusterStateForLeave(tx, node.ID)
+			err := membershipCheckClusterStateForLeave(ctx, tx, node.ID)
 			if err != nil {
 				return err
 			}
@@ -1001,7 +1001,7 @@ func newRolesChanges(state *state.State, gateway *Gateway, nodes []db.RaftNode, 
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
-		domains, err = tx.GetNodesFailureDomains()
+		domains, err = tx.GetNodesFailureDomains(ctx)
 		if err != nil {
 			return fmt.Errorf("Load failure domains: %w", err)
 		}
@@ -1041,7 +1041,7 @@ func Purge(c *db.Cluster, name string) error {
 
 	return c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get the node (if it doesn't exists an error is returned).
-		node, err := tx.GetNodeByName(name)
+		node, err := tx.GetNodeByName(ctx, name)
 		if err != nil {
 			return fmt.Errorf("Failed to get member %q: %w", name, err)
 		}
@@ -1125,8 +1125,8 @@ func membershipCheckNodeStateForBootstrapOrJoin(tx *db.NodeTx, address string) e
 
 // Check that cluster-related preconditions are met for bootstrapping or
 // joining a cluster.
-func membershipCheckClusterStateForBootstrapOrJoin(tx *db.ClusterTx) error {
-	nodes, err := tx.GetNodes()
+func membershipCheckClusterStateForBootstrapOrJoin(ctx context.Context, tx *db.ClusterTx) error {
+	nodes, err := tx.GetNodes(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch current cluster nodes: %w", err)
 	}
@@ -1139,8 +1139,8 @@ func membershipCheckClusterStateForBootstrapOrJoin(tx *db.ClusterTx) error {
 }
 
 // Check that cluster-related preconditions are met for accepting a new node.
-func membershipCheckClusterStateForAccept(tx *db.ClusterTx, name string, address string, schema int, api int) error {
-	nodes, err := tx.GetNodes()
+func membershipCheckClusterStateForAccept(ctx context.Context, tx *db.ClusterTx, name string, address string, schema int, api int) error {
+	nodes, err := tx.GetNodes(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch current cluster nodes: %w", err)
 	}
@@ -1171,9 +1171,9 @@ func membershipCheckClusterStateForAccept(tx *db.ClusterTx, name string, address
 }
 
 // Check that cluster-related preconditions are met for leaving a cluster.
-func membershipCheckClusterStateForLeave(tx *db.ClusterTx, nodeID int64) error {
+func membershipCheckClusterStateForLeave(ctx context.Context, tx *db.ClusterTx, nodeID int64) error {
 	// Check that it has no containers or images.
-	message, err := tx.NodeIsEmpty(nodeID)
+	message, err := tx.NodeIsEmpty(ctx, nodeID)
 	if err != nil {
 		return err
 	}
@@ -1183,7 +1183,7 @@ func membershipCheckClusterStateForLeave(tx *db.ClusterTx, nodeID int64) error {
 	}
 
 	// Check that it's not the last node.
-	nodes, err := tx.GetNodes()
+	nodes, err := tx.GetNodes(ctx)
 	if err != nil {
 		return err
 	}

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -51,7 +51,7 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 			return err
 		}
 
-		nodes, err = tx.GetNodes()
+		nodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -138,7 +138,7 @@ func (h *notifyFixtures) Nodes(cert *shared.CertInfo, n int) func() {
 	require.NoError(h.t, err)
 
 	// Set the address in the config table of the node database.
-	err = h.state.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err = h.state.DB.Node.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		require.NoError(h.t, err)
 		address := servers[0].Listener.Addr().String()
@@ -164,7 +164,7 @@ func (h *notifyFixtures) Nodes(cert *shared.CertInfo, n int) func() {
 func (h *notifyFixtures) Address(i int) string {
 	var address string
 	err := h.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		require.NoError(h.t, err)
 		address = nodes[i].Address
 		return nil
@@ -176,7 +176,7 @@ func (h *notifyFixtures) Address(i int) string {
 // Mark the i'th node as down.
 func (h *notifyFixtures) Down(i int) {
 	err := h.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		require.NoError(h.t, err)
 		err = tx.SetNodeHeartbeat(nodes[i].Address, time.Now().Add(-time.Minute))
 		require.NoError(h.t, err)

--- a/lxd/cluster/raft_test.go
+++ b/lxd/cluster/raft_test.go
@@ -1,6 +1,7 @@
 package cluster_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,7 +19,7 @@ import (
 //
 // This effectively makes the node act as a database raft node.
 func setRaftRole(t *testing.T, database *db.Node, address string) client.NodeStore {
-	require.NoError(t, database.Transaction(func(tx *db.NodeTx) error {
+	require.NoError(t, database.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		err := tx.UpdateConfig(map[string]string{"cluster.https_address": address})
 		if err != nil {
 			return err

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -19,7 +19,7 @@ func ListDatabaseNodes(database *db.Node) ([]string, error) {
 	nodes := []db.RaftNode{}
 	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		nodes, err = tx.GetRaftNodes()
+		nodes, err = tx.GetRaftNodes(ctx)
 		return err
 	})
 	if err != nil {
@@ -44,7 +44,7 @@ func Recover(database *db.Node) error {
 	var info *db.RaftNode
 	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		info, err = node.DetermineRaftNode(tx)
+		info, err = node.DetermineRaftNode(ctx, tx)
 		return err
 	})
 	if err != nil {
@@ -132,7 +132,7 @@ func Reconfigure(database *db.Node, raftNodes []db.RaftNode) error {
 	var info *db.RaftNode
 	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		info, err = node.DetermineRaftNode(tx)
+		info, err = node.DetermineRaftNode(ctx, tx)
 
 		return err
 	})

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -17,7 +17,7 @@ import (
 // ListDatabaseNodes returns a list of database node names.
 func ListDatabaseNodes(database *db.Node) ([]string, error) {
 	nodes := []db.RaftNode{}
-	err := database.Transaction(func(tx *db.NodeTx) error {
+	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		nodes, err = tx.GetRaftNodes()
 		return err
@@ -42,7 +42,7 @@ func ListDatabaseNodes(database *db.Node) ([]string, error) {
 func Recover(database *db.Node) error {
 	// Figure out if we actually act as dqlite node.
 	var info *db.RaftNode
-	err := database.Transaction(func(tx *db.NodeTx) error {
+	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		info, err = node.DetermineRaftNode(tx)
 		return err
@@ -82,7 +82,7 @@ func Recover(database *db.Node) error {
 	}
 
 	// Update the list of raft nodes.
-	err = database.Transaction(func(tx *db.NodeTx) error {
+	err = database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodes := []db.RaftNode{
 			{
 				NodeInfo: client.NodeInfo{
@@ -104,7 +104,7 @@ func Recover(database *db.Node) error {
 
 // updateLocalAddress updates the cluster.https_address for this node.
 func updateLocalAddress(database *db.Node, address string) error {
-	err := database.Transaction(func(tx *db.NodeTx) error {
+	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
@@ -130,7 +130,7 @@ func updateLocalAddress(database *db.Node, address string) error {
 // Addresses and node roles may be updated. Node IDs are read-only.
 func Reconfigure(database *db.Node, raftNodes []db.RaftNode) error {
 	var info *db.RaftNode
-	err := database.Transaction(func(tx *db.NodeTx) error {
+	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		info, err = node.DetermineRaftNode(tx)
 
@@ -172,7 +172,7 @@ func Reconfigure(database *db.Node, raftNodes []db.RaftNode) error {
 	}
 
 	// Replace cluster configuration in local raft_nodes database.
-	err = database.Transaction(func(tx *db.NodeTx) error {
+	err = database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		return tx.ReplaceRaftNodes(raftNodes)
 	})
 	if err != nil {

--- a/lxd/cluster/resolve.go
+++ b/lxd/cluster/resolve.go
@@ -23,7 +23,7 @@ func ResolveTarget(cluster *db.Cluster, target string) (string, error) {
 			return nil
 		}
 
-		node, err := tx.GetNodeByName(target)
+		node, err := tx.GetNodeByName(ctx, target)
 		if err != nil {
 			if response.IsNotFoundError(err) {
 				return fmt.Errorf("No cluster member called '%s'", target)

--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -78,7 +78,7 @@ func MaybeUpdate(state *state.State) error {
 	}
 
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		outdated, err := tx.NodeIsOutdated()
+		outdated, err := tx.NodeIsOutdated(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -67,7 +67,7 @@ func TestMaybeUpdate_Upgrade(t *testing.T) {
 	state, cleanup := state.NewTestState(t)
 	defer cleanup()
 
-	_ = state.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	_ = state.DB.Node.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodes := []db.RaftNode{
 			{NodeInfo: client.NodeInfo{ID: 1, Address: "0.0.0.0:666"}},
 			{NodeInfo: client.NodeInfo{ID: 2, Address: "1.2.3.4:666"}},
@@ -82,7 +82,7 @@ func TestMaybeUpdate_Upgrade(t *testing.T) {
 		id, err := tx.CreateNode("buzz", "1.2.3.4:666")
 		require.NoError(t, err)
 
-		node, err := tx.GetNodeByName("buzz")
+		node, err := tx.GetNodeByName(ctx, "buzz")
 		require.NoError(t, err)
 
 		version := node.Version()
@@ -167,7 +167,7 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 		require.NoError(t, err)
 		_, err = tx.CreateNode("bar", "5.6.7.8")
 		require.NoError(t, err)
-		members, err = tx.GetNodes()
+		members, err = tx.GetNodes(ctx)
 		require.NoError(t, err)
 		return nil
 	})

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1076,7 +1076,7 @@ func (d *Daemon) init() error {
 
 	logger.Info("Loading daemon configuration")
 	var daemonConfig *node.Config
-	err = d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		daemonConfig, err = node.ConfigLoad(tx)
 		return err
 	})
@@ -2061,7 +2061,7 @@ func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLead
 
 	// Accept raft node list from any heartbeat type so that we get freshest data quickly.
 	logger.Debug("Replace current raft nodes", logger.Ctx{"raftMembers": raftNodes})
-	err = d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		return tx.ReplaceRaftNodes(raftNodes)
 	})
 	if err != nil {

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
@@ -17,7 +19,7 @@ func daemonConfigRender(state *state.State) (map[string]any, error) {
 	}
 
 	// Apply the local config.
-	err := state.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err := state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodeConfig, err := node.ConfigLoad(tx)
 		if err != nil {
 			return err

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -22,7 +22,7 @@ func daemonStorageVolumesUnmount(s *state.State) error {
 	var storageBackups string
 	var storageImages string
 
-	err := s.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodeConfig, err := node.ConfigLoad(tx)
 		if err != nil {
 			return err
@@ -78,7 +78,7 @@ func daemonStorageVolumesUnmount(s *state.State) error {
 func daemonStorageMount(s *state.State) error {
 	var storageBackups string
 	var storageImages string
-	err := s.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodeConfig, err := node.ConfigLoad(tx)
 		if err != nil {
 			return err

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -162,7 +162,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 
 	// Confirm volume exists.
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		_, err = tx.GetStoragePoolVolume(poolID, project.Default, db.StoragePoolVolumeTypeCustom, volumeName, true)
+		_, err = tx.GetStoragePoolVolume(ctx, poolID, project.Default, db.StoragePoolVolumeTypeCustom, volumeName, true)
 		return err
 	})
 	if err != nil {

--- a/lxd/db/backups.go
+++ b/lxd/db/backups.go
@@ -303,7 +303,7 @@ func (c *Cluster) GetStoragePoolVolumeBackups(projectName string, volumeName str
 	var backups []StoragePoolVolumeBackup
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var b StoragePoolVolumeBackup
 			var expiryTime sql.NullTime
 

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -29,7 +29,7 @@ func (db *DB) UpdateCertificate(ctx context.Context, fingerprint string, cert cl
 }
 
 // GetCertificates returns all available local certificates.
-func (n *NodeTx) GetCertificates() ([]cluster.Certificate, error) {
+func (n *NodeTx) GetCertificates(ctx context.Context) ([]cluster.Certificate, error) {
 	type cert struct {
 		fingerprint string
 		certType    cluster.CertificateType
@@ -39,7 +39,7 @@ func (n *NodeTx) GetCertificates() ([]cluster.Certificate, error) {
 
 	sql := "SELECT fingerprint, type, name, certificate FROM certificates"
 	dbCerts := []cert{}
-	err := query.Scan(n.tx, sql, func(scan func(dest ...any) error) error {
+	err := query.Scan(ctx, n.tx, sql, func(scan func(dest ...any) error) error {
 		dbCert := cert{}
 
 		err := scan(&dbCert.fingerprint, &dbCert.certType, &dbCert.name, &dbCert.certificate)

--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -71,13 +71,13 @@ WHERE cluster_groups.name = ? ORDER BY cluster_groups.name
 }
 
 //AddNodeToClusterGroup adds a given node to the given cluster group.
-func (c *ClusterTx) AddNodeToClusterGroup(groupName string, nodeName string) error {
-	groupID, err := cluster.GetClusterGroupID(context.TODO(), c.tx, groupName)
+func (c *ClusterTx) AddNodeToClusterGroup(ctx context.Context, groupName string, nodeName string) error {
+	groupID, err := cluster.GetClusterGroupID(ctx, c.tx, groupName)
 	if err != nil {
 		return fmt.Errorf("Failed to get cluster group ID: %w", err)
 	}
 
-	nodeInfo, err := c.GetNodeByName(nodeName)
+	nodeInfo, err := c.GetNodeByName(ctx, nodeName)
 	if err != nil {
 		return fmt.Errorf("Failed to get node info: %w", err)
 	}
@@ -91,13 +91,13 @@ func (c *ClusterTx) AddNodeToClusterGroup(groupName string, nodeName string) err
 }
 
 // RemoveNodeFromClusterGroup removes a given node from the given group name.
-func (c *ClusterTx) RemoveNodeFromClusterGroup(groupName string, nodeName string) error {
-	groupID, err := cluster.GetClusterGroupID(context.TODO(), c.tx, groupName)
+func (c *ClusterTx) RemoveNodeFromClusterGroup(ctx context.Context, groupName string, nodeName string) error {
+	groupID, err := cluster.GetClusterGroupID(ctx, c.tx, groupName)
 	if err != nil {
 		return fmt.Errorf("Failed to get cluster group ID: %w", err)
 	}
 
-	nodeInfo, err := c.GetNodeByName(nodeName)
+	nodeInfo, err := c.GetNodeByName(ctx, nodeName)
 	if err != nil {
 		return fmt.Errorf("Failed to get node info: %w", err)
 	}

--- a/lxd/db/cluster/certificate_projects.mapper.go
+++ b/lxd/db/cluster/certificate_projects.mapper.go
@@ -66,7 +66,7 @@ func GetCertificateProjects(ctx context.Context, tx *sql.Tx, certificateID int) 
 	}
 
 	// Select.
-	err = query.SelectObjects(sqlStmt, dest, args...)
+	err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"certificates_projects\" table: %w", err)
 	}

--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -152,10 +152,10 @@ func GetCertificates(ctx context.Context, tx *sql.Tx, filters ...CertificateFilt
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/cluster_groups.mapper.go
+++ b/lxd/db/cluster/cluster_groups.mapper.go
@@ -121,10 +121,10 @@ func GetClusterGroups(ctx context.Context, tx *sql.Tx, filters ...ClusterGroupFi
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/config.mapper.go
+++ b/lxd/db/cluster/config.mapper.go
@@ -85,7 +85,7 @@ func GetConfig(ctx context.Context, tx *sql.Tx, parent string, filters ...Config
 	}
 
 	// Select.
-	err = query.Scan(tx, queryStr, dest, args...)
+	err = query.Scan(ctx, tx, queryStr, dest, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"%s_config\" table: %w", parent, err)
 	}

--- a/lxd/db/cluster/devices.mapper.go
+++ b/lxd/db/cluster/devices.mapper.go
@@ -85,7 +85,7 @@ func GetDevices(ctx context.Context, tx *sql.Tx, parent string, filters ...Devic
 	}
 
 	// Select.
-	err = query.Scan(tx, queryStr, dest, args...)
+	err = query.Scan(ctx, tx, queryStr, dest, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"%s_devices\" table: %w", parent, err)
 	}

--- a/lxd/db/cluster/images.mapper.go
+++ b/lxd/db/cluster/images.mapper.go
@@ -291,10 +291,10 @@ func GetImages(ctx context.Context, tx *sql.Tx, filters ...ImageFilter) ([]Image
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -73,7 +73,7 @@ func GetProfileInstances(ctx context.Context, tx *sql.Tx, profileID int) ([]Inst
 	}
 
 	// Select.
-	err = query.SelectObjects(sqlStmt, dest, args...)
+	err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"instances_profiles\" table: %w", err)
 	}
@@ -120,7 +120,7 @@ func GetInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) ([]Pro
 	}
 
 	// Select.
-	err = query.SelectObjects(sqlStmt, dest, args...)
+	err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"instances_profiles\" table: %w", err)
 	}

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -621,10 +621,10 @@ func GetInstances(ctx context.Context, tx *sql.Tx, filters ...InstanceFilter) ([
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/nodes_cluster_groups.mapper.go
+++ b/lxd/db/cluster/nodes_cluster_groups.mapper.go
@@ -113,10 +113,10 @@ func GetNodeClusterGroups(ctx context.Context, tx *sql.Tx, filters ...NodeCluste
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -176,10 +176,10 @@ func GetOperations(ctx context.Context, tx *sql.Tx, filters ...OperationFilter) 
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -273,10 +273,10 @@ func GetProfiles(ctx context.Context, tx *sql.Tx, filters ...ProfileFilter) ([]P
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -152,10 +152,10 @@ func GetProjects(ctx context.Context, tx *sql.Tx, filters ...ProjectFilter) ([]P
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/query.go
+++ b/lxd/db/cluster/query.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -38,7 +39,7 @@ func selectUnclusteredNodesCount(tx *sql.Tx) (int, error) {
 
 // Return a slice of binary integer tuples. Each tuple contains the schema
 // version and number of api extensions of a node in the cluster.
-func selectNodesVersions(tx *sql.Tx) ([][2]int, error) {
+func selectNodesVersions(ctx context.Context, tx *sql.Tx) ([][2]int, error) {
 	versions := [][2]int{}
 	stmt, err := tx.Prepare("SELECT schema, api_extensions FROM nodes WHERE state=0")
 	if err != nil {
@@ -49,7 +50,7 @@ func selectNodesVersions(tx *sql.Tx) ([][2]int, error) {
 		}
 	}
 	defer func() { _ = stmt.Close() }()
-	err = query.SelectObjects(stmt, func(scan func(dest ...any) error) error {
+	err = query.SelectObjects(ctx, stmt, func(scan func(dest ...any) error) error {
 		version := [2]int{}
 		err := scan(&version[0], &version[1])
 		if err != nil {

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -187,10 +187,10 @@ func GetInstanceSnapshots(ctx context.Context, tx *sql.Tx, filters ...InstanceSn
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -106,7 +106,7 @@ var updates = map[int]schema.Update{
 }
 
 // updateFromV65 fixes typo in cephobject.radosgw.endpoint* settings.
-func updateFromV65(tx *sql.Tx) error {
+func updateFromV65(ctx context.Context, tx *sql.Tx) error {
 	q := `
 	UPDATE storage_pools_config
 	SET key = REPLACE(key, "cephobject.radosgsw.endpoint", "cephobject.radosgw.endpoint")
@@ -121,7 +121,7 @@ func updateFromV65(tx *sql.Tx) error {
 }
 
 // updatefromV64 updates nodes_cluster_groups to include an ID field so that it works well with lxd-generate.
-func updateFromV64(tx *sql.Tx) error {
+func updateFromV64(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "nodes_cluster_groups_new" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -148,7 +148,7 @@ ALTER TABLE nodes_cluster_groups_new RENAME TO nodes_cluster_groups;
 
 // updateFromV63 creates the storage buckets tables and adds features.storage.buckets=true to all projects that
 // have features.storage.volumes=true.
-func updateFromV63(tx *sql.Tx) error {
+func updateFromV63(ctx context.Context, tx *sql.Tx) error {
 	// Find all projects that have features.storage.volumes=true and add features.storage.buckets=true.
 	rows, err := tx.Query(`SELECT project_id FROM projects_config WHERE key = "features.storage.volumes" AND value = "true"`)
 	if err != nil {
@@ -228,7 +228,7 @@ CREATE TABLE "storage_buckets_keys" (
 // updateFromV62 adds unique index to storage_volumes that prevents duplicate volumes when using remote storage
 // pool where the node_id column is NULL.
 // Also ensures that the default project has features.networks set to true.
-func updateFromV62(tx *sql.Tx) error {
+func updateFromV62(ctx context.Context, tx *sql.Tx) error {
 	// Find the default project ID, and what it has features.networks config key set to (if at all).
 	rows := tx.QueryRow(`
 		SELECT
@@ -269,7 +269,7 @@ func updateFromV62(tx *sql.Tx) error {
 }
 
 // updateFromV61 converts config value fields to NOT NULL and config key fields to TEXT (from VARCHAR).
-func updateFromV61(tx *sql.Tx) error {
+func updateFromV61(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "instances_config_new" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -473,7 +473,7 @@ ALTER TABLE "storage_volumes_snapshots_config_new" RENAME TO "storage_volumes_sn
 }
 
 // updateFromV60 creates the networks_load_balancers and networks_load_balancers_config tables.
-func updateFromV60(tx *sql.Tx) error {
+func updateFromV60(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_load_balancers" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -504,7 +504,7 @@ CREATE TABLE "networks_load_balancers_config" (
 	return nil
 }
 
-func updateFromV59(tx *sql.Tx) error {
+func updateFromV59(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE networks_zones_records (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -532,7 +532,7 @@ CREATE TABLE networks_zones_records_config (
 	return nil
 }
 
-func updateFromV58(tx *sql.Tx) error {
+func updateFromV58(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (
     SELECT max(
@@ -545,7 +545,7 @@ WHERE name='storage_volumes';
 	return err
 }
 
-func updateFromV57(tx *sql.Tx) error {
+func updateFromV57(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (
     SELECT coalesce(max(max(coalesce(storage_volumes.id, 0)), max(coalesce(storage_volumes_snapshots.id, 0))), 0)
@@ -556,7 +556,7 @@ WHERE name='storage_volumes';
 	return err
 }
 
-func updateFromV56(tx *sql.Tx) error {
+func updateFromV56(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 UPDATE sqlite_sequence SET seq = (
     SELECT max(max(coalesce(storage_volumes.id, 0)), max(coalesce(storage_volumes_snapshots.id, 0)))
@@ -567,7 +567,7 @@ WHERE name='storage_volumes';
 	return err
 }
 
-func updateFromV55(tx *sql.Tx) error {
+func updateFromV55(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW storage_volumes_all;
 
@@ -1375,7 +1375,7 @@ CREATE VIEW storage_volumes_all (
 	return nil
 }
 
-func updateFromV54(tx *sql.Tx) error {
+func updateFromV54(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW certificates_projects_ref;
 DROP VIEW instances_config_ref;
@@ -1397,7 +1397,7 @@ DROP VIEW projects_used_by_ref;
 }
 
 // updateFromV53 creates the cluster_groups and nodes_cluster_groups tables.
-func updateFromV53(tx *sql.Tx) error {
+func updateFromV53(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "cluster_groups" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1426,7 +1426,7 @@ INSERT INTO nodes_cluster_groups (node_id, group_id) SELECT id, 1 FROM nodes;
 }
 
 // updateFromV52 creates the networks_zones and networks_zones_config tables.
-func updateFromV52(tx *sql.Tx) error {
+func updateFromV52(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_zones" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1454,7 +1454,7 @@ CREATE TABLE "networks_zones_config" (
 }
 
 // updateFromV51 creates the networks_peers and networks_peers_config tables.
-func updateFromV51(tx *sql.Tx) error {
+func updateFromV51(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_peers" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1487,7 +1487,7 @@ CREATE TABLE "networks_peers_config" (
 }
 
 // updateFromV50 creates the nodes_config table.
-func updateFromV50(tx *sql.Tx) error {
+func updateFromV50(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "nodes_config" (
 id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1507,7 +1507,7 @@ UNIQUE (node_id, key)
 }
 
 // updateFromV49 creates the networks_forwards and networks_forwards_config tables.
-func updateFromV49(tx *sql.Tx) error {
+func updateFromV49(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE "networks_forwards" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1538,7 +1538,7 @@ CREATE TABLE "networks_forwards_config" (
 }
 
 // updateFromV48 renames the "pending" column to "state" in the "nodes" table.
-func updateFromV48(tx *sql.Tx) error {
+func updateFromV48(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 ALTER TABLE nodes
 RENAME COLUMN pending TO state;
@@ -1551,7 +1551,7 @@ RENAME COLUMN pending TO state;
 }
 
 // updateFromV47 adds warnings.
-func updateFromV47(tx *sql.Tx) error {
+func updateFromV47(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE warnings (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1582,7 +1582,7 @@ CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_i
 }
 
 // updateFromV46 adds support for restricting certificates to projects.
-func updateFromV46(tx *sql.Tx) error {
+func updateFromV46(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 ALTER TABLE certificates ADD COLUMN restricted INTEGER NOT NULL DEFAULT 0;
 CREATE TABLE certificates_projects (
@@ -1606,7 +1606,7 @@ CREATE VIEW certificates_projects_ref (fingerprint, value) AS
 }
 
 // updateFromV45 updates projects_used_by_ref to include ceph volumes.
-func updateFromV45(tx *sql.Tx) error {
+func updateFromV45(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW projects_used_by_ref;
 CREATE VIEW projects_used_by_ref (name,
@@ -1659,7 +1659,7 @@ CREATE VIEW projects_used_by_ref (name,
 
 // updateFromV44 adds networks_acls table, and adds a foreign key relationship between networks and projects.
 // API extension: network_acl.
-func updateFromV44(tx *sql.Tx) error {
+func updateFromV44(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 DROP VIEW projects_used_by_ref;
 
@@ -1777,7 +1777,7 @@ CREATE VIEW projects_used_by_ref (name,
 }
 
 // updateFromV43 adds a unique index to the storage_pools_config and networks_config tables.
-func updateFromV43(tx *sql.Tx) error {
+func updateFromV43(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`CREATE UNIQUE INDEX storage_pools_unique_storage_pool_id_node_id_key ON storage_pools_config (storage_pool_id, IFNULL(node_id, -1), key);
 		CREATE UNIQUE INDEX networks_unique_network_id_node_id_key ON networks_config (network_id, IFNULL(node_id, -1), key);
 	`)
@@ -1790,7 +1790,7 @@ func updateFromV43(tx *sql.Tx) error {
 
 // updateFromV42 removes any duplicated storage pool config rows that have the same value.
 // This can occur when multiple create requests have been issued when setting up a clustered storage pool.
-func updateFromV42(tx *sql.Tx) error {
+func updateFromV42(ctx context.Context, tx *sql.Tx) error {
 	// Find all duplicated config rows and return comma delimited list of affected row IDs for each dupe set.
 	stmt := `SELECT storage_pool_id, IFNULL(node_id, -1), key, value, COUNT(*) AS rowCount, GROUP_CONCAT(id, ",") AS dupeRowIDs
 			FROM storage_pools_config
@@ -1856,7 +1856,7 @@ func updateFromV42(tx *sql.Tx) error {
 
 // updateFromV41 removes any duplicated network config rows that have the same value.
 // This can occur when multiple create requests have been issued when setting up a clustered network.
-func updateFromV41(tx *sql.Tx) error {
+func updateFromV41(ctx context.Context, tx *sql.Tx) error {
 	// Find all duplicated config rows and return comma delimited list of affected row IDs for each dupe set.
 	stmt := `SELECT network_id, IFNULL(node_id, -1), key, value, COUNT(*) AS rowCount, GROUP_CONCAT(id, ",") AS dupeRowIDs
 			FROM networks_config
@@ -1921,7 +1921,7 @@ func updateFromV41(tx *sql.Tx) error {
 }
 
 // Add state column to storage_pools_nodes tables. Set existing row's state to 1 ("created").
-func updateFromV40(tx *sql.Tx) error {
+func updateFromV40(ctx context.Context, tx *sql.Tx) error {
 	stmt := `
 		ALTER TABLE storage_pools_nodes ADD COLUMN state INTEGER NOT NULL DEFAULT 0;
 		UPDATE storage_pools_nodes SET state = 1;
@@ -1931,7 +1931,7 @@ func updateFromV40(tx *sql.Tx) error {
 }
 
 // Add state column to networks_nodes tables. Set existing row's state to 1 ("created").
-func updateFromV39(tx *sql.Tx) error {
+func updateFromV39(ctx context.Context, tx *sql.Tx) error {
 	stmt := `
 		ALTER TABLE networks_nodes ADD COLUMN state INTEGER NOT NULL DEFAULT 0;
 		UPDATE networks_nodes SET state = 1;
@@ -1941,7 +1941,7 @@ func updateFromV39(tx *sql.Tx) error {
 }
 
 // Add storage_volumes_backups table.
-func updateFromV38(tx *sql.Tx) error {
+func updateFromV38(ctx context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE storage_volumes_backups (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -1964,7 +1964,7 @@ CREATE TABLE storage_volumes_backups (
 }
 
 // Attempt to add missing project features.networks feature to default project.
-func updateFromV37(tx *sql.Tx) error {
+func updateFromV37(ctx context.Context, tx *sql.Tx) error {
 	ids, err := query.SelectIntegers(tx, `SELECT id FROM projects WHERE name = "default" LIMIT 1`)
 	if err != nil {
 		return err
@@ -1978,7 +1978,7 @@ func updateFromV37(tx *sql.Tx) error {
 }
 
 // Add networks to projects references.
-func updateFromV36(tx *sql.Tx) error {
+func updateFromV36(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW projects_used_by_ref;
 CREATE VIEW projects_used_by_ref (name,
@@ -2017,7 +2017,7 @@ CREATE VIEW projects_used_by_ref (name,
 
 // This fixes node IDs of storage volumes on non-remote pools which were
 // wrongly set to NULL.
-func updateFromV35(tx *sql.Tx) error {
+func updateFromV35(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 WITH storage_volumes_tmp (id, node_id)
 AS (
@@ -2045,7 +2045,7 @@ WHERE id IN (SELECT id FROM storage_volumes_tmp) AND node_id IS NULL
 // Remove multiple entries of the same volume when using remote storage.
 // Also, allow node ID to be null for the instances and storage_volumes tables, and set it to null
 // for instances and storage volumes using remote storage.
-func updateFromV34(tx *sql.Tx) error {
+func updateFromV34(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 SELECT storage_volumes.id, storage_volumes.name
 FROM storage_volumes
@@ -2073,7 +2073,7 @@ ORDER BY storage_volumes.name
 	}
 
 	volumes := make([]volume, 0, count)
-	err = query.Scan(tx, stmts, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, stmts, func(scan func(dest ...any) error) error {
 		vol := volume{}
 		err := scan(&vol.ID, &vol.Name)
 		if err != nil {
@@ -2132,7 +2132,7 @@ CREATE TABLE storage_volumes_new (
 SELECT id, name, storage_pool_id, node_id, type, coalesce(description, ''), project_id, content_type
 FROM storage_volumes`
 
-	err = query.Scan(tx, sqlStr, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sqlStr, func(scan func(dest ...any) error) error {
 		vol := volume{}
 		err := scan(&vol.ID, &vol.Name, &vol.StoragePoolID, &vol.NodeID, &vol.Type, &vol.Description, &vol.ProjectID, &vol.ContentType)
 		if err != nil {
@@ -2173,7 +2173,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
 
 	storageVolumeConfigs := make([]volumeConfig, 0, count)
 	sqlStr = `SELECT * FROM storage_volumes_config;`
-	err = query.Scan(tx, sqlStr, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sqlStr, func(scan func(dest ...any) error) error {
 		config := volumeConfig{}
 		err := scan(&config.ID, &config.StorageVolumeID, &config.Key, &config.Value)
 		if err != nil {
@@ -2204,7 +2204,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
 
 	sqlStr = `SELECT * FROM storage_volumes_snapshots;`
 	storageVolumeSnapshots := make([]volumeSnapshot, 0, count)
-	err = query.Scan(tx, sqlStr, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sqlStr, func(scan func(dest ...any) error) error {
 		vol := volumeSnapshot{}
 		err := scan(&vol.ID, &vol.StorageVolumeID, &vol.Name, &vol.Description, &vol.ExpiryDate)
 		if err != nil {
@@ -2235,7 +2235,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
 	storageVolumeSnapshotConfigs := make([]volumeSnapshotConfig, 0, count)
 
 	sqlStr = `SELECT * FROM storage_volumes_snapshots_config;`
-	err = query.Scan(tx, sqlStr, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sqlStr, func(scan func(dest ...any) error) error {
 		config := volumeSnapshotConfig{}
 		err := scan(&config.ID, &config.StorageVolumeSnapshotID, &config.Key, &config.Value)
 		if err != nil {
@@ -2334,7 +2334,7 @@ CREATE TRIGGER storage_volumes_check_id
 // and set existing networks to project_id 1.
 // This is made a lot more complex because it requires re-creating the referenced tables as there is no way to
 // disable foreign keys temporarily within a transaction.
-func updateFromV33(tx *sql.Tx) error {
+func updateFromV33(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec(`
 CREATE TABLE networks_new (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -2391,7 +2391,7 @@ ALTER TABLE networks_config_new RENAME TO networks_config;
 }
 
 // Add type field to networks.
-func updateFromV32(tx *sql.Tx) error {
+func updateFromV32(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE networks ADD COLUMN type INTEGER NOT NULL DEFAULT 0;")
 	if err != nil {
 		return fmt.Errorf("Failed to add type column to networks table: %w", err)
@@ -2401,7 +2401,7 @@ func updateFromV32(tx *sql.Tx) error {
 }
 
 // Add failure_domain column to nodes table.
-func updateFromV31(tx *sql.Tx) error {
+func updateFromV31(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE nodes_failure_domains (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -2420,7 +2420,7 @@ ALTER TABLE nodes
 }
 
 // Add content type field to storage volumes.
-func updateFromV30(tx *sql.Tx) error {
+func updateFromV30(ctx context.Context, tx *sql.Tx) error {
 	stmts := `ALTER TABLE storage_volumes ADD COLUMN content_type INTEGER NOT NULL DEFAULT 0;
 UPDATE storage_volumes SET content_type = 1 WHERE type = 3;
 UPDATE storage_volumes SET content_type = 1 WHERE storage_volumes.id IN (
@@ -2468,7 +2468,7 @@ CREATE VIEW storage_volumes_all (
 }
 
 // Add storage volumes to projects references and fix images.
-func updateFromV29(tx *sql.Tx) error {
+func updateFromV29(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW projects_used_by_ref;
 CREATE VIEW projects_used_by_ref (name,
@@ -2501,20 +2501,20 @@ CREATE VIEW projects_used_by_ref (name,
 }
 
 // Attempt to add missing project feature.
-func updateFromV28(tx *sql.Tx) error {
+func updateFromV28(ctx context.Context, tx *sql.Tx) error {
 	_, _ = tx.Exec("INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.storage.volumes', 'true');")
 	return nil
 }
 
 // Add expiry date to storage volume snapshots.
-func updateFromV27(tx *sql.Tx) error {
+func updateFromV27(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE storage_volumes_snapshots ADD COLUMN expiry_date DATETIME;")
 	return err
 }
 
 // Bump the sqlite_sequence value for storage volumes, to avoid unique
 // constraint violations when inserting new snapshots.
-func updateFromV26(tx *sql.Tx) error {
+func updateFromV26(ctx context.Context, tx *sql.Tx) error {
 	ids, err := query.SelectIntegers(tx, "SELECT coalesce(max(id), 0) FROM storage_volumes_all")
 	if err != nil {
 		return err
@@ -2525,7 +2525,7 @@ func updateFromV26(tx *sql.Tx) error {
 }
 
 // Create new storage snapshot tables and migrate data to them.
-func updateFromV25(tx *sql.Tx) error {
+func updateFromV25(ctx context.Context, tx *sql.Tx) error {
 	// Get the total number of snapshot rows in the storage_volumes table.
 	count, err := query.Count(tx, "storage_volumes", "snapshot=1")
 	if err != nil {
@@ -2554,7 +2554,7 @@ SELECT id, name, storage_pool_id, node_id, type, coalesce(description, ''), proj
 
 	// Fetch all snapshot rows in the storage_volumes table.
 	snapshots := make([]snapshot, 0, count)
-	err = query.Scan(tx, sql, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sql, func(scan func(dest ...any) error) error {
 		s := snapshot{}
 		err := scan(&s.ID, &s.Name, &s.StoragePoolID, &s.NodeID, &s.Type, &s.Description, &s.ProjectID)
 		if err != nil {
@@ -2714,7 +2714,7 @@ INSERT INTO storage_volumes_snapshots_config(storage_volume_snapshot_id, key, va
 }
 
 // The ceph.user.name config key is required for Ceph to function.
-func updateFromV24(tx *sql.Tx) error {
+func updateFromV24(ctx context.Context, tx *sql.Tx) error {
 	// Fetch the IDs of all existing Ceph pools.
 	poolIDs, err := query.SelectIntegers(tx, `SELECT id FROM storage_pools WHERE driver='ceph'`)
 	if err != nil {
@@ -2745,7 +2745,7 @@ func updateFromV24(tx *sql.Tx) error {
 }
 
 // The lvm.vg_name config key is required for LVM to function.
-func updateFromV23(tx *sql.Tx) error {
+func updateFromV23(ctx context.Context, tx *sql.Tx) error {
 	// Fetch the IDs of all existing nodes.
 	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")
 	if err != nil {
@@ -2787,7 +2787,7 @@ SELECT ?, ?, 'lvm.vg_name', name FROM storage_pools WHERE id=?
 }
 
 // The zfs.pool_name config key is required for ZFS to function.
-func updateFromV22(tx *sql.Tx) error {
+func updateFromV22(ctx context.Context, tx *sql.Tx) error {
 	// Fetch the IDs of all existing nodes.
 	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")
 	if err != nil {
@@ -2829,7 +2829,7 @@ SELECT ?, ?, 'zfs.pool_name', name FROM storage_pools WHERE id=?
 }
 
 // Fix "images_profiles" table (missing UNIQUE).
-func updateFromV21(tx *sql.Tx) error {
+func updateFromV21(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 ALTER TABLE images_profiles RENAME TO old_images_profiles;
 CREATE TABLE images_profiles (
@@ -2847,7 +2847,7 @@ DROP TABLE old_images_profiles;
 }
 
 // Add "images_profiles" table.
-func updateFromV20(tx *sql.Tx) error {
+func updateFromV20(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE images_profiles (
 	image_id INTEGER NOT NULL,
@@ -2879,7 +2879,7 @@ INSERT INTO images_profiles (image_id, profile_id)
 }
 
 // Add a new "arch" column to the "nodes" table.
-func updateFromV19(tx *sql.Tx) error {
+func updateFromV19(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("PRAGMA ignore_check_constraints=on")
 	if err != nil {
 		return err
@@ -2910,7 +2910,7 @@ func updateFromV19(tx *sql.Tx) error {
 }
 
 // Rename 'containers' to 'instances' in *_used_by_ref views.
-func updateFromV18(tx *sql.Tx) error {
+func updateFromV18(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW profiles_used_by_ref;
 CREATE VIEW profiles_used_by_ref (project,
@@ -2952,7 +2952,7 @@ CREATE VIEW projects_used_by_ref (name,
 }
 
 // Add nodes_roles table.
-func updateFromV17(tx *sql.Tx) error {
+func updateFromV17(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE nodes_roles (
     node_id INTEGER NOT NULL,
@@ -2966,13 +2966,13 @@ CREATE TABLE nodes_roles (
 }
 
 // Add image type column.
-func updateFromV16(tx *sql.Tx) error {
+func updateFromV16(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE images ADD COLUMN type INTEGER NOT NULL DEFAULT 0;")
 	return err
 }
 
 // Create new snapshot tables and migrate data to them.
-func updateFromV15(tx *sql.Tx) error {
+func updateFromV15(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE instances_snapshots (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
@@ -3072,7 +3072,7 @@ CREATE VIEW instances_snapshots_devices_ref (
 
 	sql := `SELECT id, name, type, creation_date, stateful, coalesce(description, ''), expiry_date FROM instances`
 	instances := make([]instance, 0, count)
-	err = query.Scan(tx, sql, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sql, func(scan func(dest ...any) error) error {
 		inst := instance{}
 		err := scan(&inst.ID, &inst.Name, &inst.Type, &inst.CreationDate, &inst.Stateful, &inst.Description, &inst.ExpiryDate)
 		if err != nil {
@@ -3121,7 +3121,7 @@ SELECT instances_config.id, instance_id, key, value
   WHERE instances.type = 1
 `
 
-	err = query.Scan(tx, sql, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sql, func(scan func(dest ...any) error) error {
 		config := instanceConfig{}
 		err := scan(&config.ID, &config.InstanceID, &config.Key, &config.Value)
 		if err != nil {
@@ -3171,7 +3171,7 @@ SELECT instances_devices.id, instance_id, instances_devices.name, instances_devi
   WHERE instances.type = 1
 `
 
-	err = query.Scan(tx, sql, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sql, func(scan func(dest ...any) error) error {
 		d := device{}
 		err := scan(&d.ID, &d.InstanceID, &d.Name, &d.Type)
 		if err != nil {
@@ -3353,7 +3353,7 @@ SELECT instances_devices.id, instance_id, instances_devices.name, instances_devi
 }
 
 // Rename all containers* tables to instances*/.
-func updateFromV14(tx *sql.Tx) error {
+func updateFromV14(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 ALTER TABLE containers RENAME TO instances;
 ALTER TABLE containers_backups RENAME COLUMN container_id TO instance_id;
@@ -3450,12 +3450,12 @@ CREATE VIEW profiles_used_by_ref (project,
 	return err
 }
 
-func updateFromV13(tx *sql.Tx) error {
+func updateFromV13(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.Exec("ALTER TABLE containers ADD COLUMN expiry_date DATETIME;")
 	return err
 }
 
-func updateFromV12(tx *sql.Tx) error {
+func updateFromV12(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 DROP VIEW profiles_used_by_ref;
 CREATE VIEW profiles_used_by_ref (project,
@@ -3479,7 +3479,7 @@ CREATE VIEW profiles_used_by_ref (project,
 	return err
 }
 
-func updateFromV11(tx *sql.Tx) error {
+func updateFromV11(ctx context.Context, tx *sql.Tx) error {
 	// There was at least a case of dangling references to rows in the
 	// containers table that don't exist anymore. So sanitize them before
 	// we move forward. See #5176.
@@ -3527,7 +3527,7 @@ DELETE FROM storage_volumes_config WHERE storage_volume_id NOT IN (SELECT id FRO
 
 	// Use a large timeout since the update might take a while, due to the
 	// new indexes being created.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	stmts = `
@@ -3988,7 +3988,7 @@ CREATE VIEW profiles_used_by_ref (project, name, value) AS
 	return err
 }
 
-func updateFromV10(tx *sql.Tx) error {
+func updateFromV10(ctx context.Context, tx *sql.Tx) error {
 	stmt := `
 ALTER TABLE storage_volumes ADD COLUMN snapshot INTEGER NOT NULL DEFAULT 0;
 UPDATE storage_volumes SET snapshot = 0;
@@ -3998,7 +3998,7 @@ UPDATE storage_volumes SET snapshot = 0;
 }
 
 // Add a new 'type' column to the operations table.
-func updateFromV9(tx *sql.Tx) error {
+func updateFromV9(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 	ALTER TABLE operations ADD COLUMN type INTEGER NOT NULL DEFAULT 0;
 	UPDATE operations SET type = 0;
@@ -4009,13 +4009,13 @@ func updateFromV9(tx *sql.Tx) error {
 
 // The lvm.thinpool_name and lvm.vg_name config keys are node-specific and need
 // to be linked to nodes.
-func updateFromV8(tx *sql.Tx) error {
+func updateFromV8(ctx context.Context, tx *sql.Tx) error {
 	// Moved to patchLvmNodeSpecificConfigKeys, since there's no schema
 	// change. That makes it easier to backport.
 	return nil
 }
 
-func updateFromV7(tx *sql.Tx) error {
+func updateFromV7(ctx context.Context, tx *sql.Tx) error {
 	stmts := `
 CREATE TABLE containers_backups (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4035,7 +4035,7 @@ CREATE TABLE containers_backups (
 
 // The zfs.pool_name config key is node-specific, and needs to be linked to
 // nodes.
-func updateFromV6(tx *sql.Tx) error {
+func updateFromV6(ctx context.Context, tx *sql.Tx) error {
 	// Fetch the IDs of all existing nodes.
 	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")
 	if err != nil {
@@ -4088,7 +4088,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 
 // For ceph volumes, add node-specific rows for all existing nodes, since any
 // node is able to access those volumes.
-func updateFromV5(tx *sql.Tx) error {
+func updateFromV5(ctx context.Context, tx *sql.Tx) error {
 	// Fetch the IDs of all existing nodes.
 	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")
 	if err != nil {
@@ -4129,7 +4129,7 @@ FROM storage_volumes
     WHERE storage_pools.driver='ceph'
 `
 
-	err = query.Scan(tx, sql, func(scan func(dest ...any) error) error {
+	err = query.Scan(ctx, tx, sql, func(scan func(dest ...any) error) error {
 		vol := volume{}
 		err := scan(&vol.ID, &vol.Name, &vol.StoragePoolID, &vol.NodeID, &vol.Type, &vol.Description)
 		if err != nil {
@@ -4199,13 +4199,13 @@ INSERT INTO storage_volumes_config(storage_volume_id, key, value) VALUES(?, ?, ?
 	return nil
 }
 
-func updateFromV4(tx *sql.Tx) error {
+func updateFromV4(ctx context.Context, tx *sql.Tx) error {
 	stmt := "UPDATE networks SET state = 1"
 	_, err := tx.Exec(stmt)
 	return err
 }
 
-func updateFromV3(tx *sql.Tx) error {
+func updateFromV3(ctx context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE storage_pools_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4222,7 +4222,7 @@ UPDATE storage_pools SET state = 1;
 	return err
 }
 
-func updateFromV2(tx *sql.Tx) error {
+func updateFromV2(ctx context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE operations (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4236,7 +4236,7 @@ CREATE TABLE operations (
 	return err
 }
 
-func updateFromV1(tx *sql.Tx) error {
+func updateFromV1(ctx context.Context, tx *sql.Tx) error {
 	stmt := `
 CREATE TABLE certificates (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -4443,7 +4443,7 @@ CREATE TABLE storage_volumes_config (
 	return err
 }
 
-func updateFromV0(tx *sql.Tx) error {
+func updateFromV0(ctx context.Context, tx *sql.Tx) error {
 	// v0..v1 the dawn of clustering
 	stmt := `
 CREATE TABLE nodes (

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -279,10 +279,10 @@ func GetWarnings(ctx context.Context, tx *sql.Tx, filters ...WarningFilter) ([]W
 
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(sqlStmt, dest, args...)
+		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(tx, queryStr, dest, args...)
+		err = query.Scan(ctx, tx, queryStr, dest, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -97,11 +97,11 @@ func (n *Node) Dir() string {
 // node-level database interactions invoked by the given function. If the
 // function returns no error, all database changes are committed to the
 // node-level database, otherwise they are rolled back.
-func (n *Node) Transaction(f func(*NodeTx) error) error {
+func (n *Node) Transaction(ctx context.Context, f func(context.Context, *NodeTx) error) error {
 	nodeTx := &NodeTx{}
-	return query.Transaction(context.TODO(), n.db, func(ctx context.Context, tx *sql.Tx) error {
+	return query.Transaction(ctx, n.db, func(ctx context.Context, tx *sql.Tx) error {
 		nodeTx.tx = tx
-		return f(nodeTx)
+		return f(ctx, nodeTx)
 	})
 }
 

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -245,7 +245,7 @@ func OpenCluster(closingCtx context.Context, name string, store driver.NodeStore
 
 	err = clusterDB.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		// Figure out the ID of this node.
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch nodes: %w", err)
 		}

--- a/lxd/db/entity.go
+++ b/lxd/db/entity.go
@@ -242,7 +242,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var nodeInfo NodeInfo
 
 		err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			nodeInfo, err = tx.GetNodeWithID(entityID)
+			nodeInfo, err = tx.GetNodeWithID(ctx, entityID)
 			if err != nil {
 				return err
 			}

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -311,20 +311,20 @@ func (m *Method) getMany(buf *file.Buffer) error {
 	if mapping.Type == EntityTable {
 		buf.L("// Select.")
 		buf.L("if sqlStmt != nil {")
-		buf.L("err = query.SelectObjects(sqlStmt, dest, args...)")
+		buf.L("err = query.SelectObjects(ctx, sqlStmt, dest, args...)")
 		buf.L("} else {")
 		buf.L("queryStr := strings.Join(queryParts[:], \"ORDER BY\")")
-		buf.L("err = query.Scan(tx, queryStr, dest, args...)")
+		buf.L("err = query.Scan(ctx, tx, queryStr, dest, args...)")
 		buf.L("}")
 		buf.N()
 		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	} else if mapping.Type == ReferenceTable || mapping.Type == MapTable {
 		buf.L("// Select.")
-		buf.L("err = query.Scan(tx, queryStr, dest, args...)")
+		buf.L("err = query.Scan(ctx, tx, queryStr, dest, args...)")
 		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%%s_%s\" table: %%w", parent, err)`, entityTable(m.entity, m.config["table"])))
 	} else {
 		buf.L("// Select.")
-		buf.L("err = query.SelectObjects(sqlStmt, dest, args...)")
+		buf.L("err = query.SelectObjects(ctx, sqlStmt, dest, args...)")
 		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	}
 

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -119,7 +119,7 @@ func TestImportPreClusteringData(t *testing.T) {
 			Type: &volumeType,
 		}}
 
-		dbVolumes, err = tx.GetStoragePoolVolumes(id, true, filters...)
+		dbVolumes, err = tx.GetStoragePoolVolumes(context.Background(), id, true, filters...)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage volumes: %w", err)
 		}

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -24,7 +24,7 @@ func (c *Cluster) GetNetworkACLs(project string) ([]string, error) {
 	var aclNames []string
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var aclName string
 
 			err := scan(&aclName)
@@ -54,7 +54,7 @@ func (c *Cluster) GetNetworkACLIDsByNames(project string) (map[string]int64, err
 	acls := make(map[string]int64)
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var aclID int64
 			var aclName string
 
@@ -100,7 +100,7 @@ func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.Ne
 			return err
 		}
 
-		err = networkACLConfig(tx, id, &acl)
+		err = networkACLConfig(ctx, tx, id, &acl)
 		if err != nil {
 			return fmt.Errorf("Failed loading config: %w", err)
 		}
@@ -156,7 +156,7 @@ func (c *Cluster) GetNetworkACLNameAndProjectWithID(networkACLID int) (string, s
 }
 
 // networkACLConfig populates the config map of the Network ACL with the given ID.
-func networkACLConfig(tx *ClusterTx, id int64, acl *api.NetworkACL) error {
+func networkACLConfig(ctx context.Context, tx *ClusterTx, id int64, acl *api.NetworkACL) error {
 	q := `
 		SELECT key, value
 		FROM networks_acls_config
@@ -164,7 +164,7 @@ func networkACLConfig(tx *ClusterTx, id int64, acl *api.NetworkACL) error {
 	`
 
 	acl.Config = make(map[string]string)
-	return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+	return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)

--- a/lxd/db/network_peers.go
+++ b/lxd/db/network_peers.go
@@ -192,7 +192,7 @@ func (c *Cluster) GetNetworkPeer(networkID int64, peerName string) (int64, *api.
 			return err
 		}
 
-		err = networkPeerConfig(tx, peerID, &peer)
+		err = networkPeerConfig(ctx, tx, peerID, &peer)
 		if err != nil {
 			return err
 		}
@@ -239,7 +239,7 @@ func networkPeerPopulatePeerInfo(peer *api.NetworkPeer, targetPeerNetworkProject
 }
 
 // networkPeerConfig populates the config map of the Network Peer with the given ID.
-func networkPeerConfig(tx *ClusterTx, peerID int64, peer *api.NetworkPeer) error {
+func networkPeerConfig(ctx context.Context, tx *ClusterTx, peerID int64, peer *api.NetworkPeer) error {
 	q := `
 	SELECT
 		key,
@@ -249,7 +249,7 @@ func networkPeerConfig(tx *ClusterTx, peerID int64, peer *api.NetworkPeer) error
 	`
 
 	peer.Config = make(map[string]string)
-	return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+	return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)
@@ -300,7 +300,7 @@ func (c *Cluster) GetNetworkPeers(networkID int64) (map[int64]*api.NetworkPeer, 
 	peers := make(map[int64]*api.NetworkPeer)
 
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err = query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		err = query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var peerID int64 = int64(-1)
 			var peer api.NetworkPeer
 			var targetPeerNetworkName string
@@ -323,7 +323,7 @@ func (c *Cluster) GetNetworkPeers(networkID int64) (map[int64]*api.NetworkPeer, 
 
 		// Populate config.
 		for peerID := range peers {
-			err = networkPeerConfig(tx, peerID, peers[peerID])
+			err = networkPeerConfig(ctx, tx, peerID, peers[peerID])
 			if err != nil {
 				return err
 			}
@@ -351,7 +351,7 @@ func (c *Cluster) GetNetworkPeerNames(networkID int64) (map[int64]string, error)
 	peers := make(map[int64]string)
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var peerID int64 = int64(-1)
 			var peerName string
 
@@ -462,7 +462,7 @@ func (c *Cluster) GetNetworkPeersTargetNetworkIDs(projectName string, networkTyp
 	`
 
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var peerName string
 			var networkName string
 			var targetNetworkID int64 = int64(-1)

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -24,7 +24,7 @@ func (c *Cluster) GetNetworkZones(project string) ([]string, error) {
 	var zoneNames []string
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var zoneName string
 
 			err := scan(&zoneName)
@@ -54,7 +54,7 @@ func (c *Cluster) GetNetworkZoneKeys() (map[string]string, error) {
 
 	secrets := map[string]string{}
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var name string
 			var peer string
 			var secret string
@@ -97,7 +97,7 @@ func (c *Cluster) GetNetworksForZone(projectName string, zoneName string) ([]str
 	var networkNames []string
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var networkName string
 
 			err := scan(&networkName)
@@ -140,7 +140,7 @@ func (c *Cluster) GetNetworkZone(name string) (int64, string, *api.NetworkZone, 
 			return err
 		}
 
-		err = networkZoneConfig(tx, id, &zone)
+		err = networkZoneConfig(ctx, tx, id, &zone)
 		if err != nil {
 			return fmt.Errorf("Failed loading config: %w", err)
 		}
@@ -179,7 +179,7 @@ func (c *Cluster) GetNetworkZoneByProject(projectName string, name string) (int6
 			return err
 		}
 
-		err = networkZoneConfig(tx, id, &zone)
+		err = networkZoneConfig(ctx, tx, id, &zone)
 		if err != nil {
 			return fmt.Errorf("Failed loading config: %w", err)
 		}
@@ -198,7 +198,7 @@ func (c *Cluster) GetNetworkZoneByProject(projectName string, name string) (int6
 }
 
 // networkZoneConfig populates the config map of the Network zone with the given ID.
-func networkZoneConfig(tx *ClusterTx, id int64, zone *api.NetworkZone) error {
+func networkZoneConfig(ctx context.Context, tx *ClusterTx, id int64, zone *api.NetworkZone) error {
 	q := `
 		SELECT key, value
 		FROM networks_zones_config
@@ -206,7 +206,7 @@ func networkZoneConfig(tx *ClusterTx, id int64, zone *api.NetworkZone) error {
 	`
 
 	zone.Config = make(map[string]string)
-	return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+	return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)
@@ -325,7 +325,7 @@ func (c *Cluster) GetNetworkZoneRecordNames(zone int64) ([]string, error) {
 
 	var recordNames []string
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var recordName string
 
 			err := scan(&recordName)
@@ -367,7 +367,7 @@ func (c *Cluster) GetNetworkZoneRecord(zone int64, name string) (int64, *api.Net
 			return err
 		}
 
-		err = networkZoneRecordConfig(tx, id, &record)
+		err = networkZoneRecordConfig(ctx, tx, id, &record)
 		if err != nil {
 			return fmt.Errorf("Failed loading config: %w", err)
 		}
@@ -392,7 +392,7 @@ func (c *Cluster) GetNetworkZoneRecord(zone int64, name string) (int64, *api.Net
 }
 
 // networkZoneRecordConfig populates the config map of the network zone record with the given ID.
-func networkZoneRecordConfig(tx *ClusterTx, id int64, record *api.NetworkZoneRecord) error {
+func networkZoneRecordConfig(ctx context.Context, tx *ClusterTx, id int64, record *api.NetworkZoneRecord) error {
 	q := `
 		SELECT key, value
 		FROM networks_zones_records_config
@@ -400,7 +400,7 @@ func networkZoneRecordConfig(tx *ClusterTx, id int64, record *api.NetworkZoneRec
 	`
 
 	record.Config = make(map[string]string)
-	return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+	return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -49,7 +49,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 	require.NoError(t, err)
 
 	config := map[string]string{"bridge.external_interfaces": "foo"}
-	err = tx.CreatePendingNetwork("buzz", project.Default, "network1", db.NetworkTypeBridge, config)
+	err = tx.CreatePendingNetwork(context.Background(), "buzz", project.Default, "network1", db.NetworkTypeBridge, config)
 	require.NoError(t, err)
 
 	networkID, err := tx.GetNetworkID(project.Default, "network1")
@@ -57,19 +57,19 @@ func TestCreatePendingNetwork(t *testing.T) {
 	assert.True(t, networkID > 0)
 
 	config = map[string]string{"bridge.external_interfaces": "bar"}
-	err = tx.CreatePendingNetwork("rusp", project.Default, "network1", db.NetworkTypeBridge, config)
+	err = tx.CreatePendingNetwork(context.Background(), "rusp", project.Default, "network1", db.NetworkTypeBridge, config)
 	require.NoError(t, err)
 
 	// The initial node (whose name is 'none' by default) is missing.
-	_, err = tx.NetworkNodeConfigs(networkID)
+	_, err = tx.NetworkNodeConfigs(context.Background(), networkID)
 	require.EqualError(t, err, "Network not defined on nodes: none")
 
 	config = map[string]string{"bridge.external_interfaces": "egg"}
-	err = tx.CreatePendingNetwork("none", project.Default, "network1", db.NetworkTypeBridge, config)
+	err = tx.CreatePendingNetwork(context.Background(), "none", project.Default, "network1", db.NetworkTypeBridge, config)
 	require.NoError(t, err)
 
 	// Now the storage is defined on all nodes.
-	configs, err := tx.NetworkNodeConfigs(networkID)
+	configs, err := tx.NetworkNodeConfigs(context.Background(), networkID)
 	require.NoError(t, err)
 	assert.Len(t, configs, 3)
 	assert.Equal(t, map[string]string{"bridge.external_interfaces": "foo"}, configs["buzz"])
@@ -86,10 +86,10 @@ func TestNetworksCreatePending_AlreadyDefined(t *testing.T) {
 	_, err := tx.CreateNode("buzz", "1.2.3.4:666")
 	require.NoError(t, err)
 
-	err = tx.CreatePendingNetwork("buzz", project.Default, "network1", db.NetworkTypeBridge, map[string]string{})
+	err = tx.CreatePendingNetwork(context.Background(), "buzz", project.Default, "network1", db.NetworkTypeBridge, map[string]string{})
 	require.NoError(t, err)
 
-	err = tx.CreatePendingNetwork("buzz", project.Default, "network1", db.NetworkTypeBridge, map[string]string{})
+	err = tx.CreatePendingNetwork(context.Background(), "buzz", project.Default, "network1", db.NetworkTypeBridge, map[string]string{})
 	require.Equal(t, db.ErrAlreadyDefined, err)
 }
 
@@ -98,6 +98,6 @@ func TestNetworksCreatePending_NonExistingNode(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	err := tx.CreatePendingNetwork("buzz", project.Default, "network1", db.NetworkTypeBridge, map[string]string{})
+	err := tx.CreatePendingNetwork(context.Background(), "buzz", project.Default, "network1", db.NetworkTypeBridge, map[string]string{})
 	require.True(t, response.IsNotFoundError(err))
 }

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -122,7 +122,7 @@ func (n NodeInfo) ToAPI(cluster *Cluster, node *Node, leader string) (*api.Clust
 
 	// From local database.
 	var raftNode *RaftNode
-	err = node.Transaction(func(tx *NodeTx) error {
+	err = node.Transaction(context.TODO(), func(ctx context.Context, tx *NodeTx) error {
 		nodes, err := tx.GetRaftNodes()
 		if err != nil {
 			return fmt.Errorf("Load offline threshold config: %w", err)

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -123,7 +123,7 @@ func (n NodeInfo) ToAPI(cluster *Cluster, node *Node, leader string) (*api.Clust
 	// From local database.
 	var raftNode *RaftNode
 	err = node.Transaction(context.TODO(), func(ctx context.Context, tx *NodeTx) error {
-		nodes, err := tx.GetRaftNodes()
+		nodes, err := tx.GetRaftNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Load offline threshold config: %w", err)
 		}

--- a/lxd/db/node/open.go
+++ b/lxd/db/node/open.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
@@ -30,7 +31,7 @@ func EnsureSchema(db *sql.DB, dir string) (int, error) {
 
 	schema := Schema()
 	schema.File(filepath.Join(dir, "patch.local.sql")) // Optional custom queries
-	schema.Hook(func(version int, tx *sql.Tx) error {
+	schema.Hook(func(ctx context.Context, version int, tx *sql.Tx) error {
 		if !backupDone {
 			logger.Infof("Updating the LXD database schema. Backup made as \"local.db.bak\"")
 			path := filepath.Join(dir, "local.db")

--- a/lxd/db/query/objects.go
+++ b/lxd/db/query/objects.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -8,8 +9,8 @@ import (
 
 // SelectObjects executes a statement which must yield rows with a specific
 // columns schema. It invokes the given Dest hook for each yielded row.
-func SelectObjects(stmt *sql.Stmt, rowFunc Dest, args ...any) error {
-	rows, err := stmt.Query(args...)
+func SelectObjects(ctx context.Context, stmt *sql.Stmt, rowFunc Dest, args ...any) error {
+	rows, err := stmt.QueryContext(ctx, args...)
 	if err != nil {
 		return err
 	}
@@ -28,8 +29,8 @@ func SelectObjects(stmt *sql.Stmt, rowFunc Dest, args ...any) error {
 
 // Scan runs a query with inArgs and provides the rowFunc with the scan function for each row.
 // It handles closing the rows and errors from the result set.
-func Scan(tx *sql.Tx, sql string, rowFunc Dest, inArgs ...any) error {
-	rows, err := tx.Query(sql, inArgs...)
+func Scan(ctx context.Context, tx *sql.Tx, sql string, rowFunc Dest, inArgs ...any) error {
+	rows, err := tx.QueryContext(ctx, sql, inArgs...)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/query/objects_test.go
+++ b/lxd/db/query/objects_test.go
@@ -1,6 +1,7 @@
 package query_test
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestSelectObjects_Error(t *testing.T) {
 			stmt, err := tx.Prepare(c.query)
 			require.NoError(t, err)
 
-			err = query.SelectObjects(stmt, c.dest)
+			err = query.SelectObjects(context.TODO(), stmt, c.dest)
 			assert.EqualError(t, err, c.error)
 		})
 	}
@@ -60,7 +61,7 @@ func TestSelectObjects(t *testing.T) {
 	stmt, err := tx.Prepare("SELECT id, name FROM test WHERE name=?")
 	require.NoError(t, err)
 
-	err = query.SelectObjects(stmt, dest, "bar")
+	err = query.SelectObjects(context.TODO(), stmt, dest, "bar")
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, object.ID)
@@ -119,7 +120,7 @@ func TestUpsertObject_Insert(t *testing.T) {
 	}
 
 	sql := "SELECT id, name FROM test WHERE name=?"
-	err = query.Scan(tx, sql, dest, "egg")
+	err = query.Scan(context.TODO(), tx, sql, dest, "egg")
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, object.ID)
@@ -151,7 +152,7 @@ func TestUpsertObject_Update(t *testing.T) {
 	sql := "SELECT id, name FROM test WHERE name=?"
 	require.NoError(t, err)
 
-	err = query.Scan(tx, sql, dest, "egg")
+	err = query.Scan(context.TODO(), tx, sql, dest, "egg")
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, object.ID)

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -34,11 +35,11 @@ const (
 // GetRaftNodes returns information about all LXD nodes that are members of the
 // dqlite Raft cluster (possibly including the local member). If this LXD
 // instance is not running in clustered mode, an empty list is returned.
-func (n *NodeTx) GetRaftNodes() ([]RaftNode, error) {
+func (n *NodeTx) GetRaftNodes(ctx context.Context) ([]RaftNode, error) {
 	nodes := []RaftNode{}
 
 	sql := "SELECT id, address, role, name FROM raft_nodes ORDER BY id"
-	err := query.Scan(n.tx, sql, func(scan func(dest ...any) error) error {
+	err := query.Scan(ctx, n.tx, sql, func(scan func(dest ...any) error) error {
 		node := RaftNode{}
 		err := scan(&node.ID, &node.Address, &node.Role, &node.Name)
 		if err != nil {

--- a/lxd/db/raft_test.go
+++ b/lxd/db/raft_test.go
@@ -3,6 +3,7 @@
 package db_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/canonical/go-dqlite/client"
@@ -24,7 +25,7 @@ func TestRaftNodes(t *testing.T) {
 	id2, err := tx.CreateRaftNode("5.6.7.8:666", "test")
 	require.NoError(t, err)
 
-	nodes, err := tx.GetRaftNodes()
+	nodes, err := tx.GetRaftNodes(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, uint64(id1), nodes[0].ID)
@@ -132,7 +133,7 @@ func TestReplaceRaftNodes(t *testing.T) {
 	err = tx.ReplaceRaftNodes(nodes)
 	assert.NoError(t, err)
 
-	newNodes, err := tx.GetRaftNodes()
+	newNodes, err := tx.GetRaftNodes(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, nodes, newNodes)

--- a/lxd/db/schema/query.go
+++ b/lxd/db/schema/query.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -82,7 +83,7 @@ INSERT INTO schema (version, updated_at) VALUES (?, strftime("%s"))
 }
 
 // Read the given file (if it exists) and executes all queries it contains.
-func execFromFile(tx *sql.Tx, path string, hook Hook) error {
+func execFromFile(ctx context.Context, tx *sql.Tx, path string, hook Hook) error {
 	if !shared.PathExists(path) {
 		return nil
 	}
@@ -93,7 +94,7 @@ func execFromFile(tx *sql.Tx, path string, hook Hook) error {
 	}
 
 	if hook != nil {
-		err := hook(-1, tx)
+		err := hook(ctx, -1, tx)
 		if err != nil {
 			return fmt.Errorf("failed to execute hook: %w", err)
 		}

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -48,7 +48,7 @@ func (c *ClusterTx) GetLocalExpiredInstanceSnapshots(ctx context.Context) ([]clu
 	`
 
 	snapshotIDs := []int{}
-	err := query.Scan(c.Tx(), q, func(scan func(dest ...any) error) error {
+	err := query.Scan(ctx, c.Tx(), q, func(scan func(dest ...any) error) error {
 		var id int
 		var expiry sql.NullTime
 

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -75,7 +75,7 @@ func (c *Cluster) UpdateStorageVolumeSnapshot(projectName string, volumeName str
 	}
 
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		volume, err := tx.GetStoragePoolVolume(poolID, projectName, volumeType, volumeName, true)
+		volume, err := tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func (c *Cluster) GetExpiredStorageVolumeSnapshots() ([]StorageVolumeArgs, error
 	var snapshots []StorageVolumeArgs
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(tx.Tx(), q, func(scan func(dest ...any) error) error {
+		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
 			var snap StorageVolumeArgs
 			var snapName string
 			var volName string

--- a/lxd/db/storage_volumes_test.go
+++ b/lxd/db/storage_volumes_test.go
@@ -3,6 +3,7 @@
 package db_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestGetStorageVolumeNodes(t *testing.T) {
 	addVolume(t, tx, poolID, nodeID3, "volume2")
 	addVolume(t, tx, poolID, nodeID2, "volume2")
 
-	nodes, err := tx.GetStorageVolumeNodes(poolID, "default", "volume1", 1)
+	nodes, err := tx.GetStorageVolumeNodes(context.Background(), poolID, "default", "volume1", 1)
 	require.NoError(t, err)
 
 	assert.Equal(t, []db.NodeInfo{

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -158,7 +158,7 @@ func (c *ClusterTx) createWarning(ctx context.Context, object cluster.Warning) (
 	// Populate the statement arguments.
 	if object.Node != "" {
 		// Ensure node exists
-		_, err = c.GetNodeByName(object.Node)
+		_, err = c.GetNodeByName(ctx, object.Node)
 		if err != nil {
 			return -1, fmt.Errorf("Failed to get node: %w", err)
 		}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -277,7 +277,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 				// GetStoragePoolVolume returns a volume with an empty Location field for remote drivers.
 				var dbVolume *db.StorageVolume
 				err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-					dbVolume, err = tx.GetStoragePoolVolume(d.pool.ID(), storageProjectName, db.StoragePoolVolumeTypeCustom, d.config["source"], true)
+					dbVolume, err = tx.GetStoragePoolVolume(ctx, d.pool.ID(), storageProjectName, db.StoragePoolVolumeTypeCustom, d.config["source"], true)
 					return err
 				})
 				if err != nil {
@@ -543,7 +543,7 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 
 			var dbVolume *db.StorageVolume
 			err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				dbVolume, err = tx.GetStoragePoolVolume(d.pool.ID(), storageProjectName, db.StoragePoolVolumeTypeCustom, d.config["source"], true)
+				dbVolume, err = tx.GetStoragePoolVolume(ctx, d.pool.ID(), storageProjectName, db.StoragePoolVolumeTypeCustom, d.config["source"], true)
 				return err
 			})
 			if err != nil {
@@ -1196,7 +1196,7 @@ func (d *disk) mountPoolVolume() (func(), string, error) {
 
 	var dbVolume *db.StorageVolume
 	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(d.pool.ID(), storageProjectName, db.StoragePoolVolumeTypeCustom, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, d.pool.ID(), storageProjectName, db.StoragePoolVolumeTypeCustom, volumeName, true)
 		return err
 	})
 	if err != nil {
@@ -1415,7 +1415,7 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 	var err error
 	var dbVolume *db.StorageVolume
 	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(d.pool.ID(), projectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, d.pool.ID(), projectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1705,7 +1705,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	// may be different for each cluster member.
 	var imageVolumes []string
 
-	err := d.db.Node.Transaction(func(tx *db.NodeTx) error {
+	err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
 			return err
@@ -2138,7 +2138,7 @@ func pruneLeftoverImages(d *Daemon) {
 	opRun := func(op *operations.Operation) error {
 		// Check if dealing with shared image storage.
 		var storageImages string
-		err := d.State().DB.Node.Transaction(func(tx *db.NodeTx) error {
+		err := d.State().DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 			nodeConfig, err := node.ConfigLoad(tx)
 			if err != nil {
 				return err

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1600,7 +1600,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 				err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 					var err error
 
-					nodeInfo, err := tx.GetNodeByAddress(node)
+					nodeInfo, err := tx.GetNodeByAddress(ctx, node)
 					if err != nil {
 						return err
 					}
@@ -1761,7 +1761,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 		var nodeInfo db.NodeInfo
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			nodeInfo, err = tx.GetNodeByAddress(nodeAddress)
+			nodeInfo, err = tx.GetNodeByAddress(ctx, nodeAddress)
 			return err
 		})
 		if err != nil {
@@ -1935,7 +1935,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		_, source, err = tx.GetImageSource(id)
+		_, source, err = tx.GetImageSource(ctx, id)
 		return err
 	})
 	if err != nil {

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -133,7 +133,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Load target node.
-			node, err := tx.GetNodeByName(targetNode)
+			node, err := tx.GetNodeByName(ctx, targetNode)
 			if err != nil {
 				return fmt.Errorf("Failed to get target node: %w", err)
 			}
@@ -152,7 +152,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return nil
 			}
 
-			node, err = tx.GetNodeByAddress(address)
+			node, err = tx.GetNodeByAddress(ctx, address)
 			if err != nil {
 				return fmt.Errorf("Failed to get source member for %s: %w", address, err)
 			}
@@ -561,7 +561,7 @@ func instancePostClusteringMigrate(d *Daemon, r *http.Request, inst instance.Ins
 			return fmt.Errorf("Failed to get local member address: %w", err)
 		}
 
-		node, err := tx.GetNodeByName(newNode)
+		node, err := tx.GetNodeByName(ctx, newNode)
 		if err != nil {
 			return fmt.Errorf("Failed to get new member address: %w", err)
 		}
@@ -757,7 +757,7 @@ func instancePostClusteringMigrateWithCeph(d *Daemon, r *http.Request, inst inst
 		// If the source member is online then get its address so we can connect to it and see if the
 		// instance is running later.
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			sourceMember, err = tx.GetNodeByName(inst.Location())
+			sourceMember, err = tx.GetNodeByName(ctx, inst.Location())
 			if err != nil {
 				return fmt.Errorf("Failed getting cluster member of instance %q", inst.Name())
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1020,7 +1020,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			var err error
-			targetNode, err = tx.GetNodeWithLeastInstances(architectures, defaultArchID, group, allowedGroups)
+			targetNode, err = tx.GetNodeWithLeastInstances(ctx, architectures, defaultArchID, group, allowedGroups)
 			return err
 		})
 		if err != nil {

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -184,7 +184,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
 
-			nodes, err = tx.GetNodes()
+			nodes, err = tx.GetNodes(ctx)
 			if err != nil {
 				return err
 			}

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -142,7 +142,7 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 	// Check for scheduled volume snapshots
 	var volumes []db.StorageVolumeArgs
 	err = d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		volumes, err = tx.GetStoragePoolVolumesWithType(db.StoragePoolVolumeTypeCustom)
+		volumes, err = tx.GetStoragePoolVolumesWithType(ctx, db.StoragePoolVolumeTypeCustom)
 		if err != nil {
 			return err
 		}

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -143,7 +143,7 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(`Can't edit cluster configuration as server isn't clustered (missing "cluster.https_address" config)`)
 		}
 
-		nodes, err = tx.GetRaftNodes()
+		nodes, err = tx.GetRaftNodes(ctx)
 		return err
 	})
 	if err != nil {
@@ -296,7 +296,7 @@ func (c *cmdClusterShow) Run(cmd *cobra.Command, args []string) error {
 	var nodes []db.RaftNode
 	err = database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		nodes, err = tx.GetRaftNodes()
+		nodes, err = tx.GetRaftNodes(ctx)
 		return err
 	})
 	if err != nil {

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -131,7 +132,7 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	var nodes []db.RaftNode
-	err = database.Transaction(func(tx *db.NodeTx) error {
+	err = database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
 			return err
@@ -293,7 +294,7 @@ func (c *cmdClusterShow) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	var nodes []db.RaftNode
-	err = database.Transaction(func(tx *db.NodeTx) error {
+	err = database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		nodes, err = tx.GetRaftNodes()
 		return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2514,13 +2514,13 @@ func (n *bridge) getExternalSubnetInUse() ([]externalSubnetUsage, error) {
 
 	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get all managed networks across all projects.
-		projectNetworks, err = tx.GetCreatedNetworks()
+		projectNetworks, err = tx.GetCreatedNetworks(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to load all networks: %w", err)
 		}
 
 		// Get all network forward listen addresses for forwards assigned to this specific cluster member.
-		projectNetworksForwardsOnUplink, err = tx.GetProjectNetworkForwardListenAddressesOnMember()
+		projectNetworksForwardsOnUplink, err = tx.GetProjectNetworkForwardListenAddressesOnMember(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed loading network forward listen addresses: %w", err)
 		}
@@ -2893,7 +2893,7 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 			// Load all the networks.
 			var projectNetworks map[string]map[int64]api.Network
 			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				projectNetworks, err = tx.GetCreatedNetworks()
+				projectNetworks, err = tx.GetCreatedNetworks(ctx)
 				return err
 			})
 			if err != nil {

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -79,7 +79,7 @@ func (n *physical) checkParentUse(ourConfig map[string]string) (bool, error) {
 	var projectNetworks map[string]map[int64]api.Network
 
 	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projectNetworks, err = tx.GetCreatedNetworks()
+		projectNetworks, err = tx.GetCreatedNetworks(ctx)
 		return err
 	})
 	if err != nil {

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -129,7 +129,7 @@ func UsedBy(s *state.State, networkProjectName string, networkID int64, networkN
 		var projectNetworks map[string]map[int64]api.Network
 
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			projectNetworks, err = tx.GetCreatedNetworks()
+			projectNetworks, err = tx.GetCreatedNetworks(ctx)
 			return err
 		})
 		if err != nil {

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -42,7 +42,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get all managed networks across all projects.
-		projectNetworks, err = tx.GetCreatedNetworks()
+		projectNetworks, err = tx.GetCreatedNetworks(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to load all networks: %w", err)
 		}

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lxc/lxd/lxd/config"
@@ -143,7 +144,7 @@ func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 // Deprecated.
 func HTTPSAddress(node *db.Node) (string, error) {
 	var config *Config
-	err := node.Transaction(func(tx *db.NodeTx) error {
+	err := node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		config, err = ConfigLoad(tx)
 		return err
@@ -160,7 +161,7 @@ func HTTPSAddress(node *db.Node) (string, error) {
 // Deprecated.
 func ClusterAddress(node *db.Node) (string, error) {
 	var config *Config
-	err := node.Transaction(func(tx *db.NodeTx) error {
+	err := node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
 		config, err = ConfigLoad(tx)
 		return err

--- a/lxd/node/config_test.go
+++ b/lxd/node/config_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,7 +107,7 @@ func TestHTTPSAddress(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", address)
 
-	err = nodeDB.Transaction(func(tx *db.NodeTx) error {
+	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		require.NoError(t, err)
 		_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
@@ -130,7 +131,7 @@ func TestClusterAddress(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", address)
 
-	err = nodeDB.Transaction(func(tx *db.NodeTx) error {
+	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		require.NoError(t, err)
 		_, err = config.Replace(map[string]any{"cluster.https_address": "127.0.0.1:666"})

--- a/lxd/node/raft.go
+++ b/lxd/node/raft.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"context"
+
 	"github.com/canonical/go-dqlite/client"
 
 	"github.com/lxc/lxd/lxd/db"
@@ -27,7 +29,7 @@ import (
 //   in the raft_nodes table, then this node is considered a raft node if
 //   cluster.https_address matches one of the rows in raft_nodes. In that case,
 //   the matching db.RaftNode row is returned, otherwise nil.
-func DetermineRaftNode(tx *db.NodeTx) (*db.RaftNode, error) {
+func DetermineRaftNode(ctx context.Context, tx *db.NodeTx) (*db.RaftNode, error) {
 	config, err := ConfigLoad(tx)
 	if err != nil {
 		return nil, err
@@ -42,7 +44,7 @@ func DetermineRaftNode(tx *db.NodeTx) (*db.RaftNode, error) {
 		return &db.RaftNode{NodeInfo: nodeInfo, Name: ""}, nil
 	}
 
-	nodes, err := tx.GetRaftNodes()
+	nodes, err := tx.GetRaftNodes(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/node/raft_test.go
+++ b/lxd/node/raft_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/canonical/go-dqlite/client"
@@ -65,7 +66,7 @@ func TestDetermineRaftNode(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			node, err := node.DetermineRaftNode(tx)
+			node, err := node.DetermineRaftNode(context.Background(), tx)
 			require.NoError(t, err)
 			if c.node == nil {
 				assert.Nil(t, node)

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -571,7 +571,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed getting member offline threshold value: %w", err)
 		}
 
-		nodes, err = tx.GetNodes()
+		nodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed getting members: %w", err)
 		}
@@ -690,7 +690,7 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 			return fmt.Errorf("Failed getting member offline threshold value: %w", err)
 		}
 
-		nodes, err = tx.GetNodes()
+		nodes, err = tx.GetNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed getting members: %w", err)
 		}
@@ -1140,7 +1140,7 @@ func autoRemoveOrphanedOperations(ctx context.Context, d *Daemon) error {
 			return fmt.Errorf("Load offline threshold config: %w", err)
 		}
 
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to get nodes: %w", err)
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -225,7 +225,7 @@ func patchClusteringServerCertTrust(name string, d *Daemon) error {
 
 		var nodes []db.NodeInfo
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			nodes, err = tx.GetNodes()
+			nodes, err = tx.GetNodes(ctx)
 			if err != nil {
 				return err
 			}
@@ -524,7 +524,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 // having "ipv4.nat" set is to disable NAT (bringing in line with the non-fan bridge behavior and docs).
 func patchNetworkFANEnableNAT(name string, d *Daemon) error {
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projectNetworks, err := tx.GetCreatedNetworks()
+		projectNetworks, err := tx.GetCreatedNetworks(ctx)
 		if err != nil {
 			return err
 		}
@@ -572,7 +572,7 @@ func patchNetworkFANEnableNAT(name string, d *Daemon) error {
 // networks. It was decided that the OVN NIC level equivalent settings were sufficient.
 func patchNetworkOVNRemoveRoutes(name string, d *Daemon) error {
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projectNetworks, err := tx.GetCreatedNetworks()
+		projectNetworks, err := tx.GetCreatedNetworks(ctx)
 		if err != nil {
 			return err
 		}
@@ -624,7 +624,7 @@ func patchNetworkOVNRemoveRoutes(name string, d *Daemon) error {
 // patchNetworkCearBridgeVolatileHwaddr removes the unsupported `volatile.bridge.hwaddr` config key from networks.
 func patchNetworkOVNEnableNAT(name string, d *Daemon) error {
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projectNetworks, err := tx.GetCreatedNetworks()
+		projectNetworks, err := tx.GetCreatedNetworks(ctx)
 		if err != nil {
 			return err
 		}
@@ -720,7 +720,7 @@ func patchGenericNetwork(f func(name string, d *Daemon) error) func(name string,
 
 func patchClusteringDropDatabaseRole(name string, d *Daemon) error {
 	return d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes()
+		nodes, err := tx.GetNodes(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1216,7 +1216,7 @@ func fetchProject(tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*p
 		instances = append(instances, *apiInstance)
 	}
 
-	volumes, err := tx.GetCustomVolumesInProject(projectName)
+	volumes, err := tx.GetCustomVolumesInProject(ctx, projectName)
 	if err != nil {
 		return nil, fmt.Errorf("Fetch project custom volumes from database: %w", err)
 	}

--- a/lxd/project/state.go
+++ b/lxd/project/state.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -10,7 +11,7 @@ import (
 )
 
 // GetCurrentAllocations returns the current resource utilization for a given project.
-func GetCurrentAllocations(tx *db.ClusterTx, projectName string) (map[string]api.ProjectStateResource, error) {
+func GetCurrentAllocations(ctx context.Context, tx *db.ClusterTx, projectName string) (map[string]api.ProjectStateResource, error) {
 	result := map[string]api.ProjectStateResource{}
 
 	// Get the project.
@@ -81,7 +82,7 @@ func GetCurrentAllocations(tx *db.ClusterTx, projectName string) (map[string]api
 		}
 	}
 
-	networks, err := tx.GetCreatedNetworks()
+	networks, err := tx.GetCreatedNetworks(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3343,7 +3343,7 @@ func (b *lxdBackend) UpdateBucket(projectName string, bucketName string, bucket 
 	// Get current config to compare what has changed.
 	var curBucket *db.StorageBucket
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		curBucket, err = tx.GetStoragePoolBucket(b.id, projectName, memberSpecific, bucketName)
+		curBucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, memberSpecific, bucketName)
 		return err
 	})
 	if err != nil {
@@ -3437,7 +3437,7 @@ func (b *lxdBackend) DeleteBucket(projectName string, bucketName string, op *ope
 
 	var bucket *db.StorageBucket
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		bucket, err = tx.GetStoragePoolBucket(b.id, projectName, memberSpecific, bucketName)
+		bucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, memberSpecific, bucketName)
 		return err
 	})
 	if err != nil {
@@ -3505,7 +3505,7 @@ func (b *lxdBackend) CreateBucketKey(projectName string, bucketName string, key 
 
 	var bucket *db.StorageBucket
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		bucket, err = tx.GetStoragePoolBucket(b.id, projectName, memberSpecific, bucketName)
+		bucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, memberSpecific, bucketName)
 		return err
 	})
 	if err != nil {
@@ -3618,12 +3618,12 @@ func (b *lxdBackend) UpdateBucketKey(projectName string, bucketName string, keyN
 	var bucket *db.StorageBucket
 	var curBucketKey *db.StorageBucketKey
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		bucket, err = tx.GetStoragePoolBucket(b.id, projectName, memberSpecific, bucketName)
+		bucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, memberSpecific, bucketName)
 		if err != nil {
 			return err
 		}
 
-		curBucketKey, err = tx.GetStoragePoolBucketKey(bucket.ID, keyName)
+		curBucketKey, err = tx.GetStoragePoolBucketKey(ctx, bucket.ID, keyName)
 		if err != nil {
 			return err
 		}
@@ -3759,12 +3759,12 @@ func (b *lxdBackend) DeleteBucketKey(projectName string, bucketName string, keyN
 	var bucket *db.StorageBucket
 	var bucketKey *db.StorageBucketKey
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		bucket, err = tx.GetStoragePoolBucket(b.id, projectName, memberSpecific, bucketName)
+		bucket, err = tx.GetStoragePoolBucket(ctx, b.id, projectName, memberSpecific, bucketName)
 		if err != nil {
 			return err
 		}
 
-		bucketKey, err = tx.GetStoragePoolBucketKey(bucket.ID, keyName)
+		bucketKey, err = tx.GetStoragePoolBucketKey(ctx, bucket.ID, keyName)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/pool_load.go
+++ b/lxd/storage/pool_load.go
@@ -47,7 +47,7 @@ func volIDFuncMake(state *state.State, poolID int64) func(volType drivers.Volume
 		// Get the storage volume.
 		var dbVolume *db.StorageVolume
 		err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, volTypeID, volName, true)
+			dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, volTypeID, volName, true)
 			return err
 		})
 		if err != nil {

--- a/lxd/storage/storage.go
+++ b/lxd/storage/storage.go
@@ -135,7 +135,7 @@ func UsedBy(ctx context.Context, s *state.State, pool Pool, firstOnly bool, memb
 
 	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get all the volumes using the storage pool.
-		volumes, err := tx.GetStoragePoolVolumes(pool.ID(), memberSpecific)
+		volumes, err := tx.GetStoragePoolVolumes(ctx, pool.ID(), memberSpecific)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage volumes: %w", err)
 		}
@@ -158,7 +158,7 @@ func UsedBy(ctx context.Context, s *state.State, pool Pool, firstOnly bool, memb
 
 				usedBy = append(usedBy, u.String())
 			} else if vol.Type == db.StoragePoolVolumeTypeNameImage {
-				imgProjectNames, err := tx.GetProjectsUsingImage(vol.Name)
+				imgProjectNames, err := tx.GetProjectsUsingImage(ctx, vol.Name)
 				if err != nil {
 					return fmt.Errorf("Failed loading projects using image %q: %w", vol.Name, err)
 				}
@@ -189,7 +189,7 @@ func UsedBy(ctx context.Context, s *state.State, pool Pool, firstOnly bool, memb
 			PoolID: &poolID,
 		}}
 
-		buckets, err := tx.GetStoragePoolBuckets(memberSpecific, filters...)
+		buckets, err := tx.GetStoragePoolBuckets(ctx, memberSpecific, filters...)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage buckets: %w", err)
 		}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -880,7 +880,7 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 func VolumeUsedByDaemon(s *state.State, poolName string, volumeName string) (bool, error) {
 	var storageBackups string
 	var storageImages string
-	err := s.DB.Node.Transaction(func(tx *db.NodeTx) error {
+	err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodeConfig, err := node.ConfigLoad(tx)
 		if err != nil {
 			return err

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -193,7 +193,7 @@ func VolumeDBGet(pool Pool, projectName string, volumeName string, volumeType dr
 	// Get the storage volume.
 	var dbVolume *db.StorageVolume
 	err = p.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(pool.ID(), projectName, volDBType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volDBType, volumeName, true)
 		if err != nil {
 			if response.IsNotFoundError(err) {
 				return fmt.Errorf("Storage volume %q in project %q of type %q does not exist on pool %q: %w", volumeName, projectName, volumeType, pool.Name(), err)

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -180,7 +180,7 @@ func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 			Project: &bucketProjectName,
 		}}
 
-		dbBuckets, err = tx.GetStoragePoolBuckets(memberSpecific, filters...)
+		dbBuckets, err = tx.GetStoragePoolBuckets(ctx, memberSpecific, filters...)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage buckets: %w", err)
 		}
@@ -296,7 +296,7 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 
 	var bucket *db.StorageBucket
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		bucket, err = tx.GetStoragePoolBucket(pool.ID(), bucketProjectName, memberSpecific, bucketName)
+		bucket, err = tx.GetStoragePoolBucket(ctx, pool.ID(), bucketProjectName, memberSpecific, bucketName)
 		return err
 	})
 	if err != nil {
@@ -521,7 +521,7 @@ func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 
 		var bucket *db.StorageBucket
 		err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			bucket, err = tx.GetStoragePoolBucket(pool.ID(), bucketProjectName, memberSpecific, bucketName)
+			bucket, err = tx.GetStoragePoolBucket(ctx, pool.ID(), bucketProjectName, memberSpecific, bucketName)
 			return err
 		})
 		if err != nil {
@@ -737,7 +737,7 @@ func storagePoolBucketKeysGet(d *Daemon, r *http.Request) response.Response {
 
 	var bucket *db.StorageBucket
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		bucket, err = tx.GetStoragePoolBucket(pool.ID(), bucketProjectName, memberSpecific, bucketName)
+		bucket, err = tx.GetStoragePoolBucket(ctx, pool.ID(), bucketProjectName, memberSpecific, bucketName)
 		return err
 	})
 	if err != nil {
@@ -747,7 +747,7 @@ func storagePoolBucketKeysGet(d *Daemon, r *http.Request) response.Response {
 	var dbBucketKeys []*db.StorageBucketKey
 
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbBucketKeys, err = tx.GetStoragePoolBucketKeys(bucket.ID)
+		dbBucketKeys, err = tx.GetStoragePoolBucketKeys(ctx, bucket.ID)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage bucket keys: %w", err)
 		}
@@ -1001,12 +1001,12 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 
 	var bucketKey *db.StorageBucketKey
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		bucket, err := tx.GetStoragePoolBucket(pool.ID(), bucketProjectName, memberSpecific, bucketName)
+		bucket, err := tx.GetStoragePoolBucket(ctx, pool.ID(), bucketProjectName, memberSpecific, bucketName)
 		if err != nil {
 			return err
 		}
 
-		bucketKey, err = tx.GetStoragePoolBucketKey(bucket.ID, keyName)
+		bucketKey, err = tx.GetStoragePoolBucketKey(ctx, bucket.ID, keyName)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -310,7 +310,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			return tx.CreatePendingStoragePool(targetNode, req.Name, req.Driver, req.Config)
+			return tx.CreatePendingStoragePool(ctx, targetNode, req.Name, req.Driver, req.Config)
 		})
 		if err != nil {
 			if err == db.ErrAlreadyDefined {
@@ -421,7 +421,7 @@ func storagePoolsPostCluster(d *Daemon, pool *api.StoragePool, req api.StoragePo
 		}
 
 		// Fetch the node-specific configs and check the pool is defined for all nodes.
-		configs, err = tx.GetStoragePoolNodeConfigs(poolID)
+		configs, err = tx.GetStoragePoolNodeConfigs(ctx, poolID)
 		if err != nil {
 			return err
 		}
@@ -929,7 +929,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 		err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Get all the volumes using the storage pool on this server.
 			// Only image volumes should remain now.
-			volumes, err := tx.GetStoragePoolVolumes(pool.ID(), true)
+			volumes, err := tx.GetStoragePoolVolumes(ctx, pool.ID(), true)
 			if err != nil {
 				return fmt.Errorf("Failed loading storage volumes: %w", err)
 			}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -400,7 +400,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		dbVolumes, err = tx.GetStoragePoolVolumes(poolID, memberSpecific, filters...)
+		dbVolumes, err = tx.GetStoragePoolVolumes(ctx, poolID, memberSpecific, filters...)
 		if err != nil {
 			return fmt.Errorf("Failed loading storage volumes: %w", err)
 		}
@@ -593,7 +593,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 	// Check if destination volume exists.
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, db.StoragePoolVolumeTypeCustom, req.Name, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, db.StoragePoolVolumeTypeCustom, req.Name, true)
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		}
@@ -803,7 +803,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	// Check if destination volume exists.
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, db.StoragePoolVolumeTypeCustom, req.Name, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, db.StoragePoolVolumeTypeCustom, req.Name, true)
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		} else if dbVolume != nil {
@@ -1083,7 +1083,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(srcPoolID, projectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, srcPoolID, projectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {
@@ -1361,7 +1361,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 	// Get the storage volume.
 	var dbVolume *db.StorageVolume
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(poolID, volumeProjectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, volumeProjectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {
@@ -1472,7 +1472,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 	// Get the existing storage volume.
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(pool.ID(), projectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {
@@ -1644,7 +1644,7 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 	// Get the existing storage volume.
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(pool.ID(), projectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {
@@ -1780,7 +1780,7 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 	// Get the storage volume.
 	var dbVolume *db.StorageVolume
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(pool.ID(), volumeProjectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), volumeProjectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -327,7 +327,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -191,7 +191,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 	var parentDBVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Ensure that the snapshot doesn't already exist.
-		snapDBVolume, err := tx.GetStoragePoolVolume(pool.ID(), projectName, volumeType, fmt.Sprintf("%s/%s", volumeName, req.Name), true)
+		snapDBVolume, err := tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volumeType, fmt.Sprintf("%s/%s", volumeName, req.Name), true)
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		} else if snapDBVolume != nil {
@@ -199,7 +199,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		}
 
 		// Get the parent volume so we can get the config.
-		parentDBVolume, err = tx.GetStoragePoolVolume(pool.ID(), projectName, volumeType, volumeName, true)
+		parentDBVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volumeType, volumeName, true)
 		if err != nil {
 			return err
 		}
@@ -399,7 +399,7 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 		} else {
 			var vol *db.StorageVolume
 			err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-				vol, err = tx.GetStoragePoolVolume(poolID, projectName, volumeType, volume.Name, true)
+				vol, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volume.Name, true)
 				return err
 			})
 			if err != nil {
@@ -665,7 +665,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, volumeType, fullSnapshotName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, fullSnapshotName, true)
 		return err
 	})
 	if err != nil {
@@ -785,7 +785,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, volumeType, fullSnapshotName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, fullSnapshotName, true)
 		return err
 	})
 	if err != nil {
@@ -911,7 +911,7 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(poolID, projectName, volumeType, fullSnapshotName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, fullSnapshotName, true)
 		return err
 	})
 
@@ -1176,7 +1176,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 				}
 			}
 
-			allVolumes, err := tx.GetStoragePoolVolumesWithType(db.StoragePoolVolumeTypeCustom)
+			allVolumes, err := tx.GetStoragePoolVolumesWithType(ctx, db.StoragePoolVolumeTypeCustom)
 			if err != nil {
 				return fmt.Errorf("Failed getting volumes for auto custom volume snapshot task: %w", err)
 			}
@@ -1221,7 +1221,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			var onlineNodeIDs []int64
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				// Get all the members.
-				nodes, err := tx.GetNodes()
+				nodes, err := tx.GetNodes(ctx)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -153,7 +153,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 
 	var dbVolume *db.StorageVolume
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		dbVolume, err = tx.GetStoragePoolVolume(pool.ID(), projectName, volumeType, volumeName, true)
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volumeType, volumeName, true)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
* `node.Transaction` now accepts a context that is available for use in its query hook, similar to `cluster.Transaction`. 
* `query.Scan` and `query.SelectObjects` now use `tx.QueryContext`, which means they accept a `context` argument. 
*  Several `NodeTx` helpers now also accept a `context` argument, that will get passed to `query.Scan`.

The diff here looks big but it's actually just passing `ctx` around, all the way to `query.Scan`, starting from `cluster.Transaction` and newly `node.Transaction`. 

When we restructured `cluster.Transaction` to include a `context` argument, we weren't actually passing the context down. In most (I think all actually) cases, this is just a `context.TODO()`, but I think it's still good to have this propagate down to the actual query. This will help reduce the changes significantly if we move more entities over to `lxd-generate`, and in general is a step towards more consistent DB helpers.

