### PR TITLE
Storage: Update DeleteImage to not use GetImageFromAnyProject

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3164,21 +3164,19 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 	unlock := locking.Lock(drivers.OperationLockName("DeleteImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
 	defer unlock()
 
-	// Load image info from database.
-	_, image, err := b.state.DB.Cluster.GetImageFromAnyProject(fingerprint)
+	// Load the storage volume in order to get the volume config which is needed for some drivers.
+	imgDBVol, err := VolumeDBGet(b, project.Default, fingerprint, drivers.VolumeTypeImage)
 	if err != nil {
 		return err
 	}
 
-	contentType := drivers.ContentTypeFS
-
-	// Image types are not the same as instance types, so don't use instance type constants.
-	if image.Type == "virtual-machine" {
-		contentType = drivers.ContentTypeBlock
+	// Get the content type.
+	dbContentType, err := VolumeContentTypeNameToContentType(imgDBVol.ContentType)
+	if err != nil {
+		return err
 	}
 
-	// Load the storage volume in order to get the volume config which is needed for some drivers.
-	imgDBVol, err := VolumeDBGet(b, project.Default, fingerprint, drivers.VolumeTypeImage)
+	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We can ascertain the content type of the volume from the storage volume record, rather than relying on the image DB record existing.

This makes this function more resilient as it removes the dependency of having an associated image DB record, which in some cases where the DB is not in a consistent state, can prevent the storage pool from being deleted.

Fixes https://discuss.linuxcontainers.org/t/cant-remove-node-from-cluster/15614/

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>