### PR TITLE
Network: Separate DNS IP configuration from dynamic IP extraction logic

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -33,8 +33,8 @@ type ovnNet interface {
 	network.Network
 
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
-	InstanceDevicePortSetup(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error)
-	InstanceDevicePortDelete(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *network.OVNInstanceNICStopOpts) error
+	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error)
+	InstanceDevicePortStop(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *network.OVNInstanceNICStopOpts) error
 	InstanceDevicePortDynamicIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }
 
@@ -509,7 +509,7 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			}
 
 			// Update OVN logical switch port for instance.
-			_, err = d.network.InstanceDevicePortSetup(&network.OVNInstanceNICSetupOpts{
+			_, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
 				InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 				DNSName:      d.inst.Name(),
 				DeviceName:   d.name,
@@ -555,7 +555,7 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Try and retrieve the last associated OVN switch port for the instance interface in the local OVS DB.
-	// If we cannot get this, don't fail, as InstanceDevicePortDelete will then try and generate the likely
+	// If we cannot get this, don't fail, as InstanceDevicePortStop will then try and generate the likely
 	// port name using the same regime it does for new ports. This part is only here in order to allow
 	// instance ports generated under an older regime to be cleaned up properly.
 	networkVethFillFromVolatile(d.config, d.volatileGet())
@@ -581,7 +581,7 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 	}
 
 	instanceUUID := d.inst.LocalConfig()["volatile.uuid"]
-	err = d.network.InstanceDevicePortDelete(ovsExternalOVNPort, &network.OVNInstanceNICStopOpts{
+	err = d.network.InstanceDevicePortStop(ovsExternalOVNPort, &network.OVNInstanceNICStopOpts{
 		InstanceUUID: instanceUUID,
 		DeviceName:   d.name,
 		DeviceConfig: d.config,
@@ -818,7 +818,7 @@ func (d *nicOVN) setupHostNIC(hostName string, uplink *api.Network) (revert.Hook
 	}
 
 	// Add new OVN logical switch port for instance.
-	logicalPortName, err := d.network.InstanceDevicePortSetup(&network.OVNInstanceNICSetupOpts{
+	logicalPortName, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
 		InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 		DNSName:      d.inst.Name(),
 		DeviceName:   d.name,
@@ -830,7 +830,7 @@ func (d *nicOVN) setupHostNIC(hostName string, uplink *api.Network) (revert.Hook
 	}
 
 	revert.Add(func() {
-		_ = d.network.InstanceDevicePortDelete("", &network.OVNInstanceNICStopOpts{
+		_ = d.network.InstanceDevicePortStop("", &network.OVNInstanceNICStopOpts{
 			InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 			DeviceName:   d.name,
 			DeviceConfig: d.config,

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3241,9 +3241,10 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 	return nil
 }
 
-// InstanceDevicePortAdd sets up an instance device port to the internal logical switch and returns the port name.
+// InstanceDevicePortStart sets up an instance device port to the internal logical switch.
 // Accepts a list of ACLs being removed from the NIC device (if called as part of a NIC update).
-func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error) {
+// Returns the logical switch port name.
+func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error) {
 	if opts.InstanceUUID == "" {
 		return "", fmt.Errorf("Instance UUID is required")
 	}
@@ -3731,8 +3732,8 @@ func (n *ovn) InstanceDevicePortDynamicIPs(instanceUUID string, deviceName strin
 	return client.LogicalSwitchPortDynamicIPs(instancePortName)
 }
 
-// InstanceDevicePortDelete deletes an instance device port from the internal logical switch.
-func (n *ovn) InstanceDevicePortDelete(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *OVNInstanceNICStopOpts) error {
+// InstanceDevicePortStop deletes an instance device port from the internal logical switch.
+func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *OVNInstanceNICStopOpts) error {
 	// Decide whether to use OVS provided OVN port name or internally derived OVN port name.
 	instancePortName := ovsExternalOVNPort
 	source := "OVS"
@@ -4092,7 +4093,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 					// Re-add logical switch port to apply the l2proxy DNAT_AND_SNAT rules.
 					n.logger.Debug("Re-adding instance OVN NIC port to apply ingress mode changes", logger.Ctx{"project": inst.Project, "instance": inst.Name, "device": devName})
-					_, err = n.InstanceDevicePortSetup(&OVNInstanceNICSetupOpts{
+					_, err = n.InstanceDevicePortStart(&OVNInstanceNICSetupOpts{
 						InstanceUUID: instanceUUID,
 						DNSName:      inst.Name,
 						DeviceName:   devName,

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3253,7 +3253,7 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 		return "", err
 	}
 
-	ips := []net.IP{}
+	staticIPs := []net.IP{}
 	for _, key := range []string{"ipv4.address", "ipv6.address"} {
 		if opts.DeviceConfig[key] == "" {
 			continue
@@ -3264,7 +3264,7 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 			return "", fmt.Errorf("Invalid %s value %q", key, opts.DeviceConfig[key])
 		}
 
-		ips = append(ips, ip)
+		staticIPs = append(staticIPs, ip)
 	}
 
 	internalRoutes, externalRoutes, err := n.instanceDevicePortRoutesParse(opts.DeviceConfig)
@@ -3327,9 +3327,9 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 			// addresses have been added, then add an EUI64 static IPv6 address so that the switch port has an
 			// IPv6 address that will be used to generate a DNS record. This works around a limitation in OVN
 			// that prevents us requesting dynamic IPv6 address allocation when static IPv4 allocation is used.
-			if len(ips) > 0 {
+			if len(staticIPs) > 0 {
 				hasIPv6 := false
-				for _, ip := range ips {
+				for _, ip := range staticIPs {
 					if ip.To4() == nil {
 						hasIPv6 = true
 						break
@@ -3343,7 +3343,7 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 					}
 
 					// Add EUI64 to list of static IPs for instance port.
-					ips = append(ips, eui64IP)
+					staticIPs = append(staticIPs, eui64IP)
 				}
 			}
 		}
@@ -3359,7 +3359,7 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 		DHCPv4OptsID: dhcpV4ID,
 		DHCPv6OptsID: dhcpv6ID,
 		MAC:          mac,
-		IPs:          ips,
+		IPs:          staticIPs,
 	}, true)
 	if err != nil {
 		return "", err
@@ -3368,21 +3368,57 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 	revert.Add(func() { _ = client.LogicalSwitchPortDelete(instancePortName) })
 
 	// Add DNS records for port's IPs, and retrieve the IP addresses used.
-	dnsName := fmt.Sprintf("%s.%s", opts.DNSName, n.getDomainName())
-	var dnsUUID openvswitch.OVNDNSUUID
 	var dnsIPv4, dnsIPv6 net.IP
 
-	// Retry a few times in case port has not yet allocated dynamic IPs.
-	for i := 0; i < 5; i++ {
-		dnsUUID, dnsIPv4, dnsIPv6, err = client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, dnsName)
-		if err == openvswitch.ErrOVNNoPortIPs {
-			time.Sleep(100 * time.Millisecond)
-			continue
+	// checkAndStoreIP checks if the supplied IP is valid and can be used for a missing DNS IP.
+	// If the found IP is needed, stores into the relevant dnsIPvP{X} variable.
+	checkAndStoreIP := func(ip net.IP) {
+		if ip != nil {
+			isV4 := ip.To4() != nil
+			if dhcpv4Subnet != nil && dnsIPv4 == nil && isV4 {
+				dnsIPv4 = ip
+			} else if dhcpv6Subnet != nil && dnsIPv6 == nil && !isV4 {
+				dnsIPv6 = ip
+			}
 		}
-
-		break
 	}
 
+	// Populate DNS IP variables with any static IPs first before checking if we need to extract dynamic IPs.
+	for _, staticIP := range staticIPs {
+		checkAndStoreIP(staticIP)
+	}
+
+	// Get dynamic IPs for switch port if DHCP in use and any IPs are assigned dynamically.
+	if (dnsIPv4 == nil && dhcpv4Subnet != nil) || (dnsIPv6 == nil && dhcpv6Subnet != nil) {
+		var dynamicIPs []net.IP
+
+		// Retry a few times in case port has not yet allocated dynamic IPs.
+		for i := 0; i < 5; i++ {
+			dynamicIPs, err = client.LogicalSwitchPortDynamicIPs(instancePortName)
+			if err != nil {
+				return "", err
+			}
+
+			if len(dynamicIPs) > 0 {
+				break
+			}
+
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		for _, dynamicIP := range dynamicIPs {
+			// Try and find the first IPv4 and IPv6 addresses from the dynamic address list.
+			checkAndStoreIP(dynamicIP)
+		}
+
+		// Check, after considering all dynamic IPs, whether we have got the required ones.
+		if (dnsIPv4 == nil && dhcpv4Subnet != nil) || (dnsIPv6 == nil && dhcpv6Subnet != nil) {
+			return "", fmt.Errorf("Insufficient dynamic addresses allocated")
+		}
+	}
+
+	dnsName := fmt.Sprintf("%s.%s", opts.DNSName, n.getDomainName())
+	dnsUUID, err := client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, dnsName, dnsIPv4, dnsIPv6)
 	if err != nil {
 		return "", fmt.Errorf("Failed setting DNS for %q: %w", dnsName, err)
 	}


### PR DESCRIPTION
Part of https://github.com/lxc/lxd/issues/10553

- Updates `LogicalSwitchPortSetDNS` to just accept the IPs to use for the DNS record directly rather than trying to extract them from the logical switch port config.
- Moves the logical switch port dynamic IP extraction into the `ovn` network driver and use this to drive `LogicalSwitchPortSetDNS` directly with extracted IPs.
- Adds optimisation where if all IPs are statically allocated, there's no need to ask OVN for the dynamic logical switch port IPs.
- Makes DNS name IPs dependent on the relevant protocol's DHCP setting being enabled. Because OVN will generate dynamic IPs even if DHCP is disabled, and we don't want those IPs to appear in DNS in that case.