### PR TITLE
doc: remove intro sentence for configuration

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,7 +1,5 @@
 # Configuration
 
-LXD stores the configuration for the following components:
-
 ```{toctree}
 :maxdepth: 1
 


### PR DESCRIPTION
The introduction doesn't make sense anymore after we removed most of the pages underneath.
We should probably get rid of the whole section in the future.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>