### PR TITLE
Instance: Handle unsupported devices from profiles shared with multiple instance types

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1189,6 +1189,10 @@ func (d *common) devicesAdd(inst instance.Instance, instanceRunning bool) (rever
 	for _, entry := range d.expandedDevices.Sorted() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			// If device conflicts with another device then do not call the deviceAdd function below
 			// as this could cause the original device to be disrupted (such as allowing conflicting
 			// static NIC DHCP leases to be created). Instead just log an error.
@@ -1230,6 +1234,10 @@ func (d *common) devicesRegister(inst instance.Instance) {
 	for _, entry := range d.ExpandedDevices().Sorted() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			d.logger.Error("Failed register validation for device", logger.Ctx{"err": err, "device": entry.Name})
 			continue
 		}
@@ -1258,6 +1266,10 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 		l := d.logger.AddContext(logger.Ctx{"device": entry.Name, "userRequested": userRequested})
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			// Just log an error, but still allow the device to be removed if usable device returned.
 			l.Error("Failed remove validation for device", logger.Ctx{"err": err})
 		}
@@ -1291,6 +1303,10 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 		l := d.logger.AddContext(logger.Ctx{"device": entry.Name, "userRequested": userRequested})
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			if userRequested {
 				return fmt.Errorf("Failed add validation for device %q: %w", entry.Name, err)
 			}
@@ -1334,6 +1350,10 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 		l := d.logger.AddContext(logger.Ctx{"device": entry.Name, "userRequested": userRequested})
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			if userRequested {
 				return fmt.Errorf("Failed update validation for device %q: %w", entry.Name, err)
 			}
@@ -1381,6 +1401,10 @@ func (d *common) devicesRemove(inst instance.Instance) {
 	for _, entry := range d.expandedDevices.Reversed() {
 		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			// Just log an error, but still allow the device to be removed if usable device returned.
 			d.logger.Error("Failed remove validation for device", logger.Ctx{"device": entry.Name, "err": err})
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -203,7 +203,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.In
 		return nil, nil, fmt.Errorf("Invalid config: %w", err)
 	}
 
-	err = instance.ValidDevices(s, d.project, d.Type(), d.expandedDevices, true)
+	err = instance.ValidDevices(s, d.project, d.Type(), d.localDevices, d.expandedDevices)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Invalid devices: %w", err)
 	}
@@ -3925,7 +3925,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Validate the new devices without using expanded devices validation (expensive checks disabled).
-		err = instance.ValidDevices(d.state, d.project, d.Type(), args.Devices, false)
+		err = instance.ValidDevices(d.state, d.project, d.Type(), args.Devices, nil)
 		if err != nil {
 			return fmt.Errorf("Invalid devices: %w", err)
 		}
@@ -4106,7 +4106,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Do full expanded validation of the devices diff.
-		err = instance.ValidDevices(d.state, d.project, d.Type(), d.expandedDevices, true)
+		err = instance.ValidDevices(d.state, d.project, d.Type(), d.localDevices, d.expandedDevices)
 		if err != nil {
 			return fmt.Errorf("Invalid expanded devices: %w", err)
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1945,13 +1945,17 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	nvidiaDevices := []string{}
 
 	sortedDevices := d.expandedDevices.Sorted()
-	startDevices := make([]device.Device, len(sortedDevices))
+	startDevices := make([]device.Device, 0, len(sortedDevices))
 
 	// Load devices in sorted order, this ensures that device mounts are added in path order.
 	// Loading all devices first means that validation of all devices occurs before starting any of them.
-	for i, entry := range sortedDevices {
+	for _, entry := range sortedDevices {
 		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			return "", nil, fmt.Errorf("Failed start validation for device %q: %w", entry.Name, err)
 		}
 
@@ -1961,7 +1965,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 			return "", nil, fmt.Errorf("Failed pre-start check for device %q: %w", dev.Name(), err)
 		}
 
-		startDevices[i] = dev
+		startDevices = append(startDevices, dev)
 	}
 
 	// Start devices in order.
@@ -3007,6 +3011,10 @@ func (d *lxc) cleanupDevices(instanceRunning bool, stopHookNetnsPath string) {
 
 		dev, err := d.deviceLoad(d, entry.Name, entry.Config)
 		if err != nil {
+			if errors.Is(err, device.ErrUnsupportedDevType) {
+				continue // Skip unsupported device (allows for mixed instance type profiles).
+			}
+
 			// Just log an error, but still allow the device to be stopped if usable device returned.
 			d.logger.Error("Failed stop validation for device", logger.Ctx{"device": entry.Name, "err": err})
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -231,7 +231,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.I
 		return nil, nil, fmt.Errorf("Invalid config: %w", err)
 	}
 
-	err = instance.ValidDevices(s, d.project, d.Type(), d.expandedDevices, true)
+	err = instance.ValidDevices(s, d.project, d.Type(), d.localDevices, d.expandedDevices)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Invalid devices: %w", err)
 	}
@@ -4409,7 +4409,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Validate the new devices without using expanded devices validation (expensive checks disabled).
-		err = instance.ValidDevices(d.state, d.project, d.Type(), args.Devices, false)
+		err = instance.ValidDevices(d.state, d.project, d.Type(), args.Devices, nil)
 		if err != nil {
 			return fmt.Errorf("Invalid devices: %w", err)
 		}
@@ -4561,7 +4561,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Do full expanded validation of the devices diff.
-		err = instance.ValidDevices(d.state, d.project, d.Type(), d.expandedDevices, true)
+		err = instance.ValidDevices(d.state, d.project, d.Type(), d.localDevices, d.expandedDevices)
 		if err != nil {
 			return fmt.Errorf("Invalid expanded devices: %w", err)
 		}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -39,7 +39,7 @@ import (
 )
 
 // ValidDevices is linked from instance/drivers.validDevices to validate device config.
-var ValidDevices func(state *state.State, p api.Project, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error
+var ValidDevices func(state *state.State, p api.Project, instanceType instancetype.Type, localDevices deviceConfig.Devices, expandedDevices deviceConfig.Devices) error
 
 // Load is linked from instance/drivers.load to allow different instance types to be loaded.
 var Load func(s *state.State, args db.InstanceArgs, p api.Project) (Instance, error)

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -273,7 +273,7 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// At this point we don't know the instance type, so just use instancetype.Any type for validation.
-	err = instance.ValidDevices(d.State(), *p, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
+	err = instance.ValidDevices(d.State(), *p, instancetype.Any, deviceConfig.NewDevices(req.Devices), nil)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -31,7 +31,7 @@ func doProfileUpdate(d *Daemon, p api.Project, profileName string, id int64, pro
 
 	// Profiles can be applied to any instance type, so just use instancetype.Any type for validation so that
 	// instance type specific validation checks are not performed.
-	err = instance.ValidDevices(d.State(), p, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
+	err = instance.ValidDevices(d.State(), p, instancetype.Any, deviceConfig.NewDevices(req.Devices), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When a device is added to a profile that is not supported by a specific instance type we should ignore the error and just not use the device with the specific instance.

This allows for using a sharing a profile between multiple instance types when a device isn't supported with all instance types.

However still should prevent adding unsupported devices to an instance's local config.

Fixes #10552