### PR TITLE
client: Handle nil args in CopyImage

### DIFF
--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -675,7 +675,7 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 	}
 
 	// Handle profile list overrides.
-	if args.Profiles != nil {
+	if args != nil && args.Profiles != nil {
 		if !r.HasExtension("image_copy_profile") {
 			return nil, fmt.Errorf("The server is missing the required \"image_copy_profile\" API extension")
 		}


### PR DESCRIPTION
This fixes #10929.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
