### PR TITLE
LXD: Use cached local HTTP address and remove node.HTTPAddress() function 

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -231,12 +231,9 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 	srv.Auth = "trusted"
 
-	address, err := node.HTTPSAddress(d.db.Node)
-	if err != nil {
-		return response.InternalError(err)
-	}
+	localHTTPSAddress := s.LocalConfig.HTTPSAddress()
 
-	addresses, err := util.ListenAddresses(address)
+	addresses, err := util.ListenAddresses(localHTTPSAddress)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -366,19 +366,19 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 			return fmt.Errorf("Failed to fetch member configuration: %w", err)
 		}
 
-		clusterAddress := config.ClusterAddress()
-		if clusterAddress != "" {
+		localClusterAddress := config.ClusterAddress()
+		if localClusterAddress != "" {
 			return nil
 		}
 
-		address := config.HTTPSAddress()
+		localHTTPSAddress := config.HTTPSAddress()
 
-		if util.IsWildCardAddress(address) {
-			return fmt.Errorf("Cannot use wildcard core.https_address %q for cluster.https_address. Please specify a new cluster.https_address or core.https_address", address)
+		if util.IsWildCardAddress(localHTTPSAddress) {
+			return fmt.Errorf("Cannot use wildcard core.https_address %q for cluster.https_address. Please specify a new cluster.https_address or core.https_address", localClusterAddress)
 		}
 
 		_, err = config.Patch(map[string]any{
-			"cluster.https_address": address,
+			"cluster.https_address": localHTTPSAddress,
 		})
 		if err != nil {
 			return fmt.Errorf("Copy core.https_address to cluster.https_address: %w", err)

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -319,7 +319,12 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	}
 
 	// Address of this node.
-	localClusterAddress := g.state().LocalConfig.ClusterAddress()
+	var localClusterAddress string
+	s := g.state()
+
+	if s.LocalConfig != nil {
+		localClusterAddress = s.LocalConfig.ClusterAddress()
+	}
 
 	var allNodes []db.NodeInfo
 	err = g.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1115,8 +1115,8 @@ func (d *Daemon) init() error {
 		return err
 	}
 
-	address := d.localConfig.HTTPSAddress()
-	clusterAddress := d.localConfig.ClusterAddress()
+	localHTTPAddress := d.localConfig.HTTPSAddress()
+	localClusterAddress := d.localConfig.ClusterAddress()
 	debugAddress := d.localConfig.DebugAddress()
 	metricsAddress := d.localConfig.MetricsAddress()
 	storageBucketsAddress := d.localConfig.StorageBucketsAddress()
@@ -1133,8 +1133,8 @@ func (d *Daemon) init() error {
 		RestServer:            restServer(d),
 		DevLxdServer:          devLxdServer(d),
 		LocalUnixSocketGroup:  d.config.Group,
-		NetworkAddress:        address,
-		ClusterAddress:        clusterAddress,
+		NetworkAddress:        localHTTPAddress,
+		ClusterAddress:        localClusterAddress,
 		DebugAddress:          debugAddress,
 		MetricsAddress:        metricsAddress,
 		MetricsServer:         metricsServer(d),
@@ -1185,7 +1185,7 @@ func (d *Daemon) init() error {
 			options = append(options, driver.WithTracing(dqliteClient.LogDebug))
 		}
 
-		d.db.Cluster, err = db.OpenCluster(context.Background(), "db.bin", store, clusterAddress, dir, d.config.DqliteSetupTimeout, nil, options...)
+		d.db.Cluster, err = db.OpenCluster(context.Background(), "db.bin", store, localClusterAddress, dir, d.config.DqliteSetupTimeout, nil, options...)
 		if err == nil {
 			logger.Info("Initialized global database")
 			break

--- a/lxd/init.go
+++ b/lxd/init.go
@@ -153,7 +153,7 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 
 	// Apply network configuration function.
 	applyNetwork := func(network internalClusterPostNetwork) error {
-		_, _, err := d.UseProject(network.Project).GetNetwork(network.Name)
+		currentNetwork, etag, err := d.UseProject(network.Project).GetNetwork(network.Name)
 		if err != nil {
 			// Create the network if doesn't exist.
 			err := d.UseProject(network.Project).CreateNetwork(network.NetworksPost)
@@ -164,12 +164,6 @@ func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error
 			// Setup reverter.
 			revert.Add(func() { _ = d.UseProject(network.Project).DeleteNetwork(network.Name) })
 		} else {
-			// Get the current network.
-			currentNetwork, etag, err := d.UseProject(network.Project).GetNetwork(network.Name)
-			if err != nil {
-				return fmt.Errorf("Failed to retrieve current network %q in project %q: %w", network.Name, network.Project, err)
-			}
-
 			// Prepare the update.
 			newNetwork := api.NetworkPut{}
 			err = shared.DeepCopy(currentNetwork.Writable(), &newNetwork)

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
-	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
@@ -195,11 +194,8 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		// Get local address.
-		localAddress, err := node.HTTPSAddress(d.db.Node)
-		if err != nil {
-			return err
-		}
+		// Get local cluster address.
+		localClusterAddress := d.State().LocalConfig.ClusterAddress()
 
 		// Record the results.
 		failures := map[string]error{}
@@ -213,7 +209,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 				defer wgAction.Done()
 
 				// Special handling for the local member.
-				if node.Address == localAddress {
+				if node.Address == localClusterAddress {
 					err := localAction(false)
 					if err != nil {
 						failuresLock.Lock()

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -72,13 +72,19 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 	d.db.Node = db.DirectAccess(sqldb)
 
 	// Load the configured address from the database
-	address, err := node.HTTPSAddress(d.db.Node)
+	var localConfig *node.Config
+	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		localConfig, err = node.ConfigLoad(ctx, tx)
+		return err
+	})
 	if err != nil {
 		return err
 	}
 
+	localHTTPAddress := localConfig.HTTPSAddress()
+
 	// Look for network socket
-	if address != "" {
+	if localHTTPAddress != "" {
 		logger.Debugf("Daemon has core.https_address set, activating...")
 		_, err := lxd.ConnectLXDUnix("", nil)
 		return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -32,7 +32,6 @@ import (
 	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/lxd/network/acl"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
-	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
@@ -1942,16 +1941,13 @@ func (n *bridge) HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error {
 	}
 
 	addresses := []string{}
-	localAddress, err := node.HTTPSAddress(n.state.DB.Node)
-	if err != nil {
-		return err
-	}
+	localClusterAddress := n.state.LocalConfig.ClusterAddress()
 
 	n.logger.Info("Refreshing forkdns peers")
 
 	networkCert := n.state.Endpoints.NetworkCert()
 	for _, node := range heartbeatData.Members {
-		if node.Address == localAddress {
+		if node.Address == localClusterAddress {
 			// No need to query ourselves.
 			continue
 		}

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -139,23 +139,6 @@ func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 	return c.update(values)
 }
 
-// HTTPSAddress is a convenience for loading the node configuration and
-// returning the value of core.https_address.
-// Deprecated.
-func HTTPSAddress(node *db.Node) (string, error) {
-	var config *Config
-	err := node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		var err error
-		config, err = ConfigLoad(ctx, tx)
-		return err
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return config.HTTPSAddress(), nil
-}
-
 func (c *Config) update(values map[string]any) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {


### PR DESCRIPTION
Also:

-  Remove unnecessary duplicate network load request in initDataNodeApply.
- Fixed couple of cases where the HTTP address was incorrectly being used to identify the local cluster member rather than using the local cluster address.
- Fixes clusterCertificatePut to use tx.GetNodes to get all members rather than only RAFT members.


