### PR TITLE
scripts/bash/lxd-client: fix autocompletion not working

### DIFF
--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -243,7 +243,7 @@ _have lxc && {
         _lxd_names "(STOPPED|FROZEN)"
         ;;
       "exec"|"console"|"stop"|"shell")
-        _lxd_names "RUNNING"
+        _lxd_names "RUNNING|READY"
         ;;
       "file")
         COMPREPLY=( $(compgen -W "pull push edit delete mount" -- $cur) )


### PR DESCRIPTION
Autocompletion of commands for running guests which are in a state other than RUNNING doesn't work. 

This change adds READY so now, autocompletion in lxc shell, lxc stop, lxc exec, work as expected

Signed-off-by: Norberto Bensa <nbensa@gmail.com>