### PR TITLE
Device: Add hwaddr key to liblxc NIC config

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -678,13 +678,13 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "name", Value: d.config["name"]},
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: peerName},
+		{Key: "hwaddr", Value: d.config["hwaddr"]},
 	}
 
 	if d.inst.Type() == instancetype.VM {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
-				{Key: "hwaddr", Value: d.config["hwaddr"]},
 				{Key: "mtu", Value: fmt.Sprintf("%d", mtu)},
 			}...)
 	}

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -244,13 +244,13 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "name", Value: d.config["name"]},
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: saveData["host_name"]},
+		{Key: "hwaddr", Value: d.config["hwaddr"]},
 	}
 
 	if d.inst.Type() == instancetype.VM {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
-				{Key: "hwaddr", Value: d.config["hwaddr"]},
 				{Key: "mtu", Value: d.config["mtu"]},
 			}...)
 	}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -444,7 +444,8 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "link", Value: peerName},
 	}
 
-	if d.inst.Type() == instancetype.VM {
+	instType := d.inst.Type()
+	if instType == instancetype.VM {
 		if d.config["acceleration"] == "sriov" {
 			runConf.NetworkInterface = append(runConf.NetworkInterface,
 				[]deviceConfig.RunConfigItem{
@@ -461,6 +462,10 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 					{Key: "mtu", Value: fmt.Sprintf("%d", mtu)},
 				}...)
 		}
+	} else if instType == instancetype.Container {
+		runConf.NetworkInterface = append(runConf.NetworkInterface,
+			deviceConfig.RunConfigItem{Key: "hwaddr", Value: d.config["hwaddr"]},
+		)
 	}
 
 	revert.Success()

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -137,13 +137,13 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "name", Value: d.config["name"]},
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: peerName},
+		{Key: "hwaddr", Value: d.config["hwaddr"]},
 	}
 
 	if d.inst.Type() == instancetype.VM {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
-				{Key: "hwaddr", Value: d.config["hwaddr"]},
 				{Key: "mtu", Value: fmt.Sprintf("%d", mtu)},
 			}...)
 	}


### PR DESCRIPTION
This is an attempt to workaround potential race conditions with udev/systemd-networkd when creating NICs and passing them to instances.

Although its not proven this is an actual issue. So this is more "belt and braces" approach.

By passing the hwaddr to liblxc (as well as setting it via ip link) it gives another chance for the MAC address to be set before its passed into the container.

Reported from https://bugs.launchpad.net/lxd/+bug/1991552

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>