### PR TITLE
Network: Remove unnecessary query for server name in `bridge` Leases

### DIFF
--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -191,7 +191,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 				instanceMetrics, err := inst.Metrics(hostInterfaces)
 				if err != nil {
-					logger.Warn("Failed to get instance metrics", logger.Ctx{"instance": inst.Name(), "project": inst.Project(), "err": err})
+					logger.Warn("Failed to get instance metrics", logger.Ctx{"instance": inst.Name(), "project": inst.Project().Name, "err": err})
 					return
 				}
 

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -171,8 +171,6 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	// Fetch what's missing.
 	wgInstances := sync.WaitGroup{}
 	for _, project := range toFetch {
-		newMetrics[project] = metrics.NewMetricSet(nil)
-
 		// Get the instances.
 		instances, err := instanceLoadNodeProjectAll(d.State(), project, instancetype.Any)
 		if err != nil {
@@ -189,9 +187,10 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 			go func(inst instance.Instance) {
 				defer wgInstances.Done()
 
+				projectName := inst.Project().Name
 				instanceMetrics, err := inst.Metrics(hostInterfaces)
 				if err != nil {
-					logger.Warn("Failed to get instance metrics", logger.Ctx{"instance": inst.Name(), "project": inst.Project().Name, "err": err})
+					logger.Warn("Failed to get instance metrics", logger.Ctx{"instance": inst.Name(), "project": projectName, "err": err})
 					return
 				}
 
@@ -199,7 +198,12 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 				newMetricsLock.Lock()
 				defer newMetricsLock.Unlock()
 
-				newMetrics[inst.Project().Name].Merge(instanceMetrics)
+				// Initialise metrics set for project if needed.
+				if newMetrics[projectName] == nil {
+					newMetrics[projectName] = metrics.NewMetricSet(nil)
+				}
+
+				newMetrics[projectName].Merge(instanceMetrics)
 			}(inst)
 		}
 	}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -175,7 +175,7 @@ var devlxdEventsGet = devLxdHandler{"/1.0/events", func(d *Daemon, c instance.In
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 	}
 
-	logger.Debug("New container event listener", logger.Ctx{"instance": c.Name(), "project": c.Project(), "listener_id": listener.ID})
+	logger.Debug("New container event listener", logger.Ctx{"instance": c.Name(), "project": c.Project().Name, "listener_id": listener.ID})
 	listener.Wait(r.Context())
 
 	return resp

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -573,7 +573,7 @@ func autoCreateInstanceSnapshots(ctx context.Context, d *Daemon, instances []ins
 	for _, inst := range instances {
 		ch := make(chan error)
 		go func(inst instance.Instance) {
-			l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project(), "instance": inst.Name()})
+			l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 
 			snapshotName, err := instance.NextSnapshotName(d.State(), inst, "snap%d")
 			if err != nil {
@@ -737,7 +737,7 @@ func pruneExpiredInstanceSnapshots(ctx context.Context, d *Daemon, snapshots []i
 			return fmt.Errorf("Failed to delete expired instance snapshot %q in project %q: %w", snapshot.Name(), snapshot.Project().Name, err)
 		}
 
-		logger.Debug("Deleted instance snapshot", logger.Ctx{"project": snapshot.Project(), "snapshot": snapshot.Name()})
+		logger.Debug("Deleted instance snapshot", logger.Ctx{"project": snapshot.Project().Name, "snapshot": snapshot.Name()})
 	}
 
 	return nil

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -485,7 +485,7 @@ func DeleteSnapshots(inst Instance) error {
 		k = snapInstsCount - 1 - k
 		err = snapInsts[k].Delete(true)
 		if err != nil {
-			logger.Error("Failed deleting snapshot", logger.Ctx{"project": snapInsts[k].Project(), "instance": snapInsts[k].Name(), "err": err})
+			logger.Error("Failed deleting snapshot", logger.Ctx{"project": snapInsts[k].Project().Name, "instance": snapInsts[k].Name(), "err": err})
 		}
 	}
 

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -293,7 +293,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 		return finisher(-1, err)
 	}
 
-	l := logger.AddContext(logger.Log, logger.Ctx{"project": s.instance.Project(), "instance": s.instance.Name(), "PID": cmd.PID(), "interactive": s.req.Interactive})
+	l := logger.AddContext(logger.Log, logger.Ctx{"project": s.instance.Project().Name, "instance": s.instance.Name(), "PID": cmd.PID(), "interactive": s.req.Interactive})
 	l.Debug("Instance process started")
 
 	var cmdKillOnce sync.Once
@@ -712,7 +712,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project(), "instance": inst.Name(), "PID": cmd.PID(), "recordOutput": post.RecordOutput})
+		l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "PID": cmd.PID(), "recordOutput": post.RecordOutput})
 		l.Debug("Instance process started")
 
 		exitStatus, cmdErr := cmd.Wait()

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -323,7 +323,7 @@ func (s *migrationSourceWs) preDumpLoop(state *state.State, args *preDumpLoopArg
 }
 
 func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operation) error {
-	l := logger.AddContext(logger.Log, logger.Ctx{"project": s.instance.Project(), "instance": s.instance.Name()})
+	l := logger.AddContext(logger.Log, logger.Ctx{"project": s.instance.Project().Name, "instance": s.instance.Name()})
 
 	l.Info("Waiting for migration channel connections on source")
 
@@ -802,7 +802,7 @@ func newMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {
 }
 
 func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateOp *operations.Operation) error {
-	l := logger.AddContext(logger.Log, logger.Ctx{"push": c.push, "project": c.src.instance.Project(), "instance": c.src.instance.Name()})
+	l := logger.AddContext(logger.Log, logger.Ctx{"push": c.push, "project": c.src.instance.Project().Name, "instance": c.src.instance.Name()})
 
 	var err error
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2994,17 +2994,6 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 		}
 	}
 
-	// Local server name.
-	var err error
-	var serverName string
-	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		serverName, err = tx.GetLocalNodeName(ctx)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	// Get dynamic leases.
 	leaseFile := shared.VarPath("networks", n.name, "dnsmasq.leases")
 	if !shared.PathExists(leaseFile) {
@@ -3059,7 +3048,7 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 				Address:  fields[2],
 				Hwaddr:   macStr,
 				Type:     "dynamic",
-				Location: serverName,
+				Location: n.state.ServerName,
 			})
 		}
 	}

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -1299,7 +1299,7 @@ func (s *Server) doDeviceSyscall(c Instance, args *MknodArgs, siov *Iovec) int {
 // HandleMknodSyscall handles a mknod syscall.
 func (s *Server) HandleMknodSyscall(c Instance, siov *Iovec) int {
 	ctx := logger.Ctx{"container": c.Name(),
-		"project":               c.Project(),
+		"project":               c.Project().Name,
 		"syscall_number":        siov.req.data.nr,
 		"audit_architecture":    siov.req.data.arch,
 		"seccomp_notify_id":     siov.req.id,
@@ -1350,7 +1350,7 @@ func (s *Server) HandleMknodSyscall(c Instance, siov *Iovec) int {
 // HandleMknodatSyscall handles a mknodat syscall.
 func (s *Server) HandleMknodatSyscall(c Instance, siov *Iovec) int {
 	ctx := logger.Ctx{"container": c.Name(),
-		"project":               c.Project(),
+		"project":               c.Project().Name,
 		"syscall_number":        siov.req.data.nr,
 		"audit_architecture":    siov.req.data.arch,
 		"seccomp_notify_id":     siov.req.id,
@@ -1430,7 +1430,7 @@ type SetxattrArgs struct {
 // HandleSetxattrSyscall handles setxattr syscalls.
 func (s *Server) HandleSetxattrSyscall(c Instance, siov *Iovec) int {
 	ctx := logger.Ctx{"container": c.Name(),
-		"project":               c.Project(),
+		"project":               c.Project().Name,
 		"syscall_number":        siov.req.data.nr,
 		"audit_architecture":    siov.req.data.arch,
 		"seccomp_notify_id":     siov.req.id,
@@ -1582,7 +1582,7 @@ type SchedSetschedulerArgs struct {
 // HandleSchedSetschedulerSyscall handles sched_setscheduler syscalls.
 func (s *Server) HandleSchedSetschedulerSyscall(c Instance, siov *Iovec) int {
 	ctx := logger.Ctx{"container": c.Name(),
-		"project":               c.Project(),
+		"project":               c.Project().Name,
 		"syscall_number":        siov.req.data.nr,
 		"audit_architecture":    siov.req.data.arch,
 		"seccomp_notify_id":     siov.req.id,
@@ -1719,7 +1719,7 @@ func (s *Server) HandleSchedSetschedulerSyscall(c Instance, siov *Iovec) int {
 func (s *Server) HandleSysinfoSyscall(c Instance, siov *Iovec) int {
 	l := logger.AddContext(logger.Log, logger.Ctx{
 		"container":             c.Name(),
-		"project":               c.Project(),
+		"project":               c.Project().Name,
 		"syscall_number":        siov.req.data.nr,
 		"audit_architecture":    siov.req.data.arch,
 		"seccomp_notify_id":     siov.req.id,
@@ -2018,7 +2018,7 @@ func (s *Server) mountHandleHugetlbfsArgs(c Instance, args *MountArgs, nsuid int
 // HandleMountSyscall handles mount syscalls.
 func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 	ctx := logger.Ctx{"container": c.Name(),
-		"project":               c.Project(),
+		"project":               c.Project().Name,
 		"syscall_number":        siov.req.data.nr,
 		"audit_architecture":    siov.req.data.arch,
 		"seccomp_notify_id":     siov.req.id,
@@ -2224,7 +2224,7 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 // HandleBpfSyscall handles mount syscalls.
 func (s *Server) HandleBpfSyscall(c Instance, siov *Iovec) int {
 	ctx := logger.Ctx{"container": c.Name(),
-		"project":               c.Project(),
+		"project":               c.Project().Name,
 		"syscall_number":        siov.req.data.nr,
 		"audit_architecture":    siov.req.data.arch,
 		"seccomp_notify_id":     siov.req.id,


### PR DESCRIPTION
And a couple of other bug fixes.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>