### PR TITLE
config: Fix inconsistency with acme.agree_tos option

### DIFF
--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -281,7 +281,7 @@ var ConfigSchema = config.Schema{
 	"acme.ca_url":                    {},
 	"acme.domain":                    {},
 	"acme.email":                     {},
-	"acme.agree_tos":                 {Type: config.Bool},
+	"acme.agree_tos":                 {Type: config.Bool, Default: "false"},
 	"backups.compression_algorithm":  {Default: "gzip", Validator: validate.IsCompressionAlgorithm},
 	"cluster.offline_threshold":      {Type: config.Int64, Default: offlineThresholdDefault(), Validator: offlineThresholdValidator},
 	"cluster.images_minimal_replica": {Type: config.Int64, Default: "3", Validator: imageMinimalReplicaValidator},


### PR DESCRIPTION
This fixes an inconsistency with the `acme.agree_tos` option where if set
to true, then set to false, it would show the option as `false` in
/1.0.

The correct behaviour is to omit the config key if the default value is
set.

Fixes #11153

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
