### PR TITLE
doc: allow returning traffic in DOCKER-USER custom chain

### DIFF
--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -100,6 +100,7 @@ A common reason for these issues is that Docker sets the FORWARD policy to `drop
 See [Docker on a router](https://docs.docker.com/network/iptables/#docker-on-a-router) for detailed information.
 
 The easiest way to prevent such issues is to uninstall Docker from the system that runs LXD.
-If that is not an option, use the following command to explicitly allow network traffic from your network bridge to your external network interface:
+If that is not an option, use the following commands to explicitly allow network traffic from your network bridge to your external network interface and the returning traffic:
 
     iptables -I DOCKER-USER -i <network_bridge> -o <external_interface> -j ACCEPT
+    iptables -I DOCKER-USER -o <network_bridge> -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT


### PR DESCRIPTION
Apparently, the `DOCKER-USER` custom chain does not (or no longer) allow returning traffic. Here's a sample `iptables-save` from a user:

```
# Generated by iptables-save v1.8.7 on Mon Nov 21 17:08:31 2022
*filter
:INPUT ACCEPT [0:0]
:FORWARD DROP [72:11392]
:OUTPUT ACCEPT [0:0]
:DOCKER - [0:0]
:DOCKER-ISOLATION-STAGE-1 - [0:0]
:DOCKER-ISOLATION-STAGE-2 - [0:0]
:DOCKER-USER - [0:0]
:ts-forward - [0:0]
:ts-input - [0:0]
-A INPUT -j ts-input
-A FORWARD -j ts-forward
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-ISOLATION-STAGE-1
-A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o docker0 -j DOCKER
-A FORWARD -i docker0 ! -o docker0 -j ACCEPT
-A FORWARD -i docker0 -o docker0 -j ACCEPT
-A FORWARD -o br-544f43c9c288 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o br-544f43c9c288 -j DOCKER
-A FORWARD -i br-544f43c9c288 ! -o br-544f43c9c288 -j ACCEPT
-A FORWARD -i br-544f43c9c288 -o br-544f43c9c288 -j ACCEPT
-A DOCKER -d 172.18.0.3/32 ! -i br-544f43c9c288 -o br-544f43c9c288 -p tcp -m tcp --dport 3000 -j ACCEPT
-A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i br-544f43c9c288 ! -o br-544f43c9c288 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -j RETURN
-A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-544f43c9c288 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -j RETURN
-A DOCKER-USER -i lxdbr0 -o tailscale0 -j ACCEPT
-A DOCKER-USER -i lxdbr0 -o wlp170s0 -j ACCEPT
-A DOCKER-USER -j RETURN
-A ts-forward -i tailscale0 -j MARK --set-xmark 0x40000/0xff0000
-A ts-forward -m mark --mark 0x40000/0xff0000 -j ACCEPT
-A ts-forward -s 100.64.0.0/10 -o tailscale0 -j DROP
-A ts-forward -o tailscale0 -j ACCEPT
-A ts-input -s 100.64.61.107/32 -i lo -j ACCEPT
-A ts-input -s 100.115.92.0/23 ! -i tailscale0 -j RETURN
-A ts-input -s 100.64.0.0/10 ! -i tailscale0 -j DROP
COMMIT
# Completed on Mon Nov 21 17:08:31 2022
# Generated by iptables-save v1.8.7 on Mon Nov 21 17:08:31 2022
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:DOCKER - [0:0]
:ts-postrouting - [0:0]
-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
-A POSTROUTING -j ts-postrouting
-A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
-A POSTROUTING -s 172.18.0.0/16 ! -o br-544f43c9c288 -j MASQUERADE
-A POSTROUTING -s 172.18.0.3/32 -d 172.18.0.3/32 -p tcp -m tcp --dport 3000 -j MASQUERADE
-A DOCKER -i docker0 -j RETURN
-A DOCKER -i br-544f43c9c288 -j RETURN
-A DOCKER ! -i br-544f43c9c288 -p tcp -m tcp --dport 3000 -j DNAT --to-destination 172.18.0.3:3000
-A ts-postrouting -m mark --mark 0x40000/0xff0000 -j MASQUERADE
COMMIT
# Completed on Mon Nov 21 17:08:31 2022
```

This is reportedly a typical ruleset generated by Docker (if we ignore the tailscale rules). We see that `DOCKER-USER` has the needed rule(s) for outbound traffic but nothing for the returning traffic so it will hit the `FORWARD` `DROP` policy.