### PR TITLE
lxc: Fix symlink following in cmdFilePull

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -351,6 +351,7 @@ func (c *cmdFilePull) Run(cmd *cobra.Command, args []string) error {
 
 			// Follow the symlink
 			if targetPath == "-" || c.file.flagRecursive {
+				i := 0
 				for {
 					newPath := strings.TrimSuffix(string(linkTarget), "\n")
 					if !strings.HasPrefix(newPath, "/") {
@@ -364,6 +365,17 @@ func (c *cmdFilePull) Run(cmd *cobra.Command, args []string) error {
 
 					if resp.Type != "symlink" {
 						break
+					}
+
+					i++
+					if i > 255 {
+						return fmt.Errorf("Too many links")
+					}
+
+					// Update link target for next iteration.
+					linkTarget, err = io.ReadAll(buf)
+					if err != nil {
+						return err
 					}
 				}
 			} else {


### PR DESCRIPTION
Fix symlink following in cmdFilePull when output is stdout or recursive flag is used.

Also imposes a 255 max depth for symlinks.
This aligns with the one in Go's walkSymlinks:
https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/path/filepath/symlink.go;l=99

Fixes #11016

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>