### PR TITLE
LXD: Remove use of node.ClusterAddress helper

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -685,6 +685,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	// Update the daemon config.
 	d.globalConfigMu.Lock()
 	d.globalConfig = newClusterConfig
+	d.localConfig = newNodeConfig
 	d.globalConfigMu.Unlock()
 
 	// Run any update triggers.

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1745,10 +1745,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	// Redirect all requests to the leader, which is the one with
 	// knowing what nodes are part of the raft cluster.
-	localAddress, err := node.ClusterAddress(d.db.Node)
-	if err != nil {
-		return response.SmartError(err)
-	}
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	leader, err := d.gateway.LeaderAddress()
 	if err != nil {
@@ -1757,9 +1754,9 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	var localInfo, leaderInfo db.NodeInfo
 	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		localInfo, err = tx.GetNodeByAddress(ctx, localAddress)
+		localInfo, err = tx.GetNodeByAddress(ctx, localClusterAddress)
 		if err != nil {
-			return fmt.Errorf("Failed loading local member info %q: %w", localAddress, err)
+			return fmt.Errorf("Failed loading local member info %q: %w", localClusterAddress, err)
 		}
 
 		leaderInfo, err = tx.GetNodeByAddress(ctx, leader)
@@ -1784,7 +1781,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Unable to get raft nodes: %w", err))
 	}
 
-	if localAddress != leader {
+	if localClusterAddress != leader {
 		if localInfo.Name == name {
 			// If the member being removed is ourselves and we are not the leader, then lock the
 			// clusterPutDisableMu before we forward the request to the leader, so that when the leader
@@ -1939,7 +1936,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// If this leader node removed itself, just disable clustering.
-	if address == localAddress {
+	if address == localClusterAddress {
 		return clusterPutDisable(d, r, api.ClusterPut{})
 	} else if force != 1 {
 		// Try to gracefully reset the database on the node.
@@ -2032,13 +2029,10 @@ func clusterCertificatePut(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		localAddress, err := node.ClusterAddress(d.db.Node)
-		if err != nil {
-			return response.SmartError(err)
-		}
+		localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 		for _, server := range servers {
-			if server.Address == localAddress {
+			if server.Address == localClusterAddress {
 				continue
 			}
 
@@ -2093,17 +2087,14 @@ func internalClusterPostAccept(d *Daemon, r *http.Request) response.Response {
 
 	// Redirect all requests to the leader, which is the one with
 	// knowning what nodes are part of the raft cluster.
-	address, err := node.ClusterAddress(d.db.Node)
-	if err != nil {
-		return response.SmartError(err)
-	}
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	leader, err := d.gateway.LeaderAddress()
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	if address != leader {
+	if localClusterAddress != leader {
 		logger.Debugf("Redirect member accept request to %s", leader)
 
 		if leader == "" {
@@ -2190,17 +2181,14 @@ type internalRaftNode struct {
 func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response {
 	// Redirect all requests to the leader, which is the one with with
 	// up-to-date knowledge of what nodes are part of the raft cluster.
-	localAddress, err := node.ClusterAddress(d.db.Node)
-	if err != nil {
-		return response.SmartError(err)
-	}
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	leader, err := d.gateway.LeaderAddress()
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	if localAddress != leader {
+	if localClusterAddress != leader {
 		logger.Debugf("Redirect cluster rebalance request to %s", leader)
 		url := &url.URL{
 			Scheme: "https",
@@ -2335,16 +2323,13 @@ func handoverMemberRole(d *Daemon) error {
 	}
 
 	// Figure out our own cluster address.
-	address, err := node.ClusterAddress(d.db.Node)
-	if err != nil {
-		return err
-	}
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	post := &internalClusterPostHandoverRequest{
-		Address: address,
+		Address: localClusterAddress,
 	}
 
-	logCtx := logger.Ctx{"address": address}
+	logCtx := logger.Ctx{"address": localClusterAddress}
 
 	// Find the cluster leader.
 findLeader:
@@ -2357,7 +2342,7 @@ findLeader:
 		return fmt.Errorf("No leader address found")
 	}
 
-	if leader == address {
+	if leader == localClusterAddress {
 		logger.Info("Transferring leadership", logCtx)
 		err := d.gateway.TransferLeadership()
 		if err != nil {
@@ -2436,10 +2421,7 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 
 	// Redirect all requests to the leader, which is the one with
 	// authoritative knowledge of the current raft configuration.
-	address, err := node.ClusterAddress(d.db.Node)
-	if err != nil {
-		return response.SmartError(err)
-	}
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	leader, err := d.gateway.LeaderAddress()
 	if err != nil {
@@ -2450,7 +2432,7 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("No leader address found"))
 	}
 
-	if address != leader {
+	if localClusterAddress != leader {
 		logger.Debugf("Redirect handover request to %s", leader)
 		url := &url.URL{
 			Scheme: "https",
@@ -2476,7 +2458,7 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 		goto out
 	}
 
-	logger.Info("Promoting member during handover", logger.Ctx{"address": address, "losingAddress": req.Address, "candidateAddress": target})
+	logger.Info("Promoting member during handover", logger.Ctx{"address": localClusterAddress, "losingAddress": req.Address, "candidateAddress": target})
 	err = changeMemberRole(d, r, target, nodes)
 	if err != nil {
 		return response.SmartError(err)
@@ -2489,7 +2471,7 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	logger.Info("Demoting member during handover", logger.Ctx{"address": address, "losingAddress": req.Address})
+	logger.Info("Demoting member during handover", logger.Ctx{"address": localClusterAddress, "losingAddress": req.Address})
 	err = changeMemberRole(d, r, req.Address, nodes)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -183,7 +183,7 @@ func TestGateway_RaftNodesNotLeader(t *testing.T) {
 func newGateway(t *testing.T, node *db.Node, networkCert *shared.CertInfo, serverCert *shared.CertInfo) *cluster.Gateway {
 	require.NoError(t, os.Mkdir(filepath.Join(node.Dir(), "global"), 0755))
 	serverCertFunc := func() *shared.CertInfo { return serverCert }
-	gateway, err := cluster.NewGateway(context.Background(), node, networkCert, serverCertFunc, cluster.Latency(0.2), cluster.LogLevel("TRACE"))
+	gateway, err := cluster.NewGateway(context.Background(), node, networkCert, serverCertFunc, nil, cluster.Latency(0.2), cluster.LogLevel("TRACE"))
 	require.NoError(t, err)
 	return gateway
 }

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/lxd/db/warningtype"
-	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/lxd/warnings"
@@ -320,10 +319,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	}
 
 	// Address of this node.
-	localAddress, err := node.ClusterAddress(g.db)
-	if err != nil {
-		logger.Error("Failed to fetch local cluster address", logger.Ctx{"err": err})
-	}
+	localClusterAddress := g.state().LocalConfig.ClusterAddress()
 
 	var allNodes []db.NodeInfo
 	err = g.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -350,10 +346,10 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 
 	if mode != hearbeatNormal {
 		// Log unscheduled heartbeats with a higher level than normal heartbeats.
-		logger.Info("Starting heartbeat round", logger.Ctx{"mode": modeStr, "local": localAddress})
+		logger.Info("Starting heartbeat round", logger.Ctx{"mode": modeStr, "local": localClusterAddress})
 	} else {
 		// Don't spam the normal log with regular heartbeat messages.
-		logger.Debug("Starting heartbeat round", logger.Ctx{"mode": modeStr, "local": localAddress})
+		logger.Debug("Starting heartbeat round", logger.Ctx{"mode": modeStr, "local": localClusterAddress})
 	}
 
 	// Replace the local raft_nodes table immediately because it
@@ -365,11 +361,11 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		return tx.ReplaceRaftNodes(raftNodes)
 	})
 	if err != nil {
-		logger.Warn("Failed to replace local raft members", logger.Ctx{"err": err, "mode": modeStr, "local": localAddress})
+		logger.Warn("Failed to replace local raft members", logger.Ctx{"err": err, "mode": modeStr, "local": localClusterAddress})
 		return
 	}
 
-	if localAddress == "" {
+	if localClusterAddress == "" {
 		logger.Error("No local address set, aborting heartbeat round", logger.Ctx{"mode": modeStr})
 		return
 	}
@@ -393,14 +389,14 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	// Send stale set to all nodes in database to get a fresh set of active nodes.
 	if mode == hearbeatInitial {
 		hbState.Update(false, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
-		hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, allNodes, spreadDuration)
+		hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, allNodes, spreadDuration)
 
 		// We have the latest set of node states now, lets send that state set to all nodes.
 		hbState.FullStateList = true
-		hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, allNodes, spreadDuration)
+		hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, allNodes, spreadDuration)
 	} else {
 		hbState.Update(true, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
-		hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, allNodes, spreadDuration)
+		hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, allNodes, spreadDuration)
 	}
 
 	// Check if context has been cancelled.
@@ -419,7 +415,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 			return nil
 		})
 		if err != nil {
-			logger.Warn("Failed to get current cluster members", logger.Ctx{"err": err, "mode": modeStr, "local": localAddress})
+			logger.Warn("Failed to get current cluster members", logger.Ctx{"err": err, "mode": modeStr, "local": localClusterAddress})
 			return
 		}
 
@@ -443,7 +439,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		// If any new nodes found, send heartbeat to just them (with full node state).
 		if len(newNodes) > 0 {
 			hbState.Update(true, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
-			hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, newNodes, 0)
+			hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, newNodes, 0)
 		}
 	}
 
@@ -483,7 +479,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 
 	// If the context has been cancelled, return prematurely after saving the members we did manage to ping.
 	if ctxErr != nil {
-		logger.Warn("Aborting heartbeat round", logger.Ctx{"err": ctxErr, "mode": modeStr, "local": localAddress})
+		logger.Warn("Aborting heartbeat round", logger.Ctx{"err": ctxErr, "mode": modeStr, "local": localClusterAddress})
 		return
 	}
 
@@ -499,10 +495,10 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 
 	if mode != hearbeatNormal {
 		// Log unscheduled heartbeats with a higher level than normal heartbeats.
-		logger.Info("Completed heartbeat round", logger.Ctx{"duration": duration, "local": localAddress})
+		logger.Info("Completed heartbeat round", logger.Ctx{"duration": duration, "local": localClusterAddress})
 	} else {
 		// Don't spam the normal log with regular heartbeat messages.
-		logger.Debug("Completed heartbeat round", logger.Ctx{"duration": duration, "local": localAddress})
+		logger.Debug("Completed heartbeat round", logger.Ctx{"duration": duration, "local": localClusterAddress})
 	}
 }
 

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -384,19 +384,21 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		spreadDuration = heartbeatInterval
 	}
 
+	serverCert := g.state().ServerCert()
+
 	// If this leader node hasn't sent a heartbeat recently, then its node state records
 	// are likely out of date, this can happen when a node becomes a leader.
 	// Send stale set to all nodes in database to get a fresh set of active nodes.
 	if mode == hearbeatInitial {
 		hbState.Update(false, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
-		hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, allNodes, spreadDuration)
+		hbState.Send(ctx, g.networkCert, serverCert, localClusterAddress, allNodes, spreadDuration)
 
 		// We have the latest set of node states now, lets send that state set to all nodes.
 		hbState.FullStateList = true
-		hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, allNodes, spreadDuration)
+		hbState.Send(ctx, g.networkCert, serverCert, localClusterAddress, allNodes, spreadDuration)
 	} else {
 		hbState.Update(true, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
-		hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, allNodes, spreadDuration)
+		hbState.Send(ctx, g.networkCert, serverCert, localClusterAddress, allNodes, spreadDuration)
 	}
 
 	// Check if context has been cancelled.
@@ -439,7 +441,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		// If any new nodes found, send heartbeat to just them (with full node state).
 		if len(newNodes) > 0 {
 			hbState.Update(true, raftNodes, allNodes, g.HeartbeatOfflineThreshold)
-			hbState.Send(ctx, g.networkCert, g.serverCert(), localClusterAddress, newNodes, 0)
+			hbState.Send(ctx, g.networkCert, serverCert, localClusterAddress, newNodes, 0)
 		}
 	}
 

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -665,14 +665,11 @@ func Rebalance(state *state.State, gateway *Gateway, unavailableMembers []string
 		return "", nodes, nil
 	}
 
-	address, err := node.ClusterAddress(state.DB.Node)
-	if err != nil {
-		return "", nil, err
-	}
+	localClusterAddress := state.LocalConfig.ClusterAddress()
 
 	// Check if we have a spare node that we can promote to the missing role.
 	candidateAddress := candidates[0].Address
-	logger.Info("Found cluster member whose role needs to be changed", logger.Ctx{"candidateAddress": candidateAddress, "newRole": role, "local": address})
+	logger.Info("Found cluster member whose role needs to be changed", logger.Ctx{"candidateAddress": candidateAddress, "newRole": role, "local": localClusterAddress})
 
 	for i, node := range nodes {
 		if node.Address == candidateAddress {

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -1012,7 +1012,7 @@ func newRolesChanges(state *state.State, gateway *Gateway, nodes []db.RaftNode, 
 	cluster := map[client.NodeInfo]*client.NodeMetadata{}
 
 	for _, node := range nodes {
-		if !shared.StringInSlice(node.Address, unavailableMembers) && HasConnectivity(gateway.networkCert, gateway.serverCert(), node.Address) {
+		if !shared.StringInSlice(node.Address, unavailableMembers) && HasConnectivity(gateway.networkCert, gateway.state().ServerCert(), node.Address) {
 			cluster[node.NodeInfo] = &client.NodeMetadata{
 				FailureDomain: domains[node.Address],
 			}

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -74,7 +74,8 @@ func TestBootstrap_UnmetPreconditions(t *testing.T) {
 
 			serverCert := shared.TestingKeyPair()
 			state.ServerCert = func() *shared.CertInfo { return serverCert }
-			gateway := newGateway(t, state.DB.Node, serverCert, serverCert)
+
+			gateway := newGateway(t, state.DB.Node, serverCert, state)
 			defer func() { _ = gateway.Shutdown() }()
 
 			err := cluster.Bootstrap(state, gateway, "buzz")
@@ -88,8 +89,9 @@ func TestBootstrap(t *testing.T) {
 	defer cleanup()
 
 	serverCert := shared.TestingKeyPair()
-	gateway := newGateway(t, state.DB.Node, serverCert, serverCert)
 	state.ServerCert = func() *shared.CertInfo { return serverCert }
+
+	gateway := newGateway(t, state.DB.Node, serverCert, state)
 	defer func() { _ = gateway.Shutdown() }()
 
 	mux := http.NewServeMux()
@@ -212,7 +214,9 @@ func TestAccept_UnmetPreconditions(t *testing.T) {
 			defer cleanup()
 
 			serverCert := shared.TestingKeyPair()
-			gateway := newGateway(t, state.DB.Node, serverCert, serverCert)
+			state.ServerCert = func() *shared.CertInfo { return serverCert }
+
+			gateway := newGateway(t, state.DB.Node, serverCert, state)
 			defer func() { _ = gateway.Shutdown() }()
 
 			c.setup(&membershipFixtures{t: t, state: state})
@@ -229,7 +233,9 @@ func TestAccept(t *testing.T) {
 	defer cleanup()
 
 	serverCert := shared.TestingKeyPair()
-	gateway := newGateway(t, state.DB.Node, serverCert, serverCert)
+	state.ServerCert = func() *shared.CertInfo { return serverCert }
+
+	gateway := newGateway(t, state.DB.Node, serverCert, state)
 	defer func() { _ = gateway.Shutdown() }()
 
 	f := &membershipFixtures{t: t, state: state}
@@ -274,7 +280,9 @@ func TestJoin(t *testing.T) {
 	targetState, cleanup := state.NewTestState(t)
 	defer cleanup()
 
-	targetGateway := newGateway(t, targetState.DB.Node, targetCert, targetCert)
+	targetState.ServerCert = func() *shared.CertInfo { return targetCert }
+
+	targetGateway := newGateway(t, targetState.DB.Node, targetCert, targetState)
 	defer func() { _ = targetGateway.Shutdown() }()
 
 	altServerCert := shared.TestingAltKeyPair()
@@ -339,7 +347,9 @@ func TestJoin(t *testing.T) {
 	state, cleanup := state.NewTestState(t)
 	defer cleanup()
 
-	gateway := newGateway(t, state.DB.Node, targetCert, altServerCert)
+	state.ServerCert = func() *shared.CertInfo { return altServerCert }
+
+	gateway := newGateway(t, state.DB.Node, targetCert, state)
 
 	defer func() { _ = gateway.Shutdown() }()
 

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -31,6 +31,17 @@ func TestNewNotifier(t *testing.T) {
 	f := notifyFixtures{t: t, state: state}
 	defer f.Nodes(cert, 3)()
 
+	// Populate state.LocalConfig after nodes created above.
+	var err error
+	var nodeConfig *node.Config
+	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		nodeConfig, err = node.ConfigLoad(ctx, tx)
+		return err
+	})
+	require.NoError(t, err)
+
+	state.LocalConfig = nodeConfig
+
 	notifier, err := cluster.NewNotifier(state, cert, cert, cluster.NotifyAll)
 	require.NoError(t, err)
 
@@ -69,6 +80,18 @@ func TestNewNotify_NotifyAllError(t *testing.T) {
 	defer f.Nodes(cert, 3)()
 
 	f.Down(1)
+
+	// Populate state.LocalConfig after nodes created above.
+	var err error
+	var nodeConfig *node.Config
+	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		nodeConfig, err = node.ConfigLoad(ctx, tx)
+		return err
+	})
+	require.NoError(t, err)
+
+	state.LocalConfig = nodeConfig
+
 	notifier, err := cluster.NewNotifier(state, cert, cert, cluster.NotifyAll)
 	assert.Nil(t, notifier)
 	require.Error(t, err)
@@ -87,6 +110,18 @@ func TestNewNotify_NotifyAlive(t *testing.T) {
 	defer f.Nodes(cert, 3)()
 
 	f.Down(1)
+
+	// Populate state.LocalConfig after nodes created above.
+	var err error
+	var nodeConfig *node.Config
+	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		nodeConfig, err = node.ConfigLoad(ctx, tx)
+		return err
+	})
+	require.NoError(t, err)
+
+	state.LocalConfig = nodeConfig
+
 	notifier, err := cluster.NewNotifier(state, cert, cert, cluster.NotifyAlive)
 	assert.NoError(t, err)
 

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	clusterDB "github.com/lxc/lxd/lxd/db/cluster"
+	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 )
@@ -41,8 +42,20 @@ func TestNotifyUpgradeCompleted(t *testing.T) {
 	}()
 
 	state0 := f.State(gateway0)
+
+	// Populate state.LocalConfig after nodes created above.
+	var err error
+	var nodeConfig *node.Config
+	err = state0.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		nodeConfig, err = node.ConfigLoad(ctx, tx)
+		return err
+	})
+	require.NoError(t, err)
+
+	state0.LocalConfig = nodeConfig
+
 	serverCert0 := gateway0.ServerCert()
-	err := cluster.NotifyUpgradeCompleted(state0, serverCert0, serverCert0)
+	err = cluster.NotifyUpgradeCompleted(state0, serverCert0, serverCert0)
 	require.NoError(t, err)
 
 	wg.Wait()

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -153,7 +153,9 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 	address := server.Listener.Addr().String()
 	setRaftRole(t, state.DB.Node, address)
 
-	gateway := newGateway(t, state.DB.Node, serverCert, serverCert)
+	state.ServerCert = func() *shared.CertInfo { return serverCert }
+
+	gateway := newGateway(t, state.DB.Node, serverCert, state)
 	defer func() { _ = gateway.Shutdown() }()
 
 	trustedCerts := func() map[clusterDB.CertificateType]map[string]x509.Certificate {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1080,6 +1080,7 @@ func (d *Daemon) init() error {
 		d.db.Node,
 		networkCert,
 		d.serverCert,
+		d.State,
 		cluster.Latency(d.config.RaftLatency),
 		cluster.LogLevel(clusterLogLevel))
 	if err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1079,7 +1079,6 @@ func (d *Daemon) init() error {
 		d.shutdownCtx,
 		d.db.Node,
 		networkCert,
-		d.serverCert,
 		d.State,
 		cluster.Latency(d.config.RaftLatency),
 		cluster.LogLevel(clusterLogLevel))

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2093,7 +2093,7 @@ func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLead
 		return
 	}
 
-	localAddress, _ := node.ClusterAddress(d.db.Node)
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	if hbData.FullStateList {
 		// If there is an ongoing heartbeat round (and by implication this is the leader), then this could
@@ -2114,7 +2114,7 @@ func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLead
 			return
 		}
 
-		logger.Info("Partial heartbeat received", logger.Ctx{"local": localAddress})
+		logger.Info("Partial heartbeat received", logger.Ctx{"local": localClusterAddress})
 	}
 }
 
@@ -2132,10 +2132,10 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		return
 	}
 
-	localAddress, _ := node.ClusterAddress(d.db.Node)
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	if !heartbeatData.FullStateList || len(heartbeatData.Members) <= 0 {
-		logger.Error("Heartbeat member refresh task called with partial state list", logger.Ctx{"local": localAddress})
+		logger.Error("Heartbeat member refresh task called with partial state list", logger.Ctx{"local": localClusterAddress})
 		return
 	}
 
@@ -2151,14 +2151,14 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 	stateChangeTaskFailure := false // Records whether any of the state change tasks failed.
 
 	// Handle potential OVN chassis changes.
-	err := networkUpdateOVNChassis(s, heartbeatData, localAddress)
+	err := networkUpdateOVNChassis(s, heartbeatData, localClusterAddress)
 	if err != nil {
 		stateChangeTaskFailure = true
 		logger.Error("Error restarting OVN networks", logger.Ctx{"err": err})
 	}
 
 	if d.hasMemberStateChanged(heartbeatData) {
-		logger.Info("Cluster member state has changed", logger.Ctx{"local": localAddress})
+		logger.Info("Cluster member state has changed", logger.Ctx{"local": localClusterAddress})
 
 		// Refresh cluster certificates cached.
 		updateCertificateCache(d)
@@ -2167,7 +2167,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		err := networkUpdateForkdnsServersTask(s, heartbeatData)
 		if err != nil {
 			stateChangeTaskFailure = true
-			logger.Error("Error refreshing forkdns", logger.Ctx{"err": err, "local": localAddress})
+			logger.Error("Error refreshing forkdns", logger.Ctx{"err": err, "local": localClusterAddress})
 		}
 	}
 
@@ -2223,10 +2223,10 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		// can upgrade some member.
 		if isDegraded || onlineVoters < int(maxVoters) || onlineStandbys < int(maxStandBy) {
 			d.clusterMembershipMutex.Lock()
-			logger.Debug("Rebalancing member roles in heartbeat", logger.Ctx{"local": localAddress})
+			logger.Debug("Rebalancing member roles in heartbeat", logger.Ctx{"local": localClusterAddress})
 			err := rebalanceMemberRoles(d, nil, unavailableMembers)
 			if err != nil && !errors.Is(err, cluster.ErrNotLeader) {
-				logger.Warn("Could not rebalance cluster member roles", logger.Ctx{"err": err, "local": localAddress})
+				logger.Warn("Could not rebalance cluster member roles", logger.Ctx{"err": err, "local": localClusterAddress})
 			}
 
 			d.clusterMembershipMutex.Unlock()
@@ -2234,10 +2234,10 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 
 		if hasNodesNotPartOfRaft {
 			d.clusterMembershipMutex.Lock()
-			logger.Debug("Upgrading members without raft role in heartbeat", logger.Ctx{"local": localAddress})
+			logger.Debug("Upgrading members without raft role in heartbeat", logger.Ctx{"local": localClusterAddress})
 			err := upgradeNodesWithoutRaftRole(d)
 			if err != nil && !errors.Is(err, cluster.ErrNotLeader) {
-				logger.Warn("Failed upgrading raft roles:", logger.Ctx{"err": err, "local": localAddress})
+				logger.Warn("Failed upgrading raft roles:", logger.Ctx{"err": err, "local": localClusterAddress})
 			}
 
 			d.clusterMembershipMutex.Unlock()

--- a/lxd/endpoints/cluster.go
+++ b/lxd/endpoints/cluster.go
@@ -12,8 +12,8 @@ import (
 )
 
 // ClusterAddress returns the cluster address of the cluster endpoint, or an
-// empty string if there's no cluster endpoint.
-func (e *Endpoints) ClusterAddress() string {
+// empty string if there's no cluster endpoint or the cluster endpoint is provided by the network listener.
+func (e *Endpoints) clusterAddress() string {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -34,7 +34,7 @@ func (e *Endpoints) ClusterUpdateAddress(address string) error {
 		address = util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
 	}
 
-	oldAddress := e.ClusterAddress()
+	oldAddress := e.clusterAddress()
 	if address == oldAddress {
 		return nil
 	}

--- a/lxd/endpoints/endpoints_exported_test.go
+++ b/lxd/endpoints/endpoints_exported_test.go
@@ -42,7 +42,7 @@ func (e *Endpoints) NetworkAddressAndCert() (string, *shared.CertInfo) {
 // endpoint. This method is supposed to be used in conjunction with
 // the httpGetOverTLSSocket test helper.
 func (e *Endpoints) ClusterAddressAndCert() (string, *shared.CertInfo) {
-	return e.ClusterAddress(), e.cert
+	return e.clusterAddress(), e.cert
 }
 
 // Set the file descriptor number marker that will be used when detecting

--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -65,7 +65,7 @@ func (e *Endpoints) NetworkUpdateAddress(address string) error {
 		return nil
 	}
 
-	clusterAddress := e.ClusterAddress()
+	clusterAddress := e.clusterAddress()
 
 	logger.Infof("Update network address")
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1735,7 +1735,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	}
 
 	// Skip own node
-	address, _ := node.ClusterAddress(d.db.Node)
+	localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 	// Get the IDs of all storage pools on which a storage volume
 	// for the requested image currently exists.
@@ -1753,7 +1753,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	}
 
 	for _, nodeAddress := range nodes {
-		if nodeAddress == address {
+		if nodeAddress == localClusterAddress {
 			continue
 		}
 
@@ -3975,11 +3975,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
 		// In order to only have one task operation executed per image when syncing the images
 		// across the cluster, only leader node can launch the task, no others.
-		localAddress, err := node.ClusterAddress(d.db.Node)
-		if err != nil {
-			logger.Error("Failed to get current cluster member address", logger.Ctx{"err": err})
-			return
-		}
+		localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 		leader, err := d.gateway.LeaderAddress()
 		if err != nil {
@@ -3991,7 +3987,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 			return
 		}
 
-		if localAddress != leader {
+		if localClusterAddress != leader {
 			logger.Debug("Skipping image synchronization task since we're not leader")
 			return
 		}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1378,16 +1378,13 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		}
 
 		// Setup clustered DNS.
-		clusterAddress, err := node.ClusterAddress(n.state.DB.Node)
-		if err != nil {
-			return err
-		}
+		localClusterAddress := n.state.LocalConfig.ClusterAddress()
 
 		// If clusterAddress is non-empty, this indicates the intention for this node to be
 		// part of a cluster and so we should ensure that dnsmasq and forkdns are started
 		// in cluster mode. Note: During LXD initialisation the cluster may not actually be
 		// setup yet, but we want the DNS processes to be ready for when it is.
-		if clusterAddress != "" {
+		if localClusterAddress != "" {
 			dnsClustered = true
 		}
 

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -156,23 +156,6 @@ func HTTPSAddress(node *db.Node) (string, error) {
 	return config.HTTPSAddress(), nil
 }
 
-// ClusterAddress is a convenience for loading the node configuration and
-// returning the value of cluster.https_address.
-// Deprecated.
-func ClusterAddress(node *db.Node) (string, error) {
-	var config *Config
-	err := node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		var err error
-		config, err = ConfigLoad(ctx, tx)
-		return err
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return config.ClusterAddress(), nil
-}
-
 func (c *Config) update(values map[string]any) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -340,7 +340,11 @@ func patchDBNodesAutoInc(name string, d *Daemon) error {
 		}
 
 		// Only apply patch on leader, otherwise wait for it to be applied.
-		clusterAddress, err := node.ClusterAddress(d.db.Node)
+		var localConfig *node.Config
+		err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+			localConfig, err = node.ConfigLoad(ctx, tx)
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -354,7 +358,7 @@ func patchDBNodesAutoInc(name string, d *Daemon) error {
 			return err
 		}
 
-		if clusterAddress == leaderAddress {
+		if localConfig.ClusterAddress() == leaderAddress {
 			break // Apply change on leader node.
 		}
 

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/lxd/fsmonitor"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/maas"
+	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared"
 )
@@ -66,6 +67,9 @@ type State struct {
 
 	// Global configuration
 	GlobalConfig *clusterConfig.Config
+
+	// Local configuration
+	LocalConfig *node.Config
 
 	// Local server name.
 	ServerName string


### PR DESCRIPTION
Which always loads full node config from DB unnecessarily.

Instead add and maintain a cache of the local config in the `Daemon.localConfig` variable and make available via State() function.
This aligns with what we have done for `Daemon.globalConfig`.