### PR TITLE
fsmonitor: Don't watch for WRITE events when using inotify

### DIFF
--- a/doc/backup.md
+++ b/doc/backup.md
@@ -66,7 +66,7 @@ and can be imported back into LXD using the `lxc import` command.
 
 ## Disaster recovery
 
-LXD provides the `lxd recover` command (note the the `lxd` command rather than the normal `lxc` command).
+LXD provides the `lxd recover` command (note the `lxd` command rather than the normal `lxc` command).
 This is an interactive CLI tool that will attempt to scan all storage pools that exist in the database looking for
 missing volumes that can be recovered. It also provides the ability for the user to specify the details of any
 unknown storage pools (those that exist on disk but do not exist in the database) and it will attempt to scan those

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -162,7 +162,7 @@ The basic prerequisite setup steps to achieve this are:
 PF and VF setup:
 
 Activate some VFs on PF (in this case called `enp9s0f0np0` with a PCI address of `0000:09:00.0`) and unbind them.
-Then enable `switchdev` mode and `hw-tc-offload` on the the PF.
+Then enable `switchdev` mode and `hw-tc-offload` on the PF.
 Finally rebind the VFs.
 
 ```

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -419,7 +419,7 @@ definitions:
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
     ClusterMemberPut:
-        description: ClusterMemberPut represents the the modifiable fields of a LXD cluster member
+        description: ClusterMemberPut represents the modifiable fields of a LXD cluster member
         properties:
             config:
                 additionalProperties:

--- a/doc/server.md
+++ b/doc/server.md
@@ -30,7 +30,7 @@ Key                                 | Type      | Scope     | Default           
 `acme.agree_tos`                    | bool      | global    | `false`                                          | Agree to ACME Terms of service
 `backups.compression_algorithm`     | string    | global    | `gzip`                                           | Compression algorithm to use for new images (`bzip2`, `gzip`, `lzma`, `xz` or `none`)
 `candid.api.key`                    | string    | global    | -                                                | Public key of the candid server (required for HTTP-only servers)
-`candid.api.url`                    | string    | global    | -                                                | URL of the the external authentication endpoint using Candid
+`candid.api.url`                    | string    | global    | -                                                | URL of the external authentication endpoint using Candid
 `candid.domains`                    | string    | global    | -                                                | Comma-separated list of allowed Candid domains (empty string means all domains are valid)
 `candid.expiry`                     | integer   | global    | `3600`                                           | Candid macaroon expiry in seconds
 `cluster.https_address`             | string    | local     | -                                                | Address to use for clustering traffic

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3
-	github.com/fsnotify/fsnotify v1.6.0
 	github.com/fvbommel/sortorder v1.0.2
 	github.com/go-acme/lego/v4 v4.9.0
 	github.com/google/gopacket v1.1.19
@@ -54,6 +53,7 @@ require (
 	gopkg.in/macaroon-bakery.v3 v3.0.0
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
 )
 
 require (
@@ -66,6 +66,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/eapache/channels v1.1.0 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-macaroon-bakery/macaroonpb v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -818,8 +818,6 @@ github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/gopsutil/v3 v3.22.9 h1:yibtJhIVEMcdw+tCTbOPiF1VcsuDeTE4utJ8Dm4c5eA=
 github.com/shirou/gopsutil/v3 v3.22.9/go.mod h1:bBYl1kjgEJpWpxeHmLI+dVHWtyAwfcmSBLDsp2TNT8A=
-github.com/shirou/gopsutil/v3 v3.22.10 h1:4KMHdfBRYXGF9skjDWiL4RA2N+E8dRdodU/bOZpPoVg=
-github.com/shirou/gopsutil/v3 v3.22.10/go.mod h1:QNza6r4YQoydyCfo6rH0blGfKahgibh4dQmV5xdFkQk=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
@@ -1515,6 +1513,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 h1:GfD9OzL11kvZN5iArC6oTS7RTj7oJOIfnislxYlqTj8=
+k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 launchpad.net/lpad v0.0.0-20131113112110-000000000065/go.mod h1:cItrEkWN+F4fC6+HU9vEne57WkgMNe2aIWFFiYbvJ3M=
 launchpad.net/xmlpath v0.0.0-20130614043138-000000000004/go.mod h1:vqyExLOM3qBx7mvYRkoxjSCF945s0mbe7YynlKYXtsA=

--- a/lxd/acme/acme.go
+++ b/lxd/acme/acme.go
@@ -32,7 +32,7 @@ const retries = 5
 // certificate at a later stage.
 const ClusterCertFilename = "cluster.crt.new"
 
-// certificateNeedsUpdate returns true if the the domain doesn't match the certificate's DNS names
+// certificateNeedsUpdate returns true if the domain doesn't match the certificate's DNS names
 // or it's valid for less than 30 days.
 func certificateNeedsUpdate(domain string, cert *x509.Certificate) bool {
 	return !shared.StringInSlice(domain, cert.DNSNames) || time.Now().After(cert.NotAfter.Add(-30*24*time.Hour))

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -392,7 +392,7 @@ func (c *Cluster) retry(f func() error) error {
 	return query.Retry(f)
 }
 
-// NodeID sets the the node NodeID associated with this cluster instance. It's used for
+// NodeID sets the node NodeID associated with this cluster instance. It's used for
 // backward-compatibility of all db-related APIs that were written before
 // clustering and don't accept a node NodeID, so in those cases we automatically
 // use this value as implicit node NodeID.

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-// Packages returns the the AST packages in which to search for structs.
+// Packages returns the AST packages in which to search for structs.
 //
 // By default it includes the lxd/db and shared/api packages.
 func Packages() (map[string]*ast.Package, error) {
@@ -37,7 +37,7 @@ func Packages() (map[string]*ast.Package, error) {
 	return packages, nil
 }
 
-// ParsePackage returns the the AST package in which to search for structs.
+// ParsePackage returns the AST package in which to search for structs.
 func ParsePackage(pkgPath string) (*ast.Package, error) {
 	pkg, err := lex.Parse(pkgPath)
 	if err != nil {

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -851,7 +851,7 @@ func (c *ClusterTx) DeleteInstanceConfigKey(id int64, key string) error {
 	return err
 }
 
-// UpdateInstancePowerState sets the the power state of the container with the given ID.
+// UpdateInstancePowerState sets the power state of the container with the given ID.
 func (c *ClusterTx) UpdateInstancePowerState(id int, state string) error {
 	// Set the new value
 	str := "INSERT OR REPLACE INTO instances_config (instance_id, key, value) VALUES (?, 'volatile.last_state.power', ?)"

--- a/lxd/db/transaction.go
+++ b/lxd/db/transaction.go
@@ -28,7 +28,7 @@ func (c *ClusterTx) Tx() *sql.Tx {
 	return c.tx
 }
 
-// NodeID sets the the node NodeID associated with this cluster transaction.
+// NodeID sets the node NodeID associated with this cluster transaction.
 func (c *ClusterTx) NodeID(id int64) {
 	c.nodeID = id
 }

--- a/lxd/device/device_utils_unix_events.go
+++ b/lxd/device/device_utils_unix_events.go
@@ -61,7 +61,7 @@ func unixRegisterHandler(s *state.State, inst instance.Instance, deviceName, pat
 		return fmt.Errorf("Failed to add %q to watch targets: %w", path, err)
 	}
 
-	logger.Debugf("Added %q to watch targets", filepath.Clean(path))
+	logger.Debug("Added watch target", logger.Ctx{"path": path})
 	return nil
 }
 

--- a/lxd/device/device_utils_unix_events.go
+++ b/lxd/device/device_utils_unix_events.go
@@ -49,14 +49,16 @@ func unixRegisterHandler(s *state.State, inst instance.Instance, deviceName, pat
 
 	identifier := fmt.Sprintf("%d_%s", inst.ID(), deviceName)
 
+	path = filepath.Clean(path)
+
 	// Add inotify watcher to its nearest existing ancestor.
-	err := s.DevMonitor.Watch(filepath.Clean(path), identifier, func(path, event string) bool {
+	err := s.DevMonitor.Watch(path, identifier, func(path, event string) bool {
 		e := unixNewEvent(event, path)
 		unixRunHandlers(s, &e)
 		return true
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to add %q to watch targets: %w", filepath.Clean(path), err)
+		return fmt.Errorf("Failed to add %q to watch targets: %w", path, err)
 	}
 
 	logger.Debugf("Added %q to watch targets", filepath.Clean(path))

--- a/lxd/device/device_utils_unix_events.go
+++ b/lxd/device/device_utils_unix_events.go
@@ -114,7 +114,7 @@ func unixRunHandlers(state *state.State, event *UnixEvent) {
 		// Run handler function.
 		runConf, err := sub.Handler(*event)
 		if err != nil {
-			logger.Error("Unix event hook failed", logger.Ctx{"err": err, "project": projectName, "instance": instanceName, "device": deviceName, "path": sub.Path})
+			logger.Error("Unix event hook failed", logger.Ctx{"project": projectName, "instance": instanceName, "device": deviceName, "path": sub.Path, "action": event.Action, "err": err})
 			continue
 		}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -794,7 +794,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				// raw ID maps have been supplied, then we will be running the disk proxy processes
 				// inside a user namespace as the root userns user. Therefore we need to ensure
 				// that there is a root UID and GID mapping in the raw ID maps, and if not then add
-				// one mapping the root userns user to the the nouser/nogroup host ID.
+				// one mapping the root userns user to the nouser/nogroup host ID.
 				if d.restrictedParentSourcePath != "" || len(rawIDMaps) > 0 {
 					rawIDMaps = diskAddRootUserNSEntry(rawIDMaps, 65534)
 				}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1656,7 +1656,7 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 			}
 
 			if shared.IsFalseOrEmpty(d.network.Config()["ipv6.dhcp.stateful"]) && v6subnet != nil {
-				// If stateful DHCPv6 is disabled, and IPv6 is enabled on the bridge, the the NIC
+				// If stateful DHCPv6 is disabled, and IPv6 is enabled on the bridge, the NIC
 				// is likely to use its MAC and SLAAC to configure its address.
 				if hwAddr != nil {
 					ip, err := eui64.ParseMAC(v6subnet.IP, hwAddr)

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -756,7 +756,7 @@ func (d *nicOVN) State() (*api.InstanceStateNetwork, error) {
 			})
 		} else if shared.IsFalseOrEmpty(netConfig["ipv6.dhcp.stateful"]) && d.config["hwaddr"] != "" && v6subnet != nil {
 			// If no static DHCPv6 allocation and stateful DHCPv6 is disabled, and IPv6 is enabled on
-			// the bridge, the the NIC is likely to use its MAC and SLAAC to configure its address.
+			// the bridge, the NIC is likely to use its MAC and SLAAC to configure its address.
 			hwAddr, err := net.ParseMAC(d.config["hwaddr"])
 			if err == nil {
 				ip, err := eui64.ParseMAC(v6subnet.IP, hwAddr)

--- a/lxd/device/unix_common.go
+++ b/lxd/device/unix_common.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -118,7 +119,13 @@ func (d *unixCommon) Register() error {
 			// Get the file type and ensure it matches what the user was expecting.
 			dType, _, _, err := unixDeviceAttributes(e.Path)
 			if err != nil {
-				return nil, err
+				if os.IsNotExist(err) {
+					// Skip if host side source device doesn't exist.
+					// This could be an event for the parent directory being added.
+					return nil, nil
+				}
+
+				return nil, fmt.Errorf("Failed getting device attributes: %w", err)
 			}
 
 			if !unixIsOurDeviceType(d.config, dType) {

--- a/lxd/fsmonitor/drivers/common.go
+++ b/lxd/fsmonitor/drivers/common.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -34,6 +35,8 @@ func (d *common) Watch(path string, identifier string, f func(path string, event
 		return ErrInvalidFunction
 	}
 
+	path = filepath.Clean(path)
+
 	if !strings.HasPrefix(path, d.prefixPath) {
 		return &ErrInvalidPath{PrefixPath: d.prefixPath}
 	}
@@ -60,6 +63,8 @@ func (d *common) Watch(path string, identifier string, f func(path string, event
 func (d *common) Unwatch(path string, identifier string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
+	path = filepath.Clean(path)
 
 	_, ok := d.watches[path]
 	if !ok {

--- a/lxd/fsmonitor/drivers/driver_fanotify.go
+++ b/lxd/fsmonitor/drivers/driver_fanotify.go
@@ -34,6 +34,10 @@ type fanotifyEventInfoFid struct {
 	FSID uint64
 }
 
+func (d *fanotify) Name() string {
+	return "fanotify"
+}
+
 func (d *fanotify) load(ctx context.Context) error {
 	if fanotifyLoaded {
 		return nil

--- a/lxd/fsmonitor/drivers/interface.go
+++ b/lxd/fsmonitor/drivers/interface.go
@@ -16,6 +16,7 @@ type driver interface {
 
 // Driver represents a low-level fs notification driver.
 type Driver interface {
+	Name() string
 	PrefixPath() string
 	Watch(path string, identifier string, f func(path string, event string) bool) error
 	Unwatch(path string, identifier string) error

--- a/lxd/fsmonitor/drivers/load.go
+++ b/lxd/fsmonitor/drivers/load.go
@@ -7,7 +7,7 @@ import (
 )
 
 var drivers = map[string]func() driver{
-	"fsnotify": func() driver { return &fsnotify{} },
+	"inotify":  func() driver { return &inotify{} },
 	"fanotify": func() driver { return &fanotify{} },
 }
 

--- a/lxd/fsmonitor/load.go
+++ b/lxd/fsmonitor/load.go
@@ -28,14 +28,14 @@ func New(ctx context.Context, path string) (FSMonitor, error) {
 
 	driver, monLogger, err := startMonitor("fanotify")
 	if err != nil {
-		logger.Warn("Failed to initialize fanotify, falling back on fsnotify", logger.Ctx{"err": err})
-		driver, monLogger, err = startMonitor("fsnotify")
+		logger.Warn("Failed to initialize fanotify, falling back on inotify", logger.Ctx{"err": err})
+		driver, monLogger, err = startMonitor("inotify")
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	logger.Debug("Initialized filesystem monitor", logger.Ctx{"path": path})
+	logger.Info("Initialized filesystem monitor", logger.Ctx{"path": path, "driver": driver.Name()})
 
 	monitor := fsMonitor{
 		driver: driver,

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -371,7 +371,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 		return &info, fmt.Errorf("The image already exists: %s", info.Fingerprint)
 	}
 
-	/* rename the the file to the expected name so our caller can use it */
+	/* rename the file to the expected name so our caller can use it */
 	finalName := shared.VarPath("images", info.Fingerprint)
 	err = shared.FileMove(imageFile.Name(), finalName)
 	if err != nil {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1216,7 +1216,7 @@ func (d *common) devicesAdd(inst instance.Instance, instanceRunning bool) (rever
 			// static NIC DHCP leases to be created). Instead just log an error.
 			// This will allow instances to be created with conflicting devices (such as when copying
 			// or restoring a backup) and allows the user to manually fix the conflicts in order to
-			// allow the the instance to start.
+			// allow the instance to start.
 			if api.StatusErrorCheck(err, http.StatusConflict) {
 				d.logger.Error("Failed add validation for device, skipping add action", logger.Ctx{"device": entry.Name, "err": err})
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1582,7 +1582,7 @@ func (d *lxc) deviceDetachNIC(configCopy map[string]string, netIF []deviceConfig
 		}
 	} else {
 		// Currently liblxc does not move devices back to the host on stop that were added
-		// after the the container was started. For this reason we utilise the lxc.hook.stop
+		// after the container was started. For this reason we utilise the lxc.hook.stop
 		// hook so that we can capture the netns path, enter the namespace and move the nics
 		// back to the host and rename them if liblxc hasn't already done it.
 		// We can only move back devices that have an expected host_name record and where

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2384,7 +2384,7 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 		return err
 	}
 
-	// Writing the connection info the the config drive allows the lxd-agent to start devlxd very
+	// Writing the connection info the config drive allows the lxd-agent to start devlxd very
 	// early. This is important for systemd services which want or require /dev/lxd/sock.
 	connInfo, err := d.getAgentConnectionInfo()
 	if err != nil {

--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
+	"k8s.io/utils/inotify"
 
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/shared"
@@ -34,7 +34,7 @@ var dnsServersList []string
 
 // serversFileMonitor performs an initial load of the server list and then waits for the file to be
 // modified before triggering a reload.
-func serversFileMonitor(watcher *fsnotify.Watcher, networkName string) {
+func serversFileMonitor(watcher *inotify.Watcher, networkName string) {
 	err := loadServersList(networkName)
 	if err != nil {
 		logger.Errorf("Server list load error: %v", err)
@@ -42,7 +42,7 @@ func serversFileMonitor(watcher *fsnotify.Watcher, networkName string) {
 
 	for {
 		select {
-		case ev := <-watcher.Events:
+		case ev := <-watcher.Event:
 			// Ignore files events that dont concern the servers list file.
 			if !strings.HasSuffix(ev.Name, network.ForkdnsServersListPath+"/"+network.ForkdnsServersListFile) {
 				continue
@@ -54,7 +54,7 @@ func serversFileMonitor(watcher *fsnotify.Watcher, networkName string) {
 				continue
 			}
 
-		case err := <-watcher.Errors:
+		case err := <-watcher.Error:
 			logger.Errorf("Inotify error: %v", err)
 		}
 	}
@@ -358,16 +358,16 @@ func (c *cmdForkDNS) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Setup watcher on servers file.
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := inotify.NewWatcher()
 	if err != nil {
-		return fmt.Errorf("Unable to setup fsnotify: %s", err)
+		return fmt.Errorf("Unable to setup inotify: %s", err)
 	}
 
 	networkName := args[2]
 	path := shared.VarPath("networks", networkName, network.ForkdnsServersListPath)
-	err = watcher.Add(path)
+	err = watcher.AddWatch(path, inotify.InAllEvents)
 	if err != nil {
-		return fmt.Errorf("Unable to setup fsnotify watch on %s: %w", path, err)
+		return fmt.Errorf("Unable to setup inotify watch on %s: %w", path, err)
 	}
 
 	// Run the server list monitor concurrently waiting for file changes.

--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -387,7 +387,7 @@ func (c *cmdForkDNS) Run(cmd *cobra.Command, args []string) error {
 
 	err = srv.ListenAndServe()
 	if err != nil {
-		return fmt.Errorf("Failed to set udp listener: %v\n", err)
+		return fmt.Errorf("Failed to set udp listener: %w", err)
 	}
 
 	return nil

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -37,10 +37,10 @@ func (c *cmdSql) Command() *cobra.Command {
   If <query> is the special value "-", then the query is read from
   standard input.
 
-  If <query> is the special value ".dump", the the command returns a SQL text
+  If <query> is the special value ".dump", the command returns a SQL text
   dump of the given database.
 
-  If <query> is the special value ".schema", the the command returns the SQL
+  If <query> is the special value ".schema", the command returns the SQL
   text schema of the given database.
 
   This internal command is mostly useful for debugging and disaster

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -79,7 +79,7 @@ func (n *bridge) Info() Info {
 // cluster nodes. It is not suitable to use a static MAC address when "bridge.external_interfaces" is non-empty and
 // the bridge interface has no IPv4 or IPv6 address set. This is because in a clustered environment the same bridge
 // config is applied to all nodes, and if the bridge is being used to connect multiple nodes to the same network
-// segment it would cause MAC conflicts to use the the same MAC on all nodes. If an IP address is specified then
+// segment it would cause MAC conflicts to use the same MAC on all nodes. If an IP address is specified then
 // connecting multiple nodes to the same network segment would also cause IP conflicts, so if an IP is defined
 // then we assume this is not being done. However if IP addresses are explicitly set to "none" and
 // "bridge.external_interfaces" is set then it may not be safe to use a the same MAC address on all nodes.

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -48,7 +48,7 @@ func (d *lvm) thinpoolName() string {
 	return lvmThinpoolDefaultName
 }
 
-// openLoopFile opens a loop device and returns the the device path.
+// openLoopFile opens a loop device and returns the device path.
 func (d *lvm) openLoopFile(source string) (string, error) {
 	if source == "" {
 		return "", fmt.Errorf("No source property found for the storage pool")

--- a/lxd/task/task.go
+++ b/lxd/task/task.go
@@ -25,7 +25,7 @@ func (t *Task) Reset() {
 // Execute the our task function according to our schedule, until the given
 // context gets cancelled.
 func (t *Task) loop(ctx context.Context) {
-	// Kick off the task immediately (as long as the the schedule is
+	// Kick off the task immediately (as long as the schedule is
 	// greater than zero, see below).
 	delay := immediately
 

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -25,7 +25,7 @@ import (
 
 // DebugJSON helper to log JSON.
 // Accepts a title to prefix the JSON log with, a *bytes.Bufffer containing the JSON and a logger to use for
-// logging the the JSON (allowing for custom context to be added to the log).
+// logging the JSON (allowing for custom context to be added to the log).
 func DebugJSON(title string, r *bytes.Buffer, l logger.Logger) {
 	pretty := &bytes.Buffer{}
 	err := json.Indent(pretty, r.Bytes(), "\t", "\t")

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -188,7 +188,7 @@ func (member *ClusterMember) Writable() ClusterMemberPut {
 	return member.ClusterMemberPut
 }
 
-// ClusterMemberPut represents the the modifiable fields of a LXD cluster member
+// ClusterMemberPut represents the modifiable fields of a LXD cluster member
 //
 // swagger:model
 //

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -750,7 +750,7 @@ test_clustering_storage() {
     LXD_DIR="${LXD_TWO_DIR}" lxc start foo
     LXD_DIR="${LXD_TWO_DIR}" lxc stop foo --force
 
-    # Init a new container on node2 using the the snapshot on node1
+    # Init a new container on node2 using the snapshot on node1
     LXD_DIR="${LXD_ONE_DIR}" lxc copy foo/snap-test egg --target node2
     LXD_DIR="${LXD_TWO_DIR}" lxc start egg
     LXD_DIR="${LXD_ONE_DIR}" lxc stop egg --force


### PR DESCRIPTION
Switch away from `github.com/fsnotify/fsnotify` package to `k8s.io/utils/inotify`.

There is an unfortunate behaviour in the fsnotify package in that it watches for all events
on a path, and doesn't give the user the option of only watching for specific events.

This means that when watching, for example on /dev/net, any writes to /dev/net/tun will cause
a WRITE event to be sent to LXD. As you can image, for high traffic interfaces this can cause
many events and causes LXD to use a lot of CPU. This is equally the case for other devices
that can be written to, such as block devices.

The issue is identified in the upstream package (https://github.com/fsnotify/fsnotify/issues/7)
but there doesn't seem to be any consensus on how to move forward so the issue has languished.

LXD however doesn't need cross-platform support that fsnotify package offers and so can use a
lightweight wrapper around the inotify feature (which is what we use with fsnotify anyway).

There used to be an inotify wrapper at golang.org/x/exp/inotify which has subsequently moved
to gopkg.in/fsnotify.v0. Unfortunately that doesn't support go mod and so isn't usable by
LXD. Its also not been updated since 2015.

There is however a fork of golang.org/x/exp/inotify at https://github.com/kubernetes/utils/tree/master/inotify
which has seen some minor maintenance this year. This package also has go mod support.

**If preferred we can easily copy this package into LXD instead.**

This PR also makes the following changes:
 - Avoids the need to make a stat syscall to detect if event is for a directory by using the
   `InIsdir` flag in the event Mask.
 - Avoids calling every registered handler for every new directory and instead performs a path
   prefix match.
 - Improves comments and readability.
 - Cleans the path coming from the event to ensure comparison with registered handlers works.
 - Reduces repetition in event action logic.
 - Adds device exists detection to `unixCommon` handler, otherwise we were getting an error logged if a CREATE event occurred in the same directory as was being watched but for a different file.
 - Renames fsnotify driver to inotify.
 - Adds `Name()` function to driver.
 - Logs at Info level the driver used during start up.
 - Switches forkdns to use inotify as well.

Fixes https://github.com/lxc/lxd/issues/11151