### PR TITLE
lxd: Remove shadowed variable name.

### DIFF
--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -178,8 +178,8 @@ func profilesGet(d *Daemon, r *http.Request) response.Response {
 			result = apiProfiles
 		} else {
 			urls := make([]string, len(apiProfiles))
-			for i, p := range apiProfiles {
-				urls[i] = p.URL(version.APIVersion, p.Name).String()
+			for i, apiProfile := range apiProfiles {
+				urls[i] = apiProfile.URL(version.APIVersion, p.Name).String()
 			}
 
 			result = urls


### PR DESCRIPTION
The shadowed variable "p" of type *api.Profile was being used incorrectly to retreive the project name (via p.Name). So project names were incorrect when listing profiles without recursion.

Closes #11083 