### PR TITLE
lxd/device: Continue if device is nil

### DIFF
--- a/lxd/device/unix_hotplug.go
+++ b/lxd/device/unix_hotplug.go
@@ -212,6 +212,10 @@ func (d *unixHotplug) loadUnixDevice() *udev.Device {
 	for i := range devices {
 		device = devices[i]
 
+		if device == nil {
+			continue
+		}
+
 		devnum := device.Devnum()
 		if devnum.Major() == 0 || devnum.Minor() == 0 {
 			continue


### PR DESCRIPTION
device maybe a nil pointer will cause a run-time panic

Signed-off-by: luoguanzhong <549899794@qq.com>