### PR TITLE
VM: Fix VM image unpack apparmor profile in archiveProfile

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -579,14 +579,14 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		if nodeValues["storage.backups_volume"] != nil && nodeValues["storage.backups_volume"] != newNodeConfig.StorageBackupsVolume() {
 			err := daemonStorageValidate(s, nodeValues["storage.backups_volume"].(string))
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed validation of %q: %w", "storage.backups_volume", err)
 			}
 		}
 
 		if nodeValues["storage.images_volume"] != nil && nodeValues["storage.images_volume"] != newNodeConfig.StorageImagesVolume() {
 			err := daemonStorageValidate(s, nodeValues["storage.images_volume"].(string))
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed validation of %q: %w", "storage.images_volume", err)
 			}
 		}
 

--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -95,7 +95,7 @@ func archiveProfile(outputPath string, allowedCommandPaths []string) (string, er
 
 	// Attempt to deref all paths.
 	outputPathFull, err := filepath.EvalSymlinks(outputPath)
-	if err == nil {
+	if err != nil {
 		outputPathFull = outputPath // Use requested path if cannot resolve it.
 	}
 

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -500,6 +500,13 @@ func (v Volume) ConfigSizeFromSource(srcVol Volume) (string, error) {
 			return volSize, err
 		}
 
+		// Round the vol size (for comparison only) because some storage drivers round volumes they create,
+		// and so the published images created from those volumes will also be rounded and will not be
+		// directly usable with the same size setting without also rounding for this check.
+		// Because we are not altering the actual size returned to use for the new volume, this will not
+		// affect storage drivers that do not use rounding.
+		volSizeBytes = roundVolumeBlockFileSizeBytes(volSizeBytes)
+
 		// The volume/pool specified size is smaller than image minimum size. We must not continue as
 		// these specified sizes provide protection against unpacking a massive image and filling the pool.
 		if volSizeBytes < imgSizeBytes {

--- a/lxd/storage/drivers/volume_test.go
+++ b/lxd/storage/drivers/volume_test.go
@@ -52,7 +52,7 @@ func Test_Volume_ConfigSizeFromSource(t *testing.T) {
 			// Check that the volume's smaller size than source image's rootfs size causes error.
 			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, config: map[string]string{"size": "1GB"}},
 			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "15GB"}},
-			err:    fmt.Errorf("Source image size (15000000000) exceeds specified volume size (1000000000)"),
+			err:    fmt.Errorf("Source image size (15000000000) exceeds specified volume size (1000005632)"),
 			size:   "",
 		},
 		{

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -100,6 +100,17 @@ test_server_config_storage() {
   ! lxc storage volume snapshot "${pool}" backups
   ! lxc storage volume snapshot "${pool}" images
 
+  # Modify container and publish to image on custom volume.
+  lxc start foo
+  lxc exec foo -- touch /root/foo
+  lxc stop -f foo
+  lxc publish foo --alias fooimage
+
+  # Launch container from published image on custom volume.
+  lxc init fooimage foo2
+  lxc delete -f foo2
+  lxc image delete fooimage
+
   # Reset and cleanup
   lxc config unset storage.backups_volume
   lxc config unset storage.images_volume


### PR DESCRIPTION
When using custom VM image volume.

Also fixes image volume size comparison issue.

Fixes #11081  #11150

Associated VM tests https://github.com/lxc/lxc-ci/pull/650

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>