### PR TITLE
lxd-generate: More efficient AssociationTable queries

### DIFF
--- a/lxd/db/cluster/certificate_projects.interface.mapper.go
+++ b/lxd/db/cluster/certificate_projects.interface.mapper.go
@@ -11,7 +11,7 @@ import (
 type CertificateProjectGenerated interface {
 	// GetCertificateProjects returns all available Projects for the Certificate.
 	// generator: certificate_project GetMany
-	GetCertificateProjects(ctx context.Context, tx *sql.Tx, certificateID int) ([]Project, error)
+	GetCertificateProjects(ctx context.Context, tx *sql.Tx, certificateID int, filters ...ProjectFilter) ([]Project, error)
 
 	// DeleteCertificateProjects deletes the certificate_project matching the given key parameters.
 	// generator: certificate_project DeleteMany

--- a/lxd/db/cluster/instance_profiles.interface.mapper.go
+++ b/lxd/db/cluster/instance_profiles.interface.mapper.go
@@ -11,11 +11,11 @@ import (
 type InstanceProfileGenerated interface {
 	// GetProfileInstances returns all available Instances for the Profile.
 	// generator: instance_profile GetMany
-	GetProfileInstances(ctx context.Context, tx *sql.Tx, profileID int) ([]Instance, error)
+	GetProfileInstances(ctx context.Context, tx *sql.Tx, profileID int, filters ...InstanceFilter) ([]Instance, error)
 
 	// GetInstanceProfiles returns all available Profiles for the Instance.
 	// generator: instance_profile GetMany
-	GetInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) ([]Profile, error)
+	GetInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int, filters ...ProfileFilter) ([]Profile, error)
 
 	// CreateInstanceProfiles adds a new instance_profile to the database.
 	// generator: instance_profile Create


### PR DESCRIPTION
The `GetMany` function generated for an AssociationTable type (so
InstanceProfiles and CertificateProjects) first fetched a list of
IDs, then initiated one query for each ID to retrieve the entities.
This was pretty inefficient.

With lxd-generate now supporting variadic filters, this
function has been updated to accept a list of EntityFilter for the
returned entity. This allows us two things:

1) To filter on the columns of the entity we want (except IDs, which
   will be supplied internally by the function)

2) Reduce the total number of queries to 2 (One for all the IDs, one
   for all the entities) by creating a set of filters for each
   returned ID, with all the caller supplied filters as well as the
   entity ID.
