### PR TITLE
doc: update IRC link

### DIFF
--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -137,7 +137,8 @@ ogp_image = "https://linuxcontainers.org/static/img/containers.png"
 # Links to ignore when checking links
 
 linkcheck_ignore = [
-    'https://127.0.0.1:8443/1.0'
+    'https://127.0.0.1:8443/1.0',
+    'https://web.libera.chat/#lxc'
 ]
 
 # Setup redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ find and subscribe to those at: [`https://lists.linuxcontainers.org`](https://li
 
 ### IRC
 
-If you prefer live discussions, you can find us in [`#lxc`](https://kiwiirc.com/client/irc.libera.chat/lxc) on `irc.libera.chat`. See [Getting started with IRC](https://discuss.linuxcontainers.org/t/getting-started-with-irc/11920) if needed.
+If you prefer live discussions, you can find us in [`#lxc`](https://web.libera.chat/#lxc) on `irc.libera.chat`. See [Getting started with IRC](https://discuss.linuxcontainers.org/t/getting-started-with-irc/11920) if needed.
 
 ### Commercial support
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -41,7 +41,7 @@ The LXD project is sponsored by [Canonical Ltd](https://www.canonical.com).
 - [Contribute to the project](contributing.md)
 - [Get support](support.md)
 - [Watch tutorials and announcements on YouTube](https://www.youtube.com/c/LXDvideos)
-- [Discuss on IRC](https://kiwiirc.com/client/irc.libera.chat/lxc) (see [Getting started with IRC](https://discuss.linuxcontainers.org/t/getting-started-with-irc/11920) if needed)
+- [Discuss on IRC](https://web.libera.chat/#lxc) (see [Getting started with IRC](https://discuss.linuxcontainers.org/t/getting-started-with-irc/11920) if needed)
 - [Ask and answer questions on the forum](https://discuss.linuxcontainers.org)
 - [Join the mailing lists](https://lists.linuxcontainers.org)
 


### PR DESCRIPTION
Update the IRC link to https://web.libera.chat/#lxc .

Configure the link checker to ignore that link, since `#lxc` is not an anchor and therefore would cause the link checker to fail.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>