### PR TITLE
Add resolv.conf location under WSL

### DIFF
--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -57,6 +57,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 
   {{ .rootPath }}/run/{resolvconf,NetworkManager,systemd/resolve,connman,netconfig}/resolv.conf r,
   {{ .rootPath }}/run/systemd/resolve/stub-resolv.conf r,
+  {{ .rootPath }}/mnt/wsl/resolv.conf r,
 
 {{- if .snap }}
 


### PR DESCRIPTION
When the LXD snap runs under WSL, and WSL is allowed to manage /etc/resolv.conf automatically (the default), containers are unable to resolve DNS names. This happens because when WSL manages /etc/resolv.conf automatically, /etc/resolv.conf is a symlink to /mnt/wsl/resolv.conf, and AppArmor therefore denies _dnsmasq_ access to it:

```
Oct 25 10:35:05 pallas-wsl dnsmasq[9258]: started, version 2.80 cachesize 150
Oct 25 10:35:05 pallas-wsl kernel: audit: type=1400 audit(1666712105.134:153): apparmor="DENIED" operation="open" profile="lxd_dnsmasq-lxdbr0_</var/snap/lxd/common/lxd>" name="/mnt/wsl/resolv.conf" pid=9900 comm="dnsmasq" requested_mask="r" denied_mask="r" fsuid=999 ouid=0
Oct 25 10:35:05 pallas-wsl audit[9900]: AVC apparmor="DENIED" operation="open" profile="lxd_dnsmasq-lxdbr0_</var/snap/lxd/common/lxd>" name="/mnt/wsl/resolv.conf" pid=9900 comm="dnsmasq" requested_mask="r" denied_mask="r" fsuid=999 ouid=0
Oct 25 10:35:05 pallas-wsl dnsmasq[9258]: compile time options: IPv6 GNU-getopt DBus i18n IDN DHCP DHCPv6 no-Lua TFTP conntrack ipset auth nettlehash DNSSEC loop-detect inotify dumpfile

...

Oct 25 10:35:05 pallas-wsl dnsmasq[9258]: using local addresses only for domain lxd
Oct 25 10:35:05 pallas-wsl dnsmasq[9258]: failed to read /etc/resolv.conf: Permission denied
Oct 25 10:35:05 pallas-wsl dnsmasq[9258]: no servers found in /etc/resolv.conf, will retry
```

This PR adds /mnt/wsl/resolv.conf to the generated profile for dnsmasq, thus fixing this issue.

(I note that this is parallel to the following PR submitted against AppArmor: https://gitlab.com/apparmor/apparmor/-/merge_requests/935 .)

Signed-off-by: Alistair Young <avatar@arkane-systems.net>
