### PR TITLE
Device: Fix attaching cephfs disk volumes to VMs

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -728,7 +728,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 
 				// If the pool is ceph backed, don't mount it, instead pass config to QEMU instance
 				// to use the built in RBD support.
-				if d.pool.Driver().Info().Remote {
+				if d.pool.Driver().Info().Name == "ceph" {
 					config := d.pool.ToAPI().Config
 					poolName := config["ceph.osd.pool_name"]
 


### PR DESCRIPTION
Fixes regression caused by 897a481be9738ccc1e3a0ab3c736ed02e4de05f6

The use of `if d.pool.Driver().Info().Remote` incorrectly covers both `ceph` and `cephfs` pool types, whereas it should have been `if d.pool.Driver().Info().Name == "ceph"` to only cover `ceph` type pools.

Fixes #11126

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>