### PR TITLE
lxd/init: Use strict checking for preseed

### DIFF
--- a/lxd/main_init_preseed.go
+++ b/lxd/main_init_preseed.go
@@ -21,7 +21,8 @@ func (c *cmdInit) RunPreseed(cmd *cobra.Command, args []string, d lxd.InstanceSe
 
 	// Parse the YAML
 	config := api.InitPreseed{}
-	err = yaml.Unmarshal(bytes, &config)
+	// Use strict checking to notify about unknown keys.
+	err = yaml.UnmarshalStrict(bytes, &config)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse the preseed: %w", err)
 	}


### PR DESCRIPTION
This commit adds strict checking to init preseed, and will return an
error if provided keys are unknown.

This fixes #11106.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
