### PR TITLE
Instance: Fixes missing container initiated instance-shutdown lifecycle event

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -896,8 +896,8 @@ func (d *common) maasDelete(inst instance.Instance) error {
 // onStopOperationSetup creates or picks up the relevant operation. This is used in the stopns and stop hooks to
 // ensure that a lock on their activities is held before the instance process is stopped. This prevents a start
 // request run at the same time from overlapping with the stop process.
-// Returns the operation along with a boolean indicating if the operation was created or not.
-func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOperation, bool, error) {
+// Returns the operation (with the instance initiated marker set if the operation was created).
+func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOperation, error) {
 	var err error
 
 	// Pick up the existing stop operation lock created in Stop() function.
@@ -910,11 +910,8 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 		op = nil
 	}
 
-	instanceInitiated := false
-
 	if op == nil {
 		d.logger.Debug("Instance initiated stop", logger.Ctx{"action": target})
-		instanceInitiated = true
 
 		action := operationlock.ActionStop
 		if target == "reboot" {
@@ -923,11 +920,13 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 
 		op, err = operationlock.Create(d.Project().Name, d.Name(), action, false, false)
 		if err != nil {
-			return nil, false, fmt.Errorf("Failed creating %q operation: %w", action, err)
+			return nil, fmt.Errorf("Failed creating %q operation: %w", action, err)
 		}
+
+		op.SetInstanceInitiated(true)
 	}
 
-	return op, instanceInitiated, nil
+	return op, nil
 }
 
 // warningsDelete deletes any persistent warnings for the instance.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2851,7 +2851,7 @@ func (d *lxc) onStopNS(args map[string]string) error {
 	}
 
 	// Create/pick up operation, but don't complete it as we leave operation running for the onStop hook below.
-	_, _, err := d.onStopOperationSetup(target)
+	_, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
@@ -2874,7 +2874,7 @@ func (d *lxc) onStop(args map[string]string) error {
 	}
 
 	// Create/pick up operation.
-	op, instanceInitiated, err := d.onStopOperationSetup(target)
+	op, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
@@ -2955,7 +2955,7 @@ func (d *lxc) onStop(args map[string]string) error {
 		}
 
 		// Log and emit lifecycle if not user triggered
-		if instanceInitiated {
+		if op.GetInstanceInitiated() {
 			ctxMap := logger.Ctx{
 				"action":    target,
 				"created":   d.creationDate,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -564,7 +564,7 @@ func (d *qemu) onStop(target string) error {
 	defer d.logger.Debug("onStop hook finished", logger.Ctx{"target": target})
 
 	// Create/pick up operation.
-	op, instanceInitiated, err := d.onStopOperationSetup(target)
+	op, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
@@ -617,7 +617,7 @@ func (d *qemu) onStop(target string) error {
 	}
 
 	// Log and emit lifecycle if not user triggered.
-	if instanceInitiated {
+	if op.GetInstanceInitiated() {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceShutdown.Event(d, nil))
 	}
 

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -48,13 +48,14 @@ var instanceOperations = make(map[string]*InstanceOperation)
 
 // InstanceOperation operation locking.
 type InstanceOperation struct {
-	action       Action
-	chanDone     chan error
-	chanReset    chan time.Duration
-	err          error
-	projectName  string
-	instanceName string
-	reusable     bool
+	action            Action
+	chanDone          chan error
+	chanReset         chan time.Duration
+	err               error
+	projectName       string
+	instanceName      string
+	reusable          bool
+	instanceInitiated bool
 }
 
 // Create creates a new operation lock for an Instance if one does not already exist and returns it.
@@ -262,4 +263,24 @@ func (op *InstanceOperation) Done(err error) {
 	delete(instanceOperations, opKey) // Delete before closing chanDone.
 	close(op.chanDone)
 	logger.Debug("Instance operation lock finished", logger.Ctx{"project": op.projectName, "instance": op.instanceName, "action": op.action, "reusable": op.reusable, "err": err})
+}
+
+// SetInstanceInitiated sets the instance initiated marker.
+func (op *InstanceOperation) SetInstanceInitiated(instanceInitiated bool) {
+	// This function can be called on a nil struct.
+	if op == nil {
+		return
+	}
+
+	op.instanceInitiated = instanceInitiated
+}
+
+// GetInstanceInitiated gets the instance initiated marker.
+func (op *InstanceOperation) GetInstanceInitiated() bool {
+	// This function can be called on a nil struct.
+	if op == nil {
+		return false
+	}
+
+	return op.instanceInitiated
 }


### PR DESCRIPTION
Because there are 2 container stop hooks (onstopns and onstop) the instance initiated operation lock was being created on onstopns, but the instance-shutdown lifecycle event was only being generated in the onstop hook. Because of this the operation lock already existed (because it was created by the onstopns hook) by the time onstop hook run and the instance-shutdown lifecycle event never fired.

This has been fixed by adding an instance initiated marker on the operation lock itself which can be propagated between stop hooks, allowing for the final onstop hook to detect an instance initiated stop and correctly trigger the instance-shutdown lifecycle event.

VMs were never affected because they don't have the same stop hooks that containers have.

Reported from https://discuss.linuxcontainers.org/t/container-shutdown-event-not-raised-after-executing-halt-in-container/7191