### PR TITLE
VM: Dont offer VM support if /dev/vsock is missing

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6222,6 +6222,11 @@ func (d *qemu) Info() instance.Info {
 		return data
 	}
 
+	if !shared.PathExists("/dev/vsock") {
+		data.Error = fmt.Errorf("Vsock support is missing (no /dev/vsock)")
+		return data
+	}
+
 	err := util.LoadModule("vhost_vsock")
 	if err != nil {
 		data.Error = fmt.Errorf("vhost_vsock kernel module not loaded")


### PR DESCRIPTION
Fixes #10905

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>