### PR TITLE
lxd/apparmor/instance: allow reading /proc/pid/cpuset

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -39,6 +39,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .ovmfPath }}/OVMF_CODE.fd              kr,
   /usr/share/qemu/**                        kr,
   /usr/share/seabios/**                     kr,
+  owner @{PROC}/@{pid}/cpuset               r,
   owner @{PROC}/@{pid}/task/@{tid}/comm     rw,
   {{ .rootPath }}/etc/nsswitch.conf         r,
   {{ .rootPath }}/etc/passwd                r,


### PR DESCRIPTION
Starting a VM result in this Apparmor denial:

```
Sep 26 15:15:11 sdeziel-lemur kernel: audit: type=1400 audit(1664219711.839:917): apparmor="DENIED" operation="open" profile="lxd-pylxd-test_</var/snap/lxd/common/lxd>" name="/proc/334670/cpuset" pid=334670 comm="lxd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

Environment details:

```
 lsb_release -rd
Description:	Ubuntu 22.04.1 LTS
Release:	22.04

$ uname -a
Linux sdeziel-lemur 5.15.0-48-generic #54-Ubuntu SMP Fri Aug 26 13:26:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

$ snap list lxd
Name  Version      Rev    Tracking       Publisher   Notes
lxd   5.5-37534be  23537  latest/stable  canonical✓  -
```