### PR TITLE
Device: Fix bridge NIC start failures when using `vlan` when parent bridge has no default PVID

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1508,7 +1508,7 @@ func (d *nicBridged) setupNativeBridgePortVLANs(hostName string) error {
 		// If the bridge has a default PVID and it is different to the specified untagged VLAN or if tagged
 		// VLAN is set to "none" then remove the default untagged membership.
 		if defaultPVID != "0" && (defaultPVID != d.config["vlan"] || d.config["vlan"] == "none") {
-			err = link.BridgeVLANDelete(defaultPVID, false, false)
+			err = link.BridgeVLANDelete(defaultPVID, false)
 			if err != nil {
 				return fmt.Errorf("Failed removing default PVID membership: %w", err)
 			}
@@ -1516,7 +1516,7 @@ func (d *nicBridged) setupNativeBridgePortVLANs(hostName string) error {
 
 		// Configure the untagged membership settings of the port if VLAN ID specified.
 		if d.config["vlan"] != "none" {
-			err = link.BridgeVLANAdd(d.config["vlan"], true, true, false, true)
+			err = link.BridgeVLANAdd(d.config["vlan"], true, true, false)
 			if err != nil {
 				return err
 			}
@@ -1536,7 +1536,7 @@ func (d *nicBridged) setupNativeBridgePortVLANs(hostName string) error {
 				return fmt.Errorf("VLAN tagged ID 0 is not allowed for native Linux bridges")
 			}
 
-			err := link.BridgeVLANAdd(fmt.Sprintf("%d", vlanID), false, false, false, false)
+			err := link.BridgeVLANAdd(fmt.Sprintf("%d", vlanID), false, false, false)
 			if err != nil {
 				return err
 			}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1505,12 +1505,12 @@ func (d *nicBridged) setupNativeBridgePortVLANs(hostName string) error {
 			return err
 		}
 
-		// If the default is different to the specified untagged VLAN or if tagged VLAN is set to "none"
-		// then remove the default untagged membership.
-		if defaultPVID != d.config["vlan"] || d.config["vlan"] == "none" {
+		// If the bridge has a default PVID and it is different to the specified untagged VLAN or if tagged
+		// VLAN is set to "none" then remove the default untagged membership.
+		if defaultPVID != "0" && (defaultPVID != d.config["vlan"] || d.config["vlan"] == "none") {
 			err = link.BridgeVLANDelete(defaultPVID, false, false)
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed removing default PVID membership: %w", err)
 			}
 		}
 

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -327,7 +327,7 @@ func (l *Link) Delete() error {
 }
 
 // BridgeVLANAdd adds a new vlan filter entry.
-func (l *Link) BridgeVLANAdd(vid string, pvid bool, untagged bool, self bool, master bool) error {
+func (l *Link) BridgeVLANAdd(vid string, pvid bool, untagged bool, self bool) error {
 	cmd := []string{"vlan", "add", "dev", l.Name, "vid", vid}
 
 	if pvid {
@@ -340,9 +340,7 @@ func (l *Link) BridgeVLANAdd(vid string, pvid bool, untagged bool, self bool, ma
 
 	if self {
 		cmd = append(cmd, "self")
-	}
-
-	if master {
+	} else {
 		cmd = append(cmd, "master")
 	}
 
@@ -355,14 +353,12 @@ func (l *Link) BridgeVLANAdd(vid string, pvid bool, untagged bool, self bool, ma
 }
 
 // BridgeVLANDelete removes an existing vlan filter entry.
-func (l *Link) BridgeVLANDelete(vid string, self bool, master bool) error {
+func (l *Link) BridgeVLANDelete(vid string, self bool) error {
 	cmd := []string{"vlan", "del", "dev", l.Name, "vid", vid}
 
 	if self {
 		cmd = append(cmd, "self")
-	}
-
-	if master {
+	} else {
 		cmd = append(cmd, "master")
 	}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -763,15 +763,10 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 	// Enable VLAN filtering for Linux bridges.
 	if n.config["bridge.driver"] != "openvswitch" {
+		// Enable filtering.
 		err = BridgeVLANFilterSetStatus(n.name, "1")
 		if err != nil {
-			n.logger.Warn(fmt.Sprintf("%v", err))
-		}
-
-		// Set the default PVID for new ports to 1.
-		err = BridgeVLANSetDefaultPVID(n.name, "1")
-		if err != nil {
-			n.logger.Warn(fmt.Sprintf("%v", err))
+			n.logger.Warn(fmt.Sprintf("Failed enabling VLAN filtering: %v", err))
 		}
 	}
 


### PR DESCRIPTION
If the parent bridge does not have a default PVID set then don't try to remove it from instance NICs, as this will prevent start.

Also during network setup, don't set the default PVID to 1, as if it has been previously set to something else it won't be applied if VLAN filtering is enabled.

Fixes #10926
