### PR TITLE
Instance: Improve exit status and error handling in exec

### DIFF
--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -203,15 +203,20 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 
 	// Wait for the operation to complete
 	err = op.Wait()
+	opAPI := op.Get()
+	if opAPI.Metadata != nil {
+		exitStatusRaw, ok := opAPI.Metadata["return"].(float64)
+		if ok {
+			c.global.ret = int(exitStatusRaw)
+		}
+	}
+
 	if err != nil {
 		return err
 	}
 
-	opAPI := op.Get()
-
 	// Wait for any remaining I/O to be flushed
 	<-execArgs.DataDone
 
-	c.global.ret = int(opAPI.Metadata["return"].(float64))
 	return nil
 }

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -287,7 +287,11 @@ To easily setup a local LXD server in a virtual machine, consider using: https:/
 
 		// Default error handling
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+
+		// If custom exit status not set, use default error status.
+		if globalCmd.ret == 0 {
+			globalCmd.ret = 1
+		}
 	}
 
 	if globalCmd.ret != 0 {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -35,6 +35,12 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
+// ErrExecCommandNotFound indicates the command is not found.
+var ErrExecCommandNotFound = fmt.Errorf("Command not found")
+
+// ErrExecCommandNotExecutable indicates the command is not executable.
+var ErrExecCommandNotExecutable = fmt.Errorf("Command not executable")
+
 // ErrInstanceIsStopped indicates that the instance is stopped.
 var ErrInstanceIsStopped error = fmt.Errorf("The instance is already stopped")
 

--- a/lxd/instance/drivers/driver_lxc_cmd.go
+++ b/lxd/instance/drivers/driver_lxc_cmd.go
@@ -35,6 +35,14 @@ func (c *lxcCmd) Signal(sig unix.Signal) error {
 func (c *lxcCmd) Wait() (int, error) {
 	exitStatus, err := shared.ExitStatus(c.cmd.Wait())
 
+	// Convert special exit statuses into errors.
+	switch exitStatus {
+	case 127:
+		err = ErrExecCommandNotFound
+	case 126:
+		err = ErrExecCommandNotExecutable
+	}
+
 	return exitStatus, err
 }
 

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -471,7 +471,8 @@ func (s *execWs) Do(op *operations.Operation) error {
 	}
 
 	exitStatus, err := cmd.Wait()
-	l.Debug("Instance process stopped", logger.Ctx{"exitStatus": exitStatus})
+	l.Debug("Instance process stopped", logger.Ctx{"err": err, "exitStatus": exitStatus})
+
 	return finisher(exitStatus, err)
 }
 
@@ -715,7 +716,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		l.Debug("Instance process started")
 
 		exitStatus, err := cmd.Wait()
-		l.Debug("Instance process stopped", logger.Ctx{"exitStatus": exitStatus})
+		l.Debug("Instance process stopped", logger.Ctx{"err": err, "exitStatus": exitStatus})
 		if err != nil {
 			return err
 		}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -715,17 +715,17 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "PID": cmd.PID(), "recordOutput": post.RecordOutput})
 		l.Debug("Instance process started")
 
-		exitStatus, err := cmd.Wait()
-		l.Debug("Instance process stopped", logger.Ctx{"err": err, "exitStatus": exitStatus})
-		if err != nil {
-			return err
-		}
+		exitStatus, cmdErr := cmd.Wait()
+		l.Debug("Instance process stopped", logger.Ctx{"err": cmdErr, "exitStatus": exitStatus})
 
 		metadata["return"] = exitStatus
-
 		err = op.ExtendMetadata(metadata)
 		if err != nil {
 			l.Error("Error updating metadata for cmd", logger.Ctx{"err": err, "cmd": post.Command})
+		}
+
+		if cmdErr != nil {
+			return cmdErr
 		}
 
 		return nil


### PR DESCRIPTION
Improves exit status detection when running `lxc exec` on a VM:

 - Detects missing parent directory and returns 127 exit status.
 - Detects permission denied and returns 126 exit status.

And for both containers and VMs if exit status 126 (command not executable) or 127 (command not found) occurs then an operation error is returned and `lxc exec` command will now display it, whilst still maintaining the exit status of the command.

Fixes #10534

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>