### PR TITLE
Storage: Allow ZFS block volumes to use pool's zfs.blocksize setting

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1274,19 +1274,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 
 // ValidateVolume validates the supplied volume config.
 func (d *zfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
-	rules := d.commonVolumeRules()
-
-	commonBlocksizeValidator := rules["zfs.blocksize"]
-	rules["zfs.blocksize"] = validate.Optional(func(value string) error {
-		if vol.contentType != ContentTypeFS {
-			return fmt.Errorf("Blocksize can be change only for filesystem type")
-		}
-
-		// Use the common validation after checking volume content type.
-		return commonBlocksizeValidator(value)
-	})
-
-	return d.validateVolume(vol, rules, removeUnknownKeys)
+	return d.validateVolume(vol, d.commonVolumeRules(), removeUnknownKeys)
 }
 
 // UpdateVolume applies config changes to the volume.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -220,8 +220,9 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 		return fmt.Errorf("Pool is not a lxdBackend")
 	}
 
+	// Prevent using this function to create storage volume bucket records.
 	if volumeType == drivers.VolumeTypeBucket {
-		return fmt.Errorf("Cannot storage volume using bucket type")
+		return fmt.Errorf("Cannot store volume using bucket type")
 	}
 
 	// If the volumeType represents an instance type then check that the volumeConfig doesn't contain any of


### PR DESCRIPTION
Reported from https://discuss.linuxcontainers.org/t/howto-set-zfs-recordsize-attr-on-storage-volume-creation/10008/7?u=tomp

Although this PR fixes the reported problem, while investigating it I also found a broader set of problems around incorrect values of zfs.blocksize making it into storage volume DB record (when creating volumes from other volumes/images).

Although they can occur without this change so I thought it OK to include this PR separately to fix the obvious blocking problem.