### PR TITLE
Network: Fix ipv4.routes validation in `physical` network driver

### DIFF
--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -44,7 +44,7 @@ func (n *physical) Validate(config map[string]string) error {
 		"ipv6.gateway":                validate.Optional(validate.IsNetworkAddressCIDRV6),
 		"ipv4.ovn.ranges":             validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
 		"ipv6.ovn.ranges":             validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
-		"ipv4.routes":                 validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
+		"ipv4.routes":                 validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
 		"ipv4.routes.anycast":         validate.Optional(validate.IsBool),
 		"ipv6.routes":                 validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
 		"ipv6.routes.anycast":         validate.Optional(validate.IsBool),


### PR DESCRIPTION
Fixes regression from 632c588fe8cf90af11637b307c94b3f4d8d9c599

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>