### PR TITLE
Extend CPU limit validation

### DIFF
--- a/shared/instance.go
+++ b/shared/instance.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -89,29 +88,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 
 	"cluster.evacuate": validate.Optional(validate.IsOneOf("auto", "migrate", "live-migrate", "stop")),
 
-	"limits.cpu": func(value string) error {
-		if value == "" {
-			return nil
-		}
-
-		// Validate the character set
-		match, _ := regexp.MatchString("^[-,0-9]*$", value)
-		if !match {
-			return fmt.Errorf("Invalid CPU limit syntax")
-		}
-
-		// Validate first character
-		if strings.HasPrefix(value, "-") || strings.HasPrefix(value, ",") {
-			return fmt.Errorf("CPU limit can't start with a separator")
-		}
-
-		// Validate last character
-		if strings.HasSuffix(value, "-") || strings.HasSuffix(value, ",") {
-			return fmt.Errorf("CPU limit can't end with a separator")
-		}
-
-		return nil
-	},
+	"limits.cpu":           validate.Optional(validate.IsValidCPUSet),
 	"limits.disk.priority": validate.Optional(validate.IsPriority),
 	"limits.memory": func(value string) error {
 		if value == "" {

--- a/shared/validate/validate_test.go
+++ b/shared/validate/validate_test.go
@@ -103,3 +103,40 @@ func ExampleRequired() {
 	// <nil> Invalid value for a boolean "foo"
 	// <nil> <nil>
 }
+
+func ExampleIsValidCPUSet() {
+	tests := []string{
+		"1",       // valid
+		"1,2,3",   // valid
+		"1-3",     // valid
+		"1-3,4-6", // valid
+		"1-3,4",   // valid
+		"abc",     // invalid syntax
+		"1-",      // invalid syntax
+		"1,",      // invalid syntax
+		"-1",      // invalid syntax
+		",1",      // invalid syntax
+		"1,2,3,3", // invalid: Duplicate CPU
+		"1-2,2",   // invalid: Duplicate CPU
+		"1-2,2-3", // invalid: Duplicate CPU
+	}
+
+	for _, t := range tests {
+		err := validate.IsValidCPUSet(t)
+		fmt.Printf("%v\n", err)
+	}
+
+	// Output: <nil>
+	// <nil>
+	// <nil>
+	// <nil>
+	// <nil>
+	// Invalid CPU limit syntax
+	// Invalid CPU limit syntax
+	// Invalid CPU limit syntax
+	// Invalid CPU limit syntax
+	// Invalid CPU limit syntax
+	// Cannot define CPU multiple times
+	// Cannot define CPU multiple times
+	// Cannot define CPU multiple times
+}


### PR DESCRIPTION
This moves the CPU set validator from instance.go to a separate
validator function. It extends the regular expression which allows the
previous character checks to be removed.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
