### PR TITLE
Daemon: Respect core.shutdown_timeout

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -237,13 +237,14 @@ func internalShutdown(d *Daemon, r *http.Request) response.Response {
 	}
 
 	forceCtx, forceCtxCancel := context.WithCancel(context.Background())
-	defer forceCtxCancel()
 
 	if force == "true" {
 		forceCtxCancel() // Don't wait for operations to finish.
 	}
 
 	return response.ManualResponse(func(w http.ResponseWriter) error {
+		defer forceCtxCancel()
+
 		<-d.setupChan // Wait for daemon to start.
 
 		// Run shutdown sequence synchronously.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1702,7 +1702,6 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 			// waitForOperations will block until all operations are done, or it's forced to shut down.
 			// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
 			// initiated using `lxd shutdown`.
-			logger.Info("Waiting for operations to finish")
 			waitForOperations(ctx, d.db.Cluster, s.GlobalConfig.ShutdownTimeout())
 		}
 


### PR DESCRIPTION
This fixes `lxd shutdown` to respect `core.shutdown_timeout` (and its default), as well as doing a little clean up to improve logging.