### PR TITLE
devlxd: Add volatile NIC hwaddr to devices output

### DIFF
--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -246,6 +246,17 @@ var devlxdDevicesGet = devLxdHandler{"/1.0/devices", func(d *Daemon, c instance.
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
+	// Populate NIC hwaddr from volatile if not explicitly specified.
+	// This is so cloud-init running inside the instance can identify the NIC when the interface name is
+	// different than the LXD device name (such as when run inside a VM).
+	localConfig := c.LocalConfig()
+	devices := c.ExpandedDevices()
+	for devName, devConfig := range devices {
+		if devConfig["type"] == "nic" && devConfig["hwaddr"] == "" && localConfig[fmt.Sprintf("volatile.%s.hwaddr", devName)] != "" {
+			devices[devName]["hwaddr"] = localConfig[fmt.Sprintf("volatile.%s.hwaddr", devName)]
+		}
+	}
+
 	return response.DevLxdResponse(http.StatusOK, c.ExpandedDevices(), "json", c.Type() == instancetype.VM)
 }}
 

--- a/test/devlxd-client/devlxd-client.go
+++ b/test/devlxd-client/devlxd-client.go
@@ -204,7 +204,14 @@ func main() {
 			os.Exit(0)
 		}
 
-		raw, err := c.Get(fmt.Sprintf("http://meshuggah-rocks/1.0/config/%s", os.Args[1]))
+		var path string
+		if os.Args[1] == "devices" {
+			path = "devices"
+		} else {
+			path = fmt.Sprintf("config/%s", os.Args[1])
+		}
+
+		raw, err := c.Get(fmt.Sprintf("http://meshuggah-rocks/1.0/%s", path))
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/test/suites/devlxd.sh
+++ b/test/suites/devlxd.sh
@@ -25,10 +25,11 @@ test_devlxd() {
   lxc config set devlxd security.nesting true
   ! lxc exec devlxd devlxd-client security.nesting | grep true || false
 
-  lxc exec devlxd devlxd-client monitor-websocket > "${TEST_DIR}/devlxd-websocket.log" &
+  cmd=$(unset -f lxc; command -v lxc)
+  ${cmd} exec devlxd devlxd-client monitor-websocket > "${TEST_DIR}/devlxd-websocket.log" &
   client_websocket=$!
 
-  lxc exec devlxd devlxd-client monitor-stream > "${TEST_DIR}/devlxd-stream.log" &
+  ${cmd} exec devlxd devlxd-client monitor-stream > "${TEST_DIR}/devlxd-stream.log" &
   client_stream=$!
 
   (

--- a/test/suites/devlxd.sh
+++ b/test/suites/devlxd.sh
@@ -134,6 +134,10 @@ EOF
 
   grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log" | grep -Fx 2
 
+  # Check device configs are available and that NIC hwaddr is available even if volatile.
+  hwaddr=$(lxc config get devlxd volatile.eth0.hwaddr)
+  lxc exec devlxd devlxd-client devices | jq -r .eth0.hwaddr | grep -Fx "${hwaddr}"
+
   lxc delete devlxd --force
   kill -9 ${monitorDevlxdPID} || true
 


### PR DESCRIPTION
This is so cloud-init running inside the instance can identify the NIC when the interface name is different than the LXD device name (such as when run inside a VM).

Fixes #11115