### PR TITLE
Lxd-generate: Remove superfluous GetID error check

### DIFF
--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -196,11 +196,6 @@ func GetCertificateID(ctx context.Context, tx *sql.Tx, fingerprint string) (int6
 	}
 
 	row := stmt.QueryRowContext(ctx, fingerprint)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"certificates\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -208,7 +203,7 @@ func GetCertificateID(ctx context.Context, tx *sql.Tx, fingerprint string) (int6
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"certificates\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/cluster_groups.mapper.go
+++ b/lxd/db/cluster/cluster_groups.mapper.go
@@ -165,11 +165,6 @@ func GetClusterGroupID(ctx context.Context, tx *sql.Tx, name string) (int64, err
 	}
 
 	row := stmt.QueryRowContext(ctx, name)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"clusters_groups\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -177,7 +172,7 @@ func GetClusterGroupID(ctx context.Context, tx *sql.Tx, name string) (int64, err
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"clusters_groups\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -703,11 +703,6 @@ func GetInstanceID(ctx context.Context, tx *sql.Tx, project string, name string)
 	}
 
 	row := stmt.QueryRowContext(ctx, project, name)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"instances\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -715,7 +710,7 @@ func GetInstanceID(ctx context.Context, tx *sql.Tx, project string, name string)
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"instances\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/nodes.mapper.go
+++ b/lxd/db/cluster/nodes.mapper.go
@@ -30,11 +30,6 @@ func GetNodeID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
 	}
 
 	row := stmt.QueryRowContext(ctx, name)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"nodes\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -42,7 +37,7 @@ func GetNodeID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"nodes\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/nodes_cluster_groups.mapper.go
+++ b/lxd/db/cluster/nodes_cluster_groups.mapper.go
@@ -190,11 +190,6 @@ func GetNodeClusterGroupID(ctx context.Context, tx *sql.Tx, groupID int) (int64,
 	}
 
 	row := stmt.QueryRowContext(ctx, groupID)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"nodes_clusters_groups\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -202,7 +197,7 @@ func GetNodeClusterGroupID(ctx context.Context, tx *sql.Tx, groupID int) (int64,
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"nodes_clusters_groups\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -91,11 +91,6 @@ func GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) 
 	}
 
 	row := stmt.QueryRowContext(ctx, project, name)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"profiles\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -103,7 +98,7 @@ func GetProfileID(ctx context.Context, tx *sql.Tx, project string, name string) 
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"profiles\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -287,11 +287,6 @@ func GetProjectID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
 	}
 
 	row := stmt.QueryRowContext(ctx, name)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"projects\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -299,7 +294,7 @@ func GetProjectID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"projects\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -270,11 +270,6 @@ func GetInstanceSnapshotID(ctx context.Context, tx *sql.Tx, project string, inst
 	}
 
 	row := stmt.QueryRowContext(ctx, project, instance, name)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"instances_snapshots\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -282,7 +277,7 @@ func GetInstanceSnapshotID(ctx context.Context, tx *sql.Tx, project string, inst
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"instances_snapshots\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -371,11 +371,6 @@ func GetWarningID(ctx context.Context, tx *sql.Tx, uuid string) (int64, error) {
 	}
 
 	row := stmt.QueryRowContext(ctx, uuid)
-	err = row.Err()
-	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"warnings\" ID: %w", err)
-	}
-
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -383,7 +378,7 @@ func GetWarningID(ctx context.Context, tx *sql.Tx, uuid string) (int64, error) {
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to scan ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"warnings\" ID: %w", err)
 	}
 
 	return id, nil

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -597,15 +597,13 @@ func (m *Method) id(buf *file.Buffer) error {
 
 	m.ifErrNotNil(buf, true, "-1", fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" prepared statement: %%w", err)`, stmtCodeVar(m.entity, "ID")))
 	buf.L("row := stmt.QueryRowContext(ctx, %s)", mapping.FieldParams(nk))
-	buf.L("err = row.Err()")
-	m.ifErrNotNil(buf, true, "-1", fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" ID: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	buf.L("var id int64")
 	buf.L("err = row.Scan(&id)")
 	buf.L("if errors.Is(err, sql.ErrNoRows) {")
 	buf.L(`return -1, api.StatusErrorf(http.StatusNotFound, "%s not found")`, lex.Camel(m.entity))
 	buf.L("}")
 	buf.N()
-	m.ifErrNotNil(buf, true, "-1", "fmt.Errorf(\"Failed to scan ID: %w\", err)")
+	m.ifErrNotNil(buf, true, "-1", fmt.Sprintf(`fmt.Errorf("Failed to get \"%s\" ID: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	buf.L("return id, nil")
 
 	return nil


### PR DESCRIPTION
@tomponline noted in #10899 that since we call `row.Scan`, we don't need to manually check the row error. 

Indeed the first thing `row.Scan` checks is the existing `row.err`.