### PR TITLE
Device: Add case insensitive DNS name conflict check for `bridged` and `ovn` NICs connected to managed networks

### DIFF
--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/network/acl"
@@ -122,4 +123,9 @@ func nicCheckNamesUnique(instConf instance.ConfigReader) error {
 	}
 
 	return nil
+}
+
+// nicCheckDNSNameConflict returns if instNameA matches instNameB (case insensitive).
+func nicCheckDNSNameConflict(instNameA string, instNameB string) bool {
+	return strings.EqualFold(instNameA, instNameB)
 }

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -411,6 +411,11 @@ func (d *nicBridged) checkAddressConflict() error {
 				continue
 			}
 
+			// Check there isn't another instance with the same DNS name connected to managed network.
+			if d.network != nil && nicCheckDNSNameConflict(d.inst.Name(), inst.Name) {
+				return api.StatusErrorf(http.StatusConflict, "Instance DNS name %q already used on network", strings.ToLower(inst.Name))
+			}
+
 			// Skip NICs connected to other VLANs (not perfect though as one NIC could
 			// explicitly specify the default untagged VLAN and these would be connected to
 			// same L2 even though the values are different, and there is a different default

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/mdlayher/netx/eui64"
 
@@ -248,6 +249,11 @@ func (d *nicOVN) checkAddressConflict() error {
 		// updates or when making temporary copies of our instance during migrations.
 		if instance.IsSameLogicalInstance(d.inst, &inst) && d.Name() == nicName {
 			return nil
+		}
+
+		// Check there isn't another instance with the same DNS name connected to managed network.
+		if d.network != nil && nicCheckDNSNameConflict(d.inst.Name(), inst.Name) {
+			return api.StatusErrorf(http.StatusConflict, "Instance DNS name %q already used on network", strings.ToLower(inst.Name))
 		}
 
 		// Check NIC's MAC address doesn't match this NIC's MAC address.

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -42,6 +42,9 @@ test_container_devices_nic_bridged() {
 
   lxc init testimage "${ctName}" -p "${ctName}"
 
+  # Temporarily disconnect instance from network so the device name checks don't trigger duplicate instance errors.
+  lxc config device add "${ctName}" eth0 none
+
   # Test device name validation.
   lxc config device add "${ctName}" 127.0.0.1 nic network=${brName}
   lxc config device remove "${ctName}" 127.0.0.1
@@ -54,6 +57,9 @@ test_container_devices_nic_bridged() {
   ! lxc config device add "${ctName}" .invalid nic network=${brName} || false
   ! lxc config device add "${ctName}" ./invalid nic network=${brName} || false
   ! lxc config device add "${ctName}" ../invalid nic network=${brName} || false
+
+  # Restore eth0 from profile.
+  lxc config device remove "${ctName}" eth0
 
   # Start instance.
   lxc start "${ctName}"


### PR DESCRIPTION
Fixes #10797