### PR TITLE
lxd: Fix handling of images in projects with features.images=false

### DIFF
--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -199,7 +199,7 @@ DELETE FROM projects_config WHERE projects_config.project_id = ?
 	return nil
 }
 
-// InitProjectWithoutImages updates populates the images_profiles table with
+// InitProjectWithoutImages populates the images_profiles table with
 // all images from the default project when a project is created with
 // features.images=false.
 func InitProjectWithoutImages(ctx context.Context, tx *sql.Tx, project string) error {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -1063,6 +1063,25 @@ func (c *Cluster) CreateImage(project string, fp string, fname string, sz int64,
 			}
 		}
 
+		// All projects with features.images=false can use all images added to the "default" project.
+		// If these projects also have features.profiles=true, their default profiles should be associated
+		// with all created images.
+		if imageProject == "default" {
+			_, err = tx.tx.Exec(
+				`INSERT OR IGNORE INTO images_profiles(image_id, profile_id)
+					SELECT ?, profiles.id FROM profiles
+						JOIN projects_config AS t1 ON t1.project_id = profiles.project_id
+							AND t1.key = "features.images"
+							AND t1.value = "false"
+						JOIN projects_config AS t2 ON t2.project_id = profiles.project_id
+							AND t2.key = "features.profiles"
+							AND t2.value = "true"
+						WHERE profiles.name = "default"`, id)
+			if err != nil {
+				return err
+			}
+		}
+
 		_, err = tx.tx.Exec("INSERT INTO images_nodes(image_id, node_id) VALUES(?, ?)", id, c.nodeID)
 		if err != nil {
 			return err


### PR DESCRIPTION
All projects with `features.images=false` can use all images added to the "default" project.
If these projects also have `features.profiles=true`, their default profiles should be associated
with all created images, otherwise
```
Error: Failed instance creation: Failed creating
instance record: Failed initialising instance: Failed getting root disk: No root device could be found
```
will arise on attempt to create an instance from this image inside all projects (with `features.images=false` and
`features.profiles=true`) except "default" and the project the image was created from.

The same error will take place when `features.images` option changes from `true` to `false`.

Both of these cases was fixed.