### PR TITLE
doc/rest-api: Add missing Ready state

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -142,6 +142,7 @@ Code  | Meaning
 110   | Frozen
 111   | Thawed
 112   | Error
+113   | Ready
 200   | Success
 400   | Failure
 401   | Canceled


### PR DESCRIPTION
Closes #11030

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>