### PR TITLE
Device: Speed up getting NIC host name info by loading host interface info once per request

### DIFF
--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"runtime"
 	"sync"
@@ -161,6 +162,8 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SyncResponsePlain(true, metricSet.String())
 	}
 
+	hostInterfaces, _ := net.Interfaces()
+
 	// Prepare temporary metrics storage.
 	newMetrics := map[string]*metrics.MetricSet{}
 	newMetricsLock := sync.Mutex{}
@@ -186,7 +189,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 			go func(inst instance.Instance) {
 				defer wgInstances.Done()
 
-				instanceMetrics, err := inst.Metrics()
+				instanceMetrics, err := inst.Metrics(hostInterfaces)
 				if err != nil {
 					logger.Warn("Failed to get instance metrics", logger.Ctx{"instance": inst.Name(), "project": inst.Project(), "err": err})
 					return

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6846,7 +6846,7 @@ func (d *lxc) Info() instance.Info {
 	}
 }
 
-func (d *lxc) Metrics() (*metrics.MetricSet, error) {
+func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error) {
 	out := metrics.NewMetricSet(map[string]string{"project": d.project.Name, "name": d.name, "type": instancetype.Container.String()})
 
 	// Load cgroup abstraction
@@ -6980,7 +6980,6 @@ func (d *lxc) Metrics() (*metrics.MetricSet, error) {
 	}
 
 	// Get network stats
-	hostInterfaces, _ := net.Interfaces()
 	networkState := d.networkState(hostInterfaces)
 
 	for name, state := range networkState {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5668,7 +5668,7 @@ func (d *qemu) Render(options ...func(response any) error) (any, any, error) {
 }
 
 // RenderFull returns all info about the instance.
-func (d *qemu) RenderFull() (*api.InstanceFull, any, error) {
+func (d *qemu) RenderFull(hostInterfaces []net.Interface) (*api.InstanceFull, any, error) {
 	if d.IsSnapshot() {
 		return nil, nil, fmt.Errorf("RenderFull doesn't work with snapshots")
 	}
@@ -5798,7 +5798,7 @@ func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error
 }
 
 // RenderState returns just state info about the instance.
-func (d *qemu) RenderState() (*api.InstanceState, error) {
+func (d *qemu) RenderState(hostInterfaces []net.Interface) (*api.InstanceState, error) {
 	return d.renderState(d.statusCode())
 }
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6359,7 +6359,7 @@ func (d *qemu) checkFeature(qemu string, args ...string) (bool, error) {
 	return true, nil
 }
 
-func (d *qemu) Metrics() (*metrics.MetricSet, error) {
+func (d *qemu) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error) {
 	if d.agentMetricsEnabled() {
 		return d.getAgentMetrics()
 	}

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -156,7 +156,7 @@ type Instance interface {
 
 	DeferTemplateApply(trigger TemplateTrigger) error
 
-	Metrics() (*metrics.MetricSet, error)
+	Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error)
 }
 
 // Container interface is for container specific functions.

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -105,8 +105,8 @@ type Instance interface {
 
 	// Status
 	Render(options ...func(response any) error) (any, any, error)
-	RenderFull() (*api.InstanceFull, any, error)
-	RenderState() (*api.InstanceState, error)
+	RenderFull(hostInterfaces []net.Interface) (*api.InstanceFull, any, error)
+	RenderState(hostInterfaces []net.Interface) (*api.InstanceState, error)
 	IsRunning() bool
 	IsFrozen() bool
 	IsEphemeral() bool

--- a/lxd/instance_get.go
+++ b/lxd/instance_get.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -140,7 +141,8 @@ func instanceGet(d *Daemon, r *http.Request) response.Response {
 	if recursion == 0 {
 		state, etag, err = c.Render()
 	} else {
-		state, etag, err = c.RenderFull()
+		hostInterfaces, _ := net.Interfaces()
+		state, etag, err = c.RenderFull(hostInterfaces)
 	}
 
 	if err != nil {

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -93,7 +94,8 @@ func instanceState(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	state, err := c.RenderState()
+	hostInterfaces, _ := net.Interfaces()
+	state, err := c.RenderState(hostInterfaces)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -173,10 +174,12 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	c2.IsRunning()
 	suite.Req.Nil(err)
 
-	apiC1, etagC1, err := c.RenderFull()
+	hostInterfaces, _ := net.Interfaces()
+
+	apiC1, etagC1, err := c.RenderFull(hostInterfaces)
 	suite.Req.Nil(err)
 
-	apiC2, etagC2, err := c2.RenderFull()
+	apiC2, etagC2, err := c2.RenderFull(hostInterfaces)
 	suite.Req.Nil(err)
 
 	suite.Equal(etagC1, etagC2)

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -447,6 +448,7 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 				threads = len(projectsInstances)
 			}
 
+			hostInterfaces, _ := net.Interfaces()
 			queue := make(chan [2]string, threads)
 
 			for i := 0; i < threads; i++ {
@@ -475,7 +477,7 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 							continue
 						}
 
-						c, _, err := inst.RenderFull()
+						c, _, err := inst.RenderFull(hostInterfaces)
 						if err != nil {
 							logger.Error("Unable to list instance", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "err": err})
 							resultFullListAppend(projectInstance, api.InstanceFull{}, err)

--- a/lxd/main_forknet.go
+++ b/lxd/main_forknet.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 
 	"github.com/spf13/cobra"
 
@@ -151,7 +152,8 @@ func (c *cmdForknet) Command() *cobra.Command {
 }
 
 func (c *cmdForknet) RunInfo(cmd *cobra.Command, args []string) error {
-	networks, err := netutils.NetnsGetifaddrs(-1)
+	hostInterfaces, _ := net.Interfaces()
+	networks, err := netutils.NetnsGetifaddrs(-1, hostInterfaces)
 	if err != nil {
 		return err
 	}

--- a/shared/netutils/network_linux_cgo.go
+++ b/shared/netutils/network_linux_cgo.go
@@ -62,7 +62,7 @@ const UnixFdsReceivedMore uint = C.UNIX_FDS_RECEIVED_MORE
 const UnixFdsReceivedNone uint = C.UNIX_FDS_RECEIVED_NONE
 
 // NetnsGetifaddrs returns a map of InstanceStateNetwork for a particular process.
-func NetnsGetifaddrs(initPID int32) (map[string]api.InstanceStateNetwork, error) {
+func NetnsGetifaddrs(initPID int32, hostInterfaces []net.Interface) (map[string]api.InstanceStateNetwork, error) {
 	var netnsidAware C.bool
 	var ifaddrs *C.struct_netns_ifaddrs
 	var netnsID C.__s32
@@ -133,9 +133,11 @@ func NetnsGetifaddrs(initPID int32) (map[string]api.InstanceStateNetwork, error)
 		addNetwork.Mtu = int(addr.ifa_mtu)
 
 		if initPID != 0 && int(addr.ifa_ifindex_peer) > 0 {
-			hostInterface, err := net.InterfaceByIndex(int(addr.ifa_ifindex_peer))
-			if err == nil {
-				addNetwork.HostName = hostInterface.Name
+			for _, hostInterface := range hostInterfaces {
+				if hostInterface.Index == int(addr.ifa_ifindex_peer) {
+					addNetwork.HostName = hostInterface.Name
+					break
+				}
 			}
 		}
 


### PR DESCRIPTION
Rather than for every container in a list.

This can significantly increase the speed of `lxc list` output if you have hundreds of running containers.

Fixes #11042