### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -417,7 +416,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 		contentType = "application/octet-stream"
 	} else {
 		// If split image, we need mime encoding
-		tmpfile, err := ioutil.TempFile("", "lxc_image_")
+		tmpfile, err := os.CreateTemp("", "lxc_image_")
 		if err != nil {
 			return nil, err
 		}
@@ -762,14 +761,14 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 
 	// Relay mode
 	if args != nil && args.Mode == "relay" {
-		metaFile, err := ioutil.TempFile("", "lxc_image_")
+		metaFile, err := os.CreateTemp("", "lxc_image_")
 		if err != nil {
 			return nil, err
 		}
 
 		defer func() { _ = os.Remove(metaFile.Name()) }()
 
-		rootfsFile, err := ioutil.TempFile("", "lxc_image_")
+		rootfsFile, err := os.CreateTemp("", "lxc_image_")
 		if err != nil {
 			return nil, err
 		}

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -2,7 +2,7 @@ package lxd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gorilla/websocket"
@@ -184,7 +184,7 @@ func (r *ProtocolLXD) GetMetrics() (string, error) {
 	}
 
 	// Get the content.
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -156,7 +155,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 				}
 
 				// Create temporary file for the delta
-				deltaFile, err := ioutil.TempFile("", "lxc_image_")
+				deltaFile, err := os.CreateTemp("", "lxc_image_")
 				if err != nil {
 					return nil, err
 				}
@@ -172,7 +171,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 				}
 
 				// Create temporary file for the delta
-				patchedFile, err := ioutil.TempFile("", "lxc_image_")
+				patchedFile, err := os.CreateTemp("", "lxc_image_")
 				if err != nil {
 					return nil, err
 				}

--- a/lxc-to-lxd/config.go
+++ b/lxc-to-lxd/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,7 +166,7 @@ func parseConfig(path string) ([]string, error) {
 
 			if shared.PathExists(value) {
 				if shared.IsDir(value) {
-					files, err := ioutil.ReadDir(value)
+					files, err := os.ReadDir(value)
 					if err != nil {
 						return nil, err
 					}

--- a/lxc-to-lxd/main_migrate_test.go
+++ b/lxc-to-lxd/main_migrate_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -93,7 +92,7 @@ func TestValidateConfig(t *testing.T) {
 		},
 	}
 
-	lxcPath, err := ioutil.TempDir("", "lxc-to-lxd-test-")
+	lxcPath, err := os.MkdirTemp("", "lxc-to-lxd-test-")
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(lxcPath))
 
@@ -202,7 +201,7 @@ func TestConvertNetworkConfig(t *testing.T) {
 		},
 	}
 
-	lxcPath, err := ioutil.TempDir("", "lxc-to-lxd-test-")
+	lxcPath, err := os.MkdirTemp("", "lxc-to-lxd-test-")
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(lxcPath) }()
 

--- a/lxc-to-lxd/transfer.go
+++ b/lxc-to-lxd/transfer.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -30,7 +29,7 @@ func rsyncSend(conn *websocket.Conn, path string, rsyncArgs string) error {
 
 	readDone, writeDone := shared.WebsocketMirror(conn, dataSocket, io.ReadCloser(dataSocket), nil, nil)
 
-	output, err := ioutil.ReadAll(stderr)
+	output, err := io.ReadAll(stderr)
 	if err != nil {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -633,7 +633,7 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -1009,12 +1009,12 @@ func (c *cmdClusterUpdateCertificate) Run(cmd *cobra.Command, args []string) err
 		return fmt.Errorf(i18n.G("Could not find certificate key file path: %s"), keyFile)
 	}
 
-	cert, err := ioutil.ReadFile(certFile)
+	cert, err := os.ReadFile(certFile)
 	if err != nil {
 		return fmt.Errorf(i18n.G("Could not read certificate file: %s with error: %v"), certFile, err)
 	}
 
-	key, err := ioutil.ReadFile(keyFile)
+	key, err := os.ReadFile(keyFile)
 	if err != nil {
 		return fmt.Errorf(i18n.G("Could not read certificate key file: %s with error: %v"), keyFile, err)
 	}
@@ -1031,7 +1031,7 @@ func (c *cmdClusterUpdateCertificate) Run(cmd *cobra.Command, args []string) err
 
 	certf := conf.ServerCertPath(resource.remote)
 	if shared.PathExists(certf) {
-		err = ioutil.WriteFile(certf, cert, 0644)
+		err = os.WriteFile(certf, cert, 0644)
 		if err != nil {
 			return fmt.Errorf(i18n.G("Could not write new remote certificate for remote '%s' with error: %v"), resource.remote, err)
 		}

--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -281,7 +281,7 @@ func (c *cmdClusterGroupEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -154,7 +154,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 
 		// If stdin isn't a terminal, read text from it
 		if !termios.IsTerminal(getStdinFd()) {
-			contents, err := ioutil.ReadAll(os.Stdin)
+			contents, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}
@@ -293,7 +293,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/config/file.go
+++ b/lxc/config/file.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -15,7 +14,7 @@ import (
 // not exist, it returns a default configuration.
 func LoadConfig(path string) (*Config, error) {
 	// Open the config file
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to read the configuration file: %w", err)
 	}
@@ -36,7 +35,7 @@ func LoadConfig(path string) (*Config, error) {
 
 	// Apply the global (system-wide) remotes
 	globalConf := NewConfig("", false)
-	content, err = ioutil.ReadFile(globalConf.GlobalConfigPath("config.yml"))
+	content, err = os.ReadFile(globalConf.GlobalConfigPath("config.yml"))
 	if err == nil {
 		err = yaml.Unmarshal(content, &globalConf)
 		if err != nil {

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"runtime"
@@ -253,7 +252,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 
 	// Server certificate
 	if shared.PathExists(c.ServerCertPath(name)) {
-		content, err := ioutil.ReadFile(c.ServerCertPath(name))
+		content, err := os.ReadFile(c.ServerCertPath(name))
 		if err != nil {
 			return nil, err
 		}
@@ -268,7 +267,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 
 	// Client certificate
 	if shared.PathExists(c.ConfigPath("client.crt")) {
-		content, err := ioutil.ReadFile(c.ConfigPath("client.crt"))
+		content, err := os.ReadFile(c.ConfigPath("client.crt"))
 		if err != nil {
 			return nil, err
 		}
@@ -278,7 +277,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 
 	// Client CA
 	if shared.PathExists(c.ConfigPath("client.ca")) {
-		content, err := ioutil.ReadFile(c.ConfigPath("client.ca"))
+		content, err := os.ReadFile(c.ConfigPath("client.ca"))
 		if err != nil {
 			return nil, err
 		}
@@ -288,7 +287,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 
 	// Client key
 	if shared.PathExists(c.ConfigPath("client.key")) {
-		content, err := ioutil.ReadFile(c.ConfigPath("client.key"))
+		content, err := os.ReadFile(c.ConfigPath("client.key"))
 		if err != nil {
 			return nil, err
 		}

--- a/lxc/config_metadata.go
+++ b/lxc/config_metadata.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -106,7 +106,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 	// Edit the metadata
 	if !termios.IsTerminal(getStdinFd()) {
 		metadata := api.ImageMetadata{}
-		content, err := ioutil.ReadAll(os.Stdin)
+		content, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 
@@ -187,7 +187,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	content, err := ioutil.ReadAll(reader)
+	content, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func (c *cmdConfigTemplateShow) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	content, err := ioutil.ReadAll(template)
+	content, err := io.ReadAll(template)
 	if err != nil {
 		return err
 	}

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -6,7 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -264,7 +264,7 @@ func (c *cmdConfigTrustEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -132,7 +131,7 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		stuff, err := ioutil.ReadAll(log)
+		stuff, err := io.ReadAll(log)
 		if err != nil {
 			return err
 		}
@@ -262,7 +261,7 @@ func (c *cmdConsole) vga(d lxd.InstanceServer, name string) error {
 		}
 
 		// Generate a random file name.
-		path, err := ioutil.TempFile(conf.ConfigPath("sockets"), "*.spice")
+		path, err := os.CreateTemp(conf.ConfigPath("sockets"), "*.spice")
 		if err != nil {
 			return err
 		}

--- a/lxc/console_windows.go
+++ b/lxc/console_windows.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -30,7 +30,7 @@ func (c *cmdConsole) findCommand(name string) string {
 	path, _ := exec.LookPath(name)
 	if path == "" {
 		// Let's see if it's not in the usual location.
-		programs, err := ioutil.ReadDir("\\Program Files")
+		programs, err := os.ReadDir("\\Program Files")
 		if err != nil {
 			return ""
 		}

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -170,7 +169,7 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 	var stdin io.ReadCloser
 	stdin = os.Stdin
 	if c.flagDisableStdin {
-		stdin = ioutil.NopCloser(bytes.NewReader(nil))
+		stdin = io.NopCloser(bytes.NewReader(nil))
 	}
 
 	stdout := getStdout()

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -189,7 +188,7 @@ func (c *cmdFileEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create temp file
-	f, err := ioutil.TempFile("", "lxd_file_edit_")
+	f, err := os.CreateTemp("", "lxd_file_edit_")
 	if err != nil {
 		return fmt.Errorf(i18n.G("Unable to create a temporary file: %v"), err)
 	}
@@ -345,7 +344,7 @@ func (c *cmdFilePull) Run(cmd *cobra.Command, args []string) error {
 		logger.Infof("Pulling %s from %s (%s)", targetPath, pathSpec[1], resp.Type)
 
 		if resp.Type == "symlink" {
-			linkTarget, err := ioutil.ReadAll(buf)
+			linkTarget, err := io.ReadAll(buf)
 			if err != nil {
 				return err
 			}
@@ -765,7 +764,7 @@ func (c *cmdFile) recursivePullFile(d lxd.InstanceServer, inst string, p string,
 
 		progress.Done("")
 	} else if resp.Type == "symlink" {
-		linkTarget, err := ioutil.ReadAll(buf)
+		linkTarget, err := io.ReadAll(buf)
 		if err != nil {
 			return err
 		}
@@ -819,7 +818,7 @@ func (c *cmdFile) recursivePushFile(d lxd.InstanceServer, inst string, source st
 
 			args.Type = "symlink"
 			args.Content = bytes.NewReader([]byte(symlinkTarget))
-			readCloser = ioutil.NopCloser(args.Content)
+			readCloser = io.NopCloser(args.Content)
 		} else {
 			// File handling
 			f, err := os.Open(p)

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -412,7 +411,7 @@ func (c *cmdImageEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -669,7 +668,7 @@ func (c *cmdImageImport) packImageDir(path string) (string, error) {
 		return "", fmt.Errorf(i18n.G("Must run as root to import from directory"))
 	}
 
-	outFile, err := ioutil.TempFile("", "lxd_image_")
+	outFile, err := os.CreateTemp("", "lxd_image_")
 	if err != nil {
 		return "", err
 	}

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 
@@ -705,7 +704,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, remote config.Remote, name 
 			return fmt.Errorf(i18n.G("Unsupported instance type: %s"), inst.Type)
 		}
 
-		stuff, err := ioutil.ReadAll(log)
+		stuff, err := io.ReadAll(log)
 		if err != nil {
 			return err
 		}

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -88,7 +88,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return nil, "", err
 		}

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -630,7 +630,7 @@ func (c *cmdNetworkEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -341,7 +340,7 @@ func (c *cmdNetworkACLCreate) Run(cmd *cobra.Command, args []string) error {
 	// If stdin isn't a terminal, read yaml from it.
 	var aclPut api.NetworkACLPut
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -537,7 +536,7 @@ func (c *cmdNetworkACLEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -263,7 +263,7 @@ func (c *cmdNetworkForwardCreate) Run(cmd *cobra.Command, args []string) error {
 	// If stdin isn't a terminal, read yaml from it.
 	var forwardPut api.NetworkForwardPut
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -548,7 +548,7 @@ func (c *cmdNetworkForwardEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -265,7 +265,7 @@ func (c *cmdNetworkLoadBalancerCreate) Run(cmd *cobra.Command, args []string) er
 	// If stdin isn't a terminal, read yaml from it.
 	var loadBalancerPut api.NetworkLoadBalancerPut
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -550,7 +550,7 @@ func (c *cmdNetworkLoadBalancerEdit) Run(cmd *cobra.Command, args []string) erro
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -259,7 +259,7 @@ func (c *cmdNetworkPeerCreate) Run(cmd *cobra.Command, args []string) error {
 	// If stdin isn't a terminal, read yaml from it.
 	var peerPut api.NetworkPeerPut
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -527,7 +527,7 @@ func (c *cmdNetworkPeerEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -285,7 +285,7 @@ func (c *cmdNetworkZoneCreate) Run(cmd *cobra.Command, args []string) error {
 	// If stdin isn't a terminal, read yaml from it.
 	var zonePut api.NetworkZonePut
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -467,7 +467,7 @@ func (c *cmdNetworkZoneEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -844,7 +844,7 @@ func (c *cmdNetworkZoneRecordCreate) Run(cmd *cobra.Command, args []string) erro
 	// If stdin isn't a terminal, read yaml from it.
 	var recordPut api.NetworkZoneRecordPut
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -1021,7 +1021,7 @@ func (c *cmdNetworkZoneRecordEdit) Run(cmd *cobra.Command, args []string) error 
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -464,7 +464,7 @@ func (c *cmdProfileEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -268,7 +268,7 @@ func (c *cmdProjectEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -131,7 +130,7 @@ func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
 			return cleanErr
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"sort"
@@ -267,7 +267,7 @@ func (c *cmdStorageEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/storage_bucket.go
+++ b/lxc/storage_bucket.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -115,7 +115,7 @@ func (c *cmdStorageBucketCreate) Run(cmd *cobra.Command, args []string) error {
 	// If stdin isn't a terminal, read yaml from it.
 	var bucketPut api.StorageBucketPut
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -292,7 +292,7 @@ func (c *cmdStorageBucketEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -1004,7 +1004,7 @@ func (c *cmdStorageBucketKeyEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -13,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/client"
+	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -892,7 +891,7 @@ func (c *cmdStorageVolumeEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// If stdin isn't a terminal, read text from it
 	if !termios.IsTerminal(getStdinFd()) {
-		contents, err := ioutil.ReadAll(os.Stdin)
+		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"sort"
@@ -143,7 +143,7 @@ func GetExistingAliases(aliases []string, allAliases []api.ImageAliasesEntry) []
 func getConfig(args ...string) (map[string]string, error) {
 	if len(args) == 2 && !strings.Contains(args[0], "=") {
 		if args[1] == "-" && !termios.IsTerminal(getStdinFd()) {
-			buf, err := ioutil.ReadAll(os.Stdin)
+			buf, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return nil, fmt.Errorf(i18n.G("Can't read from stdin: %w"), err)
 			}
@@ -163,7 +163,7 @@ func getConfig(args ...string) (map[string]string, error) {
 		}
 
 		if fields[1] == "-" && !termios.IsTerminal(getStdinFd()) {
-			buf, err := ioutil.ReadAll(os.Stdin)
+			buf, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return nil, fmt.Errorf(i18n.G("Can't read from stdin: %w"), err)
 			}

--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -158,12 +157,12 @@ func stopDevlxdServer(d *Daemon) error {
 }
 
 func getClient(CID int, port int, serverCertificate string) (*http.Client, error) {
-	agentCert, err := ioutil.ReadFile("agent.crt")
+	agentCert, err := os.ReadFile("agent.crt")
 	if err != nil {
 		return nil, err
 	}
 
-	agentKey, err := ioutil.ReadFile("agent.key")
+	agentKey, err := os.ReadFile("agent.key")
 	if err != nil {
 		return nil, err
 	}

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -41,7 +41,7 @@ var execCmd = APIEndpoint{
 func execPost(d *Daemon, r *http.Request) response.Response {
 	post := api.ContainerExecPost{}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -404,7 +404,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 				return
 			}
 
-			buf, err := ioutil.ReadAll(r)
+			buf, err := io.ReadAll(r)
 			if err != nil {
 				// Check if command process has finished normally, if so, no need to kill it.
 				select {

--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -262,7 +261,7 @@ func (c *cmdAgent) mountHostShares() {
 		return
 	}
 
-	b, err := ioutil.ReadFile(agentMountsFile)
+	b, err := os.ReadFile(agentMountsFile)
 	if err != nil {
 		logger.Errorf("Failed to load agent mounts file %q: %v", agentMountsFile, err)
 	}

--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -77,7 +77,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 }
 
 func getCPUMetrics(d *Daemon) (map[string]metrics.CPUMetrics, error) {
-	stats, err := ioutil.ReadFile("/proc/stat")
+	stats, err := os.ReadFile("/proc/stat")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read /proc/stat: %w", err)
 	}
@@ -159,7 +159,7 @@ func getCPUMetrics(d *Daemon) (map[string]metrics.CPUMetrics, error) {
 }
 
 func getTotalProcesses(d *Daemon) (uint64, error) {
-	entries, err := ioutil.ReadDir("/proc")
+	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return 0, fmt.Errorf("Failed to read dir %q: %w", "/proc", err)
 	}
@@ -180,7 +180,7 @@ func getTotalProcesses(d *Daemon) (uint64, error) {
 
 		cmdlinePath := filepath.Join("/proc", entry.Name(), "cmdline")
 
-		cmdline, err := ioutil.ReadFile(cmdlinePath)
+		cmdline, err := os.ReadFile(cmdlinePath)
 		if err != nil {
 			continue
 		}
@@ -196,7 +196,7 @@ func getTotalProcesses(d *Daemon) (uint64, error) {
 }
 
 func getDiskMetrics(d *Daemon) (map[string]metrics.DiskMetrics, error) {
-	diskStats, err := ioutil.ReadFile("/proc/diskstats")
+	diskStats, err := os.ReadFile("/proc/diskstats")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read /proc/diskstats: %w", err)
 	}
@@ -245,7 +245,7 @@ func getDiskMetrics(d *Daemon) (map[string]metrics.DiskMetrics, error) {
 }
 
 func getFilesystemMetrics(d *Daemon) (map[string]metrics.FilesystemMetrics, error) {
-	mounts, err := ioutil.ReadFile("/proc/mounts")
+	mounts, err := os.ReadFile("/proc/mounts")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read /proc/mounts: %w", err)
 	}
@@ -287,7 +287,7 @@ func getFilesystemMetrics(d *Daemon) (map[string]metrics.FilesystemMetrics, erro
 }
 
 func getMemoryMetrics(d *Daemon) (metrics.MemoryMetrics, error) {
-	content, err := ioutil.ReadFile("/proc/meminfo")
+	content, err := os.ReadFile("/proc/meminfo")
 	if err != nil {
 		return metrics.MemoryMetrics{}, fmt.Errorf("Failed to read /proc/meminfo: %w", err)
 	}

--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -63,7 +62,7 @@ func serverTLSConfig() (*tls.Config, error) {
 // reconfigureNetworkInterfaces checks for the existence of files under NICConfigDir in the config share.
 // Each file is named <device>.json and contains the Device Name, NIC Name, MTU and MAC address.
 func reconfigureNetworkInterfaces() {
-	nicDirEntries, err := ioutil.ReadDir(deviceConfig.NICConfigDir)
+	nicDirEntries, err := os.ReadDir(deviceConfig.NICConfigDir)
 	if err != nil {
 		// Abort if configuration folder does not exist (nothing to do), otherwise log and return.
 		if os.IsNotExist(err) {
@@ -78,7 +77,7 @@ func reconfigureNetworkInterfaces() {
 	nicData := make(map[string]deviceConfig.NICConfig, len(nicDirEntries))
 
 	for _, f := range nicDirEntries {
-		nicBytes, err := ioutil.ReadFile(filepath.Join(deviceConfig.NICConfigDir, f.Name()))
+		nicBytes, err := os.ReadFile(filepath.Join(deviceConfig.NICConfigDir, f.Name()))
 		if err != nil {
 			logger.Error("Could not read network interface configuration file", logger.Ctx{"err": err})
 		}

--- a/lxd-agent/state.go
+++ b/lxd-agent/state.go
@@ -4,9 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -49,7 +49,7 @@ func cpuState() api.InstanceStateCPU {
 
 	if shared.PathExists("/sys/fs/cgroup/cpuacct/cpuacct.usage") {
 		// CPU usage in seconds
-		value, err = ioutil.ReadFile("/sys/fs/cgroup/cpuacct/cpuacct.usage")
+		value, err = os.ReadFile("/sys/fs/cgroup/cpuacct/cpuacct.usage")
 		if err != nil {
 			cpu.Usage = -1
 			return cpu
@@ -65,7 +65,7 @@ func cpuState() api.InstanceStateCPU {
 
 		return cpu
 	} else if shared.PathExists("/sys/fs/cgroup/cpu.stat") {
-		stats, err := ioutil.ReadFile("/sys/fs/cgroup/cpu.stat")
+		stats, err := os.ReadFile("/sys/fs/cgroup/cpu.stat")
 		if err != nil {
 			cpu.Usage = -1
 			return cpu
@@ -105,7 +105,7 @@ func memoryState() api.InstanceStateMemory {
 	memory.Usage = int64(stats.MemTotalBytes) - int64(stats.MemFreeBytes)
 
 	// Memory peak in bytes
-	value, err := ioutil.ReadFile("/sys/fs/cgroup/memory/memory.max_usage_in_bytes")
+	value, err := os.ReadFile("/sys/fs/cgroup/memory/memory.max_usage_in_bytes")
 	valueInt, err1 := strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
 	if err == nil && err1 == nil {
 		memory.UsagePeak = valueInt
@@ -149,25 +149,25 @@ func networkState() map[string]api.InstanceStateNetwork {
 		}
 
 		// Counters
-		value, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/tx_bytes", iface.Name))
+		value, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/tx_bytes", iface.Name))
 		valueInt, err1 := strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.BytesSent = valueInt
 		}
 
-		value, err = ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/rx_bytes", iface.Name))
+		value, err = os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/rx_bytes", iface.Name))
 		valueInt, err1 = strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.BytesReceived = valueInt
 		}
 
-		value, err = ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/tx_packets", iface.Name))
+		value, err = os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/tx_packets", iface.Name))
 		valueInt, err1 = strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.PacketsSent = valueInt
 		}
 
-		value, err = ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/rx_packets", iface.Name))
+		value, err = os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/rx_packets", iface.Name))
 		valueInt, err1 = strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.PacketsReceived = valueInt
@@ -224,7 +224,7 @@ func processesState() int64 {
 	// Go through the pid list, adding new pids at the end so we go through them all
 	for i := 0; i < len(pids); i++ {
 		fname := fmt.Sprintf("/proc/%d/task/%d/children", pids[i], pids[i])
-		fcont, err := ioutil.ReadFile(fname)
+		fcont, err := os.ReadFile(fname)
 		if err != nil {
 			// the process terminated during execution of this loop
 			continue

--- a/lxd-agent/templates.go
+++ b/lxd-agent/templates.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,7 +19,7 @@ func templatesApply(path string) ([]string, error) {
 	}
 
 	// Parse the metadata.
-	content, err := ioutil.ReadFile(metaName)
+	content, err := os.ReadFile(metaName)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read metadata: %w", err)
 	}

--- a/lxd-benchmark/benchmark/batch.go
+++ b/lxd-benchmark/benchmark/batch.go
@@ -1,7 +1,7 @@
 package benchmark
 
 import (
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 )
@@ -10,7 +10,7 @@ func getBatchSize(parallel int) (int, error) {
 	batchSize := parallel
 	if batchSize < 1 {
 		// Detect the number of parallel actions
-		cpus, err := ioutil.ReadDir("/sys/bus/cpu/devices")
+		cpus, err := os.ReadDir("/sys/bus/cpu/devices")
 		if err != nil {
 			return -1, err
 		}

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -503,7 +502,7 @@ func (c *cmdMigrate) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the temporary directory to be used for the mounts
-	path, err := ioutil.TempDir("", "lxd-migrate_mount_")
+	path, err := os.MkdirTemp("", "lxd-migrate_mount_")
 	if err != nil {
 		return err
 	}
@@ -534,7 +533,7 @@ func (c *cmdMigrate) Run(cmd *cobra.Command, args []string) error {
 		fullPath = path
 		target := filepath.Join(path, "root.img")
 
-		err := ioutil.WriteFile(target, nil, 0644)
+		err := os.WriteFile(target, nil, 0644)
 		if err != nil {
 			return fmt.Errorf("Failed to create %q: %w", target, err)
 		}

--- a/lxd-migrate/transfer.go
+++ b/lxd-migrate/transfer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -32,7 +31,7 @@ func rsyncSend(ctx context.Context, conn *websocket.Conn, path string, rsyncArgs
 
 	readDone, writeDone := shared.WebsocketMirror(conn, dataSocket, io.ReadCloser(dataSocket), nil, nil)
 
-	output, err := ioutil.ReadAll(stderr)
+	output, err := io.ReadAll(stderr)
 	if err != nil {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -172,12 +171,12 @@ func connectTarget(url string, certPath string, keyPath string, authType string,
 		} else {
 			var err error
 
-			clientCrt, err = ioutil.ReadFile(certPath)
+			clientCrt, err = os.ReadFile(certPath)
 			if err != nil {
 				return nil, "", fmt.Errorf("Failed to read client certificate: %w", err)
 			}
 
-			clientKey, err = ioutil.ReadFile(keyPath)
+			clientKey, err = os.ReadFile(keyPath)
 			if err != nil {
 				return nil, "", fmt.Errorf("Failed to read client key: %w", err)
 			}
@@ -193,7 +192,7 @@ func connectTarget(url string, certPath string, keyPath string, authType string,
 			},
 		}
 
-		f, err := ioutil.TempFile("", "lxd-migrate_")
+		f, err := os.CreateTemp("", "lxd-migrate_")
 		if err != nil {
 			return nil, "", err
 		}

--- a/lxd-user/proxy.go
+++ b/lxd-user/proxy.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
@@ -16,7 +16,7 @@ import (
 
 func tlsConfig(uid uint32) (*tls.Config, error) {
 	// Load the client certificate.
-	content, err := ioutil.ReadFile(filepath.Join("users", fmt.Sprintf("%d", uid), "client.crt"))
+	content, err := os.ReadFile(filepath.Join("users", fmt.Sprintf("%d", uid), "client.crt"))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to open client certificate: %w", err)
 	}
@@ -24,7 +24,7 @@ func tlsConfig(uid uint32) (*tls.Config, error) {
 	tlsClientCert := string(content)
 
 	// Load the client key.
-	content, err = ioutil.ReadFile(filepath.Join("users", fmt.Sprintf("%d", uid), "client.key"))
+	content, err = os.ReadFile(filepath.Join("users", fmt.Sprintf("%d", uid), "client.key"))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to open client key: %w", err)
 	}
@@ -37,7 +37,7 @@ func tlsConfig(uid uint32) (*tls.Config, error) {
 		certPath = shared.VarPath("server.crt")
 	}
 
-	content, err = ioutil.ReadFile(certPath)
+	content, err = os.ReadFile(certPath)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to open server certificate: %w", err)
 	}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -151,13 +151,13 @@ type internalWarningCreatePost struct {
 
 // internalCreateWarning creates a warning, and is used for testing only.
 func internalCreateWarning(d *Daemon, r *http.Request) response.Response {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	rdr1 := ioutil.NopCloser(bytes.NewBuffer(body))
-	rdr2 := ioutil.NopCloser(bytes.NewBuffer(body))
+	rdr1 := io.NopCloser(bytes.NewBuffer(body))
+	rdr2 := io.NopCloser(bytes.NewBuffer(body))
 
 	reqRaw := shared.Jmap{}
 	err = json.NewDecoder(rdr1).Decode(&reqRaw)

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -599,13 +599,13 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 		return response.PreconditionFailed(err)
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	rdr1 := ioutil.NopCloser(bytes.NewBuffer(body))
-	rdr2 := ioutil.NopCloser(bytes.NewBuffer(body))
+	rdr1 := io.NopCloser(bytes.NewBuffer(body))
+	rdr2 := io.NopCloser(bytes.NewBuffer(body))
 
 	reqRaw := shared.Jmap{}
 	err = json.NewDecoder(rdr1).Decode(&reqRaw)

--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,7 +84,7 @@ func hasProfile(sysOS *sys.OS, name string) (bool, error) {
 
 	profilesPath := "/sys/kernel/security/apparmor/policy/profiles"
 	if shared.PathExists(profilesPath) {
-		entries, err := ioutil.ReadDir(profilesPath)
+		entries, err := os.ReadDir(profilesPath)
 		if err != nil {
 			return false, err
 		}

--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -1,7 +1,6 @@
 package apparmor
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ profile "{{.name}}" {
 // ArchiveLoad ensures that the archive's policy is loaded into the kernel.
 func ArchiveLoad(sysOS *sys.OS, outputPath string, allowedCommandPaths []string) error {
 	profile := filepath.Join(aaPath, "profiles", ArchiveProfileFilename(outputPath))
-	content, err := ioutil.ReadFile(profile)
+	content, err := os.ReadFile(profile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -57,7 +56,7 @@ func ArchiveLoad(sysOS *sys.OS, outputPath string, allowedCommandPaths []string)
 	}
 
 	if string(content) != string(updated) {
-		err = ioutil.WriteFile(profile, []byte(updated), 0600)
+		err = os.WriteFile(profile, []byte(updated), 0600)
 		if err != nil {
 			return err
 		}

--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -2,7 +2,6 @@ package apparmor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,7 +116,7 @@ func instanceProfileGenerate(sysOS *sys.OS, inst instance) error {
 	 * force a recompile.
 	 */
 	profile := filepath.Join(aaPath, "profiles", instanceProfileFilename(inst))
-	content, err := ioutil.ReadFile(profile)
+	content, err := os.ReadFile(profile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -128,7 +127,7 @@ func instanceProfileGenerate(sysOS *sys.OS, inst instance) error {
 	}
 
 	if string(content) != string(updated) {
-		err = ioutil.WriteFile(profile, []byte(updated), 0600)
+		err = os.WriteFile(profile, []byte(updated), 0600)
 		if err != nil {
 			return err
 		}

--- a/lxd/apparmor/instance_forkproxy.go
+++ b/lxd/apparmor/instance_forkproxy.go
@@ -2,7 +2,6 @@ package apparmor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -195,7 +194,7 @@ func ForkproxyLoad(sysOS *sys.OS, inst instance, dev device) error {
 	 * force a recompile.
 	 */
 	profile := filepath.Join(aaPath, "profiles", forkproxyProfileFilename(inst, dev))
-	content, err := ioutil.ReadFile(profile)
+	content, err := os.ReadFile(profile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -206,7 +205,7 @@ func ForkproxyLoad(sysOS *sys.OS, inst instance, dev device) error {
 	}
 
 	if string(content) != string(updated) {
-		err = ioutil.WriteFile(profile, []byte(updated), 0600)
+		err = os.WriteFile(profile, []byte(updated), 0600)
 		if err != nil {
 			return err
 		}

--- a/lxd/apparmor/network.go
+++ b/lxd/apparmor/network.go
@@ -1,7 +1,6 @@
 package apparmor
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ func NetworkLoad(sysOS *sys.OS, n network) error {
 
 	// dnsmasq
 	profile := filepath.Join(aaPath, "profiles", dnsmasqProfileFilename(n))
-	content, err := ioutil.ReadFile(profile)
+	content, err := os.ReadFile(profile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -41,7 +40,7 @@ func NetworkLoad(sysOS *sys.OS, n network) error {
 	}
 
 	if string(content) != string(updated) {
-		err = ioutil.WriteFile(profile, []byte(updated), 0600)
+		err = os.WriteFile(profile, []byte(updated), 0600)
 		if err != nil {
 			return err
 		}
@@ -55,7 +54,7 @@ func NetworkLoad(sysOS *sys.OS, n network) error {
 	// forkdns
 	if n.Config()["bridge.mode"] == "fan" {
 		profile := filepath.Join(aaPath, "profiles", forkdnsProfileFilename(n))
-		content, err := ioutil.ReadFile(profile)
+		content, err := os.ReadFile(profile)
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -66,7 +65,7 @@ func NetworkLoad(sysOS *sys.OS, n network) error {
 		}
 
 		if string(content) != string(updated) {
-			err = ioutil.WriteFile(profile, []byte(updated), 0600)
+			err = os.WriteFile(profile, []byte(updated), 0600)
 			if err != nil {
 				return err
 			}

--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -97,7 +96,7 @@ func CompressedTarReader(ctx context.Context, r io.ReadSeeker, unpacker []string
 		}
 
 		pipeReader, pipeWriter := io.Pipe()
-		p := subprocess.NewProcessWithFds(unpacker[0], unpacker[1:], ioutil.NopCloser(r), pipeWriter, nil)
+		p := subprocess.NewProcessWithFds(unpacker[0], unpacker[1:], io.NopCloser(r), pipeWriter, nil)
 		p.SetApparmor(apparmor.ArchiveProfileName(outputPath))
 		err = p.Start(ctx)
 		if err != nil {
@@ -206,7 +205,7 @@ func Unpack(file string, path string, blockBackend bool, sysOS *sys.OS, tracker 
 
 	var readCloser io.ReadCloser
 	if reader != nil {
-		readCloser = ioutil.NopCloser(reader)
+		readCloser = io.NopCloser(reader)
 	}
 
 	err = ExtractWithFds(command, args, allowedCmds, readCloser, sysOS, outputDir)

--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -3,7 +3,6 @@ package backup
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -73,7 +72,7 @@ func ConfigToInstanceDBArgs(state *state.State, c *config.Config, projectName st
 
 // ParseConfigYamlFile decodes the YAML file at path specified into a Config.
 func ParseConfigYamlFile(path string) (*config.Config, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/cgroup/abstraction.go
+++ b/lxd/cgroup/abstraction.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -924,7 +924,7 @@ func (cg *CGroup) GetOOMKills() (int64, error) {
 
 // GetIOStats returns disk stats.
 func (cg *CGroup) GetIOStats() (map[string]*IOStats, error) {
-	partitions, err := ioutil.ReadFile("/proc/partitions")
+	partitions, err := os.ReadFile("/proc/partitions")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read /proc/partitions: %w", err)
 	}

--- a/lxd/cgroup/file.go
+++ b/lxd/cgroup/file.go
@@ -2,7 +2,7 @@ package cgroup
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -17,7 +17,7 @@ func NewFileReadWriter(pid int, unifiedCapable bool) (*CGroup, error) {
 	// Locate the base path for each controller.
 	rw.paths = map[string]string{}
 
-	controllers, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	controllers, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (rw *fileReadWriter) Get(version Backend, controller string, key string) (s
 		path = filepath.Join(rw.paths["unified"], key)
 	}
 
-	value, err := ioutil.ReadFile(path)
+	value, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -86,5 +86,5 @@ func (rw *fileReadWriter) Set(version Backend, controller string, key string, va
 		path = filepath.Join(rw.paths["unified"], key)
 	}
 
-	return ioutil.WriteFile(path, []byte(value), 0600)
+	return os.WriteFile(path, []byte(value), 0600)
 }

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -576,7 +575,7 @@ func (g *Gateway) Sync() {
 	dir := filepath.Join(g.db.Dir(), "global")
 	for _, file := range files {
 		path := filepath.Join(dir, file.Name)
-		err := ioutil.WriteFile(path, file.Data, 0600)
+		err := os.WriteFile(path, file.Data, 0600)
 		if err != nil {
 			logger.Warnf("Failed to dump database file %s: %v", file.Name, err)
 		}

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -35,7 +35,7 @@ func TestBootstrap_UnmetPreconditions(t *testing.T) {
 				f.ClusterAddress("1.2.3.4:666")
 				f.RaftNode("5.6.7.8:666")
 				filename := filepath.Join(f.state.OS.VarDir, "cluster.crt")
-				_ = ioutil.WriteFile(filename, []byte{}, 0644)
+				_ = os.WriteFile(filename, []byte{}, 0644)
 			},
 			"Inconsistent state: found leftover cluster certificate",
 		},

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -52,7 +51,7 @@ func TestNotifyUpgradeCompleted(t *testing.T) {
 // The task function checks if the node is out of date and runs whatever is in
 // LXD_CLUSTER_UPDATE if so.
 func TestMaybeUpdate_Upgrade(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	defer func() { _ = os.RemoveAll(dir) }()
@@ -61,7 +60,7 @@ func TestMaybeUpdate_Upgrade(t *testing.T) {
 	stamp := filepath.Join(dir, "stamp")
 	script := filepath.Join(dir, "cluster-upgrade")
 	data := []byte(fmt.Sprintf("#!/bin/sh\ntouch %s\n", stamp))
-	err = ioutil.WriteFile(script, data, 0755)
+	err = os.WriteFile(script, data, 0755)
 	require.NoError(t, err)
 
 	state, cleanup := state.NewTestState(t)
@@ -105,7 +104,7 @@ func TestMaybeUpdate_Upgrade(t *testing.T) {
 
 // If the node is up-to-date, nothing is done.
 func TestMaybeUpdate_NothingToDo(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	defer func() { _ = os.RemoveAll(dir) }()
@@ -114,7 +113,7 @@ func TestMaybeUpdate_NothingToDo(t *testing.T) {
 	stamp := filepath.Join(dir, "stamp")
 	script := filepath.Join(dir, "cluster-upgrade")
 	data := []byte(fmt.Sprintf("#!/bin/sh\ntouch %s\n", stamp))
-	err = ioutil.WriteFile(script, data, 0755)
+	err = os.WriteFile(script, data, 0755)
 	require.NoError(t, err)
 
 	state, cleanup := state.NewTestState(t)

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -195,7 +194,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 	volStorageName := project.StorageVolume(project.Default, volumeName)
 	mountpoint := storageDrivers.GetVolumeMountPath(poolName, storageDrivers.VolumeTypeCustom, volStorageName)
 
-	entries, err := ioutil.ReadDir(mountpoint)
+	entries, err := os.ReadDir(mountpoint)
 	if err != nil {
 		return fmt.Errorf("Failed to list %q: %w", mountpoint, err)
 	}
@@ -243,7 +242,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		}
 
 		// Remove the source content.
-		entries, err := ioutil.ReadDir(source)
+		entries, err := os.ReadDir(source)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/cluster/open_test.go
+++ b/lxd/db/cluster/open_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -194,7 +193,7 @@ func assertNode(t *testing.T, db *sql.DB, address string, schema int, apiExtensi
 func newDir(t *testing.T) (string, func()) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "dqlite-replication-test-")
+	dir, err := os.MkdirTemp("", "dqlite-replication-test-")
 	assert.NoError(t, err)
 
 	cleanup := func() {

--- a/lxd/db/generate/file/write.go
+++ b/lxd/db/generate/file/write.go
@@ -3,7 +3,6 @@ package file
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -49,7 +48,7 @@ import (
 	if path == "-" {
 		_, err = os.Stdout.Write(bytes)
 	} else {
-		err = ioutil.WriteFile(path, []byte(content), 0644)
+		err = os.WriteFile(path, []byte(content), 0644)
 	}
 
 	if err != nil {
@@ -64,7 +63,7 @@ func resetInterface(path string, imports []string, buildComment string) error {
 		parts := strings.Split(path, ".")
 		interfacePath := strings.Join(parts[:len(parts)-2], ".") + ".interface.mapper.go"
 		content := fmt.Sprintf("%spackage %s", buildComment, os.Getenv("GOPACKAGE"))
-		err := ioutil.WriteFile(interfacePath, []byte(content), 0644)
+		err := os.WriteFile(interfacePath, []byte(content), 0644)
 		return err
 	}
 

--- a/lxd/db/node/open_test.go
+++ b/lxd/db/node/open_test.go
@@ -1,7 +1,6 @@
 package node_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestEnsureSchema(t *testing.T) {
 
 // Create a new temporary directory, along with a function to clean it up.
 func newDir(t *testing.T) (string, func()) {
-	dir, err := ioutil.TempDir("", "lxd-db-node-test-")
+	dir, err := os.MkdirTemp("", "lxd-db-node-test-")
 	require.NoError(t, err)
 
 	cleanup := func() {

--- a/lxd/db/schema/query.go
+++ b/lxd/db/schema/query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/lxc/lxd/lxd/db/query"
@@ -88,7 +87,7 @@ func execFromFile(ctx context.Context, tx *sql.Tx, path string, hook Hook) error
 		return nil
 	}
 
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)
 	}

--- a/lxd/db/schema/schema_test.go
+++ b/lxd/db/schema/schema_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,7 +17,7 @@ import (
 
 // WriteTempFile creates a temp file with the specified content.
 func WriteTempFile(dir string, prefix string, content string) (string, error) {
-	f, err := ioutil.TempFile(dir, prefix)
+	f, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/db/testing.go
+++ b/lxd/db/testing.go
@@ -5,7 +5,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -22,7 +21,7 @@ import (
 // NewTestNode creates a new Node for testing purposes, along with a function
 // that can be used to clean it up when done.
 func NewTestNode(t *testing.T) (*Node, func()) {
-	dir, err := ioutil.TempDir("", "lxd-db-test-node-")
+	dir, err := os.MkdirTemp("", "lxd-db-test-node-")
 	require.NoError(t, err)
 
 	db, err := OpenNode(dir, nil)
@@ -139,7 +138,7 @@ func NewTestDqliteServer(t *testing.T) (string, driver.NodeStore, func()) {
 func newDir(t *testing.T) (string, func()) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "dqlite-replication-test-")
+	dir, err := os.MkdirTemp("", "dqlite-replication-test-")
 	assert.NoError(t, err)
 
 	cleanup := func() {

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/netip"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -53,7 +53,7 @@ func NetworkSetDevMTU(devName string, mtu uint32) error {
 
 // NetworkGetDevMAC retrieves the current MAC setting for a named network device.
 func NetworkGetDevMAC(devName string) (string, error) {
-	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/address", devName))
+	content, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/address", devName))
 	if err != nil {
 		return "", err
 	}

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -2,7 +2,6 @@ package device
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -263,7 +262,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 	ourEncRelDestFile := filesystem.PathNameEncode(strings.TrimPrefix(ourDestPath, "/"))
 
 	// Load all existing host devices.
-	dents, err := ioutil.ReadDir(devicesPath)
+	dents, err := os.ReadDir(devicesPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err
@@ -381,7 +380,7 @@ func UnixDeviceExists(devicesPath string, prefix string, path string) bool {
 // Accepts an optional file prefix that will be used to narrow the selection of files to remove.
 func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, optPrefix string, runConf *deviceConfig.RunConfig) error {
 	// Load all devices.
-	dents, err := ioutil.ReadDir(devicesPath)
+	dents, err := os.ReadDir(devicesPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err
@@ -487,7 +486,7 @@ func unixDeviceDeleteFiles(s *state.State, devicesPath string, typePrefix string
 	}
 
 	// Load all devices.
-	dents, err := ioutil.ReadDir(devicesPath)
+	dents, err := os.ReadDir(devicesPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -1664,7 +1663,7 @@ func (d *disk) getDiskLimits() (map[string]diskBlockLimit, error) {
 	// Build a list of all valid block devices
 	validBlocks := []string{}
 
-	dents, err := ioutil.ReadDir("/sys/class/block/")
+	dents, err := os.ReadDir("/sys/class/block/")
 	if err != nil {
 		return nil, err
 	}
@@ -1679,7 +1678,7 @@ func (d *disk) getDiskLimits() (map[string]diskBlockLimit, error) {
 			continue
 		}
 
-		block, err := ioutil.ReadFile(fmt.Sprintf("%s/dev", fPath))
+		block, err := os.ReadFile(fmt.Sprintf("%s/dev", fPath))
 		if err != nil {
 			return nil, err
 		}
@@ -2028,7 +2027,7 @@ func (d *disk) generateVMConfigDrive() (string, error) {
 		}
 	}
 
-	err = ioutil.WriteFile(filepath.Join(scratchDir, "vendor-data"), []byte(vendorData), 0400)
+	err = os.WriteFile(filepath.Join(scratchDir, "vendor-data"), []byte(vendorData), 0400)
 	if err != nil {
 		return "", err
 	}
@@ -2042,7 +2041,7 @@ func (d *disk) generateVMConfigDrive() (string, error) {
 		}
 	}
 
-	err = ioutil.WriteFile(filepath.Join(scratchDir, "user-data"), []byte(userData), 0400)
+	err = os.WriteFile(filepath.Join(scratchDir, "user-data"), []byte(userData), 0400)
 	if err != nil {
 		return "", err
 	}
@@ -2054,7 +2053,7 @@ func (d *disk) generateVMConfigDrive() (string, error) {
 	}
 
 	if networkConfig != "" {
-		err = ioutil.WriteFile(filepath.Join(scratchDir, "network-config"), []byte(networkConfig), 0400)
+		err = os.WriteFile(filepath.Join(scratchDir, "network-config"), []byte(networkConfig), 0400)
 		if err != nil {
 			return "", err
 		}
@@ -2066,7 +2065,7 @@ local-hostname: %s
 %s
 `, d.inst.Name(), d.inst.Name(), instanceConfig["user.meta-data"])
 
-	err = ioutil.WriteFile(filepath.Join(scratchDir, "meta-data"), []byte(metaData), 0400)
+	err = os.WriteFile(filepath.Join(scratchDir, "meta-data"), []byte(metaData), 0400)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -2,7 +2,6 @@ package device
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -123,7 +122,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 		if mdevUUID == "" || !shared.PathExists(fmt.Sprintf("/sys/bus/pci/devices/%s/%s", pciAddress, mdevUUID)) {
 			mdevUUID = uuid.New()
 
-			err = ioutil.WriteFile(filepath.Join(fmt.Sprintf("/sys/bus/pci/devices/%s/mdev_supported_types/%s/create", pciAddress, d.config["mdev"])), []byte(mdevUUID), 0200)
+			err = os.WriteFile(filepath.Join(fmt.Sprintf("/sys/bus/pci/devices/%s/mdev_supported_types/%s/create", pciAddress, d.config["mdev"])), []byte(mdevUUID), 0200)
 			if err != nil {
 				if os.IsNotExist(err) {
 					return nil, fmt.Errorf("The requested profile %q does not exist", d.config["mdev"])
@@ -136,7 +135,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 				path := fmt.Sprintf("/sys/bus/mdev/devices/%s", mdevUUID)
 
 				if shared.PathExists(path) {
-					err := ioutil.WriteFile(filepath.Join(path, "remove"), []byte("1\n"), 0200)
+					err := os.WriteFile(filepath.Join(path, "remove"), []byte("1\n"), 0200)
 					if err != nil {
 						d.logger.Error("Failed to remove vgpu", logger.Ctx{"device": mdevUUID, "err": err})
 					}
@@ -195,7 +194,7 @@ func (d *gpuMdev) postStop() error {
 		path := fmt.Sprintf("/sys/bus/mdev/devices/%s", v["vgpu.uuid"])
 
 		if shared.PathExists(path) {
-			err := ioutil.WriteFile(filepath.Join(path, "remove"), []byte("1\n"), 0200)
+			err := os.WriteFile(filepath.Join(path, "remove"), []byte("1\n"), 0200)
 			if err != nil {
 				d.logger.Error("Failed to remove vgpu", logger.Ctx{"device": v["vgpu.uuid"], "err": err})
 			}

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -2,7 +2,6 @@ package device
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -405,7 +404,7 @@ func (d *gpuPhysical) deviceNumStringToUint32(devNum string) (uint32, uint32, er
 
 // getNvidiaNonCardDevices returns device information about Nvidia non-card devices.
 func (d *gpuPhysical) getNvidiaNonCardDevices() ([]nvidiaNonCardDevice, error) {
-	nvidiaEnts, err := ioutil.ReadDir("/dev")
+	nvidiaEnts, err := os.ReadDir("/dev")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, err

--- a/lxd/device/gpu_sriov.go
+++ b/lxd/device/gpu_sriov.go
@@ -2,7 +2,7 @@ package device
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -227,7 +227,7 @@ func (d *gpuSRIOV) findFreeVirtualFunction(parentDev pcidev.Device) (int, error)
 	// Get number of currently enabled VFs.
 	sriovNumVFs := fmt.Sprintf("/sys/bus/pci/devices/%s/sriov_numvfs", parentDev.SlotName)
 
-	sriovNumVfsBuf, err := ioutil.ReadFile(sriovNumVFs)
+	sriovNumVfsBuf, err := os.ReadFile(sriovNumVFs)
 	if err != nil {
 		return 0, err
 	}

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -2,7 +2,7 @@ package device
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -368,7 +368,7 @@ func (d *infinibandSRIOV) findFreeVirtualFunction(parentDev pcidev.Device) (int,
 	// Get number of currently enabled VFs.
 	sriovNumVFs := fmt.Sprintf("/sys/bus/pci/devices/%s/sriov_numvfs", parentDev.SlotName)
 
-	sriovNumVfsBuf, err := ioutil.ReadFile(sriovNumVFs)
+	sriovNumVfsBuf, err := os.ReadFile(sriovNumVFs)
 	if err != nil {
 		return 0, err
 	}

--- a/lxd/device/pci/pci.go
+++ b/lxd/device/pci/pci.go
@@ -3,7 +3,6 @@ package pci
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -62,7 +61,7 @@ func ParseUeventFile(ueventFilePath string) (Device, error) {
 // DeviceUnbind unbinds a PCI device from the OS using its PCI Slot Name.
 func DeviceUnbind(pciDev Device) error {
 	driverUnbindPath := fmt.Sprintf("/sys/bus/pci/devices/%s/driver/unbind", pciDev.SlotName)
-	err := ioutil.WriteFile(driverUnbindPath, []byte(pciDev.SlotName), 0600)
+	err := os.WriteFile(driverUnbindPath, []byte(pciDev.SlotName), 0600)
 	if err != nil {
 		if !os.IsNotExist(err) || !shared.PathExists(fmt.Sprintf("/sys/bus/pci/devices/%s/", pciDev.SlotName)) {
 			return fmt.Errorf("Failed unbinding device %q via %q: %w", pciDev.SlotName, driverUnbindPath, err)
@@ -77,7 +76,7 @@ func DeviceSetDriverOverride(pciDev Device, driverOverride string) error {
 	overridePath := filepath.Join("/sys/bus/pci/devices", pciDev.SlotName, "driver_override")
 
 	// The "\n" at end is important to allow the driver override to be cleared by passing "" in.
-	err := ioutil.WriteFile(overridePath, []byte(fmt.Sprintf("%s\n", driverOverride)), 0600)
+	err := os.WriteFile(overridePath, []byte(fmt.Sprintf("%s\n", driverOverride)), 0600)
 	if err != nil {
 		return fmt.Errorf("Failed setting driver override %q for device %q via %q: %w", driverOverride, pciDev.SlotName, overridePath, err)
 	}
@@ -88,7 +87,7 @@ func DeviceSetDriverOverride(pciDev Device, driverOverride string) error {
 // DeviceProbe probes a PCI device using its PCI Slot Name.
 func DeviceProbe(pciDev Device) error {
 	driveProbePath := "/sys/bus/pci/drivers_probe"
-	err := ioutil.WriteFile(driveProbePath, []byte(pciDev.SlotName), 0600)
+	err := os.WriteFile(driveProbePath, []byte(pciDev.SlotName), 0600)
 	if err != nil {
 		return fmt.Errorf("Failed probing device %q via %q: %w", pciDev.SlotName, driveProbePath, err)
 	}

--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -3,7 +3,6 @@ package device
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -140,7 +139,7 @@ func (d *tpm) startContainer() (*deviceConfig.RunConfig, error) {
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	line, err := ioutil.ReadFile(logPath)
+	line, err := os.ReadFile(logPath)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read %q: %w", logPath, err)
 	}

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -2,7 +2,6 @@ package device
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -236,7 +235,7 @@ func (d *usb) postStop() error {
 func (d *usb) loadUsb() ([]USBEvent, error) {
 	result := []USBEvent{}
 
-	ents, err := ioutil.ReadDir(usbDevPath)
+	ents, err := os.ReadDir(usbDevPath)
 	if err != nil {
 		/* if there are no USB devices, let's render an empty list,
 		 * i.e. no usb devices */
@@ -298,7 +297,7 @@ func (d *usb) loadRawValues(p string) (map[string]string, error) {
 	}
 
 	for k := range values {
-		v, err := ioutil.ReadFile(path.Join(p, k))
+		v, err := os.ReadFile(path.Join(p, k))
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -380,7 +379,7 @@ func findContainerForPid(pid int32, s *state.State) (instance.Container, error) 
 	origpid := pid
 
 	for pid > 1 {
-		cmdline, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+		cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 		if err != nil {
 			return nil, err
 		}
@@ -409,7 +408,7 @@ func findContainerForPid(pid int32, s *state.State) (instance.Container, error) 
 			return inst.(instance.Container), nil
 		}
 
-		status, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+		status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -40,7 +40,7 @@ func (d DevLxdDialer) DevLxdDial(ctx context.Context, network, path string) (net
 func setupDir() error {
 	var err error
 
-	testDir, err = ioutil.TempDir("", "lxd_test_devlxd_")
+	testDir, err = os.MkdirTemp("", "lxd_test_devlxd_")
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func TestHttpRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, err := ioutil.ReadAll(raw.Body)
+	resp, err := io.ReadAll(raw.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -3,7 +3,6 @@ package dnsmasq
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -52,7 +51,7 @@ func UpdateStaticEntry(network string, projectName string, instanceName string, 
 	}
 
 	deviceStaticFileName := StaticAllocationFileName(projectName, instanceName, deviceName)
-	err := ioutil.WriteFile(shared.VarPath("networks", network, "dnsmasq.hosts", deviceStaticFileName), []byte(line+"\n"), 0644)
+	err := os.WriteFile(shared.VarPath("networks", network, "dnsmasq.hosts", deviceStaticFileName), []byte(line+"\n"), 0644)
 	if err != nil {
 		return err
 	}
@@ -188,7 +187,7 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 	IPv6s := make(map[[16]byte]DHCPAllocation)
 
 	// First read all statically allocated IPs.
-	files, err := ioutil.ReadDir(shared.VarPath("networks", network, "dnsmasq.hosts"))
+	files, err := os.ReadDir(shared.VarPath("networks", network, "dnsmasq.hosts"))
 	if err != nil && os.IsNotExist(err) {
 		return nil, nil, err
 	}

--- a/lxd/endpoints/endpoints_test.go
+++ b/lxd/endpoints/endpoints_test.go
@@ -3,7 +3,7 @@ package endpoints_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -27,7 +27,7 @@ import (
 // associated with the endpoints (e.g. the temporary LXD var dir and any
 // goroutine that was spawned by the tomb).
 func newEndpoints(t *testing.T) (*endpoints.Endpoints, *endpoints.Config, func()) {
-	dir, err := ioutil.TempDir("", "lxd-endpoints-test-")
+	dir, err := os.MkdirTemp("", "lxd-endpoints-test-")
 	require.NoError(t, err)
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "devlxd"), 0755))
 
@@ -86,7 +86,7 @@ func newServer() *http.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_ = util.WriteJSON(w, api.ResponseRaw{}, nil)
 	})
-	return &http.Server{Handler: mux, ErrorLog: log.New(ioutil.Discard, "", 0)}
+	return &http.Server{Handler: mux, ErrorLog: log.New(io.Discard, "", 0)}
 }
 
 // Set the environment-variable for socket-based activation using the given

--- a/lxd/endpoints/local_test.go
+++ b/lxd/endpoints/local_test.go
@@ -1,7 +1,6 @@
 package endpoints_test
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -93,7 +92,7 @@ func TestEndpoints_LocalAlreadyRunning(t *testing.T) {
 
 // Create a UnixListener using a random and unique file name.
 func newUnixListener(t *testing.T) *net.UnixListener {
-	file, err := ioutil.TempFile("", "lxd-endpoints-test")
+	file, err := os.CreateTemp("", "lxd-endpoints-test")
 	require.NoError(t, err)
 
 	path := file.Name()

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -482,22 +481,22 @@ func (d *qemu) generateAgentCert() (string, string, string, string, error) {
 	}
 
 	// Read all the files
-	agentCert, err := ioutil.ReadFile(agentCertFile)
+	agentCert, err := os.ReadFile(agentCertFile)
 	if err != nil {
 		return "", "", "", "", err
 	}
 
-	agentKey, err := ioutil.ReadFile(agentKeyFile)
+	agentKey, err := os.ReadFile(agentKeyFile)
 	if err != nil {
 		return "", "", "", "", err
 	}
 
-	clientCert, err := ioutil.ReadFile(clientCertFile)
+	clientCert, err := os.ReadFile(clientCertFile)
 	if err != nil {
 		return "", "", "", "", err
 	}
 
-	clientKey, err := ioutil.ReadFile(clientKeyFile)
+	clientKey, err := os.ReadFile(clientKeyFile)
 	if err != nil {
 		return "", "", "", "", err
 	}
@@ -1447,7 +1446,7 @@ func (d *qemu) Start(stateful bool) error {
 
 	_, err = p.Wait(context.Background())
 	if err != nil {
-		stderr, _ := ioutil.ReadFile(d.EarlyLogFilePath())
+		stderr, _ := os.ReadFile(d.EarlyLogFilePath())
 		err = fmt.Errorf("Failed to run: %s: %s: %w", strings.Join(p.Args, " "), string(stderr), err)
 		op.Done(err)
 		return err
@@ -2159,17 +2158,17 @@ func (d *qemu) generateConfigShare() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(configDrivePath, "server.crt"), []byte(clientCert), 0400)
+	err = os.WriteFile(filepath.Join(configDrivePath, "server.crt"), []byte(clientCert), 0400)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(configDrivePath, "agent.crt"), []byte(agentCert), 0400)
+	err = os.WriteFile(filepath.Join(configDrivePath, "agent.crt"), []byte(agentCert), 0400)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(configDrivePath, "agent.key"), []byte(agentKey), 0400)
+	err = os.WriteFile(filepath.Join(configDrivePath, "agent.key"), []byte(agentKey), 0400)
 	if err != nil {
 		return err
 	}
@@ -2201,7 +2200,7 @@ StartLimitBurst=10
 WantedBy=multi-user.target
 `
 
-	err = ioutil.WriteFile(filepath.Join(configDrivePath, "systemd", "lxd-agent.service"), []byte(lxdAgentServiceUnit), 0400)
+	err = os.WriteFile(filepath.Join(configDrivePath, "systemd", "lxd-agent.service"), []byte(lxdAgentServiceUnit), 0400)
 	if err != nil {
 		return err
 	}
@@ -2247,7 +2246,7 @@ rmdir "${PREFIX}/.mnt"
 chown -R root:root "${PREFIX}"
 `
 
-	err = ioutil.WriteFile(filepath.Join(configDrivePath, "systemd", "lxd-agent-setup"), []byte(lxdAgentSetupScript), 0500)
+	err = os.WriteFile(filepath.Join(configDrivePath, "systemd", "lxd-agent-setup"), []byte(lxdAgentSetupScript), 0500)
 	if err != nil {
 		return err
 	}
@@ -2259,7 +2258,7 @@ chown -R root:root "${PREFIX}"
 	}
 
 	lxdAgentRules := `ACTION=="add", SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd", ACTION=="add", RUN+="/bin/systemctl start lxd-agent.service"`
-	err = ioutil.WriteFile(filepath.Join(configDrivePath, "udev", "99-lxd-agent.rules"), []byte(lxdAgentRules), 0400)
+	err = os.WriteFile(filepath.Join(configDrivePath, "udev", "99-lxd-agent.rules"), []byte(lxdAgentRules), 0400)
 	if err != nil {
 		return err
 	}
@@ -2294,7 +2293,7 @@ echo "LXD agent has been installed, reboot to confirm setup."
 echo "To start it now, unmount this filesystem and run: systemctl start lxd-agent"
 `
 
-	err = ioutil.WriteFile(filepath.Join(configDrivePath, "install.sh"), []byte(lxdConfigShareInstall), 0700)
+	err = os.WriteFile(filepath.Join(configDrivePath, "install.sh"), []byte(lxdConfigShareInstall), 0700)
 	if err != nil {
 		return err
 	}
@@ -2358,7 +2357,7 @@ func (d *qemu) templateApplyNow(trigger instance.TemplateTrigger, path string) e
 	}
 
 	// Parse the metadata.
-	content, err := ioutil.ReadFile(fname)
+	content, err := os.ReadFile(fname)
 	if err != nil {
 		return fmt.Errorf("Failed to read metadata: %w", err)
 	}
@@ -2423,7 +2422,7 @@ func (d *qemu) templateApplyNow(trigger instance.TemplateTrigger, path string) e
 			defer func() { _ = w.Close() }()
 
 			// Read the template.
-			tplString, err := ioutil.ReadFile(filepath.Join(d.TemplatesPath(), tpl.Template))
+			tplString, err := os.ReadFile(filepath.Join(d.TemplatesPath(), tpl.Template))
 			if err != nil {
 				return fmt.Errorf("Failed to read template file: %w", err)
 			}
@@ -2816,7 +2815,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	}
 
 	agentMountFile := filepath.Join(d.Path(), "config", "agent-mounts.json")
-	err = ioutil.WriteFile(agentMountFile, agentMountJSON, 0400)
+	err = os.WriteFile(agentMountFile, agentMountJSON, 0400)
 	if err != nil {
 		return "", nil, fmt.Errorf("Failed writing agent mounts file: %w", err)
 	}
@@ -2826,7 +2825,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	// Write the config file to disk.
 	sb := qemuStringifyCfg(cfg...)
 	configPath := filepath.Join(d.LogPath(), "qemu.conf")
-	return configPath, monHooks, ioutil.WriteFile(configPath, []byte(sb.String()), 0640)
+	return configPath, monHooks, os.WriteFile(configPath, []byte(sb.String()), 0640)
 }
 
 // addCPUMemoryConfig adds the qemu config required for setting the number of virtualised CPUs and memory.
@@ -3439,7 +3438,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 	// Detect MACVTAP interface types and figure out which tap device is being used.
 	// This is so we can open a file handle to the tap device and pass it to the qemu process.
 	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/macvtap", nicName)) {
-		content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/ifindex", nicName))
+		content, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/ifindex", nicName))
 		if err != nil {
 			return nil, fmt.Errorf("Error getting tap device ifindex: %w", err)
 		}
@@ -3631,7 +3630,7 @@ func (d *qemu) writeNICDevConfig(mtuStr string, devName string, nicName string, 
 
 	nicFile := filepath.Join(d.Path(), "config", deviceConfig.NICConfigDir, fmt.Sprintf("%s.json", filesystem.PathNameEncode(nicConfig.DeviceName)))
 
-	err = ioutil.WriteFile(nicFile, nicConfigBytes, 0700)
+	err = os.WriteFile(nicFile, nicConfigBytes, 0700)
 	if err != nil {
 		return fmt.Errorf("Failed writing NIC config: %w", err)
 	}
@@ -3836,7 +3835,7 @@ func (d *qemu) pidFilePath() string {
 
 // pid gets the PID of the running qemu process. Returns 0 if PID file or process not found, and -1 if err non-nil.
 func (d *qemu) pid() (int, error) {
-	pidStr, err := ioutil.ReadFile(d.pidFilePath())
+	pidStr, err := os.ReadFile(d.pidFilePath())
 	if os.IsNotExist(err) {
 		return 0, nil // PID file has gone.
 	}
@@ -3851,7 +3850,7 @@ func (d *qemu) pid() (int, error) {
 	}
 
 	cmdLineProcFilePath := fmt.Sprintf("/proc/%d/cmdline", pid)
-	cmdLine, err := ioutil.ReadFile(cmdLineProcFilePath)
+	cmdLine, err := os.ReadFile(cmdLineProcFilePath)
 	if err != nil {
 		return 0, nil // Process has gone.
 	}
@@ -4870,7 +4869,7 @@ func (d *qemu) removeUnixDevices() error {
 	}
 
 	// Load the directory listing.
-	dents, err := ioutil.ReadDir(d.DevicesPath())
+	dents, err := os.ReadDir(d.DevicesPath())
 	if err != nil {
 		return err
 	}
@@ -4899,7 +4898,7 @@ func (d *qemu) removeDiskDevices() error {
 	}
 
 	// Load the directory listing.
-	dents, err := ioutil.ReadDir(d.DevicesPath())
+	dents, err := os.ReadDir(d.DevicesPath())
 	if err != nil {
 		return err
 	}
@@ -5144,7 +5143,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 	fnam := filepath.Join(cDir, "metadata.yaml")
 	if !shared.PathExists(fnam) {
 		// Generate a new metadata.yaml.
-		tempDir, err := ioutil.TempDir("", "lxd_lxd_metadata_")
+		tempDir, err := os.MkdirTemp("", "lxd_lxd_metadata_")
 		if err != nil {
 			_ = tarWriter.Close()
 			d.logger.Error("Failed exporting instance", ctxMap)
@@ -5194,7 +5193,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 
 		// Write the actual file.
 		fnam = filepath.Join(tempDir, "metadata.yaml")
-		err = ioutil.WriteFile(fnam, data, 0644)
+		err = os.WriteFile(fnam, data, 0644)
 		if err != nil {
 			_ = tarWriter.Close()
 			d.logger.Error("Failed exporting instance", ctxMap)
@@ -5217,7 +5216,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 		}
 	} else {
 		// Parse the metadata.
-		content, err := ioutil.ReadFile(fnam)
+		content, err := os.ReadFile(fnam)
 		if err != nil {
 			_ = tarWriter.Close()
 			d.logger.Error("Failed exporting instance", ctxMap)
@@ -5241,7 +5240,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 
 		if properties != nil || !expiration.IsZero() {
 			// Generate a new metadata.yaml.
-			tempDir, err := ioutil.TempDir("", "lxd_lxd_metadata_")
+			tempDir, err := os.MkdirTemp("", "lxd_lxd_metadata_")
 			if err != nil {
 				_ = tarWriter.Close()
 				d.logger.Error("Failed exporting instance", ctxMap)
@@ -5259,7 +5258,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 
 			// Write the actual file.
 			fnam = filepath.Join(tempDir, "metadata.yaml")
-			err = ioutil.WriteFile(fnam, data, 0644)
+			err = os.WriteFile(fnam, data, 0644)
 			if err != nil {
 				_ = tarWriter.Close()
 				d.logger.Error("Failed exporting instance", ctxMap)
@@ -5292,7 +5291,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time
 	}
 
 	// Convert from raw to qcow2 and add to tarball.
-	tmpPath, err := ioutil.TempDir(shared.VarPath("images"), "lxd_export_")
+	tmpPath, err := os.MkdirTemp(shared.VarPath("images"), "lxd_export_")
 	if err != nil {
 		return meta, err
 	}
@@ -6279,7 +6278,7 @@ func (d *qemu) Info() instance.Info {
 }
 
 func (d *qemu) checkFeature(qemu string, args ...string) (bool, error) {
-	pidFile, err := ioutil.TempFile("", "")
+	pidFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return false, err
 	}
@@ -6318,7 +6317,7 @@ func (d *qemu) checkFeature(qemu string, args ...string) (bool, error) {
 		return false, err
 	}
 
-	content, err := ioutil.ReadAll(pidFile)
+	content, err := io.ReadAll(pidFile)
 	if err != nil {
 		return false, err
 	}

--- a/lxd/instance/drivers/driver_qemu_metrics.go
+++ b/lxd/instance/drivers/driver_qemu_metrics.go
@@ -3,7 +3,6 @@ package drivers
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -173,7 +172,7 @@ func (d *qemu) getQemuCPUMetrics(monitor *qmp.Monitor) (map[string]metrics.CPUMe
 	cpuMetrics := map[string]metrics.CPUMetrics{}
 
 	for i, threadID := range threadIDs {
-		pid, err := ioutil.ReadFile(d.pidFilePath())
+		pid, err := os.ReadFile(d.pidFilePath())
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +183,7 @@ func (d *qemu) getQemuCPUMetrics(monitor *qmp.Monitor) (map[string]metrics.CPUMe
 			continue
 		}
 
-		content, err := ioutil.ReadFile(statFile)
+		content, err := os.ReadFile(statFile)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -227,7 +227,7 @@ func (s *consoleWs) doConsole(op *operations.Operation) error {
 				return
 			}
 
-			buf, err := ioutil.ReadAll(r)
+			buf, err := io.ReadAll(r)
 			if err != nil {
 				logger.Debugf("Failed to read message: %v", err)
 				break
@@ -417,7 +417,7 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	post := api.InstanceConsolePost{}
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -320,7 +320,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 				return
 			}
 
-			buf, err := ioutil.ReadAll(r)
+			buf, err := io.ReadAll(r)
 			if err != nil {
 				// Check if command process has finished normally, if so, no need to kill it.
 				select {
@@ -509,7 +509,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	post := api.InstanceExecPost{}
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -496,7 +495,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 		return response.EmptySyncResponse
 	} else if type_ == "symlink" {
 		// Figure out target.
-		target, err := ioutil.ReadAll(r.Body)
+		target, err := io.ReadAll(r.Body)
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -39,7 +40,7 @@ func instanceSaveCache() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(shared.CachePath("instance_types.yaml"), data, 0600)
+	err = os.WriteFile(shared.CachePath("instance_types.yaml"), data, 0600)
 	if err != nil {
 		return err
 	}
@@ -52,7 +53,7 @@ func instanceLoadCache() error {
 		return nil
 	}
 
-	content, err := ioutil.ReadFile(shared.CachePath("instance_types.yaml"))
+	content, err := os.ReadFile(shared.CachePath("instance_types.yaml"))
 	if err != nil {
 		return err
 	}
@@ -146,7 +147,7 @@ func instanceRefreshTypes(ctx context.Context, d *Daemon) error {
 			return fmt.Errorf("Failed to get %s", url)
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -134,7 +133,7 @@ func instanceLogsGet(d *Daemon, r *http.Request) response.Response {
 	result := []string{}
 
 	fullName := project.Instance(projectName, name)
-	dents, err := ioutil.ReadDir(shared.LogPath(fullName))
+	dents, err := os.ReadDir(shared.LogPath(fullName))
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -124,7 +123,7 @@ func instanceMetadataGet(d *Daemon, r *http.Request) response.Response {
 
 	defer func() { _ = metadataFile.Close() }()
 
-	data, err := ioutil.ReadAll(metadataFile)
+	data, err := io.ReadAll(metadataFile)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -231,7 +230,7 @@ func instanceMetadataPatch(d *Daemon, r *http.Request) response.Response {
 
 		defer func() { _ = metadataFile.Close() }()
 
-		data, err := ioutil.ReadAll(metadataFile)
+		data, err := io.ReadAll(metadataFile)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -357,7 +356,7 @@ func doInstanceMetadataUpdate(d *Daemon, inst instance.Instance, metadata api.Im
 
 	// Update the metadata.
 	metadataPath := filepath.Join(inst.Path(), "metadata.yaml")
-	err = ioutil.WriteFile(metadataPath, data, 0644)
+	err = os.WriteFile(metadataPath, data, 0644)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -470,14 +469,14 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 
 		// List templates
 		templatesPath := filepath.Join(c.Path(), "templates")
-		filesInfo, err := ioutil.ReadDir(templatesPath)
+		entries, err := os.ReadDir(templatesPath)
 		if err != nil {
 			return response.InternalError(err)
 		}
 
-		for _, info := range filesInfo {
-			if !info.IsDir() {
-				templates = append(templates, info.Name())
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				templates = append(templates, entry.Name())
 			}
 		}
 
@@ -503,7 +502,7 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 
 	defer func() { _ = template.Close() }()
 
-	tempfile, err := ioutil.TempFile("", "lxd_template")
+	tempfile, err := os.CreateTemp("", "lxd_template")
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -94,13 +94,13 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 		return response.PreconditionFailed(err)
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	rdr1 := ioutil.NopCloser(bytes.NewBuffer(body))
-	rdr2 := ioutil.NopCloser(bytes.NewBuffer(body))
+	rdr1 := io.NopCloser(bytes.NewBuffer(body))
+	rdr2 := io.NopCloser(bytes.NewBuffer(body))
 
 	reqRaw := shared.Jmap{}
 	err = json.NewDecoder(rdr1).Decode(&reqRaw)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -203,13 +203,13 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	rdr1 := ioutil.NopCloser(bytes.NewBuffer(body))
-	rdr2 := ioutil.NopCloser(bytes.NewBuffer(body))
+	rdr1 := io.NopCloser(bytes.NewBuffer(body))
+	rdr2 := io.NopCloser(bytes.NewBuffer(body))
 
 	reqRaw := shared.Jmap{}
 	err = json.NewDecoder(rdr1).Decode(&reqRaw)

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -622,12 +622,12 @@ func snapshotGet(s *state.State, snapInst instance.Instance, name string) respon
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, containerName string) response.Response {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	rdr1 := ioutil.NopCloser(bytes.NewBuffer(body))
+	rdr1 := io.NopCloser(bytes.NewBuffer(body))
 
 	raw := shared.Jmap{}
 	err = json.NewDecoder(rdr1).Decode(&raw)
@@ -637,8 +637,8 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 
 	migration, err := raw.GetBool("migration")
 	if err == nil && migration {
-		rdr2 := ioutil.NopCloser(bytes.NewBuffer(body))
-		rdr3 := ioutil.NopCloser(bytes.NewBuffer(body))
+		rdr2 := io.NopCloser(bytes.NewBuffer(body))
+		rdr3 := io.NopCloser(bytes.NewBuffer(body))
 
 		req := api.InstancePost{}
 		err = json.NewDecoder(rdr2).Decode(&req)

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -336,14 +335,14 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 		instancetype.VM:        shared.VarPath("virtual-machines"),
 	}
 
-	instanceTypeNames := make(map[instancetype.Type][]os.FileInfo, 2)
+	instanceTypeNames := make(map[instancetype.Type][]os.DirEntry, 2)
 
-	instanceTypeNames[instancetype.Container], err = ioutil.ReadDir(instancePaths[instancetype.Container])
+	instanceTypeNames[instancetype.Container], err = os.ReadDir(instancePaths[instancetype.Container])
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 
-	instanceTypeNames[instancetype.VM], err = ioutil.ReadDir(instancePaths[instancetype.VM])
+	instanceTypeNames[instancetype.VM], err = os.ReadDir(instancePaths[instancetype.VM])
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -662,7 +661,7 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 	defer revert.Fail()
 
 	// Create temporary file to store uploaded backup data.
-	backupFile, err := ioutil.TempFile(shared.VarPath("backups"), fmt.Sprintf("%s_", backup.WorkingDirPrefix))
+	backupFile, err := os.CreateTemp(shared.VarPath("backups"), fmt.Sprintf("%s_", backup.WorkingDirPrefix))
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -692,7 +691,7 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 		decomArgs := append(decomArgs, backupFile.Name())
 
 		// Create temporary file to store the decompressed tarball in.
-		tarFile, err := ioutil.TempFile(shared.VarPath("backups"), fmt.Sprintf("%s_decompress_", backup.WorkingDirPrefix))
+		tarFile, err := os.CreateTemp(shared.VarPath("backups"), fmt.Sprintf("%s_decompress_", backup.WorkingDirPrefix))
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,7 +169,7 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 
 	var content []byte
 	if !termios.IsTerminal(unix.Stdin) {
-		content, err = ioutil.ReadAll(os.Stdin)
+		content, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -154,7 +153,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Path %s doesn't exist", config.Cluster.ClusterCertificatePath)
 		}
 
-		content, err := ioutil.ReadFile(config.Cluster.ClusterCertificatePath)
+		content, err := os.ReadFile(config.Cluster.ClusterCertificatePath)
 		if err != nil {
 			return err
 		}

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -424,7 +423,7 @@ func (c *cmdInit) askNetworking(config *cmdInitData, d lxd.InstanceServer) error
 		// At this time, only the Ubuntu kernel supports the Fan, detect it
 		fanKernel := false
 		if shared.PathExists("/proc/sys/kernel/version") {
-			content, _ := ioutil.ReadFile("/proc/sys/kernel/version")
+			content, _ := os.ReadFile("/proc/sys/kernel/version")
 			if content != nil && strings.Contains(string(content), "Ubuntu") {
 				fanKernel = true
 			}

--- a/lxd/main_init_preseed.go
+++ b/lxd/main_init_preseed.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -13,7 +13,7 @@ import (
 
 func (c *cmdInit) RunPreseed(cmd *cobra.Command, args []string, d lxd.InstanceServer) (*cmdInitData, error) {
 	// Read the YAML
-	bytes, err := ioutil.ReadAll(os.Stdin)
+	bytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read from stdin: %w", err)
 	}

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/olekukonko/tablewriter"
@@ -78,7 +78,7 @@ func (c *cmdSql) Run(cmd *cobra.Command, args []string) error {
 
 	if query == "-" {
 		// Read from stdin
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("Failed to read from stdin: %w", err)
 		}

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/stretchr/testify/require"
@@ -52,7 +51,7 @@ type lxdTestSuite struct {
 const lxdTestSuiteDefaultStoragePool string = "lxdTestrunPool"
 
 func (suite *lxdTestSuite) SetupTest() {
-	tmpdir, err := ioutil.TempDir("", "lxd_testrun_")
+	tmpdir, err := os.MkdirTemp("", "lxd_testrun_")
 	if err != nil {
 		suite.T().Errorf("failed to create temp dir: %v", err)
 	}

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -533,7 +532,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 			return abort(fmt.Errorf("Formats other than criu rsync not understood"))
 		}
 
-		checkpointDir, err := ioutil.TempDir("", "lxd_checkpoint_")
+		checkpointDir, err := os.MkdirTemp("", "lxd_checkpoint_")
 		if err != nil {
 			return abort(err)
 		}
@@ -1165,7 +1164,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 
 		if live && c.src.instance.Type() == instancetype.Container {
 			var err error
-			imagesDir, err = ioutil.TempDir("", "lxd_restore_")
+			imagesDir, err = os.MkdirTemp("", "lxd_restore_")
 			if err != nil {
 				restore <- err
 				return

--- a/lxd/migration/wsproto.go
+++ b/lxd/migration/wsproto.go
@@ -2,7 +2,7 @@ package migration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -25,7 +25,7 @@ func ProtoRecv(ws *websocket.Conn, msg proto.Message) error {
 		return fmt.Errorf("Only binary messages allowed")
 	}
 
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3,10 +3,10 @@ package network
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -1660,7 +1660,7 @@ func (n *ovn) FillConfig(config map[string]string) error {
 	}
 
 	if config["ipv6.address"] == "" {
-		content, err := ioutil.ReadFile("/proc/sys/net/ipv6/conf/default/disable_ipv6")
+		content, err := os.ReadFile("/proc/sys/net/ipv6/conf/default/disable_ipv6")
 		if err == nil && string(content) == "0\n" {
 			config["ipv6.address"] = "auto"
 		}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"net"
@@ -260,7 +259,7 @@ func isInUseByDevice(networkName string, d deviceConfig.Device) bool {
 
 // GetDevMTU retrieves the current MTU setting for a named network device.
 func GetDevMTU(devName string) (uint32, error) {
-	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/mtu", devName))
+	content, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/mtu", devName))
 	if err != nil {
 		return 0, err
 	}
@@ -441,7 +440,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 		config := n.Config()
 
 		// Wipe everything clean.
-		files, err := ioutil.ReadDir(shared.VarPath("networks", network, "dnsmasq.hosts"))
+		files, err := os.ReadDir(shared.VarPath("networks", network, "dnsmasq.hosts"))
 		if err != nil {
 			return err
 		}
@@ -797,7 +796,7 @@ func GetLeaseAddresses(networkName string, hwaddr string) ([]net.IP, error) {
 		return nil, fmt.Errorf("Leases file not found for network %q", networkName)
 	}
 
-	content, err := ioutil.ReadFile(leaseFile)
+	content, err := os.ReadFile(leaseFile)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/network/network_utils_bridge.go
+++ b/lxd/network/network_utils_bridge.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/lxc/lxd/lxd/ip"
@@ -12,7 +12,7 @@ import (
 
 // BridgeVLANFilteringStatus returns whether VLAN filtering is enabled on a bridge interface.
 func BridgeVLANFilteringStatus(interfaceName string) (string, error) {
-	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/bridge/vlan_filtering", interfaceName))
+	content, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/bridge/vlan_filtering", interfaceName))
 	if err != nil {
 		return "", fmt.Errorf("Failed getting bridge VLAN status for %q: %w", interfaceName, err)
 	}
@@ -22,7 +22,7 @@ func BridgeVLANFilteringStatus(interfaceName string) (string, error) {
 
 // BridgeVLANFilterSetStatus sets the status of VLAN filtering on a bridge interface.
 func BridgeVLANFilterSetStatus(interfaceName string, status string) error {
-	err := ioutil.WriteFile(fmt.Sprintf("/sys/class/net/%s/bridge/vlan_filtering", interfaceName), []byte(status), 0)
+	err := os.WriteFile(fmt.Sprintf("/sys/class/net/%s/bridge/vlan_filtering", interfaceName), []byte(status), 0)
 	if err != nil {
 		return fmt.Errorf("Failed enabling VLAN filtering on bridge %q: %w", interfaceName, err)
 	}
@@ -32,7 +32,7 @@ func BridgeVLANFilterSetStatus(interfaceName string, status string) error {
 
 // BridgeVLANDefaultPVID returns the VLAN default port VLAN ID (PVID).
 func BridgeVLANDefaultPVID(interfaceName string) (string, error) {
-	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/bridge/default_pvid", interfaceName))
+	content, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/bridge/default_pvid", interfaceName))
 	if err != nil {
 		return "", fmt.Errorf("Failed getting bridge VLAN default PVID for %q: %w", interfaceName, err)
 	}
@@ -42,7 +42,7 @@ func BridgeVLANDefaultPVID(interfaceName string) (string, error) {
 
 // BridgeVLANSetDefaultPVID sets the VLAN default port VLAN ID (PVID).
 func BridgeVLANSetDefaultPVID(interfaceName string, vlanID string) error {
-	err := ioutil.WriteFile(fmt.Sprintf("/sys/class/net/%s/bridge/default_pvid", interfaceName), []byte(vlanID), 0)
+	err := os.WriteFile(fmt.Sprintf("/sys/class/net/%s/bridge/default_pvid", interfaceName), []byte(vlanID), 0)
 	if err != nil {
 		return fmt.Errorf("Failed setting bridge VLAN default PVID for %q: %w", interfaceName, err)
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -680,7 +679,7 @@ func patchMoveBackupsInstances(name string, d *Daemon) error {
 		return fmt.Errorf("Failed creating instances backup directory %q: %w", backupsPath, err)
 	}
 
-	backups, err := ioutil.ReadDir(shared.VarPath("backups"))
+	backups, err := os.ReadDir(shared.VarPath("backups"))
 	if err != nil {
 		return fmt.Errorf("Failed listing existing backup directory %q: %w", shared.VarPath("backups"), err)
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -595,13 +595,13 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 		return response.PreconditionFailed(err)
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	rdr1 := ioutil.NopCloser(bytes.NewBuffer(body))
-	rdr2 := ioutil.NopCloser(bytes.NewBuffer(body))
+	rdr1 := io.NopCloser(bytes.NewBuffer(body))
+	rdr2 := io.NopCloser(bytes.NewBuffer(body))
 
 	reqRaw := shared.Jmap{}
 	err = json.NewDecoder(rdr1).Decode(&reqRaw)

--- a/lxd/resources/cpu.go
+++ b/lxd/resources/cpu.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -24,7 +23,7 @@ func GetCPUIsolated() []int64 {
 
 	isolatedCpusInt := []int64{}
 	if sysfsExists(isolatedPath) {
-		buf, err := ioutil.ReadFile(isolatedPath)
+		buf, err := os.ReadFile(isolatedPath)
 		if err != nil {
 			return isolatedCpusInt
 		}
@@ -85,7 +84,7 @@ func getCPUCache(path string) ([]api.ResourcesCPUCache, error) {
 	caches := []api.ResourcesCPUCache{}
 
 	// List all the caches
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list %q: %w", path, err)
 	}
@@ -112,7 +111,7 @@ func getCPUCache(path string) ([]api.ResourcesCPUCache, error) {
 		cache.Level = cacheLevel
 
 		// Get the cache size
-		content, err := ioutil.ReadFile(filepath.Join(entryPath, "size"))
+		content, err := os.ReadFile(filepath.Join(entryPath, "size"))
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "size"), err)
@@ -136,7 +135,7 @@ func getCPUCache(path string) ([]api.ResourcesCPUCache, error) {
 		}
 
 		// Get the cache type
-		cacheType, err := ioutil.ReadFile(filepath.Join(entryPath, "type"))
+		cacheType, err := os.ReadFile(filepath.Join(entryPath, "type"))
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "type"), err)
@@ -208,7 +207,7 @@ func GetCPU() (*api.ResourcesCPU, error) {
 	cpuInfo := bufio.NewScanner(f)
 
 	// List all the CPUs
-	entries, err := ioutil.ReadDir(sysDevicesCPU)
+	entries, err := os.ReadDir(sysDevicesCPU)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list %q: %w", sysDevicesCPU, err)
 	}

--- a/lxd/resources/gpu.go
+++ b/lxd/resources/gpu.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,7 +29,7 @@ func loadNvidiaProc() (map[string]*api.ResourcesGPUCardNvidia, error) {
 	}
 
 	// List the GPUs from /proc
-	entries, err := ioutil.ReadDir(gpusPath)
+	entries, err := os.ReadDir(gpusPath)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list %q: %w", gpusPath, err)
 	}
@@ -204,7 +203,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 		// Vendor and product
 		deviceVendorPath := filepath.Join(devicePath, "vendor")
 		if sysfsExists(deviceVendorPath) {
-			id, err := ioutil.ReadFile(deviceVendorPath)
+			id, err := os.ReadFile(deviceVendorPath)
 			if err != nil {
 				return fmt.Errorf("Failed to read %q: %w", deviceVendorPath, err)
 			}
@@ -214,7 +213,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 
 		deviceDevicePath := filepath.Join(devicePath, "device")
 		if sysfsExists(deviceDevicePath) {
-			id, err := ioutil.ReadFile(deviceDevicePath)
+			id, err := os.ReadFile(deviceDevicePath)
 			if err != nil {
 				return fmt.Errorf("Failed to read %q: %w", deviceDevicePath, err)
 			}
@@ -250,7 +249,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 		card.Driver = filepath.Base(linkTarget)
 
 		// Try to get the version, fallback to kernel version
-		out, err := ioutil.ReadFile(filepath.Join(driverPath, "module", "version"))
+		out, err := os.ReadFile(filepath.Join(driverPath, "module", "version"))
 		if err == nil {
 			card.DriverVersion = strings.TrimSpace(string(out))
 		} else {
@@ -277,7 +276,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 		drm := api.ResourcesGPUCardDRM{}
 
 		// List all the devices
-		entries, err := ioutil.ReadDir(drmPath)
+		entries, err := os.ReadDir(drmPath)
 		if err != nil {
 			return fmt.Errorf("Failed to list %q: %w", drmPath, err)
 		}
@@ -295,7 +294,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 					return fmt.Errorf("Failed to parse card number: %w", err)
 				}
 
-				dev, err := ioutil.ReadFile(filepath.Join(entryPath, "dev"))
+				dev, err := os.ReadFile(filepath.Join(entryPath, "dev"))
 				if err != nil {
 					return fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "dev"), err)
 				}
@@ -306,7 +305,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 			}
 
 			if strings.HasPrefix(entryName, "controlD") {
-				dev, err := ioutil.ReadFile(filepath.Join(entryPath, "dev"))
+				dev, err := os.ReadFile(filepath.Join(entryPath, "dev"))
 				if err != nil {
 					return fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "dev"), err)
 				}
@@ -316,7 +315,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 			}
 
 			if strings.HasPrefix(entryName, "renderD") {
-				dev, err := ioutil.ReadFile(filepath.Join(entryPath, "dev"))
+				dev, err := os.ReadFile(filepath.Join(entryPath, "dev"))
 				if err != nil {
 					return fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "dev"), err)
 				}
@@ -335,7 +334,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 		card.Mdev = map[string]api.ResourcesGPUCardMdev{}
 
 		// List all the devices
-		entries, err := ioutil.ReadDir(mdevPath)
+		entries, err := os.ReadDir(mdevPath)
 		if err != nil {
 			return fmt.Errorf("Failed to list %q: %w", mdevPath, err)
 		}
@@ -349,7 +348,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 			// API
 			apiPath := filepath.Join(entryPath, "device_api")
 			if sysfsExists(apiPath) {
-				api, err := ioutil.ReadFile(apiPath)
+				api, err := os.ReadFile(apiPath)
 				if err != nil {
 					return fmt.Errorf("Failed to read %q: %w", apiPath, err)
 				}
@@ -371,7 +370,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 			// Description
 			descriptionPath := filepath.Join(entryPath, "description")
 			if sysfsExists(descriptionPath) {
-				description, err := ioutil.ReadFile(descriptionPath)
+				description, err := os.ReadFile(descriptionPath)
 				if err != nil {
 					return fmt.Errorf("Failed to read %q: %w", descriptionPath, err)
 				}
@@ -382,7 +381,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 			// Devices
 			mdevDevicesPath := filepath.Join(entryPath, "devices")
 			if sysfsExists(mdevDevicesPath) {
-				devs, err := ioutil.ReadDir(mdevDevicesPath)
+				devs, err := os.ReadDir(mdevDevicesPath)
 				if err != nil {
 					return fmt.Errorf("Failed to list %q: %w", mdevDevicesPath, err)
 				}
@@ -396,7 +395,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 			// Name
 			namePath := filepath.Join(entryPath, "name")
 			if sysfsExists(namePath) {
-				name, err := ioutil.ReadFile(namePath)
+				name, err := os.ReadFile(namePath)
 				if err != nil {
 					return fmt.Errorf("Failed to read %q: %w", namePath, err)
 				}
@@ -444,7 +443,7 @@ func GetGPU() (*api.ResourcesGPU, error) {
 
 	// Detect all GPUs available through kernel drm interface
 	if sysfsExists(sysClassDrm) {
-		entries, err := ioutil.ReadDir(sysClassDrm)
+		entries, err := os.ReadDir(sysClassDrm)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list %q: %w", sysClassDrm, err)
 		}
@@ -515,7 +514,7 @@ func GetGPU() (*api.ResourcesGPU, error) {
 
 	// Detect remaining GPUs on PCI bus
 	if sysfsExists(sysBusPci) {
-		entries, err := ioutil.ReadDir(sysBusPci)
+		entries, err := os.ReadDir(sysBusPci)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list %q: %w", sysBusPci, err)
 		}
@@ -535,7 +534,7 @@ func GetGPU() (*api.ResourcesGPU, error) {
 				continue
 			}
 
-			class, err := ioutil.ReadFile(filepath.Join(devicePath, "class"))
+			class, err := os.ReadFile(filepath.Join(devicePath, "class"))
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "class"), err)
 			}

--- a/lxd/resources/memory.go
+++ b/lxd/resources/memory.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -143,7 +142,7 @@ func getMemoryBlockSizeBytes() uint64 {
 	}
 
 	// Get block size
-	content, err := ioutil.ReadFile(memoryBlockSizePath)
+	content, err := os.ReadFile(memoryBlockSizePath)
 	if err != nil {
 		return 0
 	}
@@ -162,7 +161,7 @@ func getTotalMemory(sysDevicesBase string) uint64 {
 		return 0
 	}
 
-	entries, err := ioutil.ReadDir(sysDevicesBase)
+	entries, err := os.ReadDir(sysDevicesBase)
 	if err != nil {
 		return 0
 	}
@@ -183,7 +182,7 @@ func getTotalMemory(sysDevicesBase string) uint64 {
 			continue
 		}
 
-		content, err := ioutil.ReadFile(filepath.Join(entryPath, "online"))
+		content, err := os.ReadFile(filepath.Join(entryPath, "online"))
 		if err != nil {
 			return 0
 		}
@@ -228,7 +227,7 @@ func GetMemory() (*api.ResourcesMemory, error) {
 		memory.Nodes = []api.ResourcesMemoryNode{}
 
 		// List all the nodes
-		entries, err := ioutil.ReadDir(sysDevicesNode)
+		entries, err := os.ReadDir(sysDevicesNode)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list %q: %w", sysDevicesNode, err)
 		}

--- a/lxd/resources/network.go
+++ b/lxd/resources/network.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -72,7 +71,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	// Vendor and product
 	deviceVendorPath := filepath.Join(devicePath, "vendor")
 	if sysfsExists(deviceVendorPath) {
-		id, err := ioutil.ReadFile(deviceVendorPath)
+		id, err := os.ReadFile(deviceVendorPath)
 		if err != nil {
 			return fmt.Errorf("Failed to read %q: %w", deviceVendorPath, err)
 		}
@@ -82,7 +81,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 
 	deviceDevicePath := filepath.Join(devicePath, "device")
 	if sysfsExists(deviceDevicePath) {
-		id, err := ioutil.ReadFile(deviceDevicePath)
+		id, err := os.ReadFile(deviceDevicePath)
 		if err != nil {
 			return fmt.Errorf("Failed to read %q: %w", deviceDevicePath, err)
 		}
@@ -117,7 +116,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 		card.Driver = filepath.Base(linkTarget)
 
 		// Try to get the version, fallback to kernel version
-		out, err := ioutil.ReadFile(filepath.Join(driverPath, "module", "version"))
+		out, err := os.ReadFile(filepath.Join(driverPath, "module", "version"))
 		if err == nil {
 			card.DriverVersion = strings.TrimSpace(string(out))
 		} else {
@@ -130,7 +129,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	if sysfsExists(netPath) {
 		card.Ports = []api.ResourcesNetworkCardPort{}
 
-		entries, err := ioutil.ReadDir(netPath)
+		entries, err := os.ReadDir(netPath)
 		if err != nil {
 			return fmt.Errorf("Failed to list %q: %w", netPath, err)
 		}
@@ -159,7 +158,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 
 			// Add MAC address
 			if info.Address == "" && sysfsExists(filepath.Join(interfacePath, "address")) {
-				address, err := ioutil.ReadFile(filepath.Join(interfacePath, "address"))
+				address, err := os.ReadFile(filepath.Join(interfacePath, "address"))
 				if err != nil {
 					return fmt.Errorf("Failed to read %q: %w", filepath.Join(interfacePath, "address"), err)
 				}
@@ -185,7 +184,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 				if sysfsExists(madPath) {
 					ibPort := info.Port + 1
 
-					entries, err := ioutil.ReadDir(madPath)
+					entries, err := os.ReadDir(madPath)
 					if err != nil {
 						return fmt.Errorf("Failed to list %q: %w", madPath, err)
 					}
@@ -205,7 +204,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 							continue
 						}
 
-						dev, err := ioutil.ReadFile(filepath.Join(madPath, entryName, "dev"))
+						dev, err := os.ReadFile(filepath.Join(madPath, entryName, "dev"))
 						if err != nil {
 							return fmt.Errorf("Failed to read %q: %w", filepath.Join(madPath, entryName, "dev"), err)
 						}
@@ -224,7 +223,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 
 				verbsPath := filepath.Join(devicePath, "infiniband_verbs")
 				if sysfsExists(verbsPath) {
-					entries, err := ioutil.ReadDir(verbsPath)
+					entries, err := os.ReadDir(verbsPath)
 					if err != nil {
 						return fmt.Errorf("Failed to list %q: %w", verbsPath, err)
 					}
@@ -237,7 +236,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 							continue
 						}
 
-						dev, err := ioutil.ReadFile(filepath.Join(verbsPath, verbName, "dev"))
+						dev, err := os.ReadFile(filepath.Join(verbsPath, verbName, "dev"))
 						if err != nil {
 							return fmt.Errorf("Failed to read %q: %w", filepath.Join(verbsPath, verbName, "dev"), err)
 						}
@@ -299,7 +298,7 @@ func GetNetwork() (*api.ResourcesNetwork, error) {
 
 	// Detect all Networks available through kernel network interface
 	if sysfsExists(sysClassNet) {
-		entries, err := ioutil.ReadDir(sysClassNet)
+		entries, err := os.ReadDir(sysClassNet)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list %q: %w", sysClassNet, err)
 		}
@@ -365,7 +364,7 @@ func GetNetwork() (*api.ResourcesNetwork, error) {
 
 	// Detect remaining Networks on PCI bus
 	if sysfsExists(sysBusPci) {
-		entries, err := ioutil.ReadDir(sysBusPci)
+		entries, err := os.ReadDir(sysBusPci)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list %q: %w", sysBusPci, err)
 		}
@@ -385,7 +384,7 @@ func GetNetwork() (*api.ResourcesNetwork, error) {
 				continue
 			}
 
-			class, err := ioutil.ReadFile(filepath.Join(devicePath, "class"))
+			class, err := os.ReadFile(filepath.Join(devicePath, "class"))
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "class"), err)
 			}
@@ -524,13 +523,13 @@ func GetNetworkState(name string) (*api.NetworkState, error) {
 		bonding := api.NetworkStateBond{}
 
 		// Bond mode.
-		strValue, err := ioutil.ReadFile(filepath.Join(bondPath, "mode"))
+		strValue, err := os.ReadFile(filepath.Join(bondPath, "mode"))
 		if err == nil {
 			bonding.Mode = strings.Split(strings.TrimSpace(string(strValue)), " ")[0]
 		}
 
 		// Bond transmit policy.
-		strValue, err = ioutil.ReadFile(filepath.Join(bondPath, "xmit_hash_policy"))
+		strValue, err = os.ReadFile(filepath.Join(bondPath, "xmit_hash_policy"))
 		if err == nil {
 			bonding.TransmitPolicy = strings.Split(strings.TrimSpace(string(strValue)), " ")[0]
 		}
@@ -554,13 +553,13 @@ func GetNetworkState(name string) (*api.NetworkState, error) {
 		}
 
 		// MII state.
-		strValue, err = ioutil.ReadFile(filepath.Join(bondPath, "mii_status"))
+		strValue, err = os.ReadFile(filepath.Join(bondPath, "mii_status"))
 		if err == nil {
 			bonding.MIIState = strings.TrimSpace(string(strValue))
 		}
 
 		// Lower devices.
-		strValue, err = ioutil.ReadFile(filepath.Join(bondPath, "slaves"))
+		strValue, err = os.ReadFile(filepath.Join(bondPath, "slaves"))
 		if err == nil {
 			bonding.LowerDevices = strings.Split(strings.TrimSpace(string(strValue)), " ")
 		}
@@ -574,7 +573,7 @@ func GetNetworkState(name string) (*api.NetworkState, error) {
 		bridge := api.NetworkStateBridge{}
 
 		// Bridge ID.
-		strValue, err := ioutil.ReadFile(filepath.Join(bridgePath, "bridge_id"))
+		strValue, err := os.ReadFile(filepath.Join(bridgePath, "bridge_id"))
 		if err == nil {
 			bridge.ID = strings.TrimSpace(string(strValue))
 		}
@@ -606,7 +605,7 @@ func GetNetworkState(name string) (*api.NetworkState, error) {
 		// Upper devices.
 		bridgeIfPath := fmt.Sprintf("/sys/class/net/%s/brif", name)
 		if sysfsExists(bridgeIfPath) {
-			entries, err := ioutil.ReadDir(bridgeIfPath)
+			entries, err := os.ReadDir(bridgeIfPath)
 			if err == nil {
 				bridge.UpperDevices = []string{}
 				for _, entry := range entries {
@@ -628,7 +627,7 @@ func GetNetworkState(name string) (*api.NetworkState, error) {
 
 	vlanPath := "/proc/net/vlan/config"
 	if sysfsExists(vlanPath) {
-		entries, err := ioutil.ReadFile(vlanPath)
+		entries, err := os.ReadFile(vlanPath)
 		if err != nil {
 			return nil, err
 		}
@@ -679,7 +678,7 @@ func GetNetworkCounters(name string) (*api.NetworkStateCounters, error) {
 	counters := api.NetworkStateCounters{}
 
 	// Get counters
-	content, err := ioutil.ReadFile("/proc/net/dev")
+	content, err := os.ReadFile("/proc/net/dev")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &counters, nil

--- a/lxd/resources/pci.go
+++ b/lxd/resources/pci.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -37,7 +36,7 @@ func GetPCI() (*api.ResourcesPCI, error) {
 	}
 
 	// List all PCI devices
-	entries, err := ioutil.ReadDir(sysBusPci)
+	entries, err := os.ReadDir(sysBusPci)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list %q: %w", sysBusPci, err)
 	}
@@ -59,7 +58,7 @@ func GetPCI() (*api.ResourcesPCI, error) {
 			device.Driver = filepath.Base(linkTarget)
 
 			// Try to get the version, fallback to kernel version
-			out, err := ioutil.ReadFile(filepath.Join(driverPath, "module", "version"))
+			out, err := os.ReadFile(filepath.Join(driverPath, "module", "version"))
 			if err == nil {
 				device.DriverVersion = strings.TrimSpace(string(out))
 			} else {
@@ -85,7 +84,7 @@ func GetPCI() (*api.ResourcesPCI, error) {
 		// Get product ID node
 		deviceDevicePath := filepath.Join(devicePath, "device")
 		if sysfsExists(deviceDevicePath) {
-			id, err := ioutil.ReadFile(deviceDevicePath)
+			id, err := os.ReadFile(deviceDevicePath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", deviceDevicePath, err)
 			}
@@ -96,7 +95,7 @@ func GetPCI() (*api.ResourcesPCI, error) {
 		// Get vendor ID node
 		deviceVendorPath := filepath.Join(devicePath, "vendor")
 		if sysfsExists(deviceVendorPath) {
-			id, err := ioutil.ReadFile(deviceVendorPath)
+			id, err := os.ReadFile(deviceVendorPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", deviceVendorPath, err)
 			}
@@ -139,7 +138,7 @@ func GetPCI() (*api.ResourcesPCI, error) {
 		// Get VPD info
 		vpdSysPath := filepath.Join(devicePath, "vpd")
 		if sysfsExists(vpdSysPath) {
-			data, err := ioutil.ReadFile(vpdSysPath)
+			data, err := os.ReadFile(vpdSysPath)
 
 			// If the file is readable, parse the VPD data.
 			if err == nil {

--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -122,7 +121,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 	// Detect all block devices
 	if sysfsExists(sysClassBlock) {
-		entries, err := ioutil.ReadDir(sysClassBlock)
+		entries, err := os.ReadDir(sysClassBlock)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list %q: %w", sysClassBlock, err)
 		}
@@ -144,7 +143,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 			// Firmware revision
 			if sysfsExists(filepath.Join(devicePath, "firmware_rev")) {
-				firmwareRevision, err := ioutil.ReadFile(filepath.Join(devicePath, "firmware_rev"))
+				firmwareRevision, err := os.ReadFile(filepath.Join(devicePath, "firmware_rev"))
 				if err != nil {
 					return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "firmware_rev"), err)
 				}
@@ -153,7 +152,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			}
 
 			// Device node
-			diskDev, err := ioutil.ReadFile(filepath.Join(entryPath, "dev"))
+			diskDev, err := os.ReadFile(filepath.Join(entryPath, "dev"))
 			if err != nil {
 				if os.IsNotExist(err) {
 					// This happens on multipath devices, just skip as we only care about the main node.
@@ -199,7 +198,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 			// Disk model
 			if sysfsExists(filepath.Join(devicePath, "model")) {
-				diskModel, err := ioutil.ReadFile(filepath.Join(devicePath, "model"))
+				diskModel, err := os.ReadFile(filepath.Join(devicePath, "model"))
 				if err != nil {
 					return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "model"), err)
 				}
@@ -248,7 +247,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 			// WWN
 			if sysfsExists(filepath.Join(entryPath, "wwid")) {
-				diskWWN, err := ioutil.ReadFile(filepath.Join(entryPath, "wwid"))
+				diskWWN, err := os.ReadFile(filepath.Join(entryPath, "wwid"))
 				if err != nil {
 					return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "wwid"), err)
 				}
@@ -293,7 +292,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 				partition.Partition = partitionNumber
 
 				// Device node
-				partitionDev, err := ioutil.ReadFile(filepath.Join(subEntryPath, "dev"))
+				partitionDev, err := os.ReadFile(filepath.Join(subEntryPath, "dev"))
 				if err != nil {
 					return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(subEntryPath, "dev"), err)
 				}
@@ -322,7 +321,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 			// Try to find the udev device path
 			if sysfsExists(devDiskByPath) {
-				links, err := ioutil.ReadDir(devDiskByPath)
+				links, err := os.ReadDir(devDiskByPath)
 				if err != nil {
 					return nil, fmt.Errorf("Failed to list the links in %q: %w", devDiskByPath, err)
 				}
@@ -344,7 +343,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 			// Try to find the udev device id
 			if sysfsExists(devDiskByID) {
-				links, err := ioutil.ReadDir(devDiskByID)
+				links, err := os.ReadDir(devDiskByID)
 				if err != nil {
 					return nil, fmt.Errorf("Failed to list the links in %q: %w", devDiskByID, err)
 				}

--- a/lxd/resources/system.go
+++ b/lxd/resources/system.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +32,7 @@ func GetSystem() (*api.ResourcesSystem, error) {
 	// Product UUID
 	productUUIDPath := filepath.Join(sysClassDMIID, "product_uuid")
 	if sysfsExists(productUUIDPath) {
-		content, err := ioutil.ReadFile(productUUIDPath)
+		content, err := os.ReadFile(productUUIDPath)
 		if err != nil && !os.IsPermission(err) {
 			return nil, fmt.Errorf("Failed to read %q: %w", productUUIDPath, err)
 		}
@@ -44,7 +43,7 @@ func GetSystem() (*api.ResourcesSystem, error) {
 	// Vendor
 	vendorPath := filepath.Join(sysClassDMIID, "sys_vendor")
 	if sysfsExists(vendorPath) {
-		content, err := ioutil.ReadFile(vendorPath)
+		content, err := os.ReadFile(vendorPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", vendorPath, err)
 		}
@@ -55,7 +54,7 @@ func GetSystem() (*api.ResourcesSystem, error) {
 	// Product name
 	productNamePath := filepath.Join(sysClassDMIID, "product_name")
 	if sysfsExists(productNamePath) {
-		content, err := ioutil.ReadFile(productNamePath)
+		content, err := os.ReadFile(productNamePath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", productNamePath, err)
 		}
@@ -66,7 +65,7 @@ func GetSystem() (*api.ResourcesSystem, error) {
 	// Product family
 	productFamilyPath := filepath.Join(sysClassDMIID, "product_family")
 	if sysfsExists(productFamilyPath) {
-		content, err := ioutil.ReadFile(productFamilyPath)
+		content, err := os.ReadFile(productFamilyPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", productFamilyPath, err)
 		}
@@ -77,7 +76,7 @@ func GetSystem() (*api.ResourcesSystem, error) {
 	// Product version
 	productVersion := filepath.Join(sysClassDMIID, "product_version")
 	if sysfsExists(productVersion) {
-		content, err := ioutil.ReadFile(productVersion)
+		content, err := os.ReadFile(productVersion)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", productVersion, err)
 		}
@@ -88,7 +87,7 @@ func GetSystem() (*api.ResourcesSystem, error) {
 	// Product SKU
 	productSKUPath := filepath.Join(sysClassDMIID, "product_sku")
 	if sysfsExists(productSKUPath) {
-		content, err := ioutil.ReadFile(productSKUPath)
+		content, err := os.ReadFile(productSKUPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", productSKUPath, err)
 		}
@@ -99,7 +98,7 @@ func GetSystem() (*api.ResourcesSystem, error) {
 	// Product serial
 	productSerialPath := filepath.Join(sysClassDMIID, "product_serial")
 	if sysfsExists(productSerialPath) {
-		content, err := ioutil.ReadFile(productSerialPath)
+		content, err := os.ReadFile(productSerialPath)
 		if err != nil && !os.IsPermission(err) {
 			return nil, fmt.Errorf("Failed to read %q: %w", productSerialPath, err)
 		}
@@ -160,7 +159,7 @@ func systemGetFirmware() (*api.ResourcesSystemFirmware, error) {
 	// Firmware vendor
 	biosVendorPath := filepath.Join(sysClassDMIID, "bios_vendor")
 	if sysfsExists(biosVendorPath) {
-		content, err := ioutil.ReadFile(biosVendorPath)
+		content, err := os.ReadFile(biosVendorPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", biosVendorPath, err)
 		}
@@ -171,7 +170,7 @@ func systemGetFirmware() (*api.ResourcesSystemFirmware, error) {
 	// Firmware date
 	biosDatePath := filepath.Join(sysClassDMIID, "bios_date")
 	if sysfsExists(biosDatePath) {
-		content, err := ioutil.ReadFile(biosDatePath)
+		content, err := os.ReadFile(biosDatePath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", biosDatePath, err)
 		}
@@ -182,7 +181,7 @@ func systemGetFirmware() (*api.ResourcesSystemFirmware, error) {
 	// Firmware version
 	biosVersionPath := filepath.Join(sysClassDMIID, "bios_version")
 	if sysfsExists(biosVersionPath) {
-		content, err := ioutil.ReadFile(biosVersionPath)
+		content, err := os.ReadFile(biosVersionPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", biosVersionPath, err)
 		}
@@ -199,7 +198,7 @@ func systemGetChassis() (*api.ResourcesSystemChassis, error) {
 	// Chassis vendor
 	chassisVendorPath := filepath.Join(sysClassDMIID, "chassis_vendor")
 	if sysfsExists(chassisVendorPath) {
-		content, err := ioutil.ReadFile(chassisVendorPath)
+		content, err := os.ReadFile(chassisVendorPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", chassisVendorPath, err)
 		}
@@ -261,7 +260,7 @@ func systemGetChassis() (*api.ResourcesSystemChassis, error) {
 	// Chassis serial
 	chassisSerialPath := filepath.Join(sysClassDMIID, "chassis_serial")
 	if sysfsExists(chassisSerialPath) {
-		content, err := ioutil.ReadFile(chassisSerialPath)
+		content, err := os.ReadFile(chassisSerialPath)
 		if err != nil && !os.IsPermission(err) {
 			return nil, fmt.Errorf("Failed to read %q: %w", chassisSerialPath, err)
 		}
@@ -272,7 +271,7 @@ func systemGetChassis() (*api.ResourcesSystemChassis, error) {
 	// Chassis version
 	chassisVersionPath := filepath.Join(sysClassDMIID, "chassis_version")
 	if sysfsExists(chassisVersionPath) {
-		content, err := ioutil.ReadFile(chassisVersionPath)
+		content, err := os.ReadFile(chassisVersionPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", chassisVersionPath, err)
 		}
@@ -289,7 +288,7 @@ func systemGetMotherboard() (*api.ResourcesSystemMotherboard, error) {
 	// Motherboard vendor name
 	boardVendorPath := filepath.Join(sysClassDMIID, "board_vendor")
 	if sysfsExists(boardVendorPath) {
-		content, err := ioutil.ReadFile(boardVendorPath)
+		content, err := os.ReadFile(boardVendorPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", boardVendorPath, err)
 		}
@@ -300,7 +299,7 @@ func systemGetMotherboard() (*api.ResourcesSystemMotherboard, error) {
 	// Motherboard product name
 	boardNamePath := filepath.Join(sysClassDMIID, "board_name")
 	if sysfsExists(boardNamePath) {
-		content, err := ioutil.ReadFile(boardNamePath)
+		content, err := os.ReadFile(boardNamePath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", boardNamePath, err)
 		}
@@ -311,7 +310,7 @@ func systemGetMotherboard() (*api.ResourcesSystemMotherboard, error) {
 	// Motherboard serial
 	boardSerialPath := filepath.Join(sysClassDMIID, "board_serial")
 	if sysfsExists(boardSerialPath) {
-		content, err := ioutil.ReadFile(boardSerialPath)
+		content, err := os.ReadFile(boardSerialPath)
 		if err != nil && !os.IsPermission(err) {
 			return nil, fmt.Errorf("Failed to read %q: %w", boardSerialPath, err)
 		}
@@ -322,7 +321,7 @@ func systemGetMotherboard() (*api.ResourcesSystemMotherboard, error) {
 	// Motherboard version
 	boardVersionPath := filepath.Join(sysClassDMIID, "board_version")
 	if sysfsExists(boardVersionPath) {
-		content, err := ioutil.ReadFile(boardVersionPath)
+		content, err := os.ReadFile(boardVersionPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read %q: %w", boardVersionPath, err)
 		}

--- a/lxd/resources/usb.go
+++ b/lxd/resources/usb.go
@@ -2,7 +2,7 @@ package resources
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -28,7 +28,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 	}
 
 	// List all USB devices
-	entries, err := ioutil.ReadDir(sysBusUSB)
+	entries, err := os.ReadDir(sysBusUSB)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list %q: %w", sysBusUSB, err)
 	}
@@ -51,7 +51,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 
 		devClassFile := filepath.Join(devicePath, "bDeviceClass")
 		if sysfsExists(devClassFile) {
-			content, err := ioutil.ReadFile(devClassFile)
+			content, err := os.ReadFile(devClassFile)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", devClassFile, err)
 			}
@@ -86,7 +86,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 
 		deviceProductIDPath := filepath.Join(devicePath, "idProduct")
 		if sysfsExists(deviceProductIDPath) {
-			content, err := ioutil.ReadFile(deviceProductIDPath)
+			content, err := os.ReadFile(deviceProductIDPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", deviceProductIDPath, err)
 			}
@@ -104,7 +104,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 
 		deviceVendorIDPath := filepath.Join(devicePath, "idVendor")
 		if sysfsExists(deviceVendorIDPath) {
-			content, err := ioutil.ReadFile(deviceVendorIDPath)
+			content, err := os.ReadFile(deviceVendorIDPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", deviceVendorIDPath, err)
 			}
@@ -120,7 +120,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 		// Get vendor and product name
 		deviceProductPath := filepath.Join(devicePath, "product")
 		if sysfsExists(deviceProductPath) {
-			content, err := ioutil.ReadFile(deviceProductPath)
+			content, err := os.ReadFile(deviceProductPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", deviceProductPath, err)
 			}
@@ -144,7 +144,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 		// Get speed
 		deviceSpeedPath := filepath.Join(devicePath, "speed")
 		if sysfsExists(deviceSpeedPath) {
-			content, err := ioutil.ReadFile(deviceSpeedPath)
+			content, err := os.ReadFile(deviceSpeedPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read %q: %w", deviceSpeedPath, err)
 			}
@@ -156,7 +156,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 		}
 
 		// List USB interfaces
-		subEntries, err := ioutil.ReadDir(devicePath)
+		subEntries, err := os.ReadDir(devicePath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list %q: %w", devicePath, err)
 		}
@@ -177,7 +177,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 
 			interfaceClassPath := filepath.Join(subDevicePath, "bInterfaceClass")
 			if sysfsExists(interfaceClassPath) {
-				content, err := ioutil.ReadFile(interfaceClassPath)
+				content, err := os.ReadFile(interfaceClassPath)
 				if err != nil {
 					return nil, fmt.Errorf("Failed to read %q: %w", interfaceClassPath, err)
 				}
@@ -198,7 +198,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 			// Get subclass ID
 			interfaceSubClassPath := filepath.Join(subDevicePath, "bInterfaceSubClass")
 			if sysfsExists(interfaceSubClassPath) {
-				content, err := ioutil.ReadFile(interfaceSubClassPath)
+				content, err := os.ReadFile(interfaceSubClassPath)
 				if err != nil {
 					return nil, fmt.Errorf("Failed to read %q: %w", interfaceSubClassPath, err)
 				}
@@ -219,7 +219,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 			// Get number
 			interfaceNumber := filepath.Join(subDevicePath, "bInterfaceNumber")
 			if sysfsExists(interfaceNumber) {
-				content, err := ioutil.ReadFile(interfaceNumber)
+				content, err := os.ReadFile(interfaceNumber)
 				if err != nil {
 					return nil, fmt.Errorf("Failed to read %q: %w", interfaceNumber, err)
 				}
@@ -241,7 +241,7 @@ func GetUSB() (*api.ResourcesUSB, error) {
 				iface.Driver = filepath.Base(linkTarget)
 
 				// Try to get the version, fallback to kernel version
-				out, err := ioutil.ReadFile(filepath.Join(driverPath, "module", "version"))
+				out, err := os.ReadFile(filepath.Join(driverPath, "module", "version"))
 				if err == nil {
 					iface.DriverVersion = strings.TrimSpace(string(out))
 				} else {

--- a/lxd/resources/utils.go
+++ b/lxd/resources/utils.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,7 +21,7 @@ func isDir(name string) bool {
 }
 
 func readUint(path string) (uint64, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}
@@ -36,7 +35,7 @@ func readUint(path string) (uint64, error) {
 }
 
 func readInt(path string) (int64, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return -1, err
 	}
@@ -74,7 +73,7 @@ func sysfsExists(path string) bool {
 
 func sysfsNumaNode(path string) (uint64, error) {
 	// List all the directory entries
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return 0, err
 	}

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -3,7 +3,6 @@ package rsync
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -177,14 +176,14 @@ func sendSetup(name string, path string, bwlimit string, execPath string, featur
 	select {
 	case conn = <-chConn:
 		if conn == nil {
-			output, _ := ioutil.ReadAll(stderr)
+			output, _ := io.ReadAll(stderr)
 			_ = cmd.Process.Kill()
 			_ = cmd.Wait()
 			return nil, nil, nil, fmt.Errorf("Failed to connect to rsync socket (%s)", string(output))
 		}
 
 	case <-time.After(10 * time.Second):
-		output, _ := ioutil.ReadAll(stderr)
+		output, _ := io.ReadAll(stderr)
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 		return nil, nil, nil, fmt.Errorf("rsync failed to spawn after 10s (%s)", string(output))
@@ -230,7 +229,7 @@ func Send(name string, path string, conn io.ReadWriteCloser, tracker *ioprogress
 	}()
 
 	// Wait for rsync to complete.
-	output, err := ioutil.ReadAll(stderr)
+	output, err := io.ReadAll(stderr)
 	if err != nil {
 		_ = cmd.Process.Kill()
 		logger.Errorf("Rsync stderr read failed: %s: %v", path, err)
@@ -328,7 +327,7 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 		return err
 	}
 
-	output, err := ioutil.ReadAll(stderr)
+	output, err := io.ReadAll(stderr)
 	if err != nil {
 		logger.Errorf("Rsync stderr read failed: %s: %v", path, err)
 	}

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -866,7 +865,7 @@ func CreateProfile(s *state.State, c Instance) error {
 		return err
 	}
 
-	return ioutil.WriteFile(ProfilePath(c), []byte(profile), 0600)
+	return os.WriteFile(ProfilePath(c), []byte(profile), 0600)
 }
 
 // DeleteProfile removes a seccomp profile.
@@ -1112,7 +1111,7 @@ func NewSeccompServer(s *state.State, path string, findPID func(pid int32, state
 
 // TaskIDs returns the task IDs for a process.
 func TaskIDs(pid int) (int64, int64, int64, int64, error) {
-	status, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
 	if err != nil {
 		return -1, -1, -1, -1, err
 	}
@@ -1195,7 +1194,7 @@ func FindTGID(procFd int) (int, error) {
 	}
 
 	statusFile = os.NewFile(uintptr(fd), "/proc/<pid>/status")
-	status, err := ioutil.ReadAll(statusFile)
+	status, err := io.ReadAll(statusFile)
 	_ = statusFile.Close()
 	if err != nil {
 		return -1, err
@@ -1753,7 +1752,7 @@ func (s *Server) HandleSysinfoSyscall(c Instance, siov *Iovec) int {
 	}
 
 	// Get instance uptime.
-	pidStat, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/stat", siov.msg.init_pid))
+	pidStat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", siov.msg.init_pid))
 	if err != nil {
 		l.Warn("Failed getting init process info", logger.Ctx{"err": err, "pid": siov.msg.init_pid})
 		C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -4176,7 +4175,7 @@ func (b *lxdBackend) migrationIndexHeaderSend(l logger.Logger, indexHeaderVersio
 
 		l.Debug("Sent migration index header, waiting for response", logger.Ctx{"version": indexHeaderVersion})
 
-		respBuf, err := ioutil.ReadAll(conn)
+		respBuf, err := io.ReadAll(conn)
 		if err != nil {
 			return nil, fmt.Errorf("Failed reading migration index header: %w", err)
 		}
@@ -4205,7 +4204,7 @@ func (b *lxdBackend) migrationIndexHeaderReceive(l logger.Logger, indexHeaderVer
 	if indexHeaderVersion > 0 {
 		l.Debug("Waiting for migration index header", logger.Ctx{"version": indexHeaderVersion})
 
-		buf, err := ioutil.ReadAll(conn)
+		buf, err := io.ReadAll(conn)
 		if err != nil {
 			return nil, fmt.Errorf("Failed reading migration index header: %w", err)
 		}

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -319,7 +318,7 @@ func (d *btrfs) sendSubvolume(path string, parent string, conn io.ReadWriteClose
 	}
 
 	// Read any error.
-	output, err := ioutil.ReadAll(stderr)
+	output, err := io.ReadAll(stderr)
 	if err != nil {
 		logger.Errorf("Problem reading btrfs send stderr: %s", err)
 	}
@@ -558,7 +557,7 @@ func (d *btrfs) loadOptimizedBackupHeader(r io.ReadSeeker, mountPath string) (*B
 
 // receiveSubVolume receives a subvolume from an io.Reader into the receivePath and returns the path to the received subvolume.
 func (d *btrfs) receiveSubVolume(r io.Reader, receivePath string) (string, error) {
-	files, err := ioutil.ReadDir(receivePath)
+	files, err := os.ReadDir(receivePath)
 	if err != nil {
 		return "", fmt.Errorf("Failed listing contents of %q: %w", receivePath, err)
 	}
@@ -569,7 +568,7 @@ func (d *btrfs) receiveSubVolume(r io.Reader, receivePath string) (string, error
 	}
 
 	// Check contents of target path is expected after receive.
-	newFiles, err := ioutil.ReadDir(receivePath)
+	newFiles, err := os.ReadDir(receivePath)
 	if err != nil {
 		return "", fmt.Errorf("Failed listing contents of %q: %w", receivePath, err)
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -206,7 +205,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcDat
 	}
 
 	// Create a temporary directory to unpack the backup into.
-	tmpUnpackDir, err := ioutil.TempDir(GetVolumeMountPath(d.name, vol.volType, ""), "backup.")
+	tmpUnpackDir, err := os.MkdirTemp(GetVolumeMountPath(d.name, vol.volType, ""), "backup.")
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to create temporary directory %q: %w", tmpUnpackDir, err)
 	}
@@ -493,7 +492,7 @@ func (d *btrfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, v
 
 	// Inspect negotiated features to see if we are expecting to get a metadata migration header frame.
 	if shared.StringInSlice(migration.BTRFSFeatureMigrationHeader, volTargetArgs.MigrationType.Features) {
-		buf, err := ioutil.ReadAll(conn)
+		buf, err := io.ReadAll(conn)
 		if err != nil {
 			return fmt.Errorf("Failed reading BTRFS migration header: %w", err)
 		}
@@ -647,7 +646,7 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 	instancesPath := GetVolumeMountPath(d.name, vol.volType, "")
 
 	// Create a temporary directory which will act as the parent directory of the received ro snapshot.
-	tmpVolumesMountPoint, err := ioutil.TempDir(instancesPath, "migration.")
+	tmpVolumesMountPoint, err := os.MkdirTemp(instancesPath, "migration.")
 	if err != nil {
 		return fmt.Errorf("Failed to create temporary directory under %q: %w", instancesPath, err)
 	}
@@ -1162,7 +1161,7 @@ func (d *btrfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 
 	sourcePath := vol.MountPath()
 	poolPath := GetPoolMountPath(d.name)
-	tmpDir, err := ioutil.TempDir(poolPath, "backup.")
+	tmpDir, err := os.MkdirTemp(poolPath, "backup.")
 	if err != nil {
 		return "", nil, err
 	}
@@ -1277,7 +1276,7 @@ func (d *btrfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *m
 	if volSrcArgs.Refresh && shared.StringInSlice(migration.BTRFSFeatureSubvolumeUUIDs, volSrcArgs.MigrationType.Features) {
 		migrationHeader = &BTRFSMetaDataHeader{}
 
-		buf, err := ioutil.ReadAll(conn)
+		buf, err := io.ReadAll(conn)
 		if err != nil {
 			return fmt.Errorf("Failed reading BTRFS migration header: %w", err)
 		}
@@ -1414,7 +1413,7 @@ func (d *btrfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volS
 	instancesPath := GetVolumeMountPath(d.name, vol.volType, "")
 
 	// Create a temporary directory which will act as the parent directory of the read-only snapshot.
-	tmpVolumesMountPoint, err := ioutil.TempDir(instancesPath, "migration.")
+	tmpVolumesMountPoint, err := os.MkdirTemp(instancesPath, "migration.")
 	if err != nil {
 		return fmt.Errorf("Failed to create temporary directory under %q: %w", instancesPath, err)
 	}
@@ -1512,7 +1511,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 
 		// Create temporary file to store output of btrfs send.
 		backupsPath := shared.VarPath("backups")
-		tmpFile, err := ioutil.TempFile(backupsPath, fmt.Sprintf("%s_btrfs", backup.WorkingDirPrefix))
+		tmpFile, err := os.CreateTemp(backupsPath, fmt.Sprintf("%s_btrfs", backup.WorkingDirPrefix))
 		if err != nil {
 			return fmt.Errorf("Failed to open temporary file for BTRFS backup: %w", err)
 		}
@@ -1643,7 +1642,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 	sourceVolume := vol.MountPath()
 	instancesPath := GetVolumeMountPath(d.name, vol.volType, "")
 
-	tmpInstanceMntPoint, err := ioutil.TempDir(instancesPath, "backup.")
+	tmpInstanceMntPoint, err := os.MkdirTemp(instancesPath, "backup.")
 	if err != nil {
 		return fmt.Errorf("Failed to create temporary directory under %q: %w", instancesPath, err)
 	}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -1084,7 +1083,7 @@ func (d *ceph) ListVolumes() ([]Volume, error) {
 		return nil, fmt.Errorf("Unexpected duplicate volume %q found", volName)
 	}
 
-	errMsg, err := ioutil.ReadAll(stderr)
+	errMsg, err := io.ReadAll(stderr)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,7 +123,7 @@ func (d *cephfs) Create() error {
 	}
 
 	// Create a temporary mountpoint.
-	mountPath, err := ioutil.TempDir("", "lxd_cephfs_")
+	mountPath, err := os.MkdirTemp("", "lxd_cephfs_")
 	if err != nil {
 		return fmt.Errorf("Failed to create temporary directory under: %w", err)
 	}
@@ -184,7 +183,7 @@ func (d *cephfs) Delete(op *operations.Operation) error {
 	}
 
 	// Create a temporary mountpoint.
-	mountPath, err := ioutil.TempDir("", "lxd_cephfs_")
+	mountPath, err := os.MkdirTemp("", "lxd_cephfs_")
 	if err != nil {
 		return fmt.Errorf("Failed to create temporary directory under: %w", err)
 	}

--- a/lxd/storage/drivers/driver_cephobject_buckets.go
+++ b/lxd/storage/drivers/driver_cephobject_buckets.go
@@ -5,9 +5,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"time"
 
@@ -41,7 +41,7 @@ func (d *cephobject) s3Client(creds S3Credentials) (*minio.Client, error) {
 		certFilePath = shared.HostPath(certFilePath)
 
 		// Read in the cert file.
-		certs, err := ioutil.ReadFile(certFilePath)
+		certs, err := os.ReadFile(certFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed reading %q: %w", certFilePath, err)
 		}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/exec"
@@ -594,7 +593,7 @@ func (d *lvm) ListVolumes() ([]Volume, error) {
 		return nil, fmt.Errorf("Unexpected duplicate volume %q found", volName)
 	}
 
-	errMsg, err := ioutil.ReadAll(stderr)
+	errMsg, err := io.ReadAll(stderr)
 	if err != nil {
 		return nil, err
 	}
@@ -1139,7 +1138,7 @@ func (d *lvm) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 		snapshots = append(snapshots, snapName)
 	}
 
-	errMsg, err := ioutil.ReadAll(stderr)
+	errMsg, err := io.ReadAll(stderr)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -3,7 +3,7 @@ package drivers
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -258,7 +258,7 @@ func (d *zfs) version() (string, error) {
 
 	// Loaded kernel module version
 	if shared.PathExists("/sys/module/zfs/version") {
-		out, err := ioutil.ReadFile("/sys/module/zfs/version")
+		out, err := os.ReadFile("/sys/module/zfs/version")
 		if err == nil {
 			return strings.TrimSpace(string(out)), nil
 		}
@@ -337,7 +337,7 @@ func (d *zfs) sendDataset(dataset string, parent string, volSrcArgs *migration.V
 	}
 
 	// Read any error.
-	output, _ := ioutil.ReadAll(stderr)
+	output, _ := io.ReadAll(stderr)
 
 	// Handle errors.
 	errs := []error{}
@@ -392,7 +392,7 @@ func (d *zfs) receiveDataset(vol Volume, conn io.ReadWriteCloser, writeWrapper f
 	}
 
 	// Read any error.
-	output, _ := ioutil.ReadAll(stderr)
+	output, _ := io.ReadAll(stderr)
 
 	// Handle errors.
 	errs := []error{}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -736,7 +735,7 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 
 	if shared.StringInSlice(migration.ZFSFeatureMigrationHeader, volTargetArgs.MigrationType.Features) {
 		// The source will send all of its snapshots with their respective GUID.
-		buf, err := ioutil.ReadAll(conn)
+		buf, err := io.ReadAll(conn)
 		if err != nil {
 			return fmt.Errorf("Failed reading ZFS migration header: %w", err)
 		}
@@ -1503,7 +1502,7 @@ func (d *zfs) GetVolumeDiskPath(vol Volume) (string, error) {
 	}
 
 	// List all the device nodes.
-	entries, err := ioutil.ReadDir("/dev")
+	entries, err := os.ReadDir("/dev")
 	if err != nil {
 		return "", fmt.Errorf("Failed to read /dev: %w", err)
 	}
@@ -1616,7 +1615,7 @@ func (d *zfs) ListVolumes() ([]Volume, error) {
 		return nil, fmt.Errorf("Unexpected duplicate volume %q found", volName)
 	}
 
-	errMsg, err := ioutil.ReadAll(stderr)
+	errMsg, err := io.ReadAll(stderr)
 	if err != nil {
 		return nil, err
 	}
@@ -1922,7 +1921,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 	var migrationHeader ZFSMetaDataHeader
 
 	if volSrcArgs.Refresh && shared.StringInSlice(migration.ZFSFeatureMigrationHeader, volSrcArgs.MigrationType.Features) {
-		buf, err := ioutil.ReadAll(conn)
+		buf, err := io.ReadAll(conn)
 		if err != nil {
 			return fmt.Errorf("Failed reading ZFS migration header: %w", err)
 		}
@@ -2078,7 +2077,7 @@ func (d *zfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 	defer revert.Fail()
 
 	poolPath := GetPoolMountPath(d.name)
-	tmpDir, err := ioutil.TempDir(poolPath, "backup.")
+	tmpDir, err := os.MkdirTemp(poolPath, "backup.")
 	if err != nil {
 		return "", nil, err
 	}
@@ -2183,7 +2182,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 
 		// Create temporary file to store output of ZFS send.
 		backupsPath := shared.VarPath("backups")
-		tmpFile, err := ioutil.TempFile(backupsPath, fmt.Sprintf("%s_zfs", backup.WorkingDirPrefix))
+		tmpFile, err := os.CreateTemp(backupsPath, fmt.Sprintf("%s_zfs", backup.WorkingDirPrefix))
 		if err != nil {
 			return fmt.Errorf("Failed to open temporary file for ZFS backup: %w", err)
 		}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,7 +97,7 @@ func genericVFSVolumeSnapshots(d Driver, vol Volume, op *operations.Operation) (
 	snapshotDir := GetVolumeSnapshotDir(d.Name(), vol.volType, vol.name)
 	snapshots := []string{}
 
-	ents, err := ioutil.ReadDir(snapshotDir)
+	ents, err := os.ReadDir(snapshotDir)
 	if err != nil {
 		// If the snapshots directory doesn't exist, there are no snapshots.
 		if os.IsNotExist(err) {
@@ -709,7 +708,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 				allowedCmds = append(allowedCmds, unpacker[0])
 			}
 
-			err = archive.ExtractWithFds("tar", args, allowedCmds, ioutil.NopCloser(r), sysOS, f)
+			err = archive.ExtractWithFds("tar", args, allowedCmds, io.NopCloser(r), sysOS, f)
 			if err != nil {
 				return fmt.Errorf("Error starting unpack: %w", err)
 			}
@@ -1074,7 +1073,7 @@ func genericVFSListVolumes(d Driver) ([]Volume, error) {
 		}
 
 		volTypePath := filepath.Join(poolMountPath, BaseDirectories[volType][0])
-		ents, err := ioutil.ReadDir(volTypePath)
+		ents, err := os.ReadDir(volTypePath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to list directory %q for volume type %q: %w", volTypePath, volType, err)
 		}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,7 +25,7 @@ const MinBlockBoundary = 8192
 // wipeDirectory empties the contents of a directory, but leaves it in place.
 func wipeDirectory(path string) error {
 	// List all entries.
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -629,7 +628,7 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 		}
 	} else {
 		// Dealing with unified tarballs require an initial unpack to a temporary directory.
-		tempDir, err := ioutil.TempDir(shared.VarPath("images"), "lxd_image_unpack_")
+		tempDir, err := os.MkdirTemp(shared.VarPath("images"), "lxd_image_unpack_")
 		if err != nil {
 			return -1, err
 		}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -1840,7 +1839,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 	defer revert.Fail()
 
 	// Create temporary file to store uploaded backup data.
-	backupFile, err := ioutil.TempFile(shared.VarPath("backups"), fmt.Sprintf("%s_", backup.WorkingDirPrefix))
+	backupFile, err := os.CreateTemp(shared.VarPath("backups"), fmt.Sprintf("%s_", backup.WorkingDirPrefix))
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -1870,7 +1869,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 		decomArgs := append(decomArgs, backupFile.Name())
 
 		// Create temporary file to store the decompressed tarball in.
-		tarFile, err := ioutil.TempFile(shared.VarPath("backups"), fmt.Sprintf("%s_decompress_", backup.WorkingDirPrefix))
+		tarFile, err := os.CreateTemp(shared.VarPath("backups"), fmt.Sprintf("%s_decompress_", backup.WorkingDirPrefix))
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/sys/apparmor.go
+++ b/lxd/sys/apparmor.go
@@ -3,7 +3,6 @@
 package sys
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -51,7 +50,7 @@ func (s *OS) initAppArmor() []cluster.Warning {
 
 	/* Detect existing AppArmor stack */
 	if shared.PathExists("/sys/kernel/security/apparmor/.ns_stacked") {
-		contentBytes, err := ioutil.ReadFile("/sys/kernel/security/apparmor/.ns_stacked")
+		contentBytes, err := os.ReadFile("/sys/kernel/security/apparmor/.ns_stacked")
 		if err == nil && string(contentBytes) == "yes\n" {
 			s.AppArmorStacked = true
 		}
@@ -103,7 +102,7 @@ func haveMacAdmin() bool {
 
 // Returns true if AppArmor stacking support is available.
 func appArmorCanStack() bool {
-	contentBytes, err := ioutil.ReadFile("/sys/kernel/security/apparmor/features/domain/stack")
+	contentBytes, err := os.ReadFile("/sys/kernel/security/apparmor/features/domain/stack")
 	if err != nil {
 		return false
 	}
@@ -112,7 +111,7 @@ func appArmorCanStack() bool {
 		return false
 	}
 
-	contentBytes, err = ioutil.ReadFile("/sys/kernel/security/apparmor/features/domain/version")
+	contentBytes, err = os.ReadFile("/sys/kernel/security/apparmor/features/domain/version")
 	if err != nil {
 		return false
 	}

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -3,7 +3,7 @@
 package sys
 
 import (
-	"io/ioutil"
+	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -214,7 +214,7 @@ func (s *OS) Init() ([]cluster.Warning, error) {
 	}
 
 	// Fill in the boot time.
-	out, err := ioutil.ReadFile("/proc/stat")
+	out, err := os.ReadFile("/proc/stat")
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/sys/testing.go
+++ b/lxd/sys/testing.go
@@ -3,7 +3,6 @@
 package sys
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,7 +13,7 @@ import (
 
 // NewTestOS returns a new OS instance initialized with test values.
 func NewTestOS(t *testing.T) (*OS, func()) {
-	dir, err := ioutil.TempDir("", "lxd-sys-os-test-")
+	dir, err := os.MkdirTemp("", "lxd-sys-os-test-")
 	require.NoError(t, err)
 	require.NoError(t, SetupTestCerts(dir))
 

--- a/lxd/template/chroot.go
+++ b/lxd/template/chroot.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -42,7 +42,7 @@ func (l ChrootLoader) Get(path string) (io.Reader, error) {
 	}
 
 	// Open and read the file
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/util/apparmor.go
+++ b/lxd/util/apparmor.go
@@ -1,13 +1,13 @@
 package util
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
 // AppArmorProfile returns the current apparmor profile.
 func AppArmorProfile() string {
-	contents, err := ioutil.ReadFile("/proc/self/attr/current")
+	contents, err := os.ReadFile("/proc/self/attr/current")
 	if err == nil {
 		return strings.TrimSpace(string(contents))
 	}

--- a/lxd/util/encryption.go
+++ b/lxd/util/encryption.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"golang.org/x/crypto/scrypt"
@@ -84,18 +84,18 @@ func LoadServerCert(dir string) (*shared.CertInfo, error) {
 // WriteCert writes the given material to the appropriate certificate files in
 // the given LXD var directory.
 func WriteCert(dir, prefix string, cert, key, ca []byte) error {
-	err := ioutil.WriteFile(filepath.Join(dir, prefix+".crt"), cert, 0644)
+	err := os.WriteFile(filepath.Join(dir, prefix+".crt"), cert, 0644)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(dir, prefix+".key"), key, 0600)
+	err = os.WriteFile(filepath.Join(dir, prefix+".key"), key, 0600)
 	if err != nil {
 		return err
 	}
 
 	if ca != nil {
-		err = ioutil.WriteFile(filepath.Join(dir, prefix+".ca"), ca, 0644)
+		err = os.WriteFile(filepath.Join(dir, prefix+".ca"), ca, 0644)
 		if err != nil {
 			return err
 		}

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
@@ -272,7 +272,7 @@ func IsWildCardAddress(address string) bool {
 // SysctlGet retrieves the value of a sysctl file in /proc/sys.
 func SysctlGet(path string) (string, error) {
 	// Read the current content
-	content, err := ioutil.ReadFile(fmt.Sprintf("/proc/sys/%s", path))
+	content, err := os.ReadFile(fmt.Sprintf("/proc/sys/%s", path))
 	if err != nil {
 		return "", err
 	}
@@ -299,7 +299,7 @@ func SysctlSet(parts ...string) error {
 			return nil
 		}
 
-		err = ioutil.WriteFile(fmt.Sprintf("/proc/sys/%s", path), []byte(newValue), 0)
+		err = os.WriteFile(fmt.Sprintf("/proc/sys/%s", path), []byte(newValue), 0)
 		if err != nil {
 			return err
 		}

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -75,7 +74,7 @@ func KeyPairAndCA(dir, prefix string, kind CertKind, addHosts bool) (*CertInfo, 
 	crlFilename := filepath.Join(dir, "ca.crl")
 	var crl *pkix.CertificateList
 	if PathExists(crlFilename) {
-		data, err := ioutil.ReadFile(crlFilename)
+		data, err := os.ReadFile(crlFilename)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +382,7 @@ func GenerateMemCert(client bool, addHosts bool) ([]byte, []byte, error) {
 }
 
 func ReadCert(fpath string) (*x509.Certificate, error) {
-	cf, err := ioutil.ReadFile(fpath)
+	cf, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/cert_test.go
+++ b/shared/cert_test.go
@@ -3,7 +3,6 @@ package shared_test
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 // A new key pair is generated if none exists and saved to the appropriate
 // files.
 func TestKeyPairAndCA(t *testing.T) {
-	dir, err := ioutil.TempDir("", "lxd-shared-test-")
+	dir, err := os.MkdirTemp("", "lxd-shared-test-")
 	if err != nil {
 		t.Errorf("failed to create temporary dir: %v", err)
 	}

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -4,7 +4,6 @@ package idmap
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"unsafe"
@@ -472,7 +471,7 @@ func shiftAclType(path string, aclType int, shiftIds func(uid int64, gid int64) 
 }
 
 func SupportsVFS3Fscaps(prefix string) bool {
-	tmpfile, err := ioutil.TempFile(prefix, ".lxd_fcaps_v3_")
+	tmpfile, err := os.CreateTemp(prefix, ".lxd_fcaps_v3_")
 	if err != nil {
 		return false
 	}

--- a/shared/logger/log.go
+++ b/shared/logger/log.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -14,7 +13,7 @@ import (
 // Setup a basic empty logger on init.
 func init() {
 	logger := logrus.New()
-	logger.SetOutput(ioutil.Discard)
+	logger.SetOutput(io.Discard)
 
 	Log = newWrapper(logger)
 }

--- a/shared/network.go
+++ b/shared/network.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -121,7 +120,7 @@ func GetTLSConfig(tlsClientCertFile string, tlsClientKeyFile string, tlsClientCA
 	}
 
 	if tlsClientCAFile != "" {
-		caCertificates, err := ioutil.ReadFile(tlsClientCAFile)
+		caCertificates, err := os.ReadFile(tlsClientCAFile)
 		if err != nil {
 			return nil, err
 		}
@@ -230,7 +229,7 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 				break
 			}
 
-			buf, err := ioutil.ReadAll(r)
+			buf, err := io.ReadAll(r)
 			if err != nil {
 				logger.Debug("WebsocketRecvStream got error writing to writer", logger.Ctx{"err": err})
 				break
@@ -351,7 +350,7 @@ func DefaultWriter(conn *websocket.Conn, w io.WriteCloser, writeDone chan<- bool
 			break
 		}
 
-		buf, err := ioutil.ReadAll(r)
+		buf, err := io.ReadAll(r)
 		if err != nil {
 			logger.Debug("DefaultWriter got error writing to writer", logger.Ctx{"err": err})
 			break

--- a/shared/network_unix.go
+++ b/shared/network_unix.go
@@ -4,7 +4,7 @@ package shared
 
 import (
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 )
 
 func systemCertPool() (*x509.CertPool, error) {
@@ -16,7 +16,7 @@ func systemCertPool() (*x509.CertPool, error) {
 
 	// Attempt to load the system's pool too (for snaps)
 	if PathExists("/var/lib/snapd/hostfs/etc/ssl/certs/ca-certificates.crt") {
-		snapCerts, err := ioutil.ReadFile("/var/lib/snapd/hostfs/etc/ssl/certs/ca-certificates.crt")
+		snapCerts, err := os.ReadFile("/var/lib/snapd/hostfs/etc/ssl/certs/ca-certificates.crt")
 		if err == nil {
 			pool.AppendCertsFromPEM(snapCerts)
 		}

--- a/shared/osarch/release.go
+++ b/shared/osarch/release.go
@@ -2,7 +2,6 @@ package osarch
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -20,7 +19,7 @@ func GetLSBRelease() (map[string]string, error) {
 func getLSBRelease(filename string) (map[string]string, error) {
 	osRelease := make(map[string]string)
 
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return osRelease, nil

--- a/shared/osarch/tempfile_test.go
+++ b/shared/osarch/tempfile_test.go
@@ -1,7 +1,6 @@
 package osarch
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/stretchr/testify/suite"
@@ -9,7 +8,7 @@ import (
 
 // WriteTempFile writes content to a temporary file.
 func WriteTempFile(s *suite.Suite, dir string, prefix string, content string) (string, func()) {
-	f, err := ioutil.TempFile(dir, prefix)
+	f, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		s.T().Errorf("Failed to create temporary file: %v", err)
 	}

--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -3,7 +3,7 @@ package simplestreams
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -76,7 +76,7 @@ func (s *SimpleStreams) readCache(path string) ([]byte, bool) {
 		return nil, false
 	}
 
-	body, err := ioutil.ReadFile(cacheName)
+	body, err := os.ReadFile(cacheName)
 	if err != nil {
 		_ = os.Remove(cacheName)
 		return nil, false
@@ -133,7 +133,7 @@ func (s *SimpleStreams) cachedDownload(path string) ([]byte, error) {
 		return nil, fmt.Errorf("Unable to fetch %s: %s", uri, r.Status)
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (s *SimpleStreams) cachedDownload(path string) ([]byte, error) {
 	if s.cachePath != "" {
 		cacheName := filepath.Join(s.cachePath, fileName)
 		_ = os.Remove(cacheName)
-		_ = ioutil.WriteFile(cacheName, body, 0644)
+		_ = os.WriteFile(cacheName, body, 0644)
 	}
 
 	return body, nil

--- a/shared/subprocess/manager.go
+++ b/shared/subprocess/manager.go
@@ -5,7 +5,6 @@ package subprocess
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/yaml.v2"
@@ -53,7 +52,7 @@ func NewProcessWithFds(name string, args []string, stdin io.ReadCloser, stdout i
 
 // ImportProcess imports a saved process into a subprocess object.
 func ImportProcess(path string) (*Process, error) {
-	dat, err := ioutil.ReadFile(path)
+	dat, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to read PID file %q: %w", path, err)
 	}

--- a/shared/subprocess/proc.go
+++ b/shared/subprocess/proc.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -228,7 +227,7 @@ func (p *Process) Save(path string) error {
 		return fmt.Errorf("Unable to serialize process struct to YAML: %w", err)
 	}
 
-	err = ioutil.WriteFile(path, dat, 0644)
+	err = os.WriteFile(path, dat, 0644)
 	if err != nil {
 		return fmt.Errorf("Unable to write to file '%s': %w", path, err)
 	}

--- a/shared/util.go
+++ b/shared/util.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -519,7 +518,7 @@ func DirCopy(source string, dest string) error {
 	}
 
 	// Copy all files.
-	entries, err := ioutil.ReadDir(source)
+	entries, err := os.ReadDir(source)
 	if err != nil {
 		return fmt.Errorf("failed to read source directory %s: %w", source, err)
 	}
@@ -809,7 +808,7 @@ func TextEditor(inPath string, inContent []byte) ([]byte, error) {
 
 	if inPath == "" {
 		// If provided input, create a new file
-		f, err = ioutil.TempFile("", "lxd_editor_")
+		f, err = os.CreateTemp("", "lxd_editor_")
 		if err != nil {
 			return []byte{}, err
 		}
@@ -858,7 +857,7 @@ func TextEditor(inPath string, inContent []byte) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/shared/util_linux_test.go
+++ b/shared/util_linux_test.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ func TestGetAllXattr(t *testing.T) {
 			"user.empty":    "",
 		}
 	)
-	xattrFile, err := ioutil.TempFile("", "")
+	xattrFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Error(err)
 		return
@@ -26,7 +25,7 @@ func TestGetAllXattr(t *testing.T) {
 	defer func() { _ = os.Remove(xattrFile.Name()) }()
 	_ = xattrFile.Close()
 
-	xattrDir, err := ioutil.TempDir("", "")
+	xattrDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Error(err)
 		return

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +42,7 @@ func TestUrlsJoin(t *testing.T) {
 
 func TestFileCopy(t *testing.T) {
 	helloWorld := []byte("hello world\n")
-	source, err := ioutil.TempFile("", "")
+	source, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Error(err)
 		return
@@ -59,7 +59,7 @@ func TestFileCopy(t *testing.T) {
 
 	_ = source.Close()
 
-	dest, err := ioutil.TempFile("", "")
+	dest, err := os.CreateTemp("", "")
 	defer func() { _ = os.Remove(dest.Name()) }()
 	if err != nil {
 		t.Error(err)
@@ -80,7 +80,7 @@ func TestFileCopy(t *testing.T) {
 		return
 	}
 
-	content, err := ioutil.ReadAll(dest2)
+	content, err := io.ReadAll(dest2)
 	if err != nil {
 		t.Error(err)
 		return
@@ -93,7 +93,7 @@ func TestFileCopy(t *testing.T) {
 }
 
 func TestDirCopy(t *testing.T) {
-	dir, err := ioutil.TempDir("", "lxd-shared-util-")
+	dir, err := os.MkdirTemp("", "lxd-shared-util-")
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(dir) }()
 
@@ -112,8 +112,8 @@ func TestDirCopy(t *testing.T) {
 	require.NoError(t, os.Mkdir(source, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(source, dir1), 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(source, dir2), 0755))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(source, file1), content1, 0755))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(source, file2), content2, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(source, file1), content1, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(source, file2), content2, 0755))
 
 	require.NoError(t, DirCopy(source, dest))
 
@@ -121,11 +121,11 @@ func TestDirCopy(t *testing.T) {
 		assert.True(t, PathExists(filepath.Join(dest, path)))
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join(dest, file1))
+	bytes, err := os.ReadFile(filepath.Join(dest, file1))
 	require.NoError(t, err)
 	assert.Equal(t, content1, bytes)
 
-	bytes, err = ioutil.ReadFile(filepath.Join(dest, file2))
+	bytes, err = os.ReadFile(filepath.Join(dest, file2))
 	require.NoError(t, err)
 	assert.Equal(t, content2, bytes)
 }

--- a/shared/version/platform_linux.go
+++ b/shared/version/platform_linux.go
@@ -3,7 +3,7 @@
 package version
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/lxc/lxd/shared"
@@ -34,7 +34,7 @@ func getPlatformVersionStrings() []string {
 
 	// Add chromebook info
 	if len(versions) == 1 && shared.PathExists("/run/cros_milestone") {
-		content, err := ioutil.ReadFile("/run/cros_milestone")
+		content, err := os.ReadFile("/run/cros_milestone")
 		if err == nil {
 			versions = append(versions, "Chrome OS")
 			versions = append(versions, strings.TrimSpace(string(content)))

--- a/test/devlxd-client/devlxd-client.go
+++ b/test/devlxd-client/devlxd-client.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -162,7 +162,7 @@ func main() {
 
 	if raw.StatusCode != http.StatusOK {
 		fmt.Println("http error", raw.StatusCode)
-		result, err := ioutil.ReadAll(raw.Body)
+		result, err := io.ReadAll(raw.Body)
 		if err != nil {
 			os.Exit(1)
 		}
@@ -210,7 +210,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		value, err := ioutil.ReadAll(raw.Body)
+		value, err := io.ReadAll(raw.Body)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/test/macaroon-identity/auth.go
+++ b/test/macaroon-identity/auth.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -99,7 +99,7 @@ func (s *authService) formHandler(w http.ResponseWriter, req *http.Request) {
 	case "GET":
 		_ = writeJSON(w, http.StatusOK, schemaResponse)
 	case "POST":
-		content, err := ioutil.ReadAll(req.Body)
+		content, err := io.ReadAll(req.Body)
 		if err != nil {
 			s.bakeryFail(w, "failed to read request: %v", err)
 			return


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir