### PR TITLE
Storage: Run local bucket `minio` process as LXD's unprivileged user

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3282,6 +3282,8 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 			return err
 		}
 
+		revert.Add(func() { _ = b.driver.DeleteVolume(storageBucket, op) })
+
 		// Start minio process.
 		minioProc, err := b.ActivateBucket(bucket.Name, op)
 		if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3824,7 +3824,7 @@ func (b *lxdBackend) ActivateBucket(bucketName string, op *operations.Operation)
 
 	vol := b.GetVolume(drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketName, nil)
 
-	return miniod.EnsureRunning(vol)
+	return miniod.EnsureRunning(b.state, vol)
 }
 
 // GetBucketURL returns S3 URL for bucket.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -29,6 +29,10 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	revert := revert.New()
 	defer revert.Fail()
 
+	if shared.PathExists(vol.MountPath()) {
+		return fmt.Errorf("Volume path %q already exists", vol.MountPath())
+	}
+
 	// Create the volume itself.
 	err := vol.EnsureMountPath()
 	if err != nil {

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -211,9 +211,9 @@ func (v Volume) EnsureMountPath() error {
 		revert.Add(func() { _ = os.Remove(volPath) })
 	}
 
-	// Set very restrictive mode 0100 for non-custom and non-image volumes.
+	// Set very restrictive mode 0100 for non-custom, non-bucket and non-image volumes.
 	mode := os.FileMode(0711)
-	if v.volType != VolumeTypeCustom && v.volType != VolumeTypeImage {
+	if v.volType != VolumeTypeCustom && v.volType != VolumeTypeImage && v.volType != VolumeTypeBucket {
 		mode = os.FileMode(0100)
 	}
 


### PR DESCRIPTION
As this is potentially network accessible service (via LXD acting as a reverse proxy) it is preferable from a security perspective to run the `minio` process as non-root.

This PR also adds automatic on-demand correction of ownership and permissions should the LXD unprivileged user change after the `minio` process has previously written data to the volume.

Also fixes 2 other issues:

- Storage volumes on `dir` pools were being allowed to be created even if the volume already existed on disk. This is a problem as if a subsequent action (like creating a local bucket on it) should fail, the volume will be deleted via a revert, and any existing data would be lost. We should not allow creating a storage volume if one already exists.
- If creating a local storage bucket didn't succeed, the local storage volume created was not being removed via a revert.