### PR TITLE
.sphinx: Add `goroutines` and `uptime` to wordlist

### DIFF
--- a/.sphinx/.wordlist.txt
+++ b/.sphinx/.wordlist.txt
@@ -74,6 +74,7 @@ Gibit
 GID
 GIDs
 Golang
+goroutines
 GPUs
 Grafana
 HAProxy
@@ -245,6 +246,7 @@ unmanaged
 unmount
 unmounting
 uplink
+uptime
 userspace
 UUID
 vCPU


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
