### PR TITLE
lxc init: Fix usage line in the help output

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -35,7 +35,7 @@ type cmdInit struct {
 
 func (c *cmdInit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("init", i18n.G("[[<remote>:]<image>] [<remote>:][<name>] [< config"))
+	cmd.Use = usage("init", i18n.G("[<remote>:]<image> [<remote>:][<name>]"))
 	cmd.Short = i18n.G("Create instances from images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create instances from images`))
 	cmd.Example = cli.FormatSection("", i18n.G(`lxc init ubuntu:22.04 u1


### PR DESCRIPTION
The usage is currently given as `lxc init [[<remote>:]<image>] [<remote>:][<name>] [< config [flags]`
This aligns it with what we have for `lxc launch`.

No idea if there's anything else needed for the PR. ;)