### PR TITLE
lxd-agent: Fix filesystem metrics

### DIFF
--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -275,9 +275,8 @@ func getFilesystemMetrics(d *Daemon) (map[string]metrics.FilesystemMetrics, erro
 			stats.FSType = fsType
 		}
 
-		stats.SizeBytes = statfs.Blocks * uint64(statfs.Bsize)
-		stats.SizeBytes = statfs.Blocks * uint64(statfs.Bsize)
-		stats.SizeBytes = statfs.Blocks * uint64(statfs.Bsize)
+		stats.AvailableBytes = statfs.Bavail * uint64(statfs.Bsize)
+		stats.FreeBytes = statfs.Bfree * uint64(statfs.Bsize)
 		stats.SizeBytes = statfs.Blocks * uint64(statfs.Bsize)
 
 		out[fields[0]] = stats


### PR DESCRIPTION
This fixes an issue where available bytes and free bytes would always be
0.

This fixes #10994.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
