### PR TITLE
lxd: Check LXD ready state before changing instance

### DIFF
--- a/lxd/instance_delete.go
+++ b/lxd/instance_delete.go
@@ -42,6 +42,9 @@ import (
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func instanceDelete(d *Daemon, r *http.Request) response.Response {
+	// Don't mess with instance while in setup mode.
+	<-d.waitReady.Done()
+
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -55,6 +55,9 @@ import (
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func instancePatch(d *Daemon, r *http.Request) response.Response {
+	// Don't mess with instance while in setup mode.
+	<-d.waitReady.Done()
+
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -72,6 +72,9 @@ var internalClusterInstanceMovedCmd = APIEndpoint{
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func instancePost(d *Daemon, r *http.Request) response.Response {
+	// Don't mess with instance while in setup mode.
+	<-d.waitReady.Done()
+
 	s := d.State()
 
 	instanceType, err := urlInstanceTypeDetect(r)

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -57,6 +57,9 @@ import (
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func instancePut(d *Daemon, r *http.Request) response.Response {
+	// Don't mess with instance while in setup mode.
+	<-d.waitReady.Done()
+
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
 		return response.SmartError(err)


### PR DESCRIPTION
This fixes an issue where instances could be updated or deleted while
LXD is in setup mode and the instances themselves are being started.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
