### PR TITLE
Export preseed structs

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -55,6 +55,12 @@ definitions:
                 example: user@host
                 type: string
                 x-go-name: ClientName
+            expires_at:
+                description: The token's expiry date.
+                example: "2021-03-23T17:38:37.753398689-04:00"
+                format: date-time
+                type: string
+                x-go-name: ExpiresAt
             fingerprint:
                 description: The fingerprint of the network certificate
                 example: 57bb0ff4340b5bb28517e062023101adf788c37846dc8b619eb2c3cb4ef29436
@@ -378,6 +384,12 @@ definitions:
                     type: string
                 type: array
                 x-go-name: Addresses
+            expires_at:
+                description: The token's expiry date.
+                example: "2021-03-23T17:38:37.753398689-04:00"
+                format: date-time
+                type: string
+                x-go-name: ExpiresAt
             fingerprint:
                 description: The fingerprint of the network certificate
                 example: 57bb0ff4340b5bb28517e062023101adf788c37846dc8b619eb2c3cb4ef29436
@@ -469,6 +481,58 @@ definitions:
                 type: string
                 x-go-name: ServerName
         title: ClusterMembersPost represents the fields required to request a join token to add a member to the cluster.
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
+    ClusterPreseed:
+        properties:
+            cluster_address:
+                description: The address of the cluster you wish to join
+                example: 10.0.0.1:8443
+                type: string
+                x-go-name: ClusterAddress
+            cluster_certificate:
+                description: The expected certificate (X509 PEM encoded) for the cluster
+                example: X509 PEM certificate
+                type: string
+                x-go-name: ClusterCertificate
+            cluster_certificate_path:
+                description: The path to the cluster certificate
+                example: /tmp/cluster.crt
+                type: string
+                x-go-name: ClusterCertificatePath
+            cluster_password:
+                description: The trust password of the cluster you're trying to join
+                example: blah
+                type: string
+                x-go-name: ClusterPassword
+            cluster_token:
+                description: A cluster join token
+                example: BASE64-TOKEN
+                type: string
+                x-go-name: ClusterToken
+            enabled:
+                description: Whether clustering is enabled
+                example: true
+                type: boolean
+                x-go-name: Enabled
+            member_config:
+                description: List of member configuration keys (used during join)
+                example: []
+                items:
+                    $ref: '#/definitions/ClusterMemberConfigKey'
+                type: array
+                x-go-name: MemberConfig
+            server_address:
+                description: The local address to use for cluster communication
+                example: 10.0.0.2:8443
+                type: string
+                x-go-name: ServerAddress
+            server_name:
+                description: Name of the cluster member answering the request
+                example: lxd01
+                type: string
+                x-go-name: ServerName
+        title: ClusterPreseed represents initialization configuration for the LXD cluster.
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
     ClusterPut:
@@ -2171,6 +2235,47 @@ definitions:
         title: InstancesPut represents the fields available for a mass update.
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
+    LocalPreseed:
+        properties:
+            config:
+                additionalProperties: {}
+                description: Server configuration map (refer to doc/server.md)
+                example:
+                    core.https_address: :8443
+                    core.trust_password: true
+                type: object
+                x-go-name: Config
+            networks:
+                description: Networks by project to add to LXD
+                example: Network on the "default" project
+                items:
+                    $ref: '#/definitions/NetworksProjectPost'
+                type: array
+                x-go-name: Networks
+            profiles:
+                description: Profiles to add to LXD
+                example: '"default" profile with a root disk device'
+                items:
+                    $ref: '#/definitions/ProfilesPost'
+                type: array
+                x-go-name: Profiles
+            projects:
+                description: Projects to add to LXD
+                example: '"default" project'
+                items:
+                    $ref: '#/definitions/ProjectsPost'
+                type: array
+                x-go-name: Projects
+            storage_pools:
+                description: Storage Pools to add to LXD
+                example: local dir storage pool
+                items:
+                    $ref: '#/definitions/StoragePoolsPost'
+                type: array
+                x-go-name: StoragePools
+        title: LocalPreseed represents initialization configuration for the local LXD.
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
     Network:
         description: Network represents a LXD network
         properties:
@@ -3268,6 +3373,40 @@ definitions:
                 x-go-name: Type
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
+    NetworksProjectPost:
+        properties:
+            Project:
+                description: Project in which the network will reside
+                example: '"default"'
+                type: string
+            config:
+                additionalProperties:
+                    type: string
+                description: Network configuration map (refer to doc/networks.md)
+                example:
+                    ipv4.address: 10.0.0.1/24
+                    ipv4.nat: "true"
+                    ipv6.address: none
+                type: object
+                x-go-name: Config
+            description:
+                description: Description of the profile
+                example: My new LXD bridge
+                type: string
+                x-go-name: Description
+            name:
+                description: The name of the new network
+                example: lxdbr1
+                type: string
+                x-go-name: Name
+            type:
+                description: The network type (refer to doc/networks.md)
+                example: bridge
+                type: string
+                x-go-name: Type
+        title: NetworksProjectPost represents the fields of a new LXD network along with its associated project.
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
     Operation:
         description: Operation represents a LXD background operation
         properties:
@@ -3351,6 +3490,15 @@ definitions:
                 format: date-time
                 type: string
                 x-go-name: UpdatedAt
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
+    Preseed:
+        properties:
+            Node:
+                $ref: '#/definitions/LocalPreseed'
+            cluster:
+                $ref: '#/definitions/ClusterPreseed'
+        title: Preseed represents initialization configuration that can be supplied to `lxd init`.
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
     Profile:

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -593,7 +593,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			return fmt.Errorf("Failed to load projects for networks: %w", err)
 		}
 
-		networks := []internalClusterPostNetwork{}
+		networks := []api.InitNetworksProjectPost{}
 		for _, p := range projects {
 			networkNames, err := d.db.Cluster.GetNetworks(p.Name)
 			if err != nil && !response.IsNotFoundError(err) {
@@ -606,7 +606,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 					return err
 				}
 
-				internalNetwork := internalClusterPostNetwork{
+				internalNetwork := api.InitNetworksProjectPost{
 					NetworksPost: api.NetworksPost{
 						NetworkPut: network.NetworkPut,
 						Name:       network.Name,
@@ -885,7 +885,7 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 // connected to ourselves (the joining member) and one connected to the target cluster member to join.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
 func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberConfig []api.ClusterMemberConfigKey) (revert.Hook, error) {
-	data := initDataNode{}
+	data := api.InitLocalPreseed{}
 
 	// Fetch all pools currently defined in the cluster.
 	pools, err := client.GetStoragePools()
@@ -968,7 +968,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 				continue
 			}
 
-			post := internalClusterPostNetwork{
+			post := api.InitNetworksProjectPost{
 				NetworksPost: api.NetworksPost{
 					NetworkPut: network.NetworkPut,
 					Name:       network.Name,
@@ -1013,7 +1013,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 // Perform a request to the /internal/cluster/accept endpoint to check if a new
 // node can be accepted into the cluster and obtain joining information such as
 // the cluster private certificate.
-func clusterAcceptMember(client lxd.InstanceServer, name string, address string, schema int, apiExt int, pools []api.StoragePool, networks []internalClusterPostNetwork) (*internalClusterPostAcceptResponse, error) {
+func clusterAcceptMember(client lxd.InstanceServer, name string, address string, schema int, apiExt int, pools []api.StoragePool, networks []api.InitNetworksProjectPost) (*internalClusterPostAcceptResponse, error) {
 	architecture, err := osarch.ArchitectureGetLocalID()
 	if err != nil {
 		return nil, err
@@ -2243,19 +2243,13 @@ func internalClusterPostAccept(d *Daemon, r *http.Request) response.Response {
 
 // A request for the /internal/cluster/accept endpoint.
 type internalClusterPostAcceptRequest struct {
-	Name         string                       `json:"name" yaml:"name"`
-	Address      string                       `json:"address" yaml:"address"`
-	Schema       int                          `json:"schema" yaml:"schema"`
-	API          int                          `json:"api" yaml:"api"`
-	StoragePools []api.StoragePool            `json:"storage_pools" yaml:"storage_pools"`
-	Networks     []internalClusterPostNetwork `json:"networks" yaml:"networks"`
-	Architecture int                          `json:"architecture" yaml:"architecture"`
-}
-
-type internalClusterPostNetwork struct {
-	api.NetworksPost `yaml:",inline"`
-
-	Project string
+	Name         string                        `json:"name" yaml:"name"`
+	Address      string                        `json:"address" yaml:"address"`
+	Schema       int                           `json:"schema" yaml:"schema"`
+	API          int                           `json:"api" yaml:"api"`
+	StoragePools []api.StoragePool             `json:"storage_pools" yaml:"storage_pools"`
+	Networks     []api.InitNetworksProjectPost `json:"networks" yaml:"networks"`
+	Architecture int                           `json:"architecture" yaml:"architecture"`
 }
 
 // A Response for the /internal/cluster/accept endpoint.
@@ -2622,7 +2616,7 @@ func clusterCheckStoragePoolsMatch(cluster *db.Cluster, reqPools []api.StoragePo
 	return nil
 }
 
-func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []internalClusterPostNetwork) error {
+func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []api.InitNetworksProjectPost) error {
 	var err error
 
 	// Get a list of projects for networks.

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -11,13 +11,9 @@ import (
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/version"
 )
-
-type cmdInitData struct {
-	Node    initDataNode     `yaml:",inline"`
-	Cluster *initDataCluster `json:"cluster" yaml:"cluster"`
-}
 
 type cmdInit struct {
 	global *cmdGlobal
@@ -120,7 +116,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prepare the input data
-	var config *cmdInitData
+	var config *api.InitPreseed
 
 	// Preseed mode
 	if c.flagPreseed {

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*cmdInitData, error) {
+func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*api.InitPreseed, error) {
 	// Quick checks.
 	if c.flagStorageBackend != "" && !shared.StringInSlice(c.flagStorageBackend, storageDrivers.AllDriverNames()) {
 		return nil, fmt.Errorf("The requested backend '%s' isn't supported by lxd init", c.flagStorageBackend)
@@ -62,7 +62,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 	}
 
 	// Fill in the node configuration
-	config := initDataNode{}
+	config := api.InitLocalPreseed{}
 	config.Config = map[string]any{}
 
 	// Network listening
@@ -154,7 +154,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 		}
 
 		// Define the new network
-		network := internalClusterPostNetwork{}
+		network := api.InitNetworksProjectPost{}
 		network.Name = fmt.Sprintf("lxdbr%d", idx)
 		network.Project = project.Default
 		config.Networks = append(config.Networks, network)
@@ -182,5 +182,5 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 		}
 	}
 
-	return &cmdInitData{Node: config}, nil
+	return &api.InitPreseed{Node: config}, nil
 }

--- a/lxd/main_init_dump.go
+++ b/lxd/main_init_dump.go
@@ -16,7 +16,7 @@ func (c *cmdInit) RunDump(d lxd.InstanceServer) error {
 		return fmt.Errorf("Failed to retrieve current server configuration: %w", err)
 	}
 
-	var config initDataNode
+	var config api.InitLocalPreseed
 	config.Config = currentServer.Config
 
 	// Only retrieve networks in the default project as the preseed format doesn't support creating
@@ -32,7 +32,7 @@ func (c *cmdInit) RunDump(d lxd.InstanceServer) error {
 			continue
 		}
 
-		networksPost := internalClusterPostNetwork{}
+		networksPost := api.InitNetworksProjectPost{}
 		networksPost.Config = network.Config
 		networksPost.Description = network.Description
 		networksPost.Name = network.Name

--- a/lxd/main_init_preseed.go
+++ b/lxd/main_init_preseed.go
@@ -9,9 +9,10 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/shared/api"
 )
 
-func (c *cmdInit) RunPreseed(cmd *cobra.Command, args []string, d lxd.InstanceServer) (*cmdInitData, error) {
+func (c *cmdInit) RunPreseed(cmd *cobra.Command, args []string, d lxd.InstanceServer) (*api.InitPreseed, error) {
 	// Read the YAML
 	bytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -19,7 +20,7 @@ func (c *cmdInit) RunPreseed(cmd *cobra.Command, args []string, d lxd.InstanceSe
 	}
 
 	// Parse the YAML
-	config := cmdInitData{}
+	config := api.InitPreseed{}
 	err = yaml.Unmarshal(bytes, &config)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse the preseed: %w", err)

--- a/shared/api/init.go
+++ b/shared/api/init.go
@@ -1,0 +1,66 @@
+package api
+
+// InitPreseed represents initialization configuration that can be supplied to `lxd init`.
+//
+// swagger:model
+//
+// API extension: preseed.
+type InitPreseed struct {
+	Node    InitLocalPreseed    `yaml:",inline"`
+	Cluster *InitClusterPreseed `json:"cluster" yaml:"cluster"`
+}
+
+// InitLocalPreseed represents initialization configuration for the local LXD.
+//
+// swagger:model
+//
+// API extension: preseed.
+type InitLocalPreseed struct {
+	ServerPut `yaml:",inline"`
+
+	// Networks by project to add to LXD
+	// Example: Network on the "default" project
+	Networks []InitNetworksProjectPost `json:"networks" yaml:"networks"`
+
+	// Storage Pools to add to LXD
+	// Example: local dir storage pool
+	StoragePools []StoragePoolsPost `json:"storage_pools" yaml:"storage_pools"`
+
+	// Profiles to add to LXD
+	// Example: "default" profile with a root disk device
+	Profiles []ProfilesPost `json:"profiles" yaml:"profiles"`
+
+	// Projects to add to LXD
+	// Example: "default" project
+	Projects []ProjectsPost `json:"projects" yaml:"projects"`
+}
+
+// InitNetworksProjectPost represents the fields of a new LXD network along with its associated project.
+//
+// swagger:model
+//
+// API extension: preseed.
+type InitNetworksProjectPost struct {
+	NetworksPost `yaml:",inline"`
+
+	// Project in which the network will reside
+	// Example: "default"
+	Project string
+}
+
+// InitClusterPreseed represents initialization configuration for the LXD cluster.
+//
+// swagger:model
+//
+// API extension: preseed.
+type InitClusterPreseed struct {
+	ClusterPut `yaml:",inline"`
+
+	// The path to the cluster certificate
+	// Example: /tmp/cluster.crt
+	ClusterCertificatePath string `json:"cluster_certificate_path" yaml:"cluster_certificate_path"`
+
+	// A cluster join token
+	// Example: BASE64-TOKEN
+	ClusterToken string `json:"cluster_token" yaml:"cluster_token"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -352,6 +352,7 @@ var APIExtensions = []string{
 	"internal_metrics",
 	"cluster_join_token_expiry",
 	"remote_token_expiry",
+	"init_preseed",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
From the discussions with @tomponline in #11036,  this PR adds some new api structs:
* `Preseed` -- A representation of the `lxd init` preseed.yaml file.
* `LocalPreseed` -- Local node-specific initialization configuration from the preseed.yaml.
* `ClusterPreseed` -- Cluster-specific initialization configuration from the preseed.yaml.
* `NetworksProjectPost` -- effectively `api.NetworksPost` but with a project associated.