### PR TITLE
test: Adds LXD_REQUIRED_TESTS support

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -28,4 +28,4 @@ Name                           | Default                   | Description
 `LXD_IB_PHYSICAL_PARENT`       | ""                        | Enables Infiniband physical tests using the specified parent device
 `LXD_IB_SRIOV_PARENT`          | ""                        | Enables Infiniband SR-IOV tests using the specified parent device
 `LXD_NIC_BRIDGED_DRIVER`       | ""                        | Specifies bridged NIC driver for tests (either native or openvswitch, defaults to native)
-
+`LXD_REQUIRED_TESTS`           | ""                        | Space-delimited list of test names that must not be skipped if their prerequisites are not met

--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -32,9 +32,15 @@ test_storage_buckets() {
 
   lxd_backend=$(storage_backend "$LXD_DIR")
 
-  # Only run cephobject bucket tests if LXD_CEPH_CEPHOBJECT_RADOSGW specified.
-  if [ "$lxd_backend" = "ceph" ] && [ -z "${LXD_CEPH_CEPHOBJECT_RADOSGW:-}" ]; then
-    echo "==> SKIP: storage bucket tests for cephobject as LXD_CEPH_CEPHOBJECT_RADOSGW not specified"
+  if [ "$lxd_backend" = "ceph" ]; then
+    if [ -z "${LXD_CEPH_CEPHOBJECT_RADOSGW:-}" ]; then
+      # Check LXD_CEPH_CEPHOBJECT_RADOSGW specified for ceph bucket tests.
+      export TEST_UNMET_REQUIREMENT="LXD_CEPH_CEPHOBJECT_RADOSGW not specified"
+      return
+    fi
+  elif ! which minio ; then
+    # Check minio is installed for local storage pool buckets.
+    export TEST_UNMET_REQUIREMENT="minio command not found"
     return
   fi
 


### PR DESCRIPTION
And updates `test_storage_buckets` to check for `minio` command or skip (if not in `LXD_REQUIRED_TESTS`).

The aim of this PR is to prevent specialist tests that have uncommon external requirements (such as having minio installed) from failing the test suite if their external requirements are not met, unless the test name is explicitly listed `LXD_REQUIRED_TESTS` environment variable.

This allows for downstream packagers to run the common tests are part of the packaging process and not to have to worry about maintaining a list of skipped tests via the `LXD_SKIP_TESTS` environment variable (although this is possible if needed).

I originally discussed with @stgraber about adding a special return value for the test functions and checking for that.
But in the end I went for setting the `TEST_UNMET_REQUIREMENT` in order to allow logging the specific problem to aid debugging.