### PR TITLE
lxd-agent: Return correct error when querying devlxd

### DIFF
--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -28,16 +28,6 @@ func devLxdServer(d *Daemon) *http.Server {
 	}
 }
 
-type devLxdResponse struct {
-	content any
-	code    int
-	ctype   string
-}
-
-func okResponse(ct any, ctype string) *devLxdResponse {
-	return &devLxdResponse{ct, http.StatusOK, ctype}
-}
-
 type devLxdHandler struct {
 	path string
 
@@ -75,7 +65,7 @@ var devlxdConfigGet = devLxdHandler{"/1.0/config", func(d *Daemon, w http.Respon
 
 	resp, _, err := client.RawQuery("GET", "/1.0/config", nil, "")
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(err)
 	}
 
 	var config []string
@@ -113,7 +103,7 @@ var devlxdConfigKeyGet = devLxdHandler{"/1.0/config/{key}", func(d *Daemon, w ht
 
 	resp, _, err := client.RawQuery("GET", fmt.Sprintf("/1.0/config/%s", key), nil, "")
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(err)
 	}
 
 	var value string
@@ -136,7 +126,7 @@ var devlxdMetadataGet = devLxdHandler{"/1.0/meta-data", func(d *Daemon, w http.R
 
 	resp, _, err := client.RawQuery("GET", "/1.0/meta-data", nil, "")
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(err)
 	}
 
 	var metaData string
@@ -152,7 +142,7 @@ var devlxdMetadataGet = devLxdHandler{"/1.0/meta-data", func(d *Daemon, w http.R
 var devLxdEventsGet = devLxdHandler{"/1.0/events", func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	err := eventsGet(d, r).Render(w)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(err)
 	}
 
 	return okResponse("", "raw")
@@ -169,7 +159,7 @@ var devlxdAPIGet = devLxdHandler{"/1.0", func(d *Daemon, w http.ResponseWriter, 
 	if r.Method == "GET" {
 		resp, _, err := client.RawQuery(r.Method, "/1.0", nil, "")
 		if err != nil {
-			return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+			return smartResponse(err)
 		}
 
 		var instanceData agentAPI.DevLXDGet
@@ -183,7 +173,7 @@ var devlxdAPIGet = devLxdHandler{"/1.0", func(d *Daemon, w http.ResponseWriter, 
 	} else if r.Method == "PATCH" {
 		_, _, err := client.RawQuery(r.Method, "/1.0", r.Body, "")
 		if err != nil {
-			return &devLxdResponse{err.Error(), http.StatusInternalServerError, "raw"}
+			return smartResponse(err)
 		}
 
 		return okResponse("", "raw")
@@ -202,7 +192,7 @@ var devlxdDevicesGet = devLxdHandler{"/1.0/devices", func(d *Daemon, w http.Resp
 
 	resp, _, err := client.RawQuery("GET", "/1.0/devices", nil, "")
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(err)
 	}
 
 	var devices config.Devices

--- a/lxd-agent/response.go
+++ b/lxd-agent/response.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+type devLxdResponse struct {
+	content any
+	code    int
+	ctype   string
+}
+
+func errorResponse(code int, msg string) *devLxdResponse {
+	return &devLxdResponse{msg, code, "raw"}
+}
+
+func okResponse(ct any, ctype string) *devLxdResponse {
+	return &devLxdResponse{ct, http.StatusOK, ctype}
+}
+
+func smartResponse(err error) *devLxdResponse {
+	if err == nil {
+		return okResponse(nil, "")
+	}
+
+	statusCode, found := api.StatusErrorMatch(err)
+	if found {
+		return errorResponse(statusCode, err.Error())
+	}
+
+	return errorResponse(http.StatusInternalServerError, err.Error())
+}


### PR DESCRIPTION
This changes the error messages for devlxd queries, in that it
returns the correct HTTP error instead of an Internal Status Error.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
