### PR TITLE
lxd/storage/pools: Initialize pool config if nil

### DIFF
--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -261,6 +261,10 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("No driver provided"))
 	}
 
+	if req.Config == nil {
+		req.Config = map[string]string{}
+	}
+
 	ctx := logger.Ctx{}
 
 	targetNode := queryParam(r, "target")


### PR DESCRIPTION
LXD panics if the storage pool config passed to a `POST` is nil, as we try to create the storage pool. This initializes the storage pool config if it's nil, so that doesn't happen.