### PR TITLE
Export initialization helpers

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -304,38 +304,6 @@ func updateCertificateCacheFromLocal(d *Daemon) error {
 	return nil
 }
 
-// clusterMemberJoinTokenDecode decodes a base64 and JSON encode join token.
-func clusterMemberJoinTokenDecode(input string) (*api.ClusterMemberJoinToken, error) {
-	joinTokenJSON, err := base64.StdEncoding.DecodeString(input)
-	if err != nil {
-		return nil, err
-	}
-
-	var j api.ClusterMemberJoinToken
-	err = json.Unmarshal(joinTokenJSON, &j)
-	if err != nil {
-		return nil, err
-	}
-
-	if j.ServerName == "" {
-		return nil, fmt.Errorf("No server name in join token")
-	}
-
-	if len(j.Addresses) < 1 {
-		return nil, fmt.Errorf("No cluster member addresses in join token")
-	}
-
-	if j.Secret == "" {
-		return nil, fmt.Errorf("No secret in join token")
-	}
-
-	if j.Fingerprint == "" {
-		return nil, fmt.Errorf("No certificate fingerprint in join token")
-	}
-
-	return &j, nil
-}
-
 // clusterMemberJoinTokenValid searches for cluster join token that matches the join token provided.
 // Returns matching operation if found and cancels the operation, otherwise returns nil.
 func clusterMemberJoinTokenValid(d *Daemon, r *http.Request, projectName string, joinToken *api.ClusterMemberJoinToken) (*api.Operation, error) {
@@ -553,7 +521,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Check if cluster member join token supplied as password.
-		joinToken, err := clusterMemberJoinTokenDecode(req.Password)
+		joinToken, err := shared.JoinTokenDecode(req.Password)
 		if err == nil {
 			// If so then check there is a matching join operation.
 			joinOp, err := clusterMemberJoinTokenValid(d, r, project.Default, joinToken)

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -163,7 +163,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 
 	// Check if we got a cluster join token, if so, fill in the config with it.
 	if config.Cluster != nil && config.Cluster.ClusterToken != "" {
-		joinToken, err := clusterMemberJoinTokenDecode(config.Cluster.ClusterToken)
+		joinToken, err := shared.JoinTokenDecode(config.Cluster.ClusterToken)
 		if err != nil {
 			return fmt.Errorf("Invalid cluster join token: %w", err)
 		}

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -176,7 +176,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 			var joinToken *api.ClusterMemberJoinToken
 
 			validJoinToken := func(input string) error {
-				j, err := clusterMemberJoinTokenDecode(input)
+				j, err := shared.JoinTokenDecode(input)
 				if err != nil {
 					return fmt.Errorf("Invalid join token: %w", err)
 				}

--- a/shared/util.go
+++ b/shared/util.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/gob"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"hash"
 	"io"
@@ -26,6 +28,7 @@ import (
 	"github.com/flosch/pongo2"
 
 	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cancel"
 	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/units"
@@ -1316,4 +1319,36 @@ func SplitNTrimSpace(s string, sep string, n int, nilIfEmpty bool) []string {
 	}
 
 	return parts
+}
+
+// JoinTokenDecode decodes a base64 and JSON encode join token.
+func JoinTokenDecode(input string) (*api.ClusterMemberJoinToken, error) {
+	joinTokenJSON, err := base64.StdEncoding.DecodeString(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var j api.ClusterMemberJoinToken
+	err = json.Unmarshal(joinTokenJSON, &j)
+	if err != nil {
+		return nil, err
+	}
+
+	if j.ServerName == "" {
+		return nil, fmt.Errorf("No server name in join token")
+	}
+
+	if len(j.Addresses) < 1 {
+		return nil, fmt.Errorf("No cluster member addresses in join token")
+	}
+
+	if j.Secret == "" {
+		return nil, fmt.Errorf("No secret in join token")
+	}
+
+	if j.Fingerprint == "" {
+		return nil, fmt.Errorf("No certificate fingerprint in join token")
+	}
+
+	return &j, nil
 }


### PR DESCRIPTION
This exports some helpers to make it easy to initialize LXD from a `go` application. These helpers were initially under the `main` package, so I've moved the `node` related helpers to the `node` package, and moved `ClusterMemberJoinTokenDecode` to the cluster package.

This will be particularly helpful in bootstrapping LXD for MicroCloud, reducing code duplication.