### PR TITLE
Daemon: Wait until server is ready before handling metrics and bucket API requests that can cause mounts

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -161,6 +161,9 @@ func storageBucketsServer(d *Daemon) *http.Server {
 	m.SkipClean(true)
 
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Wait until daemon is fully started.
+		<-d.waitReady.Done()
+
 		// Check if request contains an access key, and if so try and route it to the associated bucket.
 		accessKey := s3.AuthorizationHeaderAccessKey(r.Header.Get("Authorization"))
 		if accessKey != "" {
@@ -216,6 +219,9 @@ func storageBucketsServer(d *Daemon) *http.Server {
 
 	// We use the NotFoundHandler to reverse proxy requests to dynamically started local MinIO processes.
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wait until daemon is fully started.
+		<-d.waitReady.Done()
+
 		pathParts := strings.Split(r.RequestURI, "/")
 		bucketName, err := url.PathUnescape(pathParts[1])
 		if err != nil {

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -700,7 +700,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *clusterConfig.Config) error {
 	// Don't apply changes to settings until daemon is full started.
-	<-d.readyChan
+	<-d.waitReady.Done()
 
 	s := d.State()
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -699,7 +699,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 }
 
 func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *clusterConfig.Config) error {
-	// Don't apply changes to settings until daemon is full started.
+	// Don't apply changes to settings until daemon is fully started.
 	<-d.waitReady.Done()
 
 	s := d.State()

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -221,9 +221,7 @@ func internalWaitReady(d *Daemon, r *http.Request) response.Response {
 		return response.Unavailable(fmt.Errorf("LXD daemon is shutting down"))
 	}
 
-	select {
-	case <-d.readyChan:
-	default:
+	if d.waitReady.Err() == nil {
 		return response.Unavailable(fmt.Errorf("LXD daemon not ready yet"))
 	}
 

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -79,6 +79,9 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
+	// Wait until daemon is fully started.
+	<-d.waitReady.Done()
+
 	// Figure out the projects to retrieve.
 	var projectNames []string
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1441,6 +1441,8 @@ func (d *Daemon) init() error {
 	// Cleanup leftover images.
 	pruneLeftoverImages(d)
 
+	var instances []instance.Instance
+
 	if !d.os.MockMode {
 		// Start the scheduler
 		go deviceEventListener(d.State())
@@ -1457,9 +1459,15 @@ func (d *Daemon) init() error {
 			return err
 		}
 
+		// Must occur after d.devmonitor has been initialised.
+		instances, err = instance.LoadNodeAll(d.State(), instancetype.Any)
+		if err != nil {
+			return fmt.Errorf("Failed loading local instances: %w", err)
+		}
+
 		// Register devices on running instances to receive events and reconnect to VM monitor sockets.
 		// This should come after the event handler go routines have been started.
-		devicesRegister(d.State())
+		devicesRegister(instances)
 
 		// Setup seccomp handler
 		if d.os.SeccompListener {
@@ -1576,21 +1584,13 @@ func (d *Daemon) init() error {
 	// Start all background tasks
 	d.tasks.Start(d.shutdownCtx)
 
-	// Get daemon state struct
-	s := d.State()
-
 	// Restore instances
 	if !d.db.Cluster.LocalNodeIsEvacuated() {
-		instances, err := instance.LoadNodeAll(s, instancetype.Any)
-		if err != nil {
-			return fmt.Errorf("Failed loading instances to restore: %w", err)
-		}
-
-		instancesStart(s, instances)
+		instancesStart(d.State(), instances)
 	}
 
 	// Re-balance in case things changed while LXD was down
-	deviceTaskBalance(s)
+	deviceTaskBalance(d.State())
 
 	// Unblock incoming requests
 	d.waitReady.Cancel()

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1334,9 +1334,7 @@ func (d *Daemon) init() error {
 	d.globalConfigMu.Lock()
 	bgpASN = d.globalConfig.BGPASN()
 
-	d.proxy = shared.ProxyFromConfig(
-		d.globalConfig.ProxyHTTPS(), d.globalConfig.ProxyHTTP(), d.globalConfig.ProxyIgnoreHosts(),
-	)
+	d.proxy = shared.ProxyFromConfig(d.globalConfig.ProxyHTTPS(), d.globalConfig.ProxyHTTP(), d.globalConfig.ProxyIgnoreHosts())
 
 	candidAPIURL, candidAPIKey, candidExpiry, candidDomains = d.globalConfig.CandidServer()
 	maasAPIURL, maasAPIKey = d.globalConfig.MAASController()

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -62,6 +62,7 @@ import (
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/lxd/warnings"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/cancel"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
@@ -119,7 +120,7 @@ type Daemon struct {
 
 	// Status control.
 	setupChan      chan struct{}      // Closed when basic Daemon setup is completed
-	readyChan      chan struct{}      // Closed when LXD is fully ready
+	waitReady      *cancel.Canceller  // Cancelled when LXD is fully ready
 	shutdownCtx    context.Context    // Cancelled when shutdown starts.
 	shutdownCancel context.CancelFunc // Cancels the shutdownCtx to indicate shutdown starting.
 	shutdownDoneCh chan error         // Receives the result of the d.Stop() function and tells LXD to end.
@@ -200,7 +201,7 @@ func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 		db:             &db.DB{},
 		os:             os,
 		setupChan:      make(chan struct{}),
-		readyChan:      make(chan struct{}),
+		waitReady:      cancel.New(context.Background()),
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
 		shutdownDoneCh: make(chan error),
@@ -1634,7 +1635,7 @@ func (d *Daemon) Ready() error {
 	deviceTaskBalance(s)
 
 	// Unblock incoming requests
-	close(d.readyChan)
+	d.waitReady.Cancel()
 
 	return nil
 }

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -587,14 +587,8 @@ func deviceEventListener(s *state.State) {
 
 // devicesRegister calls the Register() function on all supported devices so they receive events.
 // This also has the effect of actively reconnecting to any running VM monitor sockets.
-func devicesRegister(s *state.State) {
+func devicesRegister(instances []instance.Instance) {
 	logger.Debug("Registering running instances")
-
-	instances, err := instance.LoadNodeAll(s, instancetype.Any)
-	if err != nil {
-		logger.Error("Problem loading instances list", logger.Ctx{"err": err})
-		return
-	}
 
 	for _, inst := range instances {
 		if !inst.IsRunning() { // For VMs this will also trigger a connection to the QMP socket if running.

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -173,7 +173,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
 	}
 
-	// Don't mess with containers while in setup mode.
+	// Don't mess with instances while in setup mode.
 	<-d.waitReady.Done()
 
 	inst, err := instance.LoadByProjectAndName(d.State(), projectName, name)

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -174,7 +174,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Don't mess with containers while in setup mode.
-	<-d.readyChan
+	<-d.waitReady.Done()
 
 	inst, err := instance.LoadByProjectAndName(d.State(), projectName, name)
 	if err != nil {

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -75,7 +75,7 @@ func coalesceErrors(local bool, errors map[string]error) error {
 func instancesPut(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 
-	// Don't mess with containers while in setup mode
+	// Don't mess with instances while in setup mode.
 	<-d.waitReady.Done()
 
 	c, err := instance.LoadNodeAll(d.State(), instancetype.Any)

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -76,7 +76,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 
 	// Don't mess with containers while in setup mode
-	<-d.readyChan
+	<-d.waitReady.Done()
 
 	c, err := instance.LoadNodeAll(d.State(), instancetype.Any)
 	if err != nil {


### PR DESCRIPTION
Otherwise storage may not be ready yet and running instances may not have had their mount counters initialised. This can lead to an incoming metrics request triggering an unwanted unmount at the end of the request as it doesn't know the volume is in use.

Also removes the unnecessary loading of all local instances twice during daemon start up.