### PR TITLE
Firewall: Pass nftables rules via stdin rather than as command arguments

### DIFF
--- a/lxd/db/query/retry.go
+++ b/lxd/db/query/retry.go
@@ -3,6 +3,7 @@ package query
 import (
 	"database/sql"
 	"errors"
+	"net/http"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/canonical/go-dqlite/driver"
 	"github.com/mattn/go-sqlite3"
 
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -25,8 +27,8 @@ func Retry(f func() error) error {
 	for i := 0; i < maxRetries; i++ {
 		err = f()
 		if err != nil {
-			// No point in re-trying or logging a no-row error.
-			if errors.Is(err, sql.ErrNoRows) {
+			// No point in re-trying or logging a no-row or not found error.
+			if errors.Is(err, sql.ErrNoRows) || api.StatusErrorCheck(err, http.StatusNotFound) {
 				break
 			}
 

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -305,7 +306,7 @@ func (d Nftables) networkSetupACLChainAndJumpRules(networkName string) error {
 		return fmt.Errorf("Failed running %q template: %w", nftablesNetACLSetup.Name(), err)
 	}
 
-	_, err = shared.RunCommand("nft", config.String())
+	err = shared.RunCommandWithFds(context.TODO(), strings.NewReader(config.String()), nil, "nft", "-f", "-")
 	if err != nil {
 		return err
 	}
@@ -547,7 +548,7 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 		return fmt.Errorf("Failed running %q template: %w", nftablesNetProxyNAT.Name(), err)
 	}
 
-	_, err = shared.RunCommand("nft", config.String())
+	err = shared.RunCommandWithFds(context.TODO(), strings.NewReader(config.String()), nil, "nft", "-f", "-")
 	if err != nil {
 		return err
 	}
@@ -584,7 +585,7 @@ func (d Nftables) applyNftConfig(tpl *template.Template, tplFields map[string]an
 		return fmt.Errorf("Failed running %q template: %w", tpl.Name(), err)
 	}
 
-	_, err = shared.RunCommand("nft", config.String())
+	err = shared.RunCommandWithFds(context.TODO(), strings.NewReader(config.String()), nil, "nft", "-f", "-")
 	if err != nil {
 		return fmt.Errorf("Failed apply nftables config: %w", err)
 	}
@@ -712,7 +713,7 @@ func (d Nftables) NetworkApplyACLRules(networkName string, rules []ACLRule) erro
 		return fmt.Errorf("Failed running %q template: %w", nftablesNetACLRules.Name(), err)
 	}
 
-	_, err = shared.RunCommand("nft", config.String())
+	err = shared.RunCommandWithFds(context.TODO(), strings.NewReader(config.String()), nil, "nft", "-f", "-")
 	if err != nil {
 		return err
 	}
@@ -1044,7 +1045,7 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 			return fmt.Errorf("Failed running %q template: %w", nftablesNetProxyNAT.Name(), err)
 		}
 
-		_, err = shared.RunCommand("nft", config.String())
+		err = shared.RunCommandWithFds(context.TODO(), strings.NewReader(config.String()), nil, "nft", "-f", "-")
 		if err != nil {
 			return err
 		}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1375,30 +1375,26 @@ func (o *OVN) ChassisGroupChassisAdd(haChassisGroupName OVNChassisGroup, chassis
 // ChassisGroupChassisDelete deletes a chassis ID from an HA chassis group.
 func (o *OVN) ChassisGroupChassisDelete(haChassisGroupName OVNChassisGroup, chassisID string) error {
 	// Check if chassis group exists. ovn-nbctl doesn't provide an "--if-exists" option for this.
-	existingChassisGroup, err := o.nbctl("--no-headings", "--data=bare", "--colum=name", "find", "ha_chassis_group", fmt.Sprintf("name=%s", string(haChassisGroupName)))
+	output, err := o.nbctl("--no-headings", "--data=bare", "--colum=name,ha_chassis", "find", "ha_chassis_group", fmt.Sprintf("name=%s", string(haChassisGroupName)))
 	if err != nil {
 		return err
 	}
 
-	// Nothing to do if chassis group doesn't exist.
-	if strings.TrimSpace(existingChassisGroup) == "" {
-		return nil
-	}
+	lines := shared.SplitNTrimSpace(output, "\n", -1, true)
+	if len(lines) > 1 {
+		existingChassisGroup := lines[0]
+		members := shared.SplitNTrimSpace(lines[1], " ", -1, true)
 
-	// Check if chassis exists. ovn-nbctl doesn't provide an "--if-exists" option for this.
-	existingChassis, err := o.nbctl("--no-headings", "--data=bare", "--colum=chassis_name", "find", "ha_chassis", fmt.Sprintf("chassis_name=%s", chassisID))
-	if err != nil {
-		return err
-	}
-
-	// Remove chassis from group if exists.
-	if strings.TrimSpace(existingChassis) != "" {
-		_, err := o.nbctl("ha-chassis-group-remove-chassis", string(haChassisGroupName), chassisID)
-		if err != nil {
-			return err
+		// Remove chassis from group if exists.
+		if existingChassisGroup == string(haChassisGroupName) && shared.StringInSlice(chassisID, members) {
+			_, err := o.nbctl("ha-chassis-group-remove-chassis", string(haChassisGroupName), chassisID)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
+	// Nothing to do if chassis group doesn't exist.
 	return nil
 }
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1598,9 +1598,10 @@ func networkStartup(s *state.State) error {
 				}
 			}
 		}()
+	} else {
+		logger.Info("All networks initialized")
 	}
 
-	logger.Info("All networks initialized")
 	return nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -395,9 +395,8 @@ func (b *lxdBackend) Delete(clientType request.ClientType, op *operations.Operat
 
 // Mount mounts the storage pool.
 func (b *lxdBackend) Mount() (bool, error) {
-	l := logger.AddContext(b.logger, nil)
-	l.Debug("Mount started")
-	defer l.Debug("Mount finished")
+	b.logger.Debug("Mount started")
+	defer b.logger.Debug("Mount finished")
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -445,9 +444,8 @@ func (b *lxdBackend) Mount() (bool, error) {
 
 // Unmount unmounts the storage pool.
 func (b *lxdBackend) Unmount() (bool, error) {
-	l := logger.AddContext(b.logger, nil)
-	l.Debug("Unmount started")
-	defer l.Debug("Unmount finished")
+	b.logger.Debug("Unmount started")
+	defer b.logger.Debug("Unmount finished")
 
 	return b.driver.Unmount()
 }


### PR DESCRIPTION
This allows for larger rulesets so we don't hit the maximum number of command line arguments limit.

Reported from https://discuss.linuxcontainers.org/t/network-forward-ports-maximum-500-per-network-possible-bug/15012

In testing this it also revealed some other issues which are now fixed:

- Deferred network starting wasn't taking into account that a physical network can depend on an interface provided by a bridge network, so its important to start non-dependent networks first before networks that rely on physical interfaces being available (followed by the OVN networks that depend on the managed networks being available).
- Also improved deferred network startup by maintaining this ordering both during the initial start up phase as well as subsequent retry attempts. This means that LXD will try and start any physical networks before starting OVN networks (for example).
- During testing of removing networks it also transpired that the current OVN chassis group member removal done during network deletion wasn't correctly handling the scenario where a chassis was in multiple chassis groups (OVN networks) but that the OVN network being removed was not started yet, and thus the chassis was not in the particular chassis group for that network yet. This was leading to not being able to remove an unavailable OVN network when the chassis was in another OVN network.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>