### PR TITLE
LXD: Use consistent "member" terminology when using `tx.GetNodes()`

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -959,23 +959,23 @@ func (g *Gateway) currentRaftNodes() ([]db.RaftNode, error) {
 	// Get the names of the raft nodes from the global database.
 	if g.Cluster != nil {
 		err = g.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			nodes, err := tx.GetNodes(ctx)
+			members, err := tx.GetNodes(ctx)
 			if err != nil {
-				return fmt.Errorf("Failed loading cluster members: %w", err)
+				return fmt.Errorf("Failed getting cluster members: %w", err)
 			}
 
-			nodesByAddress := make(map[string]db.NodeInfo, len(nodes))
-			for _, node := range nodes {
-				nodesByAddress[node.Address] = node
+			membersByAddress := make(map[string]db.NodeInfo, len(members))
+			for _, member := range members {
+				membersByAddress[member.Address] = member
 			}
 
 			for i, server := range servers {
-				node, found := nodesByAddress[server.Address]
+				member, found := membersByAddress[server.Address]
 				if !found {
 					logger.Warn("Cluster member info not found", logger.Ctx{"address": server.Address})
 				}
 
-				raftNodes[i].Name = node.Name
+				raftNodes[i].Name = member.Name
 			}
 
 			return nil

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -40,10 +40,10 @@ func TestHeartbeat(t *testing.T) {
 
 	// Artificially mark all nodes as down
 	err := leaderState.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes(ctx)
+		members, err := tx.GetNodes(ctx)
 		require.NoError(t, err)
-		for _, node := range nodes {
-			err := tx.SetNodeHeartbeat(node.Address, time.Now().Add(-time.Minute))
+		for _, member := range members {
+			err := tx.SetNodeHeartbeat(member.Address, time.Now().Add(-time.Minute))
 			require.NoError(t, err)
 		}
 
@@ -59,14 +59,14 @@ func TestHeartbeat(t *testing.T) {
 
 	// The heartbeat timestamps of all nodes got updated
 	err = leaderState.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes(ctx)
+		members, err := tx.GetNodes(ctx)
 		require.NoError(t, err)
 
 		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)
 		require.NoError(t, err)
 
-		for _, node := range nodes {
-			assert.False(t, node.IsOffline(offlineThreshold))
+		for _, member := range members {
+			assert.False(t, member.IsOffline(offlineThreshold))
 		}
 
 		return nil

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -61,7 +61,7 @@ func TestBootstrap_UnmetPreconditions(t *testing.T) {
 				f.ClusterAddress("1.2.3.4:666")
 				f.ClusterNode("5.6.7.8:666")
 			},
-			"Inconsistent state: found leftover entries in nodes",
+			"Inconsistent state: Found leftover entries in cluster members",
 		},
 	}
 
@@ -118,11 +118,11 @@ func TestBootstrap(t *testing.T) {
 
 	// The cluster database has now an entry in the nodes table
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes(ctx)
+		members, err := tx.GetNodes(ctx)
 		require.NoError(t, err)
-		require.Len(t, nodes, 1)
-		assert.Equal(t, "buzz", nodes[0].Name)
-		assert.Equal(t, address, nodes[0].Address)
+		require.Len(t, members, 1)
+		assert.Equal(t, "buzz", members[0].Name)
+		assert.Equal(t, address, members[0].Address)
 		return nil
 	})
 	require.NoError(t, err)
@@ -427,9 +427,9 @@ func TestJoin(t *testing.T) {
 
 	// The node has gone from the cluster db.
 	err = targetState.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes(ctx)
+		members, err := tx.GetNodes(ctx)
 		require.NoError(t, err)
-		assert.Len(t, nodes, 1)
+		assert.Len(t, members, 1)
 		return nil
 	})
 	require.NoError(t, err)

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -199,9 +199,9 @@ func (h *notifyFixtures) Nodes(cert *shared.CertInfo, n int) func() {
 func (h *notifyFixtures) Address(i int) string {
 	var address string
 	err := h.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes(ctx)
+		members, err := tx.GetNodes(ctx)
 		require.NoError(h.t, err)
-		address = nodes[i].Address
+		address = members[i].Address
 		return nil
 	})
 	require.NoError(h.t, err)
@@ -211,9 +211,9 @@ func (h *notifyFixtures) Address(i int) string {
 // Mark the i'th node as down.
 func (h *notifyFixtures) Down(i int) {
 	err := h.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		nodes, err := tx.GetNodes(ctx)
+		members, err := tx.GetNodes(ctx)
 		require.NoError(h.t, err)
-		err = tx.SetNodeHeartbeat(nodes[i].Address, time.Now().Add(-time.Minute))
+		err = tx.SetNodeHeartbeat(members[i].Address, time.Now().Add(-time.Minute))
 		require.NoError(h.t, err)
 		return nil
 	})

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -245,33 +245,33 @@ func OpenCluster(closingCtx context.Context, name string, store driver.NodeStore
 
 	err = clusterDB.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		// Figure out the ID of this node.
-		nodes, err := tx.GetNodes(ctx)
+		members, err := tx.GetNodes(ctx)
 		if err != nil {
-			return fmt.Errorf("Failed to fetch nodes: %w", err)
+			return fmt.Errorf("Failed getting cluster members: %w", err)
 		}
 
-		nodeID := int64(-1)
-		if len(nodes) == 1 && nodes[0].Address == "0.0.0.0" {
+		memberID := int64(-1)
+		if len(members) == 1 && members[0].Address == "0.0.0.0" {
 			// We're not clustered
-			nodeID = 1
+			memberID = 1
 		} else {
-			for _, node := range nodes {
-				if node.Address == address {
-					nodeID = node.ID
+			for _, member := range members {
+				if member.Address == address {
+					memberID = member.ID
 					break
 				}
 			}
 		}
 
-		if nodeID < 0 {
+		if memberID < 0 {
 			return fmt.Errorf("No node registered with address %s", address)
 		}
 
 		// Set the local member ID
-		clusterDB.NodeID(nodeID)
+		clusterDB.NodeID(memberID)
 
 		// Delete any operation tied to this member
-		err = cluster.DeleteOperations(ctx, tx.tx, nodeID)
+		err = cluster.DeleteOperations(ctx, tx.tx, memberID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
And fixes some user facing errors that mention "nodes" rather than "members".