### PR TITLE
VM: Fix unmount race during LXD startup registeration of running VMs

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5403,6 +5403,11 @@ func (d *qemu) CGroup() (*cgroup.CGroup, error) {
 
 // FileSFTPConn returns a connection to the agent SFTP endpoint.
 func (d *qemu) FileSFTPConn() (net.Conn, error) {
+	// VMs, unlike containers, cannot perform file operations if not running and using the lxd-agent.
+	if !d.IsRunning() {
+		return nil, fmt.Errorf("Instance is not running")
+	}
+
 	// Connect to the agent.
 	client, err := d.getAgentClient()
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -305,8 +305,7 @@ type qemu struct {
 	architectureName string
 }
 
-// getAgentClient returns the current agent client handle. To avoid TLS setup each time this
-// function is called, the handle is cached internally in the Qemu struct.
+// getAgentClient returns the current agent client handle.
 func (d *qemu) getAgentClient() (*http.Client, error) {
 	// Check if the agent is running.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())


### PR DESCRIPTION
Fixes an issue introduced by `advertiseVsockAddress` by removing mount & unmount calls from `generateAgentCert`.

We expect the callers of `generateAgentCert` to have ascertained whether the VM is running (and therefore mounted) before calling this function.

By making this change it prevents a mount/unmount race when LXD starts up during the `devicesRegister` function call.

During this function call, each instance has its `IsRunning()` function called to check if it needs its devices registered. For `disk` devices of running instances its important that their `Register`functions are called on LXD start in order to initialise the mount counter for that disk (so that a subsequent unmount call isn't incorrectly run if LXD incorrectly thinks that the disk volume isn't in use anymore).

For VMs the initial call to `IsRunning()` is also important as that triggers a reconnection to the QEMU QMP monitor in the running VM and allows for gathering the lxd-agent run status.

The mount/unmount race before the `disk` devices have been registered is caused because the `IsRunning` call initialises the `getMonitorEventHandler` and causes it to call the `advertiseVsockAddress` function, which in turn uses `generateAgentCert` as part of creating a connection to the lxd-agent over vsock.

The `getMonitorEventHandler` handler is run in a separate goroutine and thus it can race the `disk` device's `Register` function (which would initialise the mount counter so that an unmount call would not be issued as the volume would be considered in use).

If the `generateAgentCert` function finishes before the `disk` device's `Register` function then an unmount call is incorrectly attempted on the running VM's root disk causing delays to LXDs start up (as the unmount call blocks for several seconds).

By removing the mount management from the `generateAgentCert` function it ensures that no early unmount attempt can occur, and doesn't affect the operation of the function as it is required that the VM be running (and thus mounted) in order to connect to the lxd-agent anyway.