### PR TITLE
shared: Increase default TCP user timeout from 30 seconds to 2 minutes 

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -431,7 +431,7 @@ func (r *ProtocolLXD) rawWebsocket(url string) (*websocket.Conn, error) {
 	// Set TCP timeout options.
 	remoteTCP, _ := tcp.ExtractConn(conn.UnderlyingConn())
 	if remoteTCP != nil {
-		err = tcp.SetTimeouts(remoteTCP)
+		err = tcp.SetTimeouts(remoteTCP, 0)
 		if err != nil {
 			logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1389,7 +1389,7 @@ func (r *ProtocolLXD) rawSFTPConn(apiURL *url.URL) (net.Conn, error) {
 
 	remoteTCP, _ := tcp.ExtractConn(conn)
 	if remoteTCP != nil {
-		err = tcp.SetTimeouts(remoteTCP)
+		err = tcp.SetTimeouts(remoteTCP, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -98,7 +98,7 @@ func restServer(d *Daemon) *http.Server {
 	}
 
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL})
+		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.NotFound(nil).Render(w)
 	})
@@ -150,7 +150,7 @@ func metricsServer(d *Daemon) *http.Server {
 	d.createCmd(mux, "1.0", metricsCmd)
 
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL})
+		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.NotFound(nil).Render(w)
 	})

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -1065,7 +1065,7 @@ func dqliteNetworkDial(ctx context.Context, name string, addr string, g *Gateway
 	if err != nil {
 		l.Error("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
 	} else {
-		err := tcp.SetTimeouts(remoteTCP)
+		err := tcp.SetTimeouts(remoteTCP, time.Second*30)
 		if err != nil {
 			l.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}
@@ -1158,7 +1158,7 @@ func dqliteProxy(name string, stopCh chan struct{}, remote net.Conn, local net.C
 	if err != nil {
 		l.Error("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
 	} else {
-		err := tcp.SetTimeouts(remoteTCP)
+		err := tcp.SetTimeouts(remoteTCP, time.Second*30)
 		if err != nil {
 			l.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -92,7 +92,7 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 				// Set TCP timeout options.
 				remoteTCP, _ := tcp.ExtractConn(conn.UnderlyingConn())
 				if remoteTCP != nil {
-					err = tcp.SetTimeouts(remoteTCP)
+					err = tcp.SetTimeouts(remoteTCP, 0)
 					if err != nil {
 						logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 					}

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -125,7 +125,7 @@ func (r *sftpServeResponse) Render(w http.ResponseWriter) error {
 	remoteTCP, _ := tcp.ExtractConn(remoteConn)
 	if remoteTCP != nil {
 		// Apply TCP timeouts if remote connection is TCP (rather than Unix).
-		err = tcp.SetTimeouts(remoteTCP)
+		err = tcp.SetTimeouts(remoteTCP, 0)
 		if err != nil {
 			return api.StatusErrorf(http.StatusInternalServerError, "Failed setting TCP timeouts on remote connection: %v", err)
 		}

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -189,10 +189,9 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 		return err
 	}
 
-	remoteTCP, err := tcp.ExtractConn(c.UnderlyingConn())
-	if err != nil {
-		logger.Error("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
-	} else {
+	// Set TCP timeout options.
+	remoteTCP, _ := tcp.ExtractConn(c.UnderlyingConn())
+	if remoteTCP != nil {
 		err = tcp.SetTimeouts(remoteTCP)
 		if err != nil {
 			logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -192,7 +192,7 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 	// Set TCP timeout options.
 	remoteTCP, _ := tcp.ExtractConn(c.UnderlyingConn())
 	if remoteTCP != nil {
-		err = tcp.SetTimeouts(remoteTCP)
+		err = tcp.SetTimeouts(remoteTCP, 0)
 		if err != nil {
 			logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}

--- a/shared/tcp/tcp_timeout_user.go
+++ b/shared/tcp/tcp_timeout_user.go
@@ -21,7 +21,7 @@ func SetUserTimeout(conn *net.TCPConn, timeout time.Duration) error {
 		err = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(timeout/time.Millisecond))
 	})
 	if err != nil {
-		return fmt.Errorf("Error setting option on socket: %w", err)
+		return fmt.Errorf("Error setting TCP_USER_TIMEOUT option on socket: %w", err)
 	}
 
 	return nil

--- a/shared/tcp/tcp_timeouts.go
+++ b/shared/tcp/tcp_timeouts.go
@@ -37,7 +37,12 @@ func ExtractConn(conn net.Conn) (*net.TCPConn, error) {
 }
 
 // SetTimeouts sets TCP_USER_TIMEOUT and TCP keep alive timeouts on a connection.
-func SetTimeouts(conn *net.TCPConn) error {
+// If userTimeout is zero, then defaults to 2 minutes.
+func SetTimeouts(conn *net.TCPConn, userTimeout time.Duration) error {
+	if userTimeout == 0 {
+		userTimeout = time.Minute * 2
+	}
+
 	// Set TCP_USER_TIMEOUT option to limit the maximum amount of time in ms that transmitted data may remain
 	// unacknowledged before TCP will forcefully close the corresponding connection and return ETIMEDOUT to the
 	// application. This combined with the TCP keepalive options on the socket will ensure that should the
@@ -46,7 +51,7 @@ func SetTimeouts(conn *net.TCPConn) error {
 	// up to 20 minutes with the current system defaults in a normal WAN environment if there are packets in
 	// the send queue that will prevent the keepalive timer from working as the retransmission timers kick in.
 	// See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dca43c75e7e545694a9dd6288553f55c53e2a3a3
-	err := SetUserTimeout(conn, time.Second*30)
+	err := SetUserTimeout(conn, userTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While keeping the dqlite TCP user timeout to 30s for fast failure detection.

Attempts to address issue raised in https://discuss.linuxcontainers.org/t/anyone-else-got-btrfs-send-failures-since-5-7/15486