### PR TITLE
scripts/bash/lxd-client: Add missing network sub-commands

### DIFF
--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -260,11 +260,11 @@ _have lxc && {
       "network")
         case $pos in
           2)
-            COMPREPLY=( $(compgen -W "list show create get set unset delete edit rename attach attach-profile detach detach-profile info" -- $cur) )
+            COMPREPLY=( $(compgen -W "list show create get set unset delete edit rename attach attach-profile detach detach-profile info acl forward list-leases load-balancer peer zone" -- $cur) )
             ;;
           3)
             case ${no_dashargs[2]} in
-              "show"|"get"|"set"|"unset"|"delete"|"edit"|"rename"|"attach"|"attach-profile"|"detach"|"detach-profile"|"info")
+              "show"|"get"|"set"|"unset"|"delete"|"edit"|"rename"|"attach"|"attach-profile"|"detach"|"detach-profile"|"info"|"acl"|"forward"|"list-leases"|"load-balancer"|"peer"|"zone")
                 _lxd_networks
                 ;;
             esac


### PR DESCRIPTION
Fixes https://github.com/lxc/lxd-pkg-snap/issues/107

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>