### PR TITLE
doc: Fix configuration directory in remotes.md

### DIFF
--- a/doc/remotes.md
+++ b/doc/remotes.md
@@ -27,8 +27,8 @@ Automatically added on first use.
 
 ### Global (per-system)
 
-By default the global configuration file is kept in either `/etc/lxc/config.yml`, or `/var/snap/lxd/common/global-conf/` for the snap version, or in `LXD_GLOBAL_CONF` if defined.
-The configuration file can be manually edited to add global remotes. Certificates for those remotes should be stored inside the `servercerts` directory (e.g. `/etc/lxc/servercerts/`) and match the remote name (e.g. `foo.crt`).
+By default the global configuration file is kept in either `/etc/lxd/config.yml`, or `/var/snap/lxd/common/global-conf/` for the snap version, or in `LXD_GLOBAL_CONF` if defined.
+The configuration file can be manually edited to add global remotes. Certificates for those remotes should be stored inside the `servercerts` directory (e.g. `/etc/lxd/servercerts/`) and match the remote name (e.g. `foo.crt`).
 
 An example configuration is below:
 


### PR DESCRIPTION
As reported in Debian bug [1021624](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1021624), the configuration directory listed in docs/remotes.md is incorrect. The string "etc/lxc" doesn't appear anywhere else in the code, so hopefully there aren't any other incorrect references remaining.