### PR TITLE
Database: Replace `tx.Query` with `tx.QueryContext` and `tx.QueryRow` with `tx.QueryRowContext` 

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -433,7 +433,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		var config *clusterConfig.Config
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			config, err = clusterConfig.Load(tx)
+			config, err = clusterConfig.Load(ctx, tx)
 			return err
 		})
 		if err != nil {
@@ -554,14 +554,14 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	var newNodeConfig *node.Config
 	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		newNodeConfig, err = node.ConfigLoad(tx)
+		newNodeConfig, err = node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("Failed to load node config: %w", err)
 		}
 
 		// We currently don't allow changing the cluster.https_address once it's set.
 		if clustered {
-			curConfig, err := tx.Config()
+			curConfig, err := tx.Config(ctx)
 			if err != nil {
 				return fmt.Errorf("Cannot fetch node config from database: %w", err)
 			}
@@ -634,7 +634,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	var newClusterConfig *clusterConfig.Config
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		newClusterConfig, err = clusterConfig.Load(tx)
+		newClusterConfig, err = clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("Failed to load cluster config: %w", err)
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -194,12 +194,12 @@ func clusterGetMemberConfig(cluster *db.Cluster) ([]api.ClusterMemberConfigKey, 
 	err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
-		pools, err = tx.GetStoragePoolsLocalConfig()
+		pools, err = tx.GetStoragePoolsLocalConfig(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch storage pools configuration: %w", err)
 		}
 
-		networks, err = tx.GetNetworksLocalConfig()
+		networks, err = tx.GetNetworksLocalConfig(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch networks configuration: %w", err)
 		}
@@ -359,7 +359,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 	// If there's no cluster.https_address set, but core.https_address is,
 	// let's default to it.
 	err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		config, err := node.ConfigLoad(tx)
+		config, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch member configuration: %w", err)
 		}
@@ -442,7 +442,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-			config, err := node.ConfigLoad(tx)
+			config, err := node.ConfigLoad(ctx, tx)
 			if err != nil {
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
@@ -473,7 +473,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Update the cluster.https_address config key.
 		err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-			config, err := node.ConfigLoad(tx)
+			config, err := node.ConfigLoad(ctx, tx)
 			if err != nil {
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
@@ -703,7 +703,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		var nodeConfig *node.Config
 		err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 			var err error
-			nodeConfig, err = node.ConfigLoad(tx)
+			nodeConfig, err = node.ConfigLoad(ctx, tx)
 			return err
 		})
 		if err != nil {
@@ -1686,7 +1686,7 @@ func clusterNodePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return tx.RenameNode(name, req.ServerName)
+		return tx.RenameNode(ctx, name, req.ServerName)
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -3319,7 +3319,7 @@ func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 
 			apiClusterGroups := make([]*api.ClusterGroup, len(clusterGroups))
 			for i, clusterGroup := range clusterGroups {
-				members, err := tx.GetClusterGroupNodes(clusterGroup.Name)
+				members, err := tx.GetClusterGroupNodes(ctx, clusterGroup.Name)
 				if err != nil {
 					return err
 				}
@@ -3329,7 +3329,7 @@ func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 
 			result = apiClusterGroups
 		} else {
-			result, err = tx.GetClusterGroupURIs(dbCluster.ClusterGroupFilter{})
+			result, err = tx.GetClusterGroupURIs(ctx, dbCluster.ClusterGroupFilter{})
 		}
 
 		return err
@@ -3596,7 +3596,7 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		members, err := tx.GetClusterGroupNodes(name)
+		members, err := tx.GetClusterGroupNodes(ctx, name)
 		if err != nil {
 			return err
 		}
@@ -3607,7 +3607,7 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 		for _, oldMember := range members {
 			if !shared.StringInSlice(oldMember, req.Members) {
 				// Get all cluster groups this member belongs to.
-				groups, err := tx.GetClusterGroupsWithNode(oldMember)
+				groups, err := tx.GetClusterGroupsWithNode(ctx, oldMember)
 				if err != nil {
 					return err
 				}
@@ -3774,7 +3774,7 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		members, err := tx.GetClusterGroupNodes(name)
+		members, err := tx.GetClusterGroupNodes(ctx, name)
 		if err != nil {
 			return err
 		}
@@ -3785,7 +3785,7 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 		for _, oldMember := range members {
 			if !shared.StringInSlice(oldMember, req.Members) {
 				// Get all cluster groups this member belongs to.
-				groups, err := tx.GetClusterGroupsWithNode(oldMember)
+				groups, err := tx.GetClusterGroupsWithNode(ctx, oldMember)
 				if err != nil {
 					return err
 				}
@@ -3862,7 +3862,7 @@ func clusterGroupDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		members, err := tx.GetClusterGroupNodes(name)
+		members, err := tx.GetClusterGroupNodes(ctx, name)
 		if err != nil {
 			return err
 		}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -223,12 +223,12 @@ func projectUsedBy(ctx context.Context, tx *db.ClusterTx, project *cluster.Proje
 		return nil, err
 	}
 
-	networks, err := tx.GetNetworkURIs(project.ID, project.Name)
+	networks, err := tx.GetNetworkURIs(ctx, project.ID, project.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	acls, err := tx.GetNetworkACLURIs(project.ID, project.Name)
+	acls, err := tx.GetNetworkACLURIs(ctx, project.ID, project.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -1013,7 +1013,7 @@ func projectIsEmpty(ctx context.Context, project *cluster.Project, tx *db.Cluste
 		return false, nil
 	}
 
-	networks, err := tx.GetNetworkURIs(project.ID, project.Name)
+	networks, err := tx.GetNetworkURIs(ctx, project.ID, project.Name)
 	if err != nil {
 		return false, err
 	}
@@ -1022,7 +1022,7 @@ func projectIsEmpty(ctx context.Context, project *cluster.Project, tx *db.Cluste
 		return false, nil
 	}
 
-	acls, err := tx.GetNetworkACLURIs(project.ID, project.Name)
+	acls, err := tx.GetNetworkACLURIs(ctx, project.ID, project.Name)
 	if err != nil {
 		return false, err
 	}

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -26,7 +26,7 @@ func authenticateAgentCert(d *Daemon, r *http.Request) (bool, instance.Instance,
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
-		clusterInst, err = tx.GetLocalInstanceWithVsockID(vsockID)
+		clusterInst, err = tx.GetLocalInstanceWithVsockID(ctx, vsockID)
 		if err != nil {
 			return err
 		}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -520,7 +520,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	// Can't us d.State().GlobalConfig.TrustPassword() here as global config is not yet updated.
 	var secret string
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := clusterConfig.Load(tx)
+		config, err := clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 // values fetched from the database.
 func Load(ctx context.Context, tx *db.ClusterTx) (*Config, error) {
 	// Load current raw values from the database, any error is fatal.
-	values, err := tx.Config()
+	values, err := tx.Config(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch node config from database: %w", err)
 	}

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -23,7 +24,7 @@ type Config struct {
 
 // Load loads a new Config object with the current cluster configuration
 // values fetched from the database.
-func Load(tx *db.ClusterTx) (*Config, error) {
+func Load(ctx context.Context, tx *db.ClusterTx) (*Config, error) {
 	// Load current raw values from the database, any error is fatal.
 	values, err := tx.Config()
 	if err != nil {

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := clusterConfig.Load(tx)
+	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{}, config.Dump())
@@ -34,7 +35,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	config, err := clusterConfig.Load(tx)
+	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
 	values := map[string]any{"core.proxy_http": "foo.bar"}
@@ -46,7 +47,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := clusterConfig.Load(tx)
+	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{}, config.Dump())
@@ -57,7 +58,7 @@ func TestConfigLoad_OfflineThresholdValidator(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := clusterConfig.Load(tx)
+	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
 	_, err = config.Patch(map[string]any{"cluster.offline_threshold": "2"})
@@ -69,7 +70,7 @@ func TestConfigLoad_MaxVotersValidator(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := clusterConfig.Load(tx)
+	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
 	_, err = config.Patch(map[string]any{"cluster.max_voters": "4"})
@@ -82,7 +83,7 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := clusterConfig.Load(tx)
+	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
 	changed, err := config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
@@ -94,7 +95,7 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 
 	assert.Equal(t, "", config.ProxyHTTP())
 
-	values, err := tx.Config()
+	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{}, values)
 }
@@ -105,7 +106,7 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	config, err := clusterConfig.Load(tx)
+	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
 	_, err = config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
@@ -116,7 +117,7 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 
 	assert.Equal(t, "foo.bar", config.ProxyHTTP())
 
-	values, err := tx.Config()
+	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.proxy_http": "foo.bar"}, values)
 }

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -88,7 +88,7 @@ func ConnectIfInstanceIsRemote(cluster *db.Cluster, projectName string, instName
 	var address string // Cluster member address.
 	err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		address, err = tx.GetNodeAddressOfInstance(projectName, instName, instanceType)
+		address, err = tx.GetNodeAddressOfInstance(ctx, projectName, instName, instanceType)
 		return err
 	})
 	if err != nil {
@@ -118,7 +118,7 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 	var nodes []db.NodeInfo
 	var poolID int64
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		poolID, err = tx.GetStoragePoolID(poolName)
+		poolID, err = tx.GetStoragePoolID(ctx, poolName)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -232,7 +232,7 @@ func EventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 				return err
 			}
 
-			offlineThreshold, err = tx.GetNodeOfflineThreshold()
+			offlineThreshold, err = tx.GetNodeOfflineThreshold(ctx)
 			if err != nil {
 				return err
 			}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -996,7 +996,7 @@ func (g *Gateway) nodeAddress(raftAddress string) (string, error) {
 	var address string
 	err := g.db.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		address, err = tx.GetRaftNodeAddress(1)
+		address, err = tx.GetRaftNodeAddress(ctx, 1)
 		if err != nil {
 			if !response.IsNotFoundError(err) {
 				return fmt.Errorf("Failed to fetch raft server address: %w", err)

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -61,7 +61,7 @@ func TestHeartbeat(t *testing.T) {
 		nodes, err := tx.GetNodes(ctx)
 		require.NoError(t, err)
 
-		offlineThreshold, err := tx.GetNodeOfflineThreshold()
+		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)
 		require.NoError(t, err)
 
 		for _, node := range nodes {
@@ -232,13 +232,13 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	require.NoError(f.t, err)
 
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		state.GlobalConfig, err = clusterConfig.Load(tx)
+		state.GlobalConfig, err = clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err
 		}
 
 		// Get the local node (will be used if clustered).
-		state.ServerName, err = tx.GetLocalNodeName()
+		state.ServerName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -239,13 +239,13 @@ func TestAccept(t *testing.T) {
 	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
-		state.GlobalConfig, err = clusterConfig.Load(tx)
+		state.GlobalConfig, err = clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err
 		}
 
 		// Get the local node (will be used if clustered).
-		state.ServerName, err = tx.GetLocalNodeName()
+		state.ServerName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}
@@ -305,13 +305,13 @@ func TestJoin(t *testing.T) {
 	require.NoError(t, err)
 
 	err = targetState.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		targetState.GlobalConfig, err = clusterConfig.Load(tx)
+		targetState.GlobalConfig, err = clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err
 		}
 
 		// Get the local node (will be used if clustered).
-		targetState.ServerName, err = tx.GetLocalNodeName()
+		targetState.ServerName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}
@@ -358,13 +358,13 @@ func TestJoin(t *testing.T) {
 	require.NoError(t, err)
 
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		state.GlobalConfig, err = clusterConfig.Load(tx)
+		state.GlobalConfig, err = clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err
 		}
 
 		// Get the local node (will be used if clustered).
-		state.ServerName, err = tx.GetLocalNodeName()
+		state.ServerName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -46,7 +46,7 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 	var nodes []db.NodeInfo
 	var offlineThreshold time.Duration
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		offlineThreshold, err = tx.GetNodeOfflineThreshold()
+		offlineThreshold, err = tx.GetNodeOfflineThreshold(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -139,7 +139,7 @@ func (h *notifyFixtures) Nodes(cert *shared.CertInfo, n int) func() {
 
 	// Set the address in the config table of the node database.
 	err = h.state.DB.Node.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
-		config, err := node.ConfigLoad(tx)
+		config, err := node.ConfigLoad(ctx, tx)
 		require.NoError(h.t, err)
 		address := servers[0].Listener.Addr().String()
 		values := map[string]any{"cluster.https_address": address}

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -106,7 +106,7 @@ func Recover(database *db.Node) error {
 func updateLocalAddress(database *db.Node, address string) error {
 	err := database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		config, err := node.ConfigLoad(tx)
+		config, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/resolve.go
+++ b/lxd/cluster/resolve.go
@@ -14,7 +14,7 @@ import (
 func ResolveTarget(cluster *db.Cluster, target string) (string, error) {
 	address := ""
 	err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		name, err := tx.GetLocalNodeName()
+		name, err := tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1077,7 +1077,7 @@ func (d *Daemon) init() error {
 	logger.Info("Loading daemon configuration")
 	var daemonConfig *node.Config
 	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		daemonConfig, err = node.ConfigLoad(tx)
+		daemonConfig, err = node.ConfigLoad(ctx, tx)
 		return err
 	})
 	if err != nil {
@@ -1280,13 +1280,13 @@ func (d *Daemon) init() error {
 	maasMachine := daemonConfig.MAASMachine()
 
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		config, err := clusterConfig.Load(tx)
+		config, err := clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err
 		}
 
 		// Get the local node (will be used if clustered).
-		serverName, err := tx.GetLocalNodeName()
+		serverName, err := tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -20,7 +20,7 @@ func daemonConfigRender(state *state.State) (map[string]any, error) {
 
 	// Apply the local config.
 	err := state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		nodeConfig, err := node.ConfigLoad(tx)
+		nodeConfig, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -23,7 +23,7 @@ func daemonStorageVolumesUnmount(s *state.State) error {
 	var storageImages string
 
 	err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		nodeConfig, err := node.ConfigLoad(tx)
+		nodeConfig, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -79,7 +79,7 @@ func daemonStorageMount(s *state.State) error {
 	var storageBackups string
 	var storageImages string
 	err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		nodeConfig, err := node.ConfigLoad(tx)
+		nodeConfig, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -35,7 +35,7 @@ JOIN nodes ON nodes.id = nodes_cluster_groups.node_id
 JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id
 WHERE cluster_groups.name = ?`
 
-	return query.SelectStrings(c.tx, q, groupName)
+	return query.SelectStrings(ctx, c.tx, q, groupName)
 }
 
 // GetClusterGroupURIs returns all available ClusterGroup URIs.
@@ -57,7 +57,7 @@ WHERE cluster_groups.name = ? ORDER BY cluster_groups.name
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
-	names, err := query.SelectStrings(c.tx, sql, args...)
+	names, err := query.SelectStrings(ctx, c.tx, sql, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -117,5 +117,5 @@ JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id
 JOIN nodes ON nodes.id = nodes_cluster_groups.node_id
 WHERE nodes.name = ?`
 
-	return query.SelectStrings(c.tx, q, nodeName)
+	return query.SelectStrings(ctx, c.tx, q, nodeName)
 }

--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -29,7 +29,7 @@ func ClusterGroupToAPI(clusterGroup *cluster.ClusterGroup, nodes []string) *api.
 }
 
 // GetClusterGroupNodes returns a list of nodes of the given cluster group.
-func (c *ClusterTx) GetClusterGroupNodes(groupName string) ([]string, error) {
+func (c *ClusterTx) GetClusterGroupNodes(ctx context.Context, groupName string) ([]string, error) {
 	q := `SELECT nodes.name FROM nodes_cluster_groups
 JOIN nodes ON nodes.id = nodes_cluster_groups.node_id
 JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id
@@ -40,7 +40,7 @@ WHERE cluster_groups.name = ?`
 
 // GetClusterGroupURIs returns all available ClusterGroup URIs.
 // generator: ClusterGroup URIs
-func (c *ClusterTx) GetClusterGroupURIs(filter cluster.ClusterGroupFilter) ([]string, error) {
+func (c *ClusterTx) GetClusterGroupURIs(ctx context.Context, filter cluster.ClusterGroupFilter) ([]string, error) {
 	var args []any
 	var sql string
 	if filter.Name != nil && filter.ID == nil {
@@ -111,7 +111,7 @@ func (c *ClusterTx) RemoveNodeFromClusterGroup(ctx context.Context, groupName st
 }
 
 //GetClusterGroupsWithNode returns a list of cluster group names the given node belongs to.
-func (c *ClusterTx) GetClusterGroupsWithNode(nodeName string) ([]string, error) {
+func (c *ClusterTx) GetClusterGroupsWithNode(ctx context.Context, nodeName string) ([]string, error) {
 	q := `SELECT cluster_groups.name FROM nodes_cluster_groups
 JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id
 JOIN nodes ON nodes.id = nodes_cluster_groups.node_id

--- a/lxd/db/cluster/certificates.go
+++ b/lxd/db/cluster/certificates.go
@@ -131,7 +131,7 @@ WHERE certificates.fingerprint LIKE ?
 ORDER BY certificates.fingerprint
 		`
 
-	fingerprints, err := query.SelectStrings(tx, sql, fingerprintPrefix+"%")
+	fingerprints, err := query.SelectStrings(ctx, tx, sql, fingerprintPrefix+"%")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch certificates fingerprints matching prefix %q: %w", fingerprintPrefix, err)
 	}

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -65,7 +65,7 @@ func EnsureSchema(db *sql.DB, address string, dir string) (bool, error) {
 	backupDone := false
 	hook := (func(ctx context.Context, version int, tx *sql.Tx) error {
 		// Check if this is a fresh instance.
-		isUpdate, err := schema.DoesSchemaTableExist(tx)
+		isUpdate, err := schema.DoesSchemaTableExist(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("failed to check if schema table exists: %w", err)
 		}
@@ -76,7 +76,7 @@ func EnsureSchema(db *sql.DB, address string, dir string) (bool, error) {
 
 		// Check if we're clustered
 		clustered := true
-		n, err := selectUnclusteredNodesCount(tx)
+		n, err := selectUnclusteredNodesCount(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("failed to fetch unclustered nodes count: %w", err)
 		}
@@ -122,7 +122,7 @@ func EnsureSchema(db *sql.DB, address string, dir string) (bool, error) {
 		}
 
 		// Check if we're clustered
-		n, err := selectUnclusteredNodesCount(tx)
+		n, err := selectUnclusteredNodesCount(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("failed to fetch unclustered nodes count: %w", err)
 		}

--- a/lxd/db/cluster/open_test.go
+++ b/lxd/db/cluster/open_test.go
@@ -183,7 +183,7 @@ INSERT INTO nodes(name, address, schema, api_extensions, arch, description) VALU
 func assertNode(t *testing.T, db *sql.DB, address string, schema int, apiExtensions int) {
 	err := query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error {
 		where := "address=? AND schema=? AND api_extensions=?"
-		n, err := query.Count(tx, "nodes", where, address, schema, apiExtensions)
+		n, err := query.Count(ctx, tx, "nodes", where, address, schema, apiExtensions)
 		assert.Equal(t, 1, n, "node does not have expected version")
 		return err
 	})

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -82,7 +82,7 @@ SELECT projects_config.value
   JOIN projects ON projects.id=projects_config.project_id
  WHERE projects.name=? AND projects_config.key='features.profiles'
 `
-	values, err := query.SelectStrings(tx, stmt, name)
+	values, err := query.SelectStrings(ctx, tx, stmt, name)
 	if err != nil {
 		return false, fmt.Errorf("Fetch project config: %w", err)
 	}
@@ -98,7 +98,7 @@ SELECT projects_config.value
 func GetProjectNames(ctx context.Context, tx *sql.Tx) ([]string, error) {
 	stmt := "SELECT name FROM projects"
 
-	names, err := query.SelectStrings(tx, stmt)
+	names, err := query.SelectStrings(ctx, tx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("Fetch project names: %w", err)
 	}

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -111,7 +111,7 @@ func GetProjectNames(ctx context.Context, tx *sql.Tx) ([]string, error) {
 func GetProjectIDsToNames(ctx context.Context, tx *sql.Tx) (map[int64]string, error) {
 	stmt := "SELECT id, name FROM projects"
 
-	rows, err := tx.Query(stmt)
+	rows, err := tx.QueryContext(ctx, stmt)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/cluster/query.go
+++ b/lxd/db/cluster/query.go
@@ -34,7 +34,7 @@ func updateNodeVersion(tx *sql.Tx, address string, apiExtensions int) error {
 // Return the number of rows in the nodes table that have their address column
 // set to '0.0.0.0'.
 func selectUnclusteredNodesCount(ctx context.Context, tx *sql.Tx) (int, error) {
-	return query.Count(tx, "nodes", "address='0.0.0.0'")
+	return query.Count(ctx, tx, "nodes", "address='0.0.0.0'")
 }
 
 // Return a slice of binary integer tuples. Each tuple contains the schema

--- a/lxd/db/cluster/query.go
+++ b/lxd/db/cluster/query.go
@@ -33,7 +33,7 @@ func updateNodeVersion(tx *sql.Tx, address string, apiExtensions int) error {
 
 // Return the number of rows in the nodes table that have their address column
 // set to '0.0.0.0'.
-func selectUnclusteredNodesCount(tx *sql.Tx) (int, error) {
+func selectUnclusteredNodesCount(ctx context.Context, tx *sql.Tx) (int, error) {
 	return query.Count(tx, "nodes", "address='0.0.0.0'")
 }
 

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -150,7 +150,7 @@ ALTER TABLE nodes_cluster_groups_new RENAME TO nodes_cluster_groups;
 // have features.storage.volumes=true.
 func updateFromV63(ctx context.Context, tx *sql.Tx) error {
 	// Find all projects that have features.storage.volumes=true and add features.storage.buckets=true.
-	rows, err := tx.Query(`SELECT project_id FROM projects_config WHERE key = "features.storage.volumes" AND value = "true"`)
+	rows, err := tx.QueryContext(ctx, `SELECT project_id FROM projects_config WHERE key = "features.storage.volumes" AND value = "true"`)
 	if err != nil {
 		return fmt.Errorf("Failed getting projects with features.storage.volumes=true: %w", err)
 	}
@@ -1797,7 +1797,7 @@ func updateFromV42(ctx context.Context, tx *sql.Tx) error {
 			GROUP BY storage_pool_id, node_id, key, value
 			HAVING rowCount > 1
 		`
-	rows, err := tx.Query(stmt)
+	rows, err := tx.QueryContext(ctx, stmt)
 	if err != nil {
 		return fmt.Errorf("Failed running query: %w", err)
 	}
@@ -1863,7 +1863,7 @@ func updateFromV41(ctx context.Context, tx *sql.Tx) error {
 			GROUP BY network_id, node_id, key, value
 			HAVING rowCount > 1
 		`
-	rows, err := tx.Query(stmt)
+	rows, err := tx.QueryContext(ctx, stmt)
 	if err != nil {
 		return fmt.Errorf("Failed running query: %w", err)
 	}

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -230,7 +230,7 @@ CREATE TABLE "storage_buckets_keys" (
 // Also ensures that the default project has features.networks set to true.
 func updateFromV62(ctx context.Context, tx *sql.Tx) error {
 	// Find the default project ID, and what it has features.networks config key set to (if at all).
-	rows := tx.QueryRow(`
+	rows := tx.QueryRowContext(ctx, `
 		SELECT
 			projects.id,
 			IFNULL(projects_config.key, "") as key,
@@ -2314,7 +2314,7 @@ CREATE TRIGGER storage_volumes_check_id
 	if count > 0 {
 		var maxID int64
 
-		row := tx.QueryRow("SELECT MAX(id) FROM storage_volumes_all LIMIT 1")
+		row := tx.QueryRowContext(ctx, "SELECT MAX(id) FROM storage_volumes_all LIMIT 1")
 		err = row.Scan(&maxID)
 		if err != nil {
 			return err

--- a/lxd/db/config.go
+++ b/lxd/db/config.go
@@ -10,7 +10,7 @@ import (
 
 // Config fetches all LXD node-level config keys.
 func (n *NodeTx) Config(ctx context.Context) (map[string]string, error) {
-	return query.SelectConfig(n.tx, "config", "")
+	return query.SelectConfig(ctx, n.tx, "config", "")
 }
 
 // UpdateConfig updates the given LXD node-level configuration keys in the
@@ -21,7 +21,7 @@ func (n *NodeTx) UpdateConfig(values map[string]string) error {
 
 // Config fetches all LXD cluster config keys.
 func (c *ClusterTx) Config(ctx context.Context) (map[string]string, error) {
-	return query.SelectConfig(c.tx, "config", "")
+	return query.SelectConfig(ctx, c.tx, "config", "")
 }
 
 // UpdateClusterConfig updates the given LXD cluster configuration keys in the

--- a/lxd/db/config.go
+++ b/lxd/db/config.go
@@ -3,11 +3,13 @@
 package db
 
 import (
+	"context"
+
 	"github.com/lxc/lxd/lxd/db/query"
 )
 
 // Config fetches all LXD node-level config keys.
-func (n *NodeTx) Config() (map[string]string, error) {
+func (n *NodeTx) Config(ctx context.Context) (map[string]string, error) {
 	return query.SelectConfig(n.tx, "config", "")
 }
 
@@ -18,7 +20,7 @@ func (n *NodeTx) UpdateConfig(values map[string]string) error {
 }
 
 // Config fetches all LXD cluster config keys.
-func (c *ClusterTx) Config() (map[string]string, error) {
+func (c *ClusterTx) Config(ctx context.Context) (map[string]string, error) {
 	return query.SelectConfig(c.tx, "config", "")
 }
 

--- a/lxd/db/config_test.go
+++ b/lxd/db/config_test.go
@@ -3,6 +3,7 @@
 package db_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ import (
 func TestTx_Config(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
-	values, err := tx.Config()
+	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{}, values)
 	assert.NoError(t, err)
@@ -29,7 +30,7 @@ func TestTx_UpdateConfig(t *testing.T) {
 	err := tx.UpdateConfig(map[string]string{"foo": "x", "bar": "y"})
 	require.NoError(t, err)
 
-	values, err := tx.Config()
+	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"foo": "x", "bar": "y"}, values)
 }
@@ -44,7 +45,7 @@ func TestTx_UpdateConfigUnsetKeys(t *testing.T) {
 	err = tx.UpdateConfig(map[string]string{"foo": "x", "bar": ""})
 	require.NoError(t, err)
 
-	values, err := tx.Config()
+	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"foo": "x"}, values)
 }

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -510,7 +510,7 @@ func doDbScan(c *Cluster, q string, args []any, outargs []any) ([][]any, error) 
 
 	err := c.retry(func() error {
 		return query.Transaction(context.TODO(), c.db, func(ctx context.Context, tx *sql.Tx) error {
-			rows, err := tx.Query(q, args...)
+			rows, err := tx.QueryContext(ctx, q, args...)
 			if err != nil {
 				return err
 			}

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -500,7 +500,7 @@ func DqliteLatestSegment() (string, error) {
 func dbQueryRowScan(c *Cluster, q string, args []any, outargs []any) error {
 	return c.retry(func() error {
 		return query.Transaction(context.TODO(), c.db, func(ctx context.Context, tx *sql.Tx) error {
-			return tx.QueryRow(q, args...).Scan(outargs...)
+			return tx.QueryRowContext(ctx, q, args...).Scan(outargs...)
 		})
 	})
 }

--- a/lxd/db/db_test.go
+++ b/lxd/db/db_test.go
@@ -3,6 +3,7 @@
 package db_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestNode_Schema(t *testing.T) {
 	db := node.DB()
 	tx, err := db.Begin()
 	require.NoError(t, err)
-	n, err := query.Count(tx, "schema", "")
+	n, err := query.Count(context.Background(), tx, "schema", "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 
@@ -41,7 +42,7 @@ func TestCluster_Setup(t *testing.T) {
 	db := cluster.DB()
 	tx, err := db.Begin()
 	require.NoError(t, err)
-	n, err := query.Count(tx, "schema", "")
+	n, err := query.Count(context.Background(), tx, "schema", "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -26,7 +26,7 @@ var ImageSourceProtocol = map[int]string{
 }
 
 // GetLocalImagesFingerprints returns the fingerprints of all local images.
-func (c *ClusterTx) GetLocalImagesFingerprints() ([]string, error) {
+func (c *ClusterTx) GetLocalImagesFingerprints(ctx context.Context) ([]string, error) {
 	q := `
 SELECT images.fingerprint
   FROM images_nodes
@@ -150,7 +150,7 @@ func (c *ClusterTx) imageFill(ctx context.Context, id int, image *api.Image, cre
 	return nil
 }
 
-func (c *ClusterTx) imageFillProfiles(id int, image *api.Image, project string) error {
+func (c *ClusterTx) imageFillProfiles(ctx context.Context, id int, image *api.Image, project string) error {
 	// Check which project name to use
 	enabled, err := cluster.ProjectHasProfiles(context.Background(), c.tx, project)
 	if err != nil {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -1131,7 +1131,7 @@ func (c *Cluster) GetImages() (map[string][]string, error) {
     SELECT images.fingerprint, projects.name FROM images
       LEFT JOIN projects ON images.project_id = projects.id
 		`
-		rows, err := tx.tx.Query(stmt)
+		rows, err := tx.tx.QueryContext(ctx, stmt)
 		if err != nil {
 			return err
 		}
@@ -1168,7 +1168,7 @@ func (c *Cluster) GetImagesOnNode(id int64) (map[string][]string, error) {
 			LEFT JOIN projects ON images.project_id = projects.id
     WHERE nodes.id = ?
 		`
-		rows, err := tx.tx.Query(stmt, id)
+		rows, err := tx.tx.QueryContext(ctx, stmt, id)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -746,7 +746,7 @@ func (c *Cluster) GetImageAlias(project, name string, isTrustedClient bool) (int
 
 		arg1 := []any{project, name}
 		arg2 := []any{&id, &fingerprint, &imageType, &description}
-		err = tx.tx.QueryRow(q, arg1...).Scan(arg2...)
+		err = tx.tx.QueryRowContext(ctx, q, arg1...).Scan(arg2...)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return api.StatusErrorf(http.StatusNotFound, "Image alias not found")

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -33,7 +33,7 @@ SELECT images.fingerprint
   JOIN images ON images.id = images_nodes.image_id
  WHERE node_id = ?
 `
-	return query.SelectStrings(c.tx, q, c.nodeID)
+	return query.SelectStrings(ctx, c.tx, q, c.nodeID)
 }
 
 // GetImageSource returns the image source with the given ID.
@@ -114,7 +114,7 @@ func (c *ClusterTx) imageFill(ctx context.Context, id int, image *api.Image, cre
 	image.UploadedAt = *upload
 
 	// Get the properties
-	properties, err := query.SelectConfig(c.tx, "images_properties", "image_id=?", id)
+	properties, err := query.SelectConfig(ctx, c.tx, "images_properties", "image_id=?", id)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ SELECT profiles.name FROM profiles
 	JOIN projects ON profiles.project_id = projects.id
 WHERE images_profiles.image_id = ? AND projects.name = ?
 `
-	profiles, err := query.SelectStrings(c.tx, q, id, project)
+	profiles, err := query.SelectStrings(ctx, c.tx, q, id, project)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ SELECT fingerprint
 			project = "default"
 		}
 
-		fingerprints, err = query.SelectStrings(tx.tx, q, project)
+		fingerprints, err = query.SelectStrings(ctx, tx.tx, q, project)
 		return err
 	})
 	if err != nil {
@@ -322,7 +322,7 @@ func (c *Cluster) GetCachedImageSourceFingerprint(server string, protocol string
 	var fingerprints []string
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		var err error
-		fingerprints, err = query.SelectStrings(tx.tx, q, args...)
+		fingerprints, err = query.SelectStrings(ctx, tx.tx, q, args...)
 		return err
 	})
 	if err != nil {
@@ -352,7 +352,7 @@ func (c *Cluster) ImageExists(project string, fingerprint string) (bool, error) 
 			project = "default"
 		}
 
-		count, err := query.Count(tx.tx, table, where, project, fingerprint)
+		count, err := query.Count(ctx, tx.tx, table, where, project, fingerprint)
 		if err != nil {
 			return err
 		}
@@ -384,7 +384,7 @@ func (c *Cluster) ImageIsReferencedByOtherProjects(project string, fingerprint s
 			project = "default"
 		}
 
-		count, err := query.Count(tx.tx, table, where, project, fingerprint)
+		count, err := query.Count(ctx, tx.tx, table, where, project, fingerprint)
 		if err != nil {
 			return err
 		}
@@ -480,7 +480,7 @@ func (c *ClusterTx) GetImageByFingerprintPrefix(ctx context.Context, fingerprint
 		return -1, nil, fmt.Errorf("Fill image details: %w", err)
 	}
 
-	err = c.imageFillProfiles(object.ID, &image, profileProject)
+	err = c.imageFillProfiles(ctx, object.ID, &image, profileProject)
 	if err != nil {
 		return -1, nil, fmt.Errorf("Fill image profiles: %w", err)
 	}
@@ -608,17 +608,17 @@ WHERE images.fingerprint = ?
 	var addresses []string  // Addresses of online nodes with the image
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		offlineThreshold, err := tx.GetNodeOfflineThreshold()
+		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)
 		if err != nil {
 			return err
 		}
 
-		localAddress, err = tx.GetLocalNodeAddress()
+		localAddress, err = tx.GetLocalNodeAddress(ctx)
 		if err != nil {
 			return err
 		}
 
-		allAddresses, err := query.SelectStrings(tx.tx, stmt, fingerprint)
+		allAddresses, err := query.SelectStrings(ctx, tx.tx, stmt, fingerprint)
 		if err != nil {
 			return err
 		}
@@ -706,7 +706,7 @@ SELECT images_aliases.name
 			project = "default"
 		}
 
-		names, err = query.SelectStrings(tx.tx, q, project)
+		names, err = query.SelectStrings(ctx, tx.tx, q, project)
 		return err
 	})
 	if err != nil {
@@ -1079,7 +1079,7 @@ func (c *Cluster) GetPoolsWithImage(imageFingerprint string) ([]int64, error) {
 	var ids []int
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		var err error
-		ids, err = query.SelectIntegers(tx.tx, q, c.nodeID, imageFingerprint, StoragePoolVolumeTypeImage)
+		ids, err = query.SelectIntegers(ctx, tx.tx, q, c.nodeID, imageFingerprint, StoragePoolVolumeTypeImage)
 		return err
 	})
 	if err != nil {
@@ -1109,7 +1109,7 @@ func (c *Cluster) GetPoolNamesFromIDs(poolIDs []int64) ([]string, error) {
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		var err error
-		poolNames, err = query.SelectStrings(tx.tx, q, args...)
+		poolNames, err = query.SelectStrings(ctx, tx.tx, q, args...)
 		return err
 	})
 	if err != nil {
@@ -1226,7 +1226,7 @@ SELECT DISTINCT nodes.address FROM nodes WHERE nodes.address NOT IN (
 func (c *Cluster) getNodesByImageFingerprint(stmt, fingerprint string, autoUpdate *bool) ([]string, error) {
 	var addresses []string // Addresses of online nodes with the image
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		offlineThreshold, err := tx.GetNodeOfflineThreshold()
+		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)
 		if err != nil {
 			return err
 		}
@@ -1234,9 +1234,9 @@ func (c *Cluster) getNodesByImageFingerprint(stmt, fingerprint string, autoUpdat
 		var allAddresses []string
 
 		if autoUpdate == nil {
-			allAddresses, err = query.SelectStrings(tx.tx, stmt, fingerprint)
+			allAddresses, err = query.SelectStrings(ctx, tx.tx, stmt, fingerprint)
 		} else {
-			allAddresses, err = query.SelectStrings(tx.tx, stmt, fingerprint, autoUpdate)
+			allAddresses, err = query.SelectStrings(ctx, tx.tx, stmt, fingerprint, autoUpdate)
 		}
 
 		if err != nil {

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -51,7 +51,7 @@ SELECT instances.name FROM instances
   JOIN projects ON projects.id = instances.project_id
   WHERE projects.name = ? AND instances.type = ?
 `
-	return query.SelectStrings(c.tx, stmt, project, instancetype.Any)
+	return query.SelectStrings(ctx, c.tx, stmt, project, instancetype.Any)
 }
 
 // GetNodeAddressOfInstance returns the address of the node hosting the
@@ -150,7 +150,7 @@ SELECT nodes.id, nodes.address
 //
 // Instances whose node is down are added to the special address "0.0.0.0".
 func (c *ClusterTx) GetProjectAndInstanceNamesByNodeAddress(ctx context.Context, projects []string, instType instancetype.Type) (map[string][][2]string, error) {
-	offlineThreshold, err := c.GetNodeOfflineThreshold()
+	offlineThreshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -703,12 +703,12 @@ func (c *ClusterTx) UpdateInstanceNode(ctx context.Context, project, oldName str
 		return fmt.Errorf("Failed to get instance's storage pool name: %w", err)
 	}
 
-	poolID, err := c.GetStoragePoolID(poolName)
+	poolID, err := c.GetStoragePoolID(ctx, poolName)
 	if err != nil {
 		return fmt.Errorf("Failed to get instance's storage pool ID: %w", err)
 	}
 
-	poolDriver, err := c.GetStoragePoolDriver(poolID)
+	poolDriver, err := c.GetStoragePoolDriver(ctx, poolID)
 	if err != nil {
 		return fmt.Errorf("Failed to get instance's storage pool driver: %w", err)
 	}
@@ -770,7 +770,7 @@ func (c *ClusterTx) UpdateInstanceNode(ctx context.Context, project, oldName str
 // GetLocalInstancesInProject retuurns all instances of the given type on the local member in the given project.
 // If projectName is empty then all instances in all projects are returned.
 func (c *ClusterTx) GetLocalInstancesInProject(ctx context.Context, filter cluster.InstanceFilter) ([]cluster.Instance, error) {
-	node, err := c.GetLocalNodeName()
+	node, err := c.GetLocalNodeName(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Local node name: %w", err)
 	}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -109,7 +109,7 @@ SELECT nodes.id, nodes.address
 
 	var address string
 	var id int64
-	rows, err := c.tx.Query(stmt, args...)
+	rows, err := c.tx.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return "", err
 	}
@@ -179,7 +179,7 @@ SELECT instances.name, nodes.id, nodes.address, nodes.heartbeat, projects.name
   ORDER BY instances.id
 `, filters.String())
 
-	rows, err := c.tx.Query(stmt, args...)
+	rows, err := c.tx.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -664,7 +664,7 @@ SELECT instances.name, nodes.name, projects.name
   WHERE %s
 `, filters.String())
 
-	rows, err := c.tx.Query(stmt, args...)
+	rows, err := c.tx.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -45,7 +45,7 @@ type InstanceArgs struct {
 }
 
 // GetInstanceNames returns the names of all containers the given project.
-func (c *ClusterTx) GetInstanceNames(project string) ([]string, error) {
+func (c *ClusterTx) GetInstanceNames(ctx context.Context, project string) ([]string, error) {
 	stmt := `
 SELECT instances.name FROM instances
   JOIN projects ON projects.id = instances.project_id
@@ -58,7 +58,7 @@ SELECT instances.name FROM instances
 // instance with the given name in the given project.
 //
 // It returns the empty string if the container is hosted on this node.
-func (c *ClusterTx) GetNodeAddressOfInstance(project string, name string, instType instancetype.Type) (string, error) {
+func (c *ClusterTx) GetNodeAddressOfInstance(ctx context.Context, project string, name string, instType instancetype.Type) (string, error) {
 	var stmt string
 
 	args := make([]any, 0, 4) // Expect up to 4 filters.
@@ -149,7 +149,7 @@ SELECT nodes.id, nodes.address
 // string, to distinguish it from remote nodes.
 //
 // Instances whose node is down are added to the special address "0.0.0.0".
-func (c *ClusterTx) GetProjectAndInstanceNamesByNodeAddress(projects []string, instType instancetype.Type) (map[string][][2]string, error) {
+func (c *ClusterTx) GetProjectAndInstanceNamesByNodeAddress(ctx context.Context, projects []string, instType instancetype.Type) (map[string][][2]string, error) {
 	offlineThreshold, err := c.GetNodeOfflineThreshold()
 	if err != nil {
 		return nil, err
@@ -640,7 +640,7 @@ func (c *ClusterTx) InstancesToInstanceArgs(ctx context.Context, fillProfiles bo
 
 // GetProjectInstanceToNodeMap returns a map associating the project (key element 0) and name (key element 1) of each
 // instance in the given projects to the name of the node hosting the instance.
-func (c *ClusterTx) GetProjectInstanceToNodeMap(projects []string, instType instancetype.Type) (map[[2]string]string, error) {
+func (c *ClusterTx) GetProjectInstanceToNodeMap(ctx context.Context, projects []string, instType instancetype.Type) (map[[2]string]string, error) {
 	args := make([]any, 0, 2) // Expect up to 2 filters.
 	var filters strings.Builder
 

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -424,7 +424,7 @@ func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 	addContainer(t, tx, nodeID2, "c4")
 
 	instType := instancetype.Container
-	result, err := tx.GetProjectAndInstanceNamesByNodeAddress([]string{"default"}, instType)
+	result, err := tx.GetProjectAndInstanceNamesByNodeAddress(context.Background(), []string{"default"}, instType)
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -449,7 +449,7 @@ func TestGetInstanceToNodeMap(t *testing.T) {
 	addContainer(t, tx, nodeID1, "c2")
 
 	instType := instancetype.Container
-	result, err := tx.GetProjectInstanceToNodeMap([]string{"default"}, instType)
+	result, err := tx.GetProjectInstanceToNodeMap(context.Background(), []string{"default"}, instType)
 	require.NoError(t, err)
 	assert.Equal(
 		t,

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -19,7 +20,7 @@ import (
 // upgraded from a version without clustering to a version that supports
 // clustering, since in those version all data lives in the cluster database
 // (regardless of whether clustering is actually on or off).
-func LoadPreClusteringData(tx *sql.Tx) (*Dump, error) {
+func LoadPreClusteringData(ctx context.Context, tx *sql.Tx) (*Dump, error) {
 	// Sanitize broken foreign key references that might be around from the
 	// time where we didn't enforce foreign key constraints.
 	_, err := tx.Exec(`

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -55,7 +55,7 @@ DELETE FROM storage_volumes_config WHERE storage_volume_id NOT IN (SELECT id FRO
 		data := [][]any{}
 		stmt := fmt.Sprintf("SELECT * FROM %s", table)
 
-		rows, err := tx.Query(stmt)
+		rows, err := tx.QueryContext(ctx, stmt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch rows from %s: %w", table, err)
 		}

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -319,7 +319,7 @@ func (c *Cluster) DeleteNetworkACL(id int64) error {
 func (c *ClusterTx) GetNetworkACLURIs(ctx context.Context, projectID int, project string) ([]string, error) {
 	sql := `SELECT networks_acls.name from networks_acls WHERE networks_acls.project_id = ?`
 
-	names, err := query.SelectStrings(c.tx, sql, projectID)
+	names, err := query.SelectStrings(ctx, c.tx, sql, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get URIs for network acl: %w", err)
 	}

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -95,7 +95,7 @@ func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.Ne
 	`
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err := tx.tx.QueryRow(q, projectName, name).Scan(&id, &acl.Description, &ingressJSON, &egressJSON)
+		err := tx.tx.QueryRowContext(ctx, q, projectName, name).Scan(&id, &acl.Description, &ingressJSON, &egressJSON)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func (c *Cluster) GetNetworkACLNameAndProjectWithID(networkACLID int) (string, s
 	q := `SELECT networks_acls.name, projects.name FROM networks_acls JOIN projects ON projects.id=networks.project_id WHERE networks_acls.id=?`
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return tx.tx.QueryRow(q, networkACLID).Scan(&networkACLName, &projectName)
+		return tx.tx.QueryRowContext(ctx, q, networkACLID).Scan(&networkACLName, &projectName)
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -316,7 +316,7 @@ func (c *Cluster) DeleteNetworkACL(id int64) error {
 }
 
 // GetNetworkACLURIs returns the URIs for the network ACLs with the given project.
-func (c *ClusterTx) GetNetworkACLURIs(projectID int, project string) ([]string, error) {
+func (c *ClusterTx) GetNetworkACLURIs(ctx context.Context, projectID int, project string) ([]string, error) {
 	sql := `SELECT networks_acls.name from networks_acls WHERE networks_acls.project_id = ?`
 
 	names, err := query.SelectStrings(c.tx, sql, projectID)

--- a/lxd/db/network_peers.go
+++ b/lxd/db/network_peers.go
@@ -77,7 +77,7 @@ func (c *Cluster) CreateNetworkPeer(networkID int64, info *api.NetworkPeersPost)
 
 		var targetPeerID int64 = int64(-1)
 
-		err = tx.tx.QueryRow(q, info.TargetProject, info.TargetNetwork, networkID, localPeerID).Scan(&targetPeerID, &targetPeerNetworkID)
+		err = tx.tx.QueryRowContext(ctx, q, info.TargetProject, info.TargetNetwork, networkID, localPeerID).Scan(&targetPeerID, &targetPeerNetworkID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("Failed looking up mutual peering: %w", err)
 		} else if err == nil {
@@ -183,7 +183,7 @@ func (c *Cluster) GetNetworkPeer(networkID int64, peerName string) (int64, *api.
 	var targetPeerNetworkProject string
 
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err = tx.tx.QueryRow(q, networkID, peerName).Scan(&peerID, &peer.Name, &peer.Description, &peer.TargetProject, &peer.TargetNetwork, &targetPeerNetworkName, &targetPeerNetworkProject)
+		err = tx.tx.QueryRowContext(ctx, q, networkID, peerName).Scan(&peerID, &peer.Name, &peer.Description, &peer.TargetProject, &peer.TargetNetwork, &targetPeerNetworkName, &targetPeerNetworkProject)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return api.StatusErrorf(http.StatusNotFound, "Network peer not found")

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -135,7 +135,7 @@ func (c *Cluster) GetNetworkZone(name string) (int64, string, *api.NetworkZone, 
 
 	var projectName string
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err := tx.tx.QueryRow(q, name).Scan(&id, &projectName, &zone.Description)
+		err := tx.tx.QueryRowContext(ctx, q, name).Scan(&id, &projectName, &zone.Description)
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func (c *Cluster) GetNetworkZoneByProject(projectName string, name string) (int6
 	`
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err := tx.tx.QueryRow(q, projectName, name).Scan(&id, &zone.Description)
+		err := tx.tx.QueryRowContext(ctx, q, projectName, name).Scan(&id, &zone.Description)
 		if err != nil {
 			return err
 		}
@@ -362,7 +362,7 @@ func (c *Cluster) GetNetworkZoneRecord(zone int64, name string) (int64, *api.Net
 
 	var entries string
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err := tx.tx.QueryRow(q, zone, name).Scan(&id, &record.Description, &entries)
+		err := tx.tx.QueryRowContext(ctx, q, zone, name).Scan(&id, &record.Description, &entries)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -21,7 +21,7 @@ import (
 // node-specific config values on the local member (i.e. the ones where node_id
 // equals the ID of the local member).
 func (c *ClusterTx) GetNetworksLocalConfig(ctx context.Context) (map[string]map[string]string, error) {
-	names, err := query.SelectStrings(c.tx, "SELECT name FROM networks")
+	names, err := query.SelectStrings(ctx, c.tx, "SELECT name FROM networks")
 	if err != nil {
 		return nil, err
 	}
@@ -29,8 +29,7 @@ func (c *ClusterTx) GetNetworksLocalConfig(ctx context.Context) (map[string]map[
 	networks := make(map[string]map[string]string, len(names))
 	for _, name := range names {
 		table := "networks_config JOIN networks ON networks.id=networks_config.network_id"
-		config, err := query.SelectConfig(
-			c.tx, table, "networks.name=? AND networks_config.node_id=?",
+		config, err := query.SelectConfig(ctx, c.tx, table, "networks.name=? AND networks_config.node_id=?",
 			name, c.nodeID)
 		if err != nil {
 			return nil, err
@@ -158,7 +157,7 @@ func (c *ClusterTx) getCreatedNetworks(ctx context.Context, projectName string) 
 	// Populate config.
 	for projectName, networks := range projectNetworks {
 		for networkID, network := range networks {
-			networkConfig, err := query.SelectConfig(c.tx, "networks_config", "network_id=? AND (node_id=? OR node_id IS NULL)", networkID, c.nodeID)
+			networkConfig, err := query.SelectConfig(ctx, c.tx, "networks_config", "network_id=? AND (node_id=? OR node_id IS NULL)", networkID, c.nodeID)
 			if err != nil {
 				return nil, err
 			}
@@ -184,7 +183,7 @@ func (c *ClusterTx) getCreatedNetworks(ctx context.Context, projectName string) 
 // GetNetworkID returns the ID of the network with the given name.
 func (c *ClusterTx) GetNetworkID(ctx context.Context, projectName string, name string) (int64, error) {
 	stmt := "SELECT id FROM networks WHERE project_id = (SELECT id FROM projects WHERE name = ?) AND name=?"
-	ids, err := query.SelectIntegers(c.tx, stmt, projectName, name)
+	ids, err := query.SelectIntegers(ctx, c.tx, stmt, projectName, name)
 	if err != nil {
 		return -1, err
 	}
@@ -257,7 +256,7 @@ SELECT nodes.name FROM nodes
   LEFT JOIN networks ON networks_nodes.network_id = networks.id
 WHERE networks.id = ? AND networks.state = ?
 `
-	defined, err := query.SelectStrings(c.tx, stmt, networkID, networkPending)
+	defined, err := query.SelectStrings(ctx, c.tx, stmt, networkID, networkPending)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +275,7 @@ WHERE networks.id = ? AND networks.state = ?
 
 	configs := map[string]map[string]string{}
 	for _, node := range nodes {
-		config, err := query.SelectConfig(c.tx, "networks_config", "node_id=?", node.ID)
+		config, err := query.SelectConfig(ctx, c.tx, "networks_config", "node_id=?", node.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -345,7 +344,7 @@ func (c *ClusterTx) CreatePendingNetwork(ctx context.Context, node string, proje
 	}
 
 	// Check that no network entry for this node and network exists yet.
-	count, err = query.Count(c.tx, "networks_nodes", "network_id=? AND node_id=?", networkID, nodeInfo.ID)
+	count, err = query.Count(ctx, c.tx, "networks_nodes", "network_id=? AND node_id=?", networkID, nodeInfo.ID)
 	if err != nil {
 		return err
 	}
@@ -481,7 +480,7 @@ func (c *ClusterTx) NetworkNodes(ctx context.Context, networkID int64) (map[int6
 func (c *ClusterTx) GetNetworkURIs(ctx context.Context, projectID int, project string) ([]string, error) {
 	sql := `SELECT networks.name from networks WHERE networks.project_id = ?`
 
-	names, err := query.SelectStrings(c.tx, sql, projectID)
+	names, err := query.SelectStrings(ctx, c.tx, sql, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get URIs for network: %w", err)
 	}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -116,7 +116,7 @@ func (c *ClusterTx) getCreatedNetworks(ctx context.Context, projectName string) 
 		args = append(args, projectName)
 	}
 
-	rows, err := c.tx.Query(sb.String(), args...)
+	rows, err := c.tx.QueryContext(ctx, sb.String(), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -20,7 +20,7 @@ import (
 // GetNetworksLocalConfig returns a map associating each network name to its
 // node-specific config values on the local member (i.e. the ones where node_id
 // equals the ID of the local member).
-func (c *ClusterTx) GetNetworksLocalConfig() (map[string]map[string]string, error) {
+func (c *ClusterTx) GetNetworksLocalConfig(ctx context.Context) (map[string]map[string]string, error) {
 	names, err := query.SelectStrings(c.tx, "SELECT name FROM networks")
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func (c *ClusterTx) getCreatedNetworks(ctx context.Context, projectName string) 
 }
 
 // GetNetworkID returns the ID of the network with the given name.
-func (c *ClusterTx) GetNetworkID(projectName string, name string) (int64, error) {
+func (c *ClusterTx) GetNetworkID(ctx context.Context, projectName string, name string) (int64, error) {
 	stmt := "SELECT id FROM networks WHERE project_id = (SELECT id FROM projects WHERE name = ?) AND name=?"
 	ids, err := query.SelectIntegers(c.tx, stmt, projectName, name)
 	if err != nil {
@@ -478,7 +478,7 @@ func (c *ClusterTx) NetworkNodes(ctx context.Context, networkID int64) (map[int6
 }
 
 // GetNetworkURIs returns the URIs for the networks with the given project.
-func (c *ClusterTx) GetNetworkURIs(projectID int, project string) ([]string, error) {
+func (c *ClusterTx) GetNetworkURIs(ctx context.Context, projectID int, project string) ([]string, error) {
 	sql := `SELECT networks.name from networks WHERE networks.project_id = ?`
 
 	names, err := query.SelectStrings(c.tx, sql, projectID)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -576,7 +576,7 @@ func (c *Cluster) getNetworkByProjectAndName(projectName string, networkName str
 	var nodes map[int64]NetworkNode
 
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		networkID, networkState, networkType, network, err = c.getPartialNetworkByProjectAndName(tx, projectName, networkName, stateFilter)
+		networkID, networkState, networkType, network, err = c.getPartialNetworkByProjectAndName(ctx, tx, projectName, networkName, stateFilter)
 		if err != nil {
 			return err
 		}
@@ -598,7 +598,7 @@ func (c *Cluster) getNetworkByProjectAndName(projectName string, networkName str
 // getPartialNetworkByProjectAndName gets the network with the given project, name and state.
 // If stateFilter is -1, then a network can be in any state.
 // Returns network ID, network state, network type, and partially populated network info.
-func (c *Cluster) getPartialNetworkByProjectAndName(tx *ClusterTx, projectName string, networkName string, stateFilter NetworkState) (int64, NetworkState, NetworkType, *api.Network, error) {
+func (c *Cluster) getPartialNetworkByProjectAndName(ctx context.Context, tx *ClusterTx, projectName string, networkName string, stateFilter NetworkState) (int64, NetworkState, NetworkType, *api.Network, error) {
 	var err error
 	var networkID int64 = int64(-1)
 	var network api.Network
@@ -624,7 +624,7 @@ func (c *Cluster) getPartialNetworkByProjectAndName(tx *ClusterTx, projectName s
 
 	q.WriteString(" LIMIT 1")
 
-	err = tx.tx.QueryRow(q.String(), args...).Scan(&networkID, &network.Name, &network.Description, &networkState, &networkType)
+	err = tx.tx.QueryRowContext(ctx, q.String(), args...).Scan(&networkID, &network.Name, &network.Description, &networkState, &networkType)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return -1, -1, -1, nil, api.StatusErrorf(http.StatusNotFound, "Network not found")

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -29,7 +29,7 @@ func TestGetNetworksLocalConfigs(t *testing.T) {
 
 	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		config, err = tx.GetNetworksLocalConfig()
+		config, err = tx.GetNetworksLocalConfig(ctx)
 		return err
 	})
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 	err = tx.CreatePendingNetwork(context.Background(), "buzz", project.Default, "network1", db.NetworkTypeBridge, config)
 	require.NoError(t, err)
 
-	networkID, err := tx.GetNetworkID(project.Default, "network1")
+	networkID, err := tx.GetNetworkID(context.Background(), project.Default, "network1")
 	require.NoError(t, err)
 	assert.True(t, networkID > 0)
 

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -316,7 +316,7 @@ func (c *ClusterTx) GetNodeByName(ctx context.Context, name string) (NodeInfo, e
 
 // GetLocalNodeName returns the name of the node this method is invoked on.
 // Usually you should not use this function directly but instead use the cached State.ServerName value.
-func (c *ClusterTx) GetLocalNodeName() (string, error) {
+func (c *ClusterTx) GetLocalNodeName(ctx context.Context) (string, error) {
 	stmt := "SELECT name FROM nodes WHERE id=?"
 	names, err := query.SelectStrings(c.tx, stmt, c.nodeID)
 	if err != nil {
@@ -334,7 +334,7 @@ func (c *ClusterTx) GetLocalNodeName() (string, error) {
 }
 
 // GetLocalNodeAddress returns the address of the node this method is invoked on.
-func (c *ClusterTx) GetLocalNodeAddress() (string, error) {
+func (c *ClusterTx) GetLocalNodeAddress(ctx context.Context) (string, error) {
 	stmt := "SELECT address FROM nodes WHERE id=?"
 	addresses, err := query.SelectStrings(c.tx, stmt, c.nodeID)
 	if err != nil {
@@ -402,7 +402,7 @@ func (c *ClusterTx) GetNodes(ctx context.Context) ([]NodeInfo, error) {
 //
 // Since there's always at least one node row, even when not-clustered, the
 // return value is greater than zero.
-func (c *ClusterTx) GetNodesCount() (int, error) {
+func (c *ClusterTx) GetNodesCount(ctx context.Context) (int, error) {
 	count, err := query.Count(c.tx, "nodes", "")
 	if err != nil {
 		return 0, fmt.Errorf("failed to count existing nodes: %w", err)
@@ -414,7 +414,7 @@ func (c *ClusterTx) GetNodesCount() (int, error) {
 // RenameNode changes the name of an existing node.
 //
 // Return an error if a node with the same name already exists.
-func (c *ClusterTx) RenameNode(old, new string) error {
+func (c *ClusterTx) RenameNode(ctx context.Context, old string, new string) error {
 	count, err := query.Count(c.tx, "nodes", "name=?", new)
 	if err != nil {
 		return fmt.Errorf("failed to check existing nodes: %w", err)
@@ -1023,7 +1023,7 @@ func (c *ClusterTx) NodeIsEmpty(ctx context.Context, id int64) (string, error) {
 }
 
 // ClearNode removes any instance or image associated with this node.
-func (c *ClusterTx) ClearNode(id int64) error {
+func (c *ClusterTx) ClearNode(ctx context.Context, id int64) error {
 	_, err := c.tx.Exec("DELETE FROM instances WHERE node_id=?", id)
 	if err != nil {
 		return err
@@ -1064,7 +1064,7 @@ func (c *ClusterTx) ClearNode(id int64) error {
 // GetNodeOfflineThreshold returns the amount of time that needs to elapse after
 // which a series of unsuccessful heartbeat will make the node be considered
 // offline.
-func (c *ClusterTx) GetNodeOfflineThreshold() (time.Duration, error) {
+func (c *ClusterTx) GetNodeOfflineThreshold(ctx context.Context) (time.Duration, error) {
 	threshold := time.Duration(DefaultOfflineThreshold) * time.Second
 	values, err := query.SelectStrings(
 		c.tx, "SELECT value FROM config WHERE key='cluster.offline_threshold'")

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -240,7 +240,7 @@ func (c *ClusterTx) GetNodeMaxVersion(ctx context.Context) ([2]int, error) {
 
 	// Get the maximum DB schema.
 	var maxSchema int
-	row := c.tx.QueryRow("SELECT MAX(schema) FROM nodes")
+	row := c.tx.QueryRowContext(ctx, "SELECT MAX(schema) FROM nodes")
 	err := row.Scan(&maxSchema)
 	if err != nil {
 		return version, err
@@ -248,7 +248,7 @@ func (c *ClusterTx) GetNodeMaxVersion(ctx context.Context) ([2]int, error) {
 
 	// Get the maximum API extension.
 	var maxAPI int
-	row = c.tx.QueryRow("SELECT MAX(api_extensions) FROM nodes")
+	row = c.tx.QueryRowContext(ctx, "SELECT MAX(api_extensions) FROM nodes")
 	err = row.Scan(&maxAPI)
 	if err != nil {
 		return version, err
@@ -760,7 +760,7 @@ func (c *ClusterTx) UpdateNodeFailureDomain(ctx context.Context, id int64, domai
 	if domain == "default" {
 		domainID = nil
 	} else {
-		row := c.tx.QueryRow("SELECT id FROM nodes_failure_domains WHERE name=?", domain)
+		row := c.tx.QueryRowContext(ctx, "SELECT id FROM nodes_failure_domains WHERE name=?", domain)
 		err := row.Scan(&domainID)
 		if err != nil {
 			if err != sql.ErrNoRows {
@@ -824,7 +824,7 @@ SELECT coalesce(nodes_failure_domains.name,'default')
 `
 	var domain string
 
-	err := c.tx.QueryRow(stmt, id).Scan(&domain)
+	err := c.tx.QueryRowContext(ctx, stmt, id).Scan(&domain)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -492,7 +492,7 @@ func updateFromV18(ctx context.Context, tx *sql.Tx) error {
 	var value string
 
 	// Update container config
-	rows, err := tx.Query("SELECT id, value FROM containers_config WHERE key='limits.memory'")
+	rows, err := tx.QueryContext(ctx, "SELECT id, value FROM containers_config WHERE key='limits.memory'")
 	if err != nil {
 		return err
 	}
@@ -538,7 +538,7 @@ func updateFromV18(ctx context.Context, tx *sql.Tx) error {
 	}
 
 	// Update profiles config
-	rows, err = tx.Query("SELECT id, value FROM profiles_config WHERE key='limits.memory'")
+	rows, err = tx.QueryContext(ctx, "SELECT id, value FROM profiles_config WHERE key='limits.memory'")
 	if err != nil {
 		return err
 	}
@@ -858,7 +858,7 @@ PRAGMA foreign_keys=ON; -- Make sure we turn integrity checks back on.`
 	}
 
 	// Get the rows with broken foreign keys an nuke them
-	rows, err := tx.Query("PRAGMA foreign_key_check;")
+	rows, err := tx.QueryContext(ctx, "PRAGMA foreign_key_check;")
 	if err != nil {
 		return err
 	}

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -182,7 +182,7 @@ func updateFromV39(ctx context.Context, tx *sql.Tx) error {
 		return nil
 	}
 
-	config, err := query.SelectConfig(tx, "config", "")
+	config, err := query.SelectConfig(ctx, tx, "config", "")
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ ALTER TABLE raft_nodes ADD COLUMN role INTEGER NOT NULL DEFAULT 0;
 // Copy core.https_address to cluster.https_address in case this node is
 // clustered.
 func updateFromV37(ctx context.Context, tx *sql.Tx) error {
-	count, err := query.Count(tx, "raft_nodes", "")
+	count, err := query.Count(ctx, tx, "raft_nodes", "")
 	if err != nil {
 		return fmt.Errorf("Fetch count of Raft nodes: %w", err)
 	}

--- a/lxd/db/node/update_test.go
+++ b/lxd/db/node/update_test.go
@@ -22,7 +22,7 @@ func TestUpdateFromV38_RaftNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	err = query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error {
-		roles, err := query.SelectIntegers(tx, "SELECT role FROM raft_nodes")
+		roles, err := query.SelectIntegers(ctx, tx, "SELECT role FROM raft_nodes")
 		require.NoError(t, err)
 		assert.Equal(t, roles, []int{0})
 		return nil
@@ -50,7 +50,7 @@ func TestUpdateFromV36_DropTables(t *testing.T) {
 	err = query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		stmt := "SELECT name FROM sqlite_master WHERE type='table'"
-		current, err = query.SelectStrings(tx, stmt)
+		current, err = query.SelectStrings(ctx, tx, stmt)
 		return err
 	})
 	require.NoError(t, err)

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -49,14 +49,14 @@ func TestGetNodesCount(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	count, err := tx.GetNodesCount()
+	count, err := tx.GetNodesCount(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, count) // There's always at least one node.
 
 	_, err = tx.CreateNode("buzz", "1.2.3.4:666")
 	require.NoError(t, err)
 
-	count, err = tx.GetNodesCount()
+	count, err = tx.GetNodesCount(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 }
@@ -122,7 +122,7 @@ func TestGetLocalNodeName(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	name, err := tx.GetLocalNodeName()
+	name, err := tx.GetLocalNodeName(context.Background())
 	require.NoError(t, err)
 
 	// The default node 1 has a conventional name 'none'.
@@ -136,7 +136,7 @@ func TestRenameNode(t *testing.T) {
 
 	_, err := tx.CreateNode("buzz", "1.2.3.4:666")
 	require.NoError(t, err)
-	err = tx.RenameNode("buzz", "rusp")
+	err = tx.RenameNode(context.Background(), "buzz", "rusp")
 	require.NoError(t, err)
 	node, err := tx.GetNodeByName(context.Background(), "rusp")
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestRenameNode(t *testing.T) {
 
 	_, err = tx.CreateNode("buzz", "5.6.7.8:666")
 	require.NoError(t, err)
-	err = tx.RenameNode("rusp", "buzz")
+	err = tx.RenameNode(context.Background(), "rusp", "buzz")
 	assert.Equal(t, db.ErrAlreadyDefined, err)
 }
 
@@ -241,7 +241,7 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.NoError(t, err)
 	assert.Equal(t, "Node still has the following containers: foo", message)
 
-	err = tx.ClearNode(id)
+	err = tx.ClearNode(context.Background(), id)
 	require.NoError(t, err)
 
 	message, err = tx.NodeIsEmpty(context.Background(), id)

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -33,7 +33,7 @@ SELECT operations.id, operations.uuid, operations.type, nodes.address
   JOIN nodes on nodes.id = operations.node_id
 WHERE (projects.name = ? OR operations.project_id IS NULL) and operations.type = ?
 `
-	rows, err := c.tx.Query(stmt, projectName, opType)
+	rows, err := c.tx.QueryContext(ctx, stmt, projectName, opType)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -19,7 +19,7 @@ SELECT DISTINCT nodes.address
   JOIN nodes ON nodes.id = operations.node_id
  WHERE projects.name = ? OR operations.project_id IS NULL
 `
-	return query.SelectStrings(c.tx, stmt, project)
+	return query.SelectStrings(ctx, c.tx, stmt, project)
 }
 
 // GetOperationsOfType returns a list operations that belong to the specified project and have the desired type.

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -3,13 +3,15 @@
 package db
 
 import (
+	"context"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/operationtype"
 	"github.com/lxc/lxd/lxd/db/query"
 )
 
 // GetNodesWithOperations returns a list of nodes that have operations.
-func (c *ClusterTx) GetNodesWithOperations(project string) ([]string, error) {
+func (c *ClusterTx) GetNodesWithOperations(ctx context.Context, project string) ([]string, error) {
 	stmt := `
 SELECT DISTINCT nodes.address
   FROM operations
@@ -21,7 +23,7 @@ SELECT DISTINCT nodes.address
 }
 
 // GetOperationsOfType returns a list operations that belong to the specified project and have the desired type.
-func (c *ClusterTx) GetOperationsOfType(projectName string, opType operationtype.Type) ([]cluster.Operation, error) {
+func (c *ClusterTx) GetOperationsOfType(ctx context.Context, projectName string, opType operationtype.Type) ([]cluster.Operation, error) {
 	var ops []cluster.Operation
 
 	stmt := `

--- a/lxd/db/patches.go
+++ b/lxd/db/patches.go
@@ -14,7 +14,7 @@ func (n *Node) GetAppliedPatches() ([]string, error) {
 	var response []string
 	err := query.Transaction(context.TODO(), n.db, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
-		response, err = query.SelectStrings(tx, "SELECT name FROM patches")
+		response, err = query.SelectStrings(ctx, tx, "SELECT name FROM patches")
 		return err
 	})
 	if err != nil {

--- a/lxd/db/query/config.go
+++ b/lxd/db/query/config.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -11,7 +12,7 @@ import (
 // additional WHERE filters can be specified.
 //
 // Returns a map of key names to their associated values.
-func SelectConfig(tx *sql.Tx, table string, where string, args ...any) (map[string]string, error) {
+func SelectConfig(ctx context.Context, tx *sql.Tx, table string, where string, args ...any) (map[string]string, error) {
 	query := fmt.Sprintf("SELECT key, value FROM %s", table)
 	if where != "" {
 		query += fmt.Sprintf(" WHERE %s", where)

--- a/lxd/db/query/config.go
+++ b/lxd/db/query/config.go
@@ -18,7 +18,7 @@ func SelectConfig(ctx context.Context, tx *sql.Tx, table string, where string, a
 		query += fmt.Sprintf(" WHERE %s", where)
 	}
 
-	rows, err := tx.Query(query, args...)
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/query/config_test.go
+++ b/lxd/db/query/config_test.go
@@ -1,6 +1,7 @@
 package query_test
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -12,14 +13,14 @@ import (
 
 func TestSelectConfig(t *testing.T) {
 	tx := newTxForConfig(t)
-	values, err := query.SelectConfig(tx, "test", "")
+	values, err := query.SelectConfig(context.Background(), tx, "test", "")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"foo": "x", "bar": "zz"}, values)
 }
 
 func TestSelectConfig_WithFilters(t *testing.T) {
 	tx := newTxForConfig(t)
-	values, err := query.SelectConfig(tx, "test", "key=?", "bar")
+	values, err := query.SelectConfig(context.Background(), tx, "test", "key=?", "bar")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"bar": "zz"}, values)
 }
@@ -32,7 +33,7 @@ func TestUpdateConfig_NewKeys(t *testing.T) {
 	err := query.UpdateConfig(tx, "test", values)
 	require.NoError(t, err)
 
-	values, err = query.SelectConfig(tx, "test", "")
+	values, err = query.SelectConfig(context.Background(), tx, "test", "")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"foo": "y", "bar": "zz"}, values)
 }
@@ -45,7 +46,7 @@ func TestDeleteConfig_Delete(t *testing.T) {
 	err := query.UpdateConfig(tx, "test", values)
 
 	require.NoError(t, err)
-	values, err = query.SelectConfig(tx, "test", "")
+	values, err = query.SelectConfig(context.Background(), tx, "test", "")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"bar": "zz"}, values)
 }

--- a/lxd/db/query/count.go
+++ b/lxd/db/query/count.go
@@ -46,14 +46,14 @@ func Count(ctx context.Context, tx *sql.Tx, table string, where string, args ...
 // CountAll returns a map associating each table name in the database
 // with the total count of its rows.
 func CountAll(ctx context.Context, tx *sql.Tx) (map[string]int, error) {
-	tables, err := SelectStrings(tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
+	tables, err := SelectStrings(ctx, tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch table names: %w", err)
 	}
 
 	counts := map[string]int{}
 	for _, table := range tables {
-		count, err := Count(tx, table, "")
+		count, err := Count(ctx, tx, table, "")
 		if err != nil {
 			return nil, fmt.Errorf("Failed to count rows of %s: %w", table, err)
 		}

--- a/lxd/db/query/count.go
+++ b/lxd/db/query/count.go
@@ -1,12 +1,13 @@
 package query
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 )
 
 // Count returns the number of rows in the given table.
-func Count(tx *sql.Tx, table string, where string, args ...any) (int, error) {
+func Count(ctx context.Context, tx *sql.Tx, table string, where string, args ...any) (int, error) {
 	stmt := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
 	if where != "" {
 		stmt += fmt.Sprintf(" WHERE %s", where)
@@ -44,7 +45,7 @@ func Count(tx *sql.Tx, table string, where string, args ...any) (int, error) {
 
 // CountAll returns a map associating each table name in the database
 // with the total count of its rows.
-func CountAll(tx *sql.Tx) (map[string]int, error) {
+func CountAll(ctx context.Context, tx *sql.Tx) (map[string]int, error) {
 	tables, err := SelectStrings(tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch table names: %w", err)

--- a/lxd/db/query/count.go
+++ b/lxd/db/query/count.go
@@ -13,7 +13,7 @@ func Count(ctx context.Context, tx *sql.Tx, table string, where string, args ...
 		stmt += fmt.Sprintf(" WHERE %s", where)
 	}
 
-	rows, err := tx.Query(stmt, args...)
+	rows, err := tx.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/lxd/db/query/count_test.go
+++ b/lxd/db/query/count_test.go
@@ -1,6 +1,7 @@
 package query_test
 
 import (
+	"context"
 	"database/sql"
 	"strconv"
 	"testing"
@@ -38,7 +39,7 @@ func TestCount(t *testing.T) {
 	for _, c := range cases {
 		t.Run(strconv.Itoa(c.count), func(t *testing.T) {
 			tx := newTxForCount(t)
-			count, err := query.Count(tx, "test", c.where, c.args...)
+			count, err := query.Count(context.Background(), tx, "test", c.where, c.args...)
 			require.NoError(t, err)
 			assert.Equal(t, c.count, count)
 		})
@@ -49,7 +50,7 @@ func TestCountAll(t *testing.T) {
 	tx := newTxForCount(t)
 	defer func() { _ = tx.Rollback() }()
 
-	counts, err := query.CountAll(tx)
+	counts, err := query.CountAll(context.Background(), tx)
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]int{

--- a/lxd/db/query/slices.go
+++ b/lxd/db/query/slices.go
@@ -22,7 +22,7 @@ func SelectStrings(ctx context.Context, tx *sql.Tx, query string, args ...any) (
 		return nil
 	}
 
-	err := scanSingleColumn(tx, query, args, "TEXT", scan)
+	err := scanSingleColumn(ctx, tx, query, args, "TEXT", scan)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func SelectIntegers(ctx context.Context, tx *sql.Tx, query string, args ...any) 
 		return nil
 	}
 
-	err := scanSingleColumn(tx, query, args, "INTEGER", scan)
+	err := scanSingleColumn(ctx, tx, query, args, "INTEGER", scan)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/query/slices.go
+++ b/lxd/db/query/slices.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -8,7 +9,7 @@ import (
 
 // SelectStrings executes a statement which must yield rows with a single string
 // column. It returns the list of column values.
-func SelectStrings(tx *sql.Tx, query string, args ...any) ([]string, error) {
+func SelectStrings(ctx context.Context, tx *sql.Tx, query string, args ...any) ([]string, error) {
 	values := []string{}
 	scan := func(rows *sql.Rows) error {
 		var value string
@@ -31,7 +32,7 @@ func SelectStrings(tx *sql.Tx, query string, args ...any) ([]string, error) {
 
 // SelectIntegers executes a statement which must yield rows with a single integer
 // column. It returns the list of column values.
-func SelectIntegers(tx *sql.Tx, query string, args ...any) ([]int, error) {
+func SelectIntegers(ctx context.Context, tx *sql.Tx, query string, args ...any) ([]int, error) {
 	values := []int{}
 	scan := func(rows *sql.Rows) error {
 		var value int
@@ -78,7 +79,7 @@ func InsertStrings(tx *sql.Tx, stmt string, values []string) error {
 // Execute the given query and ensure that it yields rows with a single column
 // of the given database type. For every row yielded, execute the given
 // scanner.
-func scanSingleColumn(tx *sql.Tx, query string, args []any, typeName string, scan scanFunc) error {
+func scanSingleColumn(ctx context.Context, tx *sql.Tx, query string, args []any, typeName string, scan scanFunc) error {
 	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return err

--- a/lxd/db/query/slices.go
+++ b/lxd/db/query/slices.go
@@ -80,7 +80,7 @@ func InsertStrings(tx *sql.Tx, stmt string, values []string) error {
 // of the given database type. For every row yielded, execute the given
 // scanner.
 func scanSingleColumn(ctx context.Context, tx *sql.Tx, query string, args []any, typeName string, scan scanFunc) error {
-	rows, err := tx.Query(query, args...)
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/query/slices_test.go
+++ b/lxd/db/query/slices_test.go
@@ -1,6 +1,7 @@
 package query_test
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -15,7 +16,7 @@ func TestStrings_Error(t *testing.T) {
 	for _, c := range testStringsErrorCases {
 		t.Run(c.query, func(t *testing.T) {
 			tx := newTxForSlices(t)
-			values, err := query.SelectStrings(tx, c.query)
+			values, err := query.SelectStrings(context.Background(), tx, c.query)
 			assert.EqualError(t, err, c.error)
 			assert.Nil(t, values)
 		})
@@ -33,7 +34,7 @@ var testStringsErrorCases = []struct {
 // All values yield by the query are returned.
 func TestStrings(t *testing.T) {
 	tx := newTxForSlices(t)
-	values, err := query.SelectStrings(tx, "SELECT name FROM test ORDER BY name")
+	values, err := query.SelectStrings(context.Background(), tx, "SELECT name FROM test ORDER BY name")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"bar", "foo"}, values)
 }
@@ -43,7 +44,7 @@ func TestIntegers_Error(t *testing.T) {
 	for _, c := range testIntegersErrorCases {
 		t.Run(c.query, func(t *testing.T) {
 			tx := newTxForSlices(t)
-			values, err := query.SelectIntegers(tx, c.query)
+			values, err := query.SelectIntegers(context.Background(), tx, c.query)
 			assert.EqualError(t, err, c.error)
 			assert.Nil(t, values)
 		})
@@ -61,7 +62,7 @@ var testIntegersErrorCases = []struct {
 // All values yield by the query are returned.
 func TestIntegers(t *testing.T) {
 	tx := newTxForSlices(t)
-	values, err := query.SelectIntegers(tx, "SELECT id FROM test ORDER BY id")
+	values, err := query.SelectIntegers(context.Background(), tx, "SELECT id FROM test ORDER BY id")
 	assert.Nil(t, err)
 	assert.Equal(t, []int{0, 1}, values)
 }
@@ -73,7 +74,7 @@ func TestInsertStrings(t *testing.T) {
 	err := query.InsertStrings(tx, "INSERT INTO test(name) VALUES %s", []string{"xx", "yy"})
 	require.NoError(t, err)
 
-	values, err := query.SelectStrings(tx, "SELECT name FROM test ORDER BY name DESC LIMIT 2")
+	values, err := query.SelectStrings(context.Background(), tx, "SELECT name FROM test ORDER BY name DESC LIMIT 2")
 	require.NoError(t, err)
 	assert.Equal(t, values, []string{"yy", "xx"})
 }

--- a/lxd/db/query/transaction_test.go
+++ b/lxd/db/query/transaction_test.go
@@ -37,7 +37,7 @@ func TestTransaction_FunctionError(t *testing.T) {
 	tx, err := db.Begin()
 	assert.NoError(t, err)
 
-	tables, err := query.SelectStrings(tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
+	tables, err := query.SelectStrings(context.Background(), tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
 	assert.NoError(t, err)
 	assert.NotContains(t, tables, "test")
 }

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -60,13 +60,13 @@ func (n *NodeTx) GetRaftNodes(ctx context.Context) ([]RaftNode, error) {
 // GetRaftNodeAddresses returns the addresses of all LXD nodes that are members of
 // the dqlite Raft cluster (possibly including the local member). If this LXD
 // instance is not running in clustered mode, an empty list is returned.
-func (n *NodeTx) GetRaftNodeAddresses() ([]string, error) {
+func (n *NodeTx) GetRaftNodeAddresses(ctx context.Context) ([]string, error) {
 	return query.SelectStrings(n.tx, "SELECT address FROM raft_nodes")
 }
 
 // GetRaftNodeAddress returns the address of the LXD raft node with the given ID,
 // if any matching row exists.
-func (n *NodeTx) GetRaftNodeAddress(id int64) (string, error) {
+func (n *NodeTx) GetRaftNodeAddress(ctx context.Context, id int64) (string, error) {
 	stmt := "SELECT address FROM raft_nodes WHERE id=?"
 	addresses, err := query.SelectStrings(n.tx, stmt, id)
 	if err != nil {

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -61,14 +61,14 @@ func (n *NodeTx) GetRaftNodes(ctx context.Context) ([]RaftNode, error) {
 // the dqlite Raft cluster (possibly including the local member). If this LXD
 // instance is not running in clustered mode, an empty list is returned.
 func (n *NodeTx) GetRaftNodeAddresses(ctx context.Context) ([]string, error) {
-	return query.SelectStrings(n.tx, "SELECT address FROM raft_nodes")
+	return query.SelectStrings(ctx, n.tx, "SELECT address FROM raft_nodes")
 }
 
 // GetRaftNodeAddress returns the address of the LXD raft node with the given ID,
 // if any matching row exists.
 func (n *NodeTx) GetRaftNodeAddress(ctx context.Context, id int64) (string, error) {
 	stmt := "SELECT address FROM raft_nodes WHERE id=?"
-	addresses, err := query.SelectStrings(n.tx, stmt, id)
+	addresses, err := query.SelectStrings(ctx, n.tx, stmt, id)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/db/raft_test.go
+++ b/lxd/db/raft_test.go
@@ -45,7 +45,7 @@ func TestGetRaftNodeAddresses(t *testing.T) {
 	_, err = tx.CreateRaftNode("5.6.7.8:666", "test")
 	require.NoError(t, err)
 
-	addresses, err := tx.GetRaftNodeAddresses()
+	addresses, err := tx.GetRaftNodeAddresses(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"1.2.3.4:666", "5.6.7.8:666"}, addresses)
@@ -62,7 +62,7 @@ func TestGetRaftNodeAddress(t *testing.T) {
 	id, err := tx.CreateRaftNode("5.6.7.8:666", "test")
 	require.NoError(t, err)
 
-	address, err := tx.GetRaftNodeAddress(id)
+	address, err := tx.GetRaftNodeAddress(context.Background(), id)
 	require.NoError(t, err)
 	assert.Equal(t, "5.6.7.8:666", address)
 }
@@ -81,7 +81,7 @@ func TestCreateFirstRaftNode(t *testing.T) {
 	err = tx.CreateFirstRaftNode("5.6.7.8:666", "test")
 	assert.NoError(t, err)
 
-	address, err := tx.GetRaftNodeAddress(1)
+	address, err := tx.GetRaftNodeAddress(context.Background(), 1)
 	require.NoError(t, err)
 	assert.Equal(t, "5.6.7.8:666", address)
 }

--- a/lxd/db/schema/query.go
+++ b/lxd/db/schema/query.go
@@ -13,7 +13,7 @@ import (
 
 // DoesSchemaTableExist return whether the schema table is present in the
 // database.
-func DoesSchemaTableExist(tx *sql.Tx) (bool, error) {
+func DoesSchemaTableExist(ctx context.Context, tx *sql.Tx) (bool, error) {
 	statement := `
 SELECT COUNT(name) FROM sqlite_master WHERE type = 'table' AND name = 'schema'
 `
@@ -39,7 +39,7 @@ SELECT COUNT(name) FROM sqlite_master WHERE type = 'table' AND name = 'schema'
 }
 
 // Return all versions in the schema table, in increasing order.
-func selectSchemaVersions(tx *sql.Tx) ([]int, error) {
+func selectSchemaVersions(ctx context.Context, tx *sql.Tx) ([]int, error) {
 	statement := `
 SELECT version FROM schema ORDER BY version
 `
@@ -48,7 +48,7 @@ SELECT version FROM schema ORDER BY version
 
 // Return a list of SQL statements that can be used to create all tables in the
 // database.
-func selectTablesSQL(tx *sql.Tx) ([]string, error) {
+func selectTablesSQL(ctx context.Context, tx *sql.Tx) ([]string, error) {
 	statement := `
 SELECT sql FROM sqlite_master WHERE
   type IN ('table', 'index', 'view', 'trigger') AND

--- a/lxd/db/schema/query.go
+++ b/lxd/db/schema/query.go
@@ -17,7 +17,7 @@ func DoesSchemaTableExist(ctx context.Context, tx *sql.Tx) (bool, error) {
 	statement := `
 SELECT COUNT(name) FROM sqlite_master WHERE type = 'table' AND name = 'schema'
 `
-	rows, err := tx.Query(statement)
+	rows, err := tx.QueryContext(ctx, statement)
 	if err != nil {
 		return false, err
 	}

--- a/lxd/db/schema/query.go
+++ b/lxd/db/schema/query.go
@@ -43,7 +43,7 @@ func selectSchemaVersions(ctx context.Context, tx *sql.Tx) ([]int, error) {
 	statement := `
 SELECT version FROM schema ORDER BY version
 `
-	return query.SelectIntegers(tx, statement)
+	return query.SelectIntegers(ctx, tx, statement)
 }
 
 // Return a list of SQL statements that can be used to create all tables in the
@@ -56,7 +56,7 @@ SELECT sql FROM sqlite_master WHERE
   name NOT LIKE 'sqlite_%'
 ORDER BY name
 `
-	return query.SelectStrings(tx, statement)
+	return query.SelectStrings(ctx, tx, statement)
 }
 
 // Create the schema table.

--- a/lxd/db/schema/schema.go
+++ b/lxd/db/schema/schema.go
@@ -144,12 +144,12 @@ func (s *Schema) Ensure(db *sql.DB) (int, error) {
 			return fmt.Errorf("failed to execute queries from %s: %w", s.path, err)
 		}
 
-		err = ensureSchemaTableExists(tx)
+		err = ensureSchemaTableExists(ctx, tx)
 		if err != nil {
 			return err
 		}
 
-		current, err = queryCurrentVersion(tx)
+		current, err = queryCurrentVersion(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -204,12 +204,12 @@ func (s *Schema) Ensure(db *sql.DB) (int, error) {
 func (s *Schema) Dump(db *sql.DB) (string, error) {
 	var statements []string
 	err := query.Transaction(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) error {
-		err := checkAllUpdatesAreApplied(tx, s.updates)
+		err := checkAllUpdatesAreApplied(ctx, tx, s.updates)
 		if err != nil {
 			return err
 		}
 
-		statements, err = selectTablesSQL(tx)
+		statements, err = selectTablesSQL(ctx, tx)
 		return err
 	})
 	if err != nil {
@@ -279,7 +279,7 @@ func (s *Schema) ExerciseUpdate(version int, hook func(*sql.DB)) (*sql.DB, error
 
 // Ensure that the schema exists.
 func ensureSchemaTableExists(ctx context.Context, tx *sql.Tx) error {
-	exists, err := DoesSchemaTableExist(tx)
+	exists, err := DoesSchemaTableExist(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to check if schema table is there: %w", err)
 	}
@@ -296,7 +296,7 @@ func ensureSchemaTableExists(ctx context.Context, tx *sql.Tx) error {
 // Return the highest update version currently applied. Zero means that no
 // updates have been applied yet.
 func queryCurrentVersion(ctx context.Context, tx *sql.Tx) (int, error) {
-	versions, err := selectSchemaVersions(tx)
+	versions, err := selectSchemaVersions(ctx, tx)
 	if err != nil {
 		return -1, fmt.Errorf("failed to fetch update versions: %w", err)
 	}
@@ -309,7 +309,7 @@ func queryCurrentVersion(ctx context.Context, tx *sql.Tx) (int, error) {
 			return -1, fmt.Errorf("failed to insert missing schema version 31")
 		}
 
-		versions, err = selectSchemaVersions(tx)
+		versions, err = selectSchemaVersions(ctx, tx)
 		if err != nil {
 			return -1, fmt.Errorf("failed to fetch update versions: %w", err)
 		}
@@ -317,7 +317,7 @@ func queryCurrentVersion(ctx context.Context, tx *sql.Tx) (int, error) {
 
 	// Fix broken schema version between 37 and 38
 	if hasVersion(37) && !hasVersion(38) {
-		count, err := query.Count(tx, "config", "key = 'cluster.https_address'")
+		count, err := query.Count(ctx, tx, "config", "key = 'cluster.https_address'")
 		if err != nil {
 			return -1, fmt.Errorf("Failed to check if cluster.https_address is set: %w", err)
 		}
@@ -398,7 +398,7 @@ func checkSchemaVersionsHaveNoHoles(versions []int) error {
 
 // Check that all the given updates are applied.
 func checkAllUpdatesAreApplied(ctx context.Context, tx *sql.Tx, updates []Update) error {
-	versions, err := selectSchemaVersions(tx)
+	versions, err := selectSchemaVersions(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch update versions: %w", err)
 	}

--- a/lxd/db/schema/schema.go
+++ b/lxd/db/schema/schema.go
@@ -278,7 +278,7 @@ func (s *Schema) ExerciseUpdate(version int, hook func(*sql.DB)) (*sql.DB, error
 }
 
 // Ensure that the schema exists.
-func ensureSchemaTableExists(tx *sql.Tx) error {
+func ensureSchemaTableExists(ctx context.Context, tx *sql.Tx) error {
 	exists, err := DoesSchemaTableExist(tx)
 	if err != nil {
 		return fmt.Errorf("failed to check if schema table is there: %w", err)
@@ -295,7 +295,7 @@ func ensureSchemaTableExists(tx *sql.Tx) error {
 
 // Return the highest update version currently applied. Zero means that no
 // updates have been applied yet.
-func queryCurrentVersion(tx *sql.Tx) (int, error) {
+func queryCurrentVersion(ctx context.Context, tx *sql.Tx) (int, error) {
 	versions, err := selectSchemaVersions(tx)
 	if err != nil {
 		return -1, fmt.Errorf("failed to fetch update versions: %w", err)
@@ -397,7 +397,7 @@ func checkSchemaVersionsHaveNoHoles(versions []int) error {
 }
 
 // Check that all the given updates are applied.
-func checkAllUpdatesAreApplied(tx *sql.Tx, updates []Update) error {
+func checkAllUpdatesAreApplied(ctx context.Context, tx *sql.Tx, updates []Update) error {
 	versions, err := selectSchemaVersions(tx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch update versions: %w", err)

--- a/lxd/db/schema/schema_test.go
+++ b/lxd/db/schema/schema_test.go
@@ -111,7 +111,7 @@ func TestSchemaEnsure_ZeroUpdates(t *testing.T) {
 	tx, err := db.Begin()
 	assert.NoError(t, err)
 
-	versions, err := query.SelectIntegers(tx, "SELECT version FROM SCHEMA")
+	versions, err := query.SelectIntegers(context.Background(), tx, "SELECT version FROM SCHEMA")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{}, versions)
 }
@@ -131,12 +131,12 @@ func TestSchemaEnsure_ApplyAllUpdates(t *testing.T) {
 	assert.NoError(t, err)
 
 	// THe update version is recorded.
-	versions, err := query.SelectIntegers(tx, "SELECT version FROM SCHEMA")
+	versions, err := query.SelectIntegers(context.Background(), tx, "SELECT version FROM SCHEMA")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{1, 2}, versions)
 
 	// The two updates have been applied in order.
-	ids, err := query.SelectIntegers(tx, "SELECT id FROM test")
+	ids, err := query.SelectIntegers(context.Background(), tx, "SELECT id FROM test")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{1}, ids)
 }
@@ -168,7 +168,7 @@ func TestSchemaEnsure_ApplyAfterInitialDumpCreation(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Only updates starting from the initial dump are recorded.
-	versions, err := query.SelectIntegers(tx, "SELECT version FROM SCHEMA")
+	versions, err := query.SelectIntegers(context.Background(), tx, "SELECT version FROM SCHEMA")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{2, 3}, versions)
 }
@@ -190,12 +190,12 @@ func TestSchemaEnsure_OnlyApplyMissing(t *testing.T) {
 	assert.NoError(t, err)
 
 	// All update versions are recorded.
-	versions, err := query.SelectIntegers(tx, "SELECT version FROM SCHEMA")
+	versions, err := query.SelectIntegers(context.Background(), tx, "SELECT version FROM SCHEMA")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{1, 2}, versions)
 
 	// The two updates have been applied in order.
-	ids, err := query.SelectIntegers(tx, "SELECT id FROM test")
+	ids, err := query.SelectIntegers(context.Background(), tx, "SELECT id FROM test")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{1}, ids)
 }
@@ -213,7 +213,7 @@ func TestSchemaEnsure_FailingUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Not update was applied.
-	tables, err := query.SelectStrings(tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
+	tables, err := query.SelectStrings(context.Background(), tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
 	assert.NoError(t, err)
 	assert.NotContains(t, tables, "schema")
 	assert.NotContains(t, tables, "test")
@@ -232,7 +232,7 @@ func TestSchemaEnsure_FailingHook(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Not update was applied.
-	tables, err := query.SelectStrings(tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
+	tables, err := query.SelectStrings(context.Background(), tx, "SELECT name FROM sqlite_master WHERE type = 'table'")
 	assert.NoError(t, err)
 	assert.NotContains(t, tables, "schema")
 	assert.NotContains(t, tables, "test")
@@ -259,7 +259,7 @@ func TestSchemaEnsure_CheckGracefulAbort(t *testing.T) {
 
 	// The table created by the check function still got committed.
 	// to insert the row was not.
-	ids, err := query.SelectIntegers(tx, "SELECT n FROM test")
+	ids, err := query.SelectIntegers(context.Background(), tx, "SELECT n FROM test")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{}, ids)
 }
@@ -285,7 +285,7 @@ func TestSchemaDump(t *testing.T) {
 	assert.NoError(t, err)
 
 	// All update versions are in place.
-	versions, err := query.SelectIntegers(tx, "SELECT version FROM schema")
+	versions, err := query.SelectIntegers(context.Background(), tx, "SELECT version FROM schema")
 	assert.NoError(t, err)
 	assert.Equal(t, []int{2}, versions)
 
@@ -326,7 +326,7 @@ func TestSchema_Trim(t *testing.T) {
 	tx, err := db.Begin()
 	require.NoError(t, err)
 
-	versions, err := query.SelectIntegers(tx, "SELECT version FROM schema")
+	versions, err := query.SelectIntegers(context.Background(), tx, "SELECT version FROM schema")
 	require.NoError(t, err)
 	assert.Equal(t, []int{1, 2}, versions)
 }
@@ -347,12 +347,12 @@ func TestSchema_ExeciseUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update 2 has been applied.
-	ids, err := query.SelectIntegers(tx, "SELECT id FROM test")
+	ids, err := query.SelectIntegers(context.Background(), tx, "SELECT id FROM test")
 	require.NoError(t, err)
 	assert.Equal(t, []int{1}, ids)
 
 	// Update 3 has not been applied.
-	_, err = query.SelectStrings(tx, "SELECT name FROM test")
+	_, err = query.SelectStrings(context.Background(), tx, "SELECT name FROM test")
 	require.EqualError(t, err, "no such column: name")
 }
 
@@ -411,7 +411,7 @@ INSERT INTO test VALUES (2);
 	tx, err := db.Begin()
 	require.NoError(t, err)
 
-	ids, err := query.SelectIntegers(tx, "SELECT id FROM test ORDER BY id")
+	ids, err := query.SelectIntegers(context.Background(), tx, "SELECT id FROM test ORDER BY id")
 	require.NoError(t, err)
 	assert.Equal(t, []int{1, 2}, ids)
 }
@@ -450,7 +450,7 @@ func TestSchema_File_Hook(t *testing.T) {
 	tx, err := db.Begin()
 	require.NoError(t, err)
 
-	ids, err := query.SelectIntegers(tx, "SELECT id FROM test ORDER BY id")
+	ids, err := query.SelectIntegers(context.Background(), tx, "SELECT id FROM test ORDER BY id")
 	require.NoError(t, err)
 	assert.Equal(t, []int{1, 2}, ids)
 }

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -20,7 +20,7 @@ var StorageRemoteDriverNames func() []string
 
 // GetStoragePoolsLocalConfig returns a map associating each storage pool name to
 // its node-specific config values (i.e. the ones where node_id is not NULL).
-func (c *ClusterTx) GetStoragePoolsLocalConfig() (map[string]map[string]string, error) {
+func (c *ClusterTx) GetStoragePoolsLocalConfig(ctx context.Context) (map[string]map[string]string, error) {
 	names, err := query.SelectStrings(c.tx, "SELECT name FROM storage_pools")
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ storage_pools_config JOIN storage_pools ON storage_pools.id=storage_pools_config
 }
 
 // GetStoragePoolID returns the ID of the pool with the given name.
-func (c *ClusterTx) GetStoragePoolID(name string) (int64, error) {
+func (c *ClusterTx) GetStoragePoolID(ctx context.Context, name string) (int64, error) {
 	stmt := "SELECT id FROM storage_pools WHERE name=?"
 	ids, err := query.SelectIntegers(c.tx, stmt, name)
 	if err != nil {
@@ -63,7 +63,7 @@ func (c *ClusterTx) GetStoragePoolID(name string) (int64, error) {
 }
 
 // GetStoragePoolDriver returns the driver of the pool with the given ID.
-func (c *ClusterTx) GetStoragePoolDriver(id int64) (string, error) {
+func (c *ClusterTx) GetStoragePoolDriver(ctx context.Context, id int64) (string, error) {
 	stmt := "SELECT driver FROM storage_pools WHERE id=?"
 	drivers, err := query.SelectStrings(c.tx, stmt, id)
 	if err != nil {

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -48,7 +48,7 @@ func TestGetStoragePoolsLocalConfigs(t *testing.T) {
 
 	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		config, err = tx.GetStoragePoolsLocalConfig()
+		config, err = tx.GetStoragePoolsLocalConfig(ctx)
 		return err
 	})
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestStoragePoolsCreatePending(t *testing.T) {
 	err = tx.CreatePendingStoragePool(context.Background(), "buzz", "pool1", "dir", config)
 	require.NoError(t, err)
 
-	poolID, err := tx.GetStoragePoolID("pool1")
+	poolID, err := tx.GetStoragePoolID(context.Background(), "pool1")
 	require.NoError(t, err)
 	assert.True(t, poolID > 0)
 
@@ -118,7 +118,7 @@ func TestStoragePoolsCreatePending_OtherPool(t *testing.T) {
 	err = tx.CreatePendingStoragePool(context.Background(), "none", "pool2", "dir", config)
 	require.NoError(t, err)
 
-	poolID, err := tx.GetStoragePoolID("pool2")
+	poolID, err := tx.GetStoragePoolID(context.Background(), "pool2")
 	require.NoError(t, err)
 
 	config = map[string]string{}

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -28,8 +28,7 @@ func (c *Cluster) CreateStorageVolumeSnapshot(project, volumeName, volumeDescrip
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		// If we are creating a snapshot, figure out the volume
 		// ID of the parent.
-		parentID, err := tx.storagePoolVolumeGetTypeID(
-			project, volumeName, volumeType, poolID, c.nodeID)
+		parentID, err := tx.storagePoolVolumeGetTypeID(ctx, project, volumeName, volumeType, poolID, c.nodeID)
 		if err != nil {
 			return fmt.Errorf("Find parent volume: %w", err)
 		}

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -39,7 +39,7 @@ func (c *Cluster) CreateStorageVolumeSnapshot(project, volumeName, volumeDescrip
 			return fmt.Errorf("Increment storage volumes sequence: %w", err)
 		}
 
-		row := tx.tx.QueryRow("SELECT seq FROM sqlite_sequence WHERE name = 'storage_volumes' LIMIT 1")
+		row := tx.tx.QueryRowContext(ctx, "SELECT seq FROM sqlite_sequence WHERE name = 'storage_volumes' LIMIT 1")
 		err = row.Scan(&volumeID)
 		if err != nil {
 			return err

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -507,7 +507,7 @@ func (c *Cluster) storagePoolVolumeGetTypeID(project string, volumeName string, 
 	return id, nil
 }
 
-func (c *ClusterTx) storagePoolVolumeGetTypeID(project string, volumeName string, volumeType int, poolID, nodeID int64) (int64, error) {
+func (c *ClusterTx) storagePoolVolumeGetTypeID(ctx context.Context, project string, volumeName string, volumeType int, poolID, nodeID int64) (int64, error) {
 	remoteDrivers := StorageRemoteDriverNames()
 
 	s := fmt.Sprintf(`

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -447,7 +447,7 @@ func (c *Cluster) CreateStoragePoolVolume(project, volumeName, volumeDescription
 	remoteDrivers := StorageRemoteDriverNames()
 
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		driver, err := tx.GetStoragePoolDriver(poolID)
+		driver, err := tx.GetStoragePoolDriver(ctx, poolID)
 		if err != nil {
 			return err
 		}
@@ -497,7 +497,7 @@ func (c *Cluster) storagePoolVolumeGetTypeID(project string, volumeName string, 
 	var id int64
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		var err error
-		id, err = tx.storagePoolVolumeGetTypeID(project, volumeName, volumeType, poolID, nodeID)
+		id, err = tx.storagePoolVolumeGetTypeID(ctx, project, volumeName, volumeType, poolID, nodeID)
 		return err
 	})
 	if err != nil {
@@ -527,7 +527,7 @@ SELECT storage_volumes_all.id
 		args = append(args, driver)
 	}
 
-	result, err := query.SelectIntegers(c.tx, s, args...)
+	result, err := query.SelectIntegers(ctx, c.tx, s, args...)
 	if err != nil {
 		return -1, err
 	}
@@ -658,7 +658,7 @@ func (c *ClusterTx) GetStorageVolumeNodes(ctx context.Context, poolID int64, pro
 	if nodeCount == 0 {
 		return nil, api.StatusErrorf(http.StatusNotFound, "Storage pool volume not found")
 	} else if nodeCount > 1 {
-		driver, err := c.GetStoragePoolDriver(poolID)
+		driver, err := c.GetStoragePoolDriver(ctx, poolID)
 		if err != nil {
 			return nil, err
 		}
@@ -908,7 +908,7 @@ WHERE storage_volumes.type = ? AND projects.name = ?
 	}
 
 	for i, volume := range volumes {
-		config, err := query.SelectConfig(c.tx, "storage_volumes_config", "storage_volume_id=?", volume.ID)
+		config, err := query.SelectConfig(ctx, c.tx, "storage_volumes_config", "storage_volume_id=?", volume.ID)
 		if err != nil {
 			return nil, fmt.Errorf("Fetch custom volume config: %w", err)
 		}

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -25,7 +25,7 @@ func (c *Cluster) UpsertWarningLocalNode(projectName string, entityTypeCode int,
 	var localName string
 
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		localName, err = tx.GetLocalNodeName()
+		localName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1706,7 +1706,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	var imageVolumes []string
 
 	err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		config, err := node.ConfigLoad(tx)
+		config, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -2139,7 +2139,7 @@ func pruneLeftoverImages(d *Daemon) {
 		// Check if dealing with shared image storage.
 		var storageImages string
 		err := d.State().DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-			nodeConfig, err := node.ConfigLoad(tx)
+			nodeConfig, err := node.ConfigLoad(ctx, tx)
 			if err != nil {
 				return err
 			}
@@ -2178,7 +2178,7 @@ func pruneLeftoverImages(d *Daemon) {
 		var images []string
 		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			images, err = tx.GetLocalImagesFingerprints()
+			images, err = tx.GetLocalImagesFingerprints(ctx)
 			return err
 		})
 		if err != nil {
@@ -4067,7 +4067,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 
 		// -1 means that we want to replicate the image on all nodes
 		if desiredSyncNodeCount == -1 {
-			nodesCount, err := tx.GetNodesCount()
+			nodesCount, err := tx.GetNodesCount(ctx)
 			if err != nil {
 				return fmt.Errorf("Failed to get the number of nodes: %w", err)
 			}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -141,7 +141,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			targetNodeOffline = node.IsOffline(s.GlobalConfig.OfflineThreshold())
 
 			// Load source node.
-			address, err := tx.GetNodeAddressOfInstance(projectName, name, instanceType)
+			address, err := tx.GetNodeAddressOfInstance(ctx, projectName, name, instanceType)
 			if err != nil {
 				return fmt.Errorf("Failed to get address of instance's member: %w", err)
 			}
@@ -556,7 +556,7 @@ func instancePostClusteringMigrate(d *Daemon, r *http.Request, inst instance.Ins
 	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
-		sourceAddress, err = tx.GetLocalNodeAddress()
+		sourceAddress, err = tx.GetLocalNodeAddress(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to get local member address: %w", err)
 		}

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -300,12 +300,12 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 			filteredProjects = []string{projectName}
 		}
 
-		nodesProjectsInstances, err = tx.GetProjectAndInstanceNamesByNodeAddress(filteredProjects, instanceType)
+		nodesProjectsInstances, err = tx.GetProjectAndInstanceNamesByNodeAddress(ctx, filteredProjects, instanceType)
 		if err != nil {
 			return err
 		}
 
-		projectInstanceToNodeName, err = tx.GetProjectInstanceToNodeMap(filteredProjects, instanceType)
+		projectInstanceToNodeName, err = tx.GetProjectInstanceToNodeMap(ctx, filteredProjects, instanceType)
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1117,7 +1117,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if req.Name == "" {
-			names, err := tx.GetInstanceNames(targetProjectName)
+			names, err := tx.GetInstanceNames(ctx, targetProjectName)
 			if err != nil {
 				return err
 			}
@@ -1225,7 +1225,7 @@ func clusterCopyContainerInternal(d *Daemon, r *http.Request, source instance.In
 		var err error
 
 		// Load source node.
-		nodeAddress, err = tx.GetNodeAddressOfInstance(projectName, name, source.Type())
+		nodeAddress, err = tx.GetNodeAddressOfInstance(ctx, projectName, name, source.Type())
 		if err != nil {
 			return fmt.Errorf("Failed to get address of instance's member: %w", err)
 		}

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -133,7 +133,7 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 
 	var nodes []db.RaftNode
 	err = database.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		config, err := node.ConfigLoad(tx)
+		config, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
 		}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -3010,7 +3010,7 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 	var err error
 	var serverName string
 	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		serverName, err = tx.GetLocalNodeName()
+		serverName, err = tx.GetLocalNodeName(ctx)
 		return err
 	})
 	if err != nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -535,7 +535,7 @@ func networksPostCluster(d *Daemon, projectName string, netInfo *api.Network, re
 		}
 
 		// Fetch the network ID.
-		networkID, err := tx.GetNetworkID(projectName, req.Name)
+		networkID, err := tx.GetNetworkID(ctx, projectName, req.Name)
 		if err != nil {
 			return err
 		}

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -22,7 +22,7 @@ type Config struct {
 // can be passed, each config key must have at most one trigger.
 func ConfigLoad(ctx context.Context, tx *db.NodeTx) (*Config, error) {
 	// Load current raw values from the database, any error is fatal.
-	values, err := tx.Config()
+	values, err := tx.Config(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot fetch node config from database: %w", err)
 	}
@@ -146,7 +146,7 @@ func HTTPSAddress(node *db.Node) (string, error) {
 	var config *Config
 	err := node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		config, err = ConfigLoad(tx)
+		config, err = ConfigLoad(ctx, tx)
 		return err
 	})
 	if err != nil {
@@ -163,7 +163,7 @@ func ClusterAddress(node *db.Node) (string, error) {
 	var config *Config
 	err := node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		var err error
-		config, err = ConfigLoad(tx)
+		config, err = ConfigLoad(ctx, tx)
 		return err
 	})
 	if err != nil {

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -20,7 +20,7 @@ type Config struct {
 // ConfigLoad loads a new Config object with the current node-local configuration
 // values fetched from the database. An optional list of config value triggers
 // can be passed, each config key must have at most one trigger.
-func ConfigLoad(tx *db.NodeTx) (*Config, error) {
+func ConfigLoad(ctx context.Context, tx *db.NodeTx) (*Config, error) {
 	// Load current raw values from the database, any error is fatal.
 	values, err := tx.Config()
 	if err != nil {

--- a/lxd/node/config_test.go
+++ b/lxd/node/config_test.go
@@ -16,7 +16,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	config, err := node.ConfigLoad(tx)
+	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{}, config.Dump())
@@ -33,7 +33,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	config, err := node.ConfigLoad(tx)
+	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
 	values := map[string]any{"core.https_address": "127.0.0.1:666"}
@@ -45,7 +45,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	config, err := node.ConfigLoad(tx)
+	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{}, config.Dump())
@@ -57,7 +57,7 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	config, err := node.ConfigLoad(tx)
+	config, err := node.ConfigLoad(context.Background(), tx)
 	require.NoError(t, err)
 
 	changed, err := config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
@@ -70,7 +70,7 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 
 	assert.Equal(t, "", config.HTTPSAddress())
 
-	values, err := tx.Config()
+	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{}, values)
 }
@@ -81,7 +81,7 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	config, err := node.ConfigLoad(tx)
+	config, err := node.ConfigLoad(context.Background(), tx)
 	require.NoError(t, err)
 
 	_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
@@ -92,7 +92,7 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 
 	assert.Equal(t, "127.0.0.1:666", config.HTTPSAddress())
 
-	values, err := tx.Config()
+	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": "127.0.0.1:666"}, values)
 }
@@ -108,7 +108,7 @@ func TestHTTPSAddress(t *testing.T) {
 	assert.Equal(t, "", address)
 
 	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
-		config, err := node.ConfigLoad(tx)
+		config, err := node.ConfigLoad(ctx, tx)
 		require.NoError(t, err)
 		_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
 		require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestClusterAddress(t *testing.T) {
 	assert.Equal(t, "", address)
 
 	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
-		config, err := node.ConfigLoad(tx)
+		config, err := node.ConfigLoad(ctx, tx)
 		require.NoError(t, err)
 		_, err = config.Replace(map[string]any{"cluster.https_address": "127.0.0.1:666"})
 		require.NoError(t, err)

--- a/lxd/node/raft.go
+++ b/lxd/node/raft.go
@@ -30,7 +30,7 @@ import (
 //   cluster.https_address matches one of the rows in raft_nodes. In that case,
 //   the matching db.RaftNode row is returned, otherwise nil.
 func DetermineRaftNode(ctx context.Context, tx *db.NodeTx) (*db.RaftNode, error) {
-	config, err := ConfigLoad(tx)
+	config, err := ConfigLoad(ctx, tx)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -561,12 +561,12 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
-		membersWithOps, err = tx.GetNodesWithOperations(projectName)
+		membersWithOps, err = tx.GetNodesWithOperations(ctx, projectName)
 		if err != nil {
 			return fmt.Errorf("Failed getting members with operations: %w", err)
 		}
 
-		offlineThreshold, err = tx.GetNodeOfflineThreshold()
+		offlineThreshold, err = tx.GetNodeOfflineThreshold(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed getting member offline threshold value: %w", err)
 		}
@@ -685,7 +685,7 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 	var nodes []db.NodeInfo
 	memberOps := make(map[string]map[string]dbCluster.Operation)
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		offlineThreshold, err = tx.GetNodeOfflineThreshold()
+		offlineThreshold, err = tx.GetNodeOfflineThreshold(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed getting member offline threshold value: %w", err)
 		}
@@ -695,7 +695,7 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 			return fmt.Errorf("Failed getting members: %w", err)
 		}
 
-		ops, err := tx.GetOperationsOfType(projectName, opType)
+		ops, err := tx.GetOperationsOfType(ctx, projectName, opType)
 		if err != nil {
 			return fmt.Errorf("Failed getting operations for project %q and type %d: %w", projectName, opType, err)
 		}
@@ -1135,7 +1135,7 @@ func autoRemoveOrphanedOperations(ctx context.Context, d *Daemon) error {
 
 	err := d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get offline threshold.
-		offlineThreshold, err := tx.GetNodeOfflineThreshold()
+		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)
 		if err != nil {
 			return fmt.Errorf("Load offline threshold config: %w", err)
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -466,21 +466,20 @@ func patchThinpoolTypoFix(name string, d *Daemon) error {
 	revert.Add(func() { _ = tx.Rollback() })
 
 	// Fetch the IDs of all existing nodes.
-	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")
+	nodeIDs, err := query.SelectIntegers(context.TODO(), tx, "SELECT id FROM nodes")
 	if err != nil {
 		return fmt.Errorf("Failed to get IDs of current nodes: %w", err)
 	}
 
 	// Fetch the IDs of all existing lvm pools.
-	poolIDs, err := query.SelectIntegers(tx, "SELECT id FROM storage_pools WHERE driver='lvm'")
+	poolIDs, err := query.SelectIntegers(context.TODO(), tx, "SELECT id FROM storage_pools WHERE driver='lvm'")
 	if err != nil {
 		return fmt.Errorf("Failed to get IDs of current lvm pools: %w", err)
 	}
 
 	for _, poolID := range poolIDs {
 		// Fetch the config for this lvm pool and check if it has the lvm.thinpool_name.
-		config, err := query.SelectConfig(
-			tx, "storage_pools_config", "storage_pool_id=? AND node_id IS NULL", poolID)
+		config, err := query.SelectConfig(context.TODO(), tx, "storage_pools_config", "storage_pool_id=? AND node_id IS NULL", poolID)
 		if err != nil {
 			return fmt.Errorf("Failed to fetch of lvm pool config: %w", err)
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -180,7 +180,7 @@ func patchClusteringServerCertTrust(name string, d *Daemon) error {
 
 	var serverName string
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		serverName, err = tx.GetLocalNodeName()
+		serverName, err = tx.GetLocalNodeName(ctx)
 		return err
 	})
 	if err != nil {

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -31,7 +31,7 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 	var localNode string
 
 	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localNode, err = tx.GetLocalNodeName()
+		localNode, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to get local member name: %w", err)
 		}
@@ -61,7 +61,7 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 		var instPoolName string
 		var snapshots []cluster.Instance
 		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			instPoolName, err = tx.GetInstancePool(p.Name, inst.Name)
+			instPoolName, err = tx.GetInstancePool(ctx, p.Name, inst.Name)
 			if err != nil {
 				if api.StatusErrorCheck(err, http.StatusNotFound) {
 					// If the instance cannot be associated to a pool its got bigger problems

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -881,7 +881,7 @@ func VolumeUsedByDaemon(s *state.State, poolName string, volumeName string) (boo
 	var storageBackups string
 	var storageImages string
 	err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		nodeConfig, err := node.ConfigLoad(tx)
+		nodeConfig, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -405,7 +405,7 @@ func storagePoolsPostCluster(d *Daemon, pool *api.StoragePool, req api.StoragePo
 		var err error
 
 		// Check that the pool was defined at all. Must come before partially created checks.
-		poolID, err = tx.GetStoragePoolID(req.Name)
+		poolID, err = tx.GetStoragePoolID(ctx, req.Name)
 		if err != nil {
 			return err
 		}

--- a/lxd/warnings/warnings.go
+++ b/lxd/warnings/warnings.go
@@ -16,7 +16,7 @@ func ResolveWarningsByLocalNodeOlderThan(dbCluster *db.Cluster, date time.Time) 
 	var localName string
 
 	err = dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localName, err = tx.GetLocalNodeName()
+		localName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ func ResolveWarningsByLocalNodeAndType(dbCluster *db.Cluster, typeCode warningty
 	var localName string
 
 	err = dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localName, err = tx.GetLocalNodeName()
+		localName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func ResolveWarningsByLocalNodeAndProjectAndType(dbCluster *db.Cluster, projectN
 	var localName string
 
 	err = dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localName, err = tx.GetLocalNodeName()
+		localName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}
@@ -205,7 +205,7 @@ func ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(dbCluster *db.Cluster,
 	var localName string
 
 	err = dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localName, err = tx.GetLocalNodeName()
+		localName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}
@@ -261,7 +261,7 @@ func DeleteWarningsByLocalNodeAndProjectAndTypeAndEntity(dbCluster *db.Cluster, 
 	var localName string
 
 	err = dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localName, err = tx.GetLocalNodeName()
+		localName, err = tx.GetLocalNodeName(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Depends on #10900 

This (for the most part) eliminates `tx.Query` and `tx.QueryRow` from LXD, in favour of their context-accepting counterparts. What this means is that many more `ClusterTx` and `NodeTx` methods now accept a `context` from the transaction, and pass it down to `tx.QueryContext` or `tx.QueryRowContext`. Namely, `query.SelectObjects`, `query.SelectIntegers`, and `query.Count` now accept a context argument as well. 

For `lxd/patches.go`, a transaction is opened without calling `query.Transaction`, and so there is no context to pass down. As the `query.Transaction` contexts are all `context.TODO()` at the moment, I decided to just pass `context.TODO()` into the query helpers for `patches` for now.

I'll undraft this once #10900 is merged and this is rebased.