### PR TITLE
Instance: Prevent moving instance to invalid (or empty) name

### DIFF
--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -237,6 +237,17 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// If new instance name not supplied, assume it will be keeping its current name.
+	if req.Name == "" {
+		req.Name = inst.Name()
+	}
+
+	// Check the new instance name is valid.
+	err = instance.ValidName(req.Name, false)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
 	if req.Migration {
 		// Server-side pool migration.
 		if req.Pool != "" {


### PR DESCRIPTION
It was possible via the API to move an instance to a different cluster member using an invalid (or empty) instance name.

Reported from https://discuss.linuxcontainers.org/t/container-name-is-set-to-an-empty-string-after-move/15566

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>