### PR TITLE
Instance: Add Delete operation lock

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -291,6 +291,10 @@ func internalContainerHookLoadFromReference(s *state.State, r *http.Request) (in
 	} else {
 		inst, err = instance.LoadByProjectAndName(s, projectName, instanceRef)
 		if err != nil {
+			if api.StatusErrorCheck(err, http.StatusNotFound) {
+				return nil, err
+			}
+
 			// If DB not available, try loading from backup file.
 			logger.Warn("Failed loading instance from database, trying backup file", logger.Ctx{"project": projectName, "instance": instanceRef, "err": err})
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -643,7 +643,7 @@ func (d *qemu) onStop(target string) error {
 		_ = op.Reset() // Reset timeout to default.
 
 		// Destroy ephemeral virtual machines.
-		err = d.Delete(true)
+		err = d.delete(true)
 		if err != nil {
 			op.Done(err)
 			return err
@@ -4994,6 +4994,23 @@ func (d *qemu) init() error {
 
 // Delete the instance.
 func (d *qemu) Delete(force bool) error {
+	// Setup a new operation.
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionDelete, nil, false, false)
+	if err != nil {
+		return fmt.Errorf("Failed to create instance delete operation: %w", err)
+	}
+
+	defer op.Done(nil)
+
+	return d.delete(force)
+}
+
+// Delete the instance without creating an operation lock.
+func (d *qemu) delete(force bool) error {
+	if d.IsRunning() {
+		return api.StatusErrorf(http.StatusBadRequest, "Instance is running")
+	}
+
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -36,6 +36,9 @@ const ActionRestore Action = "restore"
 // ActionUpdate for updating an instance.
 const ActionUpdate Action = "update"
 
+// ActionDelete for deleting an instance.
+const ActionDelete Action = "delete"
+
 // ErrNonReusuableSucceeded is returned when no operation is created due to having to wait for a matching
 // non-reusuable operation that has now completed successfully.
 var ErrNonReusuableSucceeded error = fmt.Errorf("A matching non-reusable operation has now succeeded")


### PR DESCRIPTION
Prevents a Delete request from being processed while there is an ongoing start operation. 
Otherwise this can leave the mount counter in an inconsistent state.

Previously got:

```
lxc init images:alpine/edge c -p foo ; lxc start c & lxc exec c hostname; lxc delete -f c
Creating c
                                          
The instance you are starting doesn't have any network attached to it.
  To create a new network, use: lxc network create
  To attach a network to an instance, use: lxc network attach

[4] 82997
Error: Instance is not running
Error: Failed to run: /home/user/go/bin/lxd forkstart c /var/lib/lxd/containers /var/log/lxd/c/lxc.conf: exit status 1
```

Now get:

```
lxc init images:alpine/edge c -p foo ; lxc start c & lxc exec c hostname; lxc delete -f c
Creating c
                                          
The instance you are starting doesn't have any network attached to it.
  To create a new network, use: lxc network create
  To attach a network to an instance, use: lxc network attach

[4] 93340
Error: Instance is not running
Error: Failed to create instance delete operation: Instance is busy running a "start" operation
```

Fixes #10083