### PR TITLE
doc: add a link to the development process YouTube video

### DIFF
--- a/.sphinx/.markdownlint/exceptions.txt
+++ b/.sphinx/.markdownlint/exceptions.txt
@@ -5,4 +5,4 @@
 .tmp/doc/howto/network_forwards.md:63: MD005 Inconsistent indentation for list items at the same level
 .tmp/doc/howto/network_forwards.md:59: MD032 Lists should be surrounded by blank lines
 .tmp/doc/howto/network_forwards.md:63: MD032 Lists should be surrounded by blank lines
-.tmp/doc/contributing.md:6: MD002 First header should be a top level header
+.tmp/doc/contributing.md:9: MD002 First header should be a top level header

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: https://www.youtube.com/watch?v=pqV0Z1qwbkg
+---
+
 % Include content from [../CONTRIBUTING.md](../CONTRIBUTING.md)
 ```{include} ../CONTRIBUTING.md
     :end-before: <!-- Include end contributing -->


### PR DESCRIPTION
Added as a related link and not embedded since the video has a much wider focus than the documentation page.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>