### PR TITLE
Add a performance tuning section

### DIFF
--- a/.sphinx/.wordlist.txt
+++ b/.sphinx/.wordlist.txt
@@ -13,6 +13,7 @@ backend
 backends
 balancer
 balancers
+benchmarking
 BGP
 bibi
 bool

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -152,5 +152,6 @@ redirects = {
     "howto/storage_create_volume/index": "../storage_volumes/index.html#create-a-custom-storage-volume",
     "howto/storage_configure_volume/index": "../storage_volumes/index.html#configure-storage-volume-settings",
     "howto/storage_view_volumes/index": "../storage_volumes/index.html#view-storage-volumes",
-    "howto/storage_resize_volume/index": "../storage_volumes/index.html#resize-a-storage-volume"
+    "howto/storage_resize_volume/index": "../storage_volumes/index.html#resize-a-storage-volume",
+    "production-setup/index": "../explanation/performance_tuning/index.html",
 }

--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -1,0 +1,18 @@
+(performance-tuning)=
+# Performance tuning
+
+## Run benchmarks
+
+## Monitor instance metrics
+
+## Tune server settings
+
+## Tune the network bandwidth
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+Increase bandwidth <../howto/network_increase_bandwidth>
+Server settings <../production-setup>
+```

--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -7,6 +7,22 @@
 
 ## Tune server settings
 
+The vast majority of Linux distributions do not come with optimized
+kernel settings suitable for the operation of a large number of
+containers. The instructions in this document cover the most common
+limits that you're likely to hit when running containers and suggested
+updated values.
+
+### Common errors that may be encountered
+
+`Failed to allocate directory watch: Too many open files`
+
+`<Error> <Error>: Too many open files`
+
+`failed to open stream: Too many open files in...`
+
+`neighbour: ndisc_cache: neighbor table overflow!`
+
 ## Tune the network bandwidth
 
 ```{toctree}

--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -1,34 +1,54 @@
 (performance-tuning)=
 # Performance tuning
 
+When you are ready to move your LXD setup to production, you should take some time to optimize the performance of your system.
+There are different aspects that impact performance.
+The following steps help you to determine the choices and settings that you should tune to improve your LXD setup.
+
 ## Run benchmarks
+
+LXD provides a benchmarking tool to evaluate the performance of your system.
+You can use the tool to initialize or launch a number of containers and measure the time it takes for the system to create the containers.
+By running the tool repeatedly with different LXD configurations, system settings or even hardware setups, you can compare the performance and evaluate which is the ideal configuration.
 
 ## Monitor instance metrics
 
+% Include content from [../metrics.md](../metrics.md)
+```{include} ../metrics.md
+    :start-after: <!-- Include start metrics intro -->
+    :end-before: <!-- Include end metrics intro -->
+```
+
+You should regularly monitor the metrics to evaluate the resources that your instances use.
+The numbers help you to determine if there are any spikes or bottlenecks, or if usage patterns change and require updates to your configuration.
+
+See {ref}`instance-metrics` for more information about metrics collection.
+
 ## Tune server settings
 
-The vast majority of Linux distributions do not come with optimized
-kernel settings suitable for the operation of a large number of
-containers. The instructions in this document cover the most common
-limits that you're likely to hit when running containers and suggested
-updated values.
+The default kernel settings for most Linux distributions are not optimized for running a large number of containers or virtual machines.
+Therefore, you should check and modify the relevant server settings to avoid hitting limits caused by the default settings.
 
-### Common errors that may be encountered
+Typical errors that you might see when you encounter those limits are:
 
-`Failed to allocate directory watch: Too many open files`
+* `Failed to allocate directory watch: Too many open files`
+* `<Error> <Error>: Too many open files`
+* `failed to open stream: Too many open files in...`
+* `neighbour: ndisc_cache: neighbor table overflow!`
 
-`<Error> <Error>: Too many open files`
-
-`failed to open stream: Too many open files in...`
-
-`neighbour: ndisc_cache: neighbor table overflow!`
+See {ref}`server-settings` for a list of relevant server settings and suggested values.
 
 ## Tune the network bandwidth
+
+If you have a lot of local activity between instances or between the LXD host and the instances, or if you have a fast internet connection, you should consider increasing the network bandwidth of your LXD setup.
+You can do this by increasing the transmit and receive queue lengths.
+
+See {ref}`network-increase-bandwidth` for instructions.
 
 ```{toctree}
 :maxdepth: 1
 :hidden:
 
 Increase bandwidth <../howto/network_increase_bandwidth>
-Server settings <../production-setup>
+Server settings <../reference/server_settings>
 ```

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -155,7 +155,7 @@ files**.
 
 ## Networking issues
 
-In a larger [Production Environment](production-setup.md), it is common to have
+In a larger [Production Environment](performance-tuning), it is common to have
 multiple VLANs and have LXD clients attached directly to those VLANs. Be aware that
 if you are using `netplan` and `systemd-networkd`, you will encounter some bugs that
 could cause catastrophic issues.

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -1,2 +1,45 @@
 (network-increase-bandwidth)=
 # How to increase the network bandwidth
+
+If you have at least 1GbE NIC on your LXD host with a lot of local
+activity (container - container connections, or host - container
+connections), or you have 1GbE or better internet connection on your LXD
+host it worth play with `txqueuelen`. These settings work even better with
+10GbE NIC.
+
+#### Server Changes
+
+##### `txqueuelen`
+
+You need to change `txqueuelen` of your real NIC to 10000 (not sure
+about the best possible value for you), and change and change `lxdbr0`
+interface `txqueuelen` to 10000.
+
+In Debian-based distributions, you can change `txqueuelen` permanently in `/etc/network/interfaces`.
+You can add for example: `up ip link set eth0 txqueuelen 10000` to your interface configuration to set the `txqueuelen` value on boot.
+You could set `txqueuelen` temporary (for test purpose) with `ifconfig <interface> txqueuelen 10000`.
+
+##### `/etc/sysctl.conf`
+
+You also need to increase `net.core.netdev_max_backlog` value.
+You can add `net.core.netdev_max_backlog = 182757` to `/etc/sysctl.conf` to set it permanently (after reboot)
+You set `netdev_max_backlog` temporary (for test purpose) with `echo 182757 > /proc/sys/net/core/netdev_max_backlog`
+Note: You can find this value too high, most people prefer set `netdev_max_backlog` = `net.ipv4.tcp_mem` min. value.
+For example I use this values `net.ipv4.tcp_mem = 182757 243679 365514`
+
+#### Containers changes
+
+You also need to change the `txqueuelen` value for all your Ethernet interfaces in containers.
+In Debian-based distributions, you can change `txqueuelen` permanently in `/etc/network/interfaces`.
+You can add for example `up ip link set eth0 txqueuelen 10000` to your interface configuration to set the `txqueuelen` value on boot.
+
+#### Notes regarding this change
+
+10000 `txqueuelen` value commonly used with 10GbE NICs. Basically small
+`txqueuelen` values used with slow devices with a high latency, and higher
+with devices with low latency. I personally have like 3-5% improvement
+with these settings for local (host with container, container vs
+container) and internet connections. Good thing about `txqueuelen` value
+tweak, the more containers you use, the more you can be can benefit from
+this tweak. And you can always temporary set this values and check this
+tweak in your environment without LXD host reboot.

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -1,0 +1,2 @@
+(network-increase-bandwidth)=
+# How to increase the network bandwidth

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -3,13 +3,20 @@ discourse: 12281,11735
 relatedlinks: https://grafana.com/grafana/dashboards/15726
 ---
 
+(instance-metrics)=
 # Instance metrics
 
 ```{youtube} https://www.youtube.com/watch?v=EthK-8hm_fY
 ```
 
-LXD provides metrics for all running instances. Those covers CPU, memory, network, disk and process usage and are meant to be consumed by Prometheus and likely graphed in Grafana.
+<!-- Include start metrics intro -->
+LXD collects metrics for all running instances.
+These metrics cover the CPU, memory, network, disk and process usage.
+They are meant to be consumed by Prometheus, and you can use Grafana to display the metrics as graphs.
+<!-- Include end metrics intro -->
+
 In cluster environments, LXD will only return the values for instances running on the server being accessed. It's expected that each cluster member will be scraped separately.
+
 The instance metrics are updated when calling the `/1.0/metrics` endpoint.
 They are cached for 8s to handle multiple scrapers. Fetching metrics is a relatively expensive operation for LXD to perform so consider scraping at a higher than default interval
 if the impact is too high.

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -6,7 +6,7 @@
 Backups <backup>
 clustering
 instance-exec
-production-setup
+explanation/performance_tuning
 remotes
 authentication
 migration

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -1,44 +1,42 @@
-# Production setup
+(production-setup)=
+# Server settings for a LXD production setup
 
-## Introduction
+To allow your LXD server to run a large number of instances, configure the following settings to avoid hitting server limits.
 
-So you've made it past trying out [LXD live online](https://linuxcontainers.org/lxd/try-it/),
-or on a server scavenged from random parts. You like what you see,
-and now you want to try doing some serious work with LXD.
+The `Value` column contains the suggested value for each parameter.
 
-## Server Changes
+## `/etc/security/limits.conf`
 
-### `/etc/security/limits.conf`
+```{note}
+For users of the snap, those limits are automatically raised.
+```
 
-Domain  | Type  | Item      | Value     | Default   | Description
-:-----  | :---  | :----     | :-------- | :-------- | :----------
-`*`     | soft  | `nofile`  | 1048576   | unset     | maximum number of open files
-`*`     | hard  | `nofile`  | 1048576   | unset     | maximum number of open files
-`root`  | soft  | `nofile`  | 1048576   | unset     | maximum number of open files
-`root`  | hard  | `nofile`  | 1048576   | unset     | maximum number of open files
-`*`     | soft  | `memlock` | unlimited | unset     | maximum locked-in-memory address space (KB)
-`*`     | hard  | `memlock` | unlimited | unset     | maximum locked-in-memory address space (KB)
-`root`  | soft  | `memlock` | unlimited | unset     | maximum locked-in-memory address space (KB) (Only need with `bpf` syscall supervision)
-`root`  | hard  | `memlock` | unlimited | unset     | maximum locked-in-memory address space (KB) (Only need with `bpf` syscall supervision)
+Domain  | Type  | Item      | Value       | Default   | Description
+:-----  | :---  | :----     | :---------- | :-------- | :----------
+`*`     | soft  | `nofile`  | `1048576`   | unset     | Maximum number of open files
+`*`     | hard  | `nofile`  | `1048576`   | unset     | Maximum number of open files
+`root`  | soft  | `nofile`  | `1048576`   | unset     | Maximum number of open files
+`root`  | hard  | `nofile`  | `1048576`   | unset     | Maximum number of open files
+`*`     | soft  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB)
+`*`     | hard  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB)
+`root`  | soft  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB), only need with `bpf` syscall supervision
+`root`  | hard  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB), only need with `bpf` syscall supervision
 
-NOTE: For users of the snap, those limits are automatically raised by the snap/LXD.
+## `/etc/sysctl.conf`
 
-### `/etc/sysctl.conf`
+```{note}
+Reboot the server after changing any of these parameters.
+```
 
 Parameter                           | Value      | Default   | Description
 :-----                              | :---       | :---      | :---
-`fs.aio-max-nr`                     | `524288`   | `65536`   | This is the maximum number of concurrent asynchronous I/O operations. You might need to increase it further if you have a lot of workloads that use the AIO subsystem (e.g. MySQL)
-`fs.inotify.max_queued_events`      | `1048576`  | `16384`   | This specifies an upper limit on the number of events that can be queued to the corresponding `inotify` instance. [1]
-`fs.inotify.max_user_instances`     | `1048576`  | `128`     | This specifies an upper limit on the number of `inotify` instances that can be created per real user ID. [1]
-`fs.inotify.max_user_watches`       | `1048576`  | `8192`    | This specifies an upper limit on the number of watches that can be created per real user ID. [1]
-`kernel.dmesg_restrict`             | `1`        | `0`       | This denies container access to the messages in the kernel ring buffer. Please note that this also will deny access to non-root users on the host system.
-`kernel.keys.maxbytes`              | `2000000`  | `20000`   | This is the maximum size of the key ring non-root users can use
-`kernel.keys.maxkeys`               | `2000`     | `200`     | This is the maximum number of keys a non-root user can use, should be higher than the number of containers
-`net.ipv4.neigh.default.gc_thresh3` | `8192`     | `1024`    | This is the maximum number of entries in ARP table (IPv4). You should increase this if you create over 1024 containers. Otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and those containers will not be able to get a network configuration. [2]
-`net.ipv6.neigh.default.gc_thresh3` | `8192`     | `1024`    | This is the maximum number of entries in ARP table (IPv6). You should increase this if you plan to create over 1024 containers. Otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and those containers will not be able to get a network configuration. [2]
-`vm.max_map_count`                  | `262144`   | `65530`   | This file contains the maximum number of memory map areas a process may have. Memory map areas are used as a side-effect of calling `malloc`, directly by `mmap` and `mprotect`, and also when loading shared libraries.
-
-Then, reboot the server.
-
-[1]: https://man7.org/linux/man-pages/man7/inotify.7.html
-[2]: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+`fs.aio-max-nr`                     | `524288`   | `65536`   | Maximum number of concurrent asynchronous I/O operations (you might need to increase this limit further if you have a lot of workloads that use the AIO subsystem, for example, MySQL)
+`fs.inotify.max_queued_events`      | `1048576`  | `16384`   | Upper limit on the number of events that can be queued to the corresponding `inotify` instance (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))
+`fs.inotify.max_user_instances`     | `1048576`  | `128`     | Upper limit on the number of `inotify` instances that can be created per real user ID (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))
+`fs.inotify.max_user_watches`       | `1048576`  | `8192`    | Upper limit on the number of watches that can be created per real user ID (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))
+`kernel.dmesg_restrict`             | `1`        | `0`       | Whether to deny container access to the messages in the kernel ring buffer (note that this will also deny access to non-root users on the host system)
+`kernel.keys.maxbytes`              | `2000000`  | `20000`   | Maximum size of the key ring that non-root users can use
+`kernel.keys.maxkeys`               | `2000`     | `200`     | Maximum number of keys that a non-root user can use (the value should be higher than the number of instances)
+`net.ipv4.neigh.default.gc_thresh3` | `8192`     | `1024`    | Maximum number of entries in the IPv4 ARP table (increase this value if you plan to create over 1024 instances - otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and the instances cannot get a network configuration; see [`ip-sysctl`](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt))
+`net.ipv6.neigh.default.gc_thresh3` | `8192`     | `1024`    | Maximum number of entries in IPv6 ARP table (increase this value if you plan to create over 1024 instances - otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and the instances cannot get a network configuration; see [`ip-sysctl`](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt))
+`vm.max_map_count`                  | `262144`   | `65530`   | Maximum number of memory map areas a process may have (memory map areas are used as a side-effect of calling `malloc`, directly by `mmap` and `mprotect`, and also when loading shared libraries)

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -6,22 +6,6 @@ So you've made it past trying out [LXD live online](https://linuxcontainers.org/
 or on a server scavenged from random parts. You like what you see,
 and now you want to try doing some serious work with LXD.
 
-The vast majority of Linux distributions do not come with optimized
-kernel settings suitable for the operation of a large number of
-containers. The instructions in this document cover the most common
-limits that you're likely to hit when running containers and suggested
-updated values.
-
-### Common errors that may be encountered
-
-`Failed to allocate directory watch: Too many open files`
-
-`<Error> <Error>: Too many open files`
-
-`failed to open stream: Too many open files in...`
-
-`neighbour: ndisc_cache: neighbor table overflow!`
-
 ## Server Changes
 
 ### `/etc/security/limits.conf`
@@ -58,59 +42,3 @@ Then, reboot the server.
 
 [1]: https://man7.org/linux/man-pages/man7/inotify.7.html
 [2]: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
-
-### Prevent container name leakage
-
-Both `/sys/kernel/slab` and `/proc/sched_debug` make it easy to list all
-cgroups on the system and by extension, all containers.
-
-If this is something you'd like to see blocked, make sure you have the
-following done before any container is started:
-
-    chmod 400 /proc/sched_debug
-    chmod 700 /sys/kernel/slab/
-
-### Network Bandwidth Tweaking
-
-If you have at least 1GbE NIC on your LXD host with a lot of local
-activity (container - container connections, or host - container
-connections), or you have 1GbE or better internet connection on your LXD
-host it worth play with `txqueuelen`. These settings work even better with
-10GbE NIC.
-
-#### Server Changes
-
-##### `txqueuelen`
-
-You need to change `txqueuelen` of your real NIC to 10000 (not sure
-about the best possible value for you), and change and change `lxdbr0`
-interface `txqueuelen` to 10000.
-
-In Debian-based distributions, you can change `txqueuelen` permanently in `/etc/network/interfaces`.
-You can add for example: `up ip link set eth0 txqueuelen 10000` to your interface configuration to set the `txqueuelen` value on boot.
-You could set `txqueuelen` temporary (for test purpose) with `ifconfig <interface> txqueuelen 10000`.
-
-##### `/etc/sysctl.conf`
-
-You also need to increase `net.core.netdev_max_backlog` value.
-You can add `net.core.netdev_max_backlog = 182757` to `/etc/sysctl.conf` to set it permanently (after reboot)
-You set `netdev_max_backlog` temporary (for test purpose) with `echo 182757 > /proc/sys/net/core/netdev_max_backlog`
-Note: You can find this value too high, most people prefer set `netdev_max_backlog` = `net.ipv4.tcp_mem` min. value.
-For example I use this values `net.ipv4.tcp_mem = 182757 243679 365514`
-
-#### Containers changes
-
-You also need to change the `txqueuelen` value for all your Ethernet interfaces in containers.
-In Debian-based distributions, you can change `txqueuelen` permanently in `/etc/network/interfaces`.
-You can add for example `up ip link set eth0 txqueuelen 10000` to your interface configuration to set the `txqueuelen` value on boot.
-
-#### Notes regarding this change
-
-10000 `txqueuelen` value commonly used with 10GbE NICs. Basically small
-`txqueuelen` values used with slow devices with a high latency, and higher
-with devices with low latency. I personally have like 3-5% improvement
-with these settings for local (host with container, container vs
-container) and internet connections. Good thing about `txqueuelen` value
-tweak, the more containers you use, the more you can be can benefit from
-this tweak. And you can always temporary set this values and check this
-tweak in your environment without LXD host reboot.

--- a/doc/reference/server_settings.md
+++ b/doc/reference/server_settings.md
@@ -1,4 +1,4 @@
-(production-setup)=
+(server-settings)=
 # Server settings for a LXD production setup
 
 To allow your LXD server to run a large number of instances, configure the following settings to avoid hitting server limits.

--- a/doc/security.md
+++ b/doc/security.md
@@ -68,13 +68,12 @@ Note, however, that those aren't root safe, and a user with root access in such 
 More details on container security and the kernel features we use can be found on the
 [LXC security page](https://linuxcontainers.org/lxc/security/).
 
-### Prevent container name leakage
+### Container name leakage
 
-Both `/sys/kernel/slab` and `/proc/sched_debug` make it easy to list all
-cgroups on the system and by extension, all containers.
+The default server configuration makes it easy to list all cgroups on a system and, by extension, all running containers.
 
-If this is something you'd like to see blocked, make sure you have the
-following done before any container is started:
+You can prevent this name leakage by blocking access to `/sys/kernel/slab` and `/proc/sched_debug` before you start any containers.
+To do so, run the following commands:
 
     chmod 400 /proc/sched_debug
     chmod 700 /sys/kernel/slab/

--- a/doc/security.md
+++ b/doc/security.md
@@ -68,6 +68,17 @@ Note, however, that those aren't root safe, and a user with root access in such 
 More details on container security and the kernel features we use can be found on the
 [LXC security page](https://linuxcontainers.org/lxc/security/).
 
+### Prevent container name leakage
+
+Both `/sys/kernel/slab` and `/proc/sched_debug` make it easy to list all
+cgroups on the system and by extension, all containers.
+
+If this is something you'd like to see blocked, make sure you have the
+following done before any container is started:
+
+    chmod 400 /proc/sched_debug
+    chmod 700 /sys/kernel/slab/
+
 ## Network security
 
 Make sure to configure your network interfaces to be secure.


### PR DESCRIPTION
Add a performance tuning section to the docs that replaces and extends the current production setup page. That page is moved to a reference page (incl. a redirect to ensure no links/bookmarks break).

The next step will be to add a how to guide for the benchmarking tool.