### PR TITLE
Network: Manage DHCPv4 reservations when adding/removing OVN NICs

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3522,6 +3522,14 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 	revert.Add(func() { _ = client.LogicalSwitchPortDeleteDNS(n.getIntSwitchName(), dnsUUID, false) })
 
+	// If NIC has static IPv4 address then ensure a DHCPv4 reservation exists.
+	if opts.DeviceConfig["ipv4.address"] != "" && dnsIPv4 != nil {
+		err = n.instanceDevicePortDHCPv4ReservationAdd(client, dnsIPv4)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	// Publish NIC's IPs on uplink network if NAT is disabled and using l2proxy ingress mode on uplink.
 	if shared.StringInSlice(opts.UplinkConfig["ovn.ingress_mode"], []string{"l2proxy", ""}) {
 		for _, k := range []string{"ipv4.nat", "ipv6.nat"} {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3458,7 +3458,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		return "", fmt.Errorf("Failed setting DNS for %q: %w", dnsName, err)
 	}
 
-	revert.Add(func() { _ = client.LogicalSwitchPortDeleteDNS(n.getIntSwitchName(), dnsUUID) })
+	revert.Add(func() { _ = client.LogicalSwitchPortDeleteDNS(n.getIntSwitchName(), dnsUUID, false) })
 
 	// Publish NIC's IPs on uplink network if NAT is disabled and using l2proxy ingress mode on uplink.
 	if shared.StringInSlice(opts.UplinkConfig["ovn.ingress_mode"], []string{"l2proxy", ""}) {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1906,6 +1906,12 @@ func (n *ovn) setup(update bool) error {
 		updatedConfig["bridge.mtu"] = fmt.Sprintf("%d", bridgeMTU)
 	}
 
+	// Get a list of all NICs connected to this network that have static DHCP IPv4 reservations.
+	dhcpReserveIPv4s, err := n.getDHCPv4Reservations()
+	if err != nil {
+		return fmt.Errorf("Failed getting DHCPv4 IP reservations: %w", err)
+	}
+
 	// Apply any config dynamically generated to the current config and store back to DB in single transaction.
 	if len(updatedConfig) > 0 {
 		for k, v := range updatedConfig {
@@ -2169,16 +2175,11 @@ func (n *ovn) setup(update bool) error {
 		revert.Add(func() { _ = client.LogicalSwitchDelete(n.getIntSwitchName()) })
 	}
 
-	var excludeIPV4 []shared.IPRange
-	if routerIntPortIPv4 != nil {
-		excludeIPV4 = []shared.IPRange{{Start: routerIntPortIPv4}}
-	}
-
 	// Setup IP allocation config on logical switch.
 	err = client.LogicalSwitchSetIPAllocation(n.getIntSwitchName(), &openvswitch.OVNIPAllocationOpts{
 		PrefixIPv4:  routerIntPortIPv4Net,
 		PrefixIPv6:  routerIntPortIPv6Net,
-		ExcludeIPv4: excludeIPV4,
+		ExcludeIPv4: dhcpReserveIPv4s,
 	})
 	if err != nil {
 		return fmt.Errorf("Failed setting IP allocation settings on internal switch: %w", err)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1330,7 +1330,9 @@ func (o *OVN) LogicalSwitchPortCleanup(portName OVNSwitchPort, switchName OVNSwi
 	args = o.logicalSwitchPortDeleteAppendArgs(args, portName)
 
 	// Remove DNS records.
-	args = o.logicalSwitchPortDeleteDNSAppendArgs(args, switchName, dnsUUID, false)
+	if dnsUUID != "" {
+		args = o.logicalSwitchPortDeleteDNSAppendArgs(args, switchName, dnsUUID, false)
+	}
 
 	_, err = o.nbctl(args...)
 	if err != nil {


### PR DESCRIPTION
This allows for static IP allocations to be reserved even when the instance isn't running.

Uses the logical switch's `exclude_ips` list to prevent a reserved IP from being allocated dynamically to another instance NIC.

Because the `exclude_ips` list is just a list of IPs without any ability to associate them to a particular device name, this presented a problem because it is possible to have conflicting instance IP configs in the database (for example copying an instance that has a static IP configured). This would be a problem if the conflicting instance was removed as it would then remove the reservation for the original instance.

I have solved this problem by changing how DNS records in OVN are managed by LXD. An empty DNS record entry is now created on `Add()` and deleted on `Remove()`. The presence of this record will then be used to indicate that a successful add was performed and that on remove any matching DHCP reservation should be removed.

This works because a conflicting instance's NIC does not have its `Add()` function run (since https://github.com/lxc/lxd/pull/10546).

If the original instance is removed and the conflicting one is then started (because it no longer conflicts with the deleted original) then on start up the DHCP reservation will be created. This aligns with the behaviour of the `bridged` NIC.

Associated tests: https://github.com/lxc/lxc-ci/pull/629

Fixes #10553