### PR TITLE
shared/osarch: Improve 32bit arm handling

### DIFF
--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -18,12 +18,16 @@ const (
 	ARCH_64BIT_MIPS                  = 10
 	ARCH_32BIT_RISCV_LITTLE_ENDIAN   = 11
 	ARCH_64BIT_RISCV_LITTLE_ENDIAN   = 12
+	ARCH_32BIT_ARMV6_LITTLE_ENDIAN   = 13
+	ARCH_32BIT_ARMV8_LITTLE_ENDIAN   = 14
 )
 
 var architectureNames = map[int]string{
 	ARCH_32BIT_INTEL_X86:             "i686",
 	ARCH_64BIT_INTEL_X86:             "x86_64",
+	ARCH_32BIT_ARMV6_LITTLE_ENDIAN:   "armv6l",
 	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   "armv7l",
+	ARCH_32BIT_ARMV8_LITTLE_ENDIAN:   "armv8l",
 	ARCH_64BIT_ARMV8_LITTLE_ENDIAN:   "aarch64",
 	ARCH_32BIT_POWERPC_BIG_ENDIAN:    "ppc",
 	ARCH_64BIT_POWERPC_BIG_ENDIAN:    "ppc64",
@@ -38,7 +42,9 @@ var architectureNames = map[int]string{
 var architectureAliases = map[int][]string{
 	ARCH_32BIT_INTEL_X86:             {"i386", "i586", "386", "x86", "generic_32"},
 	ARCH_64BIT_INTEL_X86:             {"amd64", "generic_64"},
-	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   {"armel", "armhf", "arm", "armhfp", "armv7a_hardfp", "armv7", "armv7a_vfpv3_hardfp"},
+	ARCH_32BIT_ARMV6_LITTLE_ENDIAN:   {"armel", "arm"},
+	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   {"armhf", "armhfp", "armv7a_hardfp", "armv7", "armv7a_vfpv3_hardfp"},
+	ARCH_32BIT_ARMV8_LITTLE_ENDIAN:   {},
 	ARCH_64BIT_ARMV8_LITTLE_ENDIAN:   {"arm64", "arm64_generic"},
 	ARCH_32BIT_POWERPC_BIG_ENDIAN:    {"powerpc"},
 	ARCH_64BIT_POWERPC_BIG_ENDIAN:    {"powerpc64", "ppc64"},
@@ -52,7 +58,9 @@ var architectureAliases = map[int][]string{
 var architecturePersonalities = map[int]string{
 	ARCH_32BIT_INTEL_X86:             "linux32",
 	ARCH_64BIT_INTEL_X86:             "linux64",
+	ARCH_32BIT_ARMV6_LITTLE_ENDIAN:   "linux32",
 	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   "linux32",
+	ARCH_32BIT_ARMV8_LITTLE_ENDIAN:   "linux32",
 	ARCH_64BIT_ARMV8_LITTLE_ENDIAN:   "linux64",
 	ARCH_32BIT_POWERPC_BIG_ENDIAN:    "linux32",
 	ARCH_64BIT_POWERPC_BIG_ENDIAN:    "linux64",
@@ -67,8 +75,10 @@ var architecturePersonalities = map[int]string{
 var architectureSupportedPersonalities = map[int][]int{
 	ARCH_32BIT_INTEL_X86:             {},
 	ARCH_64BIT_INTEL_X86:             {ARCH_32BIT_INTEL_X86},
-	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   {},
-	ARCH_64BIT_ARMV8_LITTLE_ENDIAN:   {ARCH_32BIT_ARMV7_LITTLE_ENDIAN},
+	ARCH_32BIT_ARMV6_LITTLE_ENDIAN:   {},
+	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   {ARCH_32BIT_ARMV6_LITTLE_ENDIAN},
+	ARCH_32BIT_ARMV8_LITTLE_ENDIAN:   {ARCH_32BIT_ARMV6_LITTLE_ENDIAN, ARCH_32BIT_ARMV7_LITTLE_ENDIAN},
+	ARCH_64BIT_ARMV8_LITTLE_ENDIAN:   {ARCH_32BIT_ARMV6_LITTLE_ENDIAN, ARCH_32BIT_ARMV7_LITTLE_ENDIAN, ARCH_32BIT_ARMV8_LITTLE_ENDIAN},
 	ARCH_32BIT_POWERPC_BIG_ENDIAN:    {},
 	ARCH_64BIT_POWERPC_BIG_ENDIAN:    {ARCH_32BIT_POWERPC_BIG_ENDIAN},
 	ARCH_64BIT_POWERPC_LITTLE_ENDIAN: {},


### PR DESCRIPTION
This adds both armv6l and armv8l and changes the way we track personalities to chain them and hopefully result in the correct set of images being supported.

Closes #10909

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>