### PR TITLE
Image: Maintain `Cached` property when creating an image in a project from an existing project

### DIFF
--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -537,9 +537,9 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 
 	// Mark the image as "cached" if downloading for an instance
 	if args.SetCached {
-		err := d.db.Cluster.InitImageLastUseDate(fp)
+		err := d.db.Cluster.SetImageCachedAndLastUseDate(args.ProjectName, fp, time.Now().UTC())
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed setting cached flag and last use date: %w", err)
 		}
 	}
 

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -180,6 +180,14 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 				return nil, err
 			}
 
+			// Mark the image as "cached" if downloading for an instance.
+			if args.SetCached {
+				err := d.db.Cluster.SetImageCachedAndLastUseDate(args.ProjectName, imgInfo.Fingerprint, time.Now().UTC())
+				if err != nil {
+					return nil, fmt.Errorf("Failed setting cached flag and last use date: %w", err)
+				}
+			}
+
 			var id int
 			id, imgInfo, err = d.db.Cluster.GetImage(fp, cluster.ImageFilter{Project: &args.ProjectName})
 			if err != nil {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -878,10 +878,10 @@ func (c *Cluster) CopyDefaultImageProfiles(id int, newID int) error {
 
 // UpdateImageLastUseDate updates the last_use_date field of the image with the
 // given fingerprint.
-func (c *Cluster) UpdateImageLastUseDate(fingerprint string, date time.Time) error {
-	stmt := `UPDATE images SET last_use_date=? WHERE fingerprint=?`
+func (c *Cluster) UpdateImageLastUseDate(projectName string, fingerprint string, lastUsed time.Time) error {
+	stmt := `UPDATE images SET last_use_date=? WHERE fingerprint=? AND project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)`
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec(stmt, date, fingerprint)
+		_, err := tx.tx.Exec(stmt, lastUsed, fingerprint, projectName)
 		return err
 	})
 	return err

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -887,11 +887,11 @@ func (c *Cluster) UpdateImageLastUseDate(projectName string, fingerprint string,
 	return err
 }
 
-// InitImageLastUseDate inits the last_use_date field of the image with the given fingerprint.
-func (c *Cluster) InitImageLastUseDate(fingerprint string) error {
-	stmt := `UPDATE images SET cached=1, last_use_date=strftime("%s") WHERE fingerprint=?`
+// SetImageCachedAndLastUseDate sets the cached and last_use_date field of the image with the given fingerprint.
+func (c *Cluster) SetImageCachedAndLastUseDate(projectName string, fingerprint string, lastUsed time.Time) error {
+	stmt := `UPDATE images SET cached=1, last_use_date=? WHERE fingerprint=? AND project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)`
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec(stmt, fingerprint)
+		_, err := tx.tx.Exec(stmt, lastUsed, fingerprint, projectName)
 		return err
 	})
 	return err

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -974,7 +974,7 @@ func (c *Cluster) UpdateImage(id int, fname string, sz int64, public bool, autoU
 }
 
 // CreateImage creates a new image.
-func (c *Cluster) CreateImage(project, fp string, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, typeName string, profileIds []int64) error {
+func (c *Cluster) CreateImage(project string, fp string, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, typeName string, profileIds []int64) error {
 	arch, err := osarch.ArchitectureId(architecture)
 	if err != nil {
 		arch = 0

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2021,17 +2021,17 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 		}
 
 		if info.Cached {
-			err = d.db.Cluster.InitImageLastUseDate(hash)
+			err = d.db.Cluster.SetImageCachedAndLastUseDate(projectName, hash, info.LastUsedAt)
 			if err != nil {
-				logger.Error("Error setting cached flag", logger.Ctx{"err": err, "fingerprint": hash})
+				logger.Error("Error setting cached flag and last use date", logger.Ctx{"err": err, "fingerprint": hash})
 				continue
 			}
-		}
-
-		err = d.db.Cluster.UpdateImageLastUseDate(hash, info.LastUsedAt)
-		if err != nil {
-			logger.Error("Error setting last use date", logger.Ctx{"err": err, "fingerprint": hash})
-			continue
+		} else {
+			err = d.db.Cluster.UpdateImageLastUseDate(projectName, hash, info.LastUsedAt)
+			if err != nil {
+				logger.Error("Error setting last use date", logger.Ctx{"err": err, "fingerprint": hash})
+				continue
+			}
 		}
 
 		err = d.db.Cluster.MoveImageAlias(id, newID)

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -183,7 +183,7 @@ func instanceCreateFromImage(d *Daemon, r *http.Request, args db.InstanceArgs, h
 	revert.Add(cleanup)
 	defer instOp.Done(nil)
 
-	err = s.DB.Cluster.UpdateImageLastUseDate(hash, time.Now().UTC())
+	err = s.DB.Cluster.UpdateImageLastUseDate(args.Project, hash, time.Now().UTC())
 	if err != nil {
 		return nil, fmt.Errorf("Error updating image last use date: %s", err)
 	}


### PR DESCRIPTION
Fixes #10855

Also fixes some issues caused by lack of project support in some image management functions which would have caused images in different projects to have their last used date be updated incorrectly.

The database access in the image management functions is not very efficient, but fixing that will be a larger project so I've left it for now.