### PR TITLE
lxd: Limit shutdown concurrency to number of instances or number of CPU cores (which ever is less).

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1726,7 +1726,6 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 
 		// Full shutdown requested.
 		if sig == unix.SIGPWR {
-			logger.Info("Stopping instances")
 			instancesShutdown(s, instances)
 
 			logger.Info("Stopping networks")

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -234,7 +234,7 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 
 	maxAttempts := 3
 
-	// Restart the instances
+	// Start the instances
 	for _, inst := range instances {
 		// Get the instance config.
 		config := inst.ExpandedConfig()

--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -33,7 +33,7 @@ lxc_remote() {
     if [ -n "${DEBUG:-}" ]; then
         set -x
     fi
-    eval "timeout --foreground 60 ${cmd}"
+    eval "timeout --foreground 120 ${cmd}"
 }
 
 gen_cert() {


### PR DESCRIPTION
This fixes a shutdown hang I observed when stopping LXD with 500 running instances on an 8 core system.