### PR TITLE
doc/storage: add video links

### DIFF
--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -158,6 +158,9 @@ Each storage volume uses one of the following content types:
 (storage-buckets)=
 ## Storage buckets
 
+```{youtube} https://www.youtube.com/watch?v=T1EeXPrjkEY
+```
+
 Storage buckets provide object storage functionality via the S3 protocol.
 
 They can be used in a way that is similar to custom storage volumes.

--- a/doc/howto/storage_buckets.md
+++ b/doc/howto/storage_buckets.md
@@ -1,6 +1,9 @@
 (howto-storage-buckets)=
 # How to manage storage buckets and keys
 
+```{youtube} https://www.youtube.com/watch?v=T1EeXPrjkEY
+```
+
 See the following sections for instructions on how to create, configure, view and resize {ref}`storage-buckets` and how to manage storage bucket keys.
 
 ## Manage storage buckets

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -1,6 +1,9 @@
 (howto-storage-volumes)=
 # How to manage storage volumes
 
+```{youtube} https://www.youtube.com/watch?v=dvQ111pbqtk
+```
+
 See the following sections for instructions on how to create, configure, view and resize {ref}`storage-volumes`.
 
 ## Create a custom storage volume


### PR DESCRIPTION
Add a link to the YouTube video about storage buckets, and also link the volume/bucket videos from the respective how-tos.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>