### PR TITLE
client/util: Use ConnectionArgs.Proxy with unix socket client

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -197,7 +197,7 @@ func ConnectLXDUnixWithContext(ctx context.Context, path string, args *Connectio
 	path = shared.HostPath(path)
 
 	// Setup the HTTP client
-	httpClient, err := unixHTTPClient(args.HTTPClient, path)
+	httpClient, err := unixHTTPClient(args, path)
 	if err != nil {
 		return nil, err
 	}

--- a/client/util.go
+++ b/client/util.go
@@ -101,7 +101,7 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 	return client, nil
 }
 
-func unixHTTPClient(client *http.Client, path string) (*http.Client, error) {
+func unixHTTPClient(args *ConnectionArgs, path string) (*http.Client, error) {
 	// Setup a Unix socket dialer
 	unixDial := func(_ context.Context, network, addr string) (net.Conn, error) {
 		raddr, err := net.ResolveUnixAddr("unix", path)
@@ -112,16 +112,22 @@ func unixHTTPClient(client *http.Client, path string) (*http.Client, error) {
 		return net.DialUnix("unix", nil, raddr)
 	}
 
+	if args == nil {
+		args = &ConnectionArgs{}
+	}
+
 	// Define the http transport
 	transport := &http.Transport{
 		DialContext:           unixDial,
 		DisableKeepAlives:     true,
+		Proxy:                 args.Proxy,
 		ExpectContinueTimeout: time.Second * 30,
 		ResponseHeaderTimeout: time.Second * 3600,
 		TLSHandshakeTimeout:   time.Second * 5,
 	}
 
 	// Define the http client
+	client := args.HTTPClient
 	if client == nil {
 		client = &http.Client{}
 	}


### PR DESCRIPTION
Allows using a custom proxy from `ConnectionArgs` when using `ConnectLXDUnix`. This will help with MicroCloud proxying requests to `/1.0/services/lxd` to LXD via the daemon.