### PR TITLE
shared/version: Fix regression in useragent string

### DIFF
--- a/shared/version/useragent.go
+++ b/shared/version/useragent.go
@@ -27,7 +27,7 @@ func getUserAgent() string {
 		panic(err)
 	}
 
-	osTokens := []string{cases.Title(language.English).String(arch)}
+	osTokens := []string{cases.Title(language.English).String(runtime.GOOS), arch}
 	osTokens = append(osTokens, getPlatformVersionStrings()...)
 
 	// Initial version string


### PR DESCRIPTION
A recent change to the user-agent logic caused the architecture to get incorrectly capitalized and for the OS name to be dropped.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>