### PR TITLE
lxc: Allow `--device` flag to override local devices from `--storage` and `--network` flags

### DIFF
--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -93,7 +93,7 @@ func parseDeviceOverrides(deviceOverrideArgs []string) (map[string]map[string]st
 	deviceMap := map[string]map[string]string{}
 	for _, entry := range deviceOverrideArgs {
 		if !strings.Contains(entry, "=") || !strings.Contains(entry, ",") {
-			return nil, fmt.Errorf(i18n.G("Bad syntax, expecting <device>,<key>=<value>: %s"), entry)
+			return nil, fmt.Errorf(i18n.G("Bad device override syntax, expecting <device>,<key>=<value>: %s"), entry)
 		}
 
 		deviceFields := strings.SplitN(entry, ",", 2)

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -999,6 +999,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -1016,11 +1021,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
-msgstr ""
 
 #: lxc/network.go:838
 msgid "Bond:"
@@ -1168,15 +1168,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1962,7 +1957,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
@@ -2349,6 +2344,11 @@ msgstr "Akzeptiere Zertifikat"
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2866,7 +2866,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4858,7 +4858,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5646,7 +5646,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5655,12 +5655,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5727,11 +5727,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -637,7 +637,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -726,6 +726,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -742,11 +747,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -885,15 +885,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1637,7 +1632,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1998,6 +1993,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2497,7 +2497,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4377,7 +4377,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5130,7 +5130,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5139,12 +5139,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5206,11 +5206,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -882,7 +882,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -972,6 +972,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -989,11 +994,6 @@ msgstr ""
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
-msgstr ""
 
 #: lxc/network.go:838
 msgid "Bond:"
@@ -1133,15 +1133,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1896,7 +1891,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Cacheado: %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2262,6 +2257,11 @@ msgstr "Acepta certificado"
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2768,7 +2768,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -4676,7 +4676,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5433,7 +5433,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5442,12 +5442,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -909,7 +909,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1005,6 +1005,11 @@ msgstr "Image copiée avec succès !"
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -1022,11 +1027,6 @@ msgstr ""
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
-msgstr ""
 
 #: lxc/network.go:838
 msgid "Bond:"
@@ -1169,15 +1169,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1984,7 +1979,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -2383,6 +2378,11 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2912,7 +2912,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -4978,7 +4978,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5781,7 +5781,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -5792,12 +5792,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, fuzzy, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
@@ -5862,12 +5862,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -636,7 +636,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -725,6 +725,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -741,11 +746,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -883,15 +883,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1627,7 +1622,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1980,6 +1975,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5070,12 +5070,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5137,11 +5137,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -876,7 +876,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -966,6 +966,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -983,11 +988,6 @@ msgstr ""
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
-msgstr ""
 
 #: lxc/network.go:838
 msgid "Bond:"
@@ -1125,15 +1125,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1887,7 +1882,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2252,6 +2247,11 @@ msgstr "Accetta certificato"
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2755,7 +2755,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -4670,7 +4670,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5426,7 +5426,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5435,12 +5435,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5504,11 +5504,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -882,7 +882,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -975,6 +975,12 @@ msgstr "バックアップのエクスポートが成功しました!"
 msgid "Backups:"
 msgstr "バックアップ:"
 
+#: lxc/utils.go:96
+#, fuzzy, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+"書式が不適切です。次のような形式で指定してください <device>,<key>=<value>: %s"
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -992,12 +998,6 @@ msgstr "不適切な キー=値 のペア: %s"
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
-msgstr ""
-"書式が不適切です。次のような形式で指定してください <device>,<key>=<value>: %s"
 
 #: lxc/network.go:838
 msgid "Bond:"
@@ -1135,15 +1135,10 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Candid domain to use"
 msgstr "使用する Candid ドメイン"
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1907,7 +1902,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
@@ -2291,6 +2286,11 @@ msgstr "SSH ホスト鍵の生成に失敗しました: %w"
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
+msgstr ""
 
 #: lxc/file.go:1180
 #, c-format
@@ -2806,7 +2806,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -4853,7 +4853,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -5648,7 +5648,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -5657,14 +5657,14 @@ msgstr "起動しようとしたインスタンスに接続されているネッ
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:%s' を試してみてくださ"
 "い。"
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5738,13 +5738,13 @@ msgstr "インスタンスを強制停止するまで待つ時間"
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-11-17 13:12-0500\n"
+        "POT-Creation-Date: 2022-11-25 09:28+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -601,7 +601,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -689,6 +689,11 @@ msgstr  ""
 msgid   "Backups:"
 msgstr  ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr  ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285 lxc/network_load_balancer.go:287 lxc/network_peer.go:281 lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
 #, c-format
 msgid   "Bad key/value pair: %s"
@@ -702,11 +707,6 @@ msgstr  ""
 #: lxc/image.go:757
 #, c-format
 msgid   "Bad property: %s"
-msgstr  ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid   "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
 #: lxc/network.go:838
@@ -844,14 +844,9 @@ msgstr  ""
 msgid   "Candid domain to use"
 msgstr  ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid   "Cannot override config for device %q: Device not found in profile devices"
-msgstr  ""
-
-#: lxc/init.go:275
-#, c-format
-msgid   "Cannot override devices: %w"
 msgstr  ""
 
 #: lxc/network_acl.go:781
@@ -1435,7 +1430,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
@@ -1776,6 +1771,11 @@ msgstr  ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid   "Failed getting peer's status: %w"
+msgstr  ""
+
+#: lxc/init.go:288
+#, c-format
+msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
 #: lxc/file.go:1180
@@ -2250,7 +2250,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -3991,7 +3991,7 @@ msgstr  ""
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -4694,7 +4694,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -4703,12 +4703,12 @@ msgstr  ""
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr  ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr  ""
@@ -4765,11 +4765,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -852,7 +852,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -941,6 +941,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -957,11 +962,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -1099,15 +1099,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1843,7 +1838,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2196,6 +2191,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2688,7 +2688,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4541,7 +4541,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5277,7 +5277,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5286,12 +5286,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5353,11 +5353,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -886,7 +886,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -975,6 +975,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -991,11 +996,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -1133,15 +1133,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1877,7 +1872,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2230,6 +2225,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4575,7 +4575,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5311,7 +5311,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5320,12 +5320,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5387,11 +5387,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -894,7 +894,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -990,6 +990,11 @@ msgstr "Backup exportado com sucesso!"
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, fuzzy, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -1007,11 +1012,6 @@ msgstr "par de chave=valor inválido %s"
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
-msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
 #: lxc/network.go:838
 msgid "Bond:"
@@ -1150,15 +1150,10 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1937,7 +1932,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2308,6 +2303,11 @@ msgstr "Aceitar certificado"
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2814,7 +2814,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4737,7 +4737,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5511,7 +5511,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5520,12 +5520,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5588,11 +5588,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -989,6 +989,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -1005,11 +1010,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -1149,15 +1149,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1923,7 +1918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2296,6 +2291,11 @@ msgstr "Принять сертификат"
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5498,7 +5498,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5507,12 +5507,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5574,11 +5574,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -636,7 +636,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -725,6 +725,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -741,11 +746,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -883,15 +883,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1627,7 +1622,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1980,6 +1975,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5070,12 +5070,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5137,11 +5137,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -636,7 +636,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -725,6 +725,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -741,11 +746,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -883,15 +883,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1627,7 +1622,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1980,6 +1975,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5070,12 +5070,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5137,11 +5137,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -632,7 +632,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -721,6 +721,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -737,11 +742,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -879,15 +879,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1623,7 +1618,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1976,6 +1971,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2468,7 +2468,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4321,7 +4321,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5057,7 +5057,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5066,12 +5066,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5133,11 +5133,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -636,7 +636,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -725,6 +725,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -741,11 +746,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -883,15 +883,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1627,7 +1622,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1980,6 +1975,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5070,12 +5070,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5137,11 +5137,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -749,7 +749,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -838,6 +838,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -854,11 +859,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -996,15 +996,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1740,7 +1735,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2093,6 +2088,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2585,7 +2585,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4438,7 +4438,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5174,7 +5174,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5183,12 +5183,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5250,11 +5250,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-17 13:12-0500\n"
+"POT-Creation-Date: 2022-11-25 09:28+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:366
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -724,6 +724,11 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
+#: lxc/utils.go:96
+#, c-format
+msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
+msgstr ""
+
 #: lxc/network.go:325 lxc/network_acl.go:369 lxc/network_forward.go:285
 #: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
 #: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
@@ -740,11 +745,6 @@ msgstr ""
 #: lxc/image.go:757
 #, c-format
 msgid "Bad property: %s"
-msgstr ""
-
-#: lxc/utils.go:96
-#, c-format
-msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: lxc/network.go:838
@@ -882,15 +882,10 @@ msgstr ""
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:287
+#: lxc/init.go:309
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
-msgstr ""
-
-#: lxc/init.go:275
-#, c-format
-msgid "Cannot override devices: %w"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1626,7 +1621,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:426
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1979,6 +1974,11 @@ msgstr ""
 #: lxc/network_peer.go:305
 #, c-format
 msgid "Failed getting peer's status: %w"
+msgstr ""
+
+#: lxc/init.go:288
+#, c-format
+msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
 #: lxc/file.go:1180
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:416 lxc/init.go:410
+#: lxc/copy.go:416 lxc/init.go:433
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:380
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:461
+#: lxc/init.go:484
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5069,12 +5069,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/init.go:445
+#: lxc/init.go:468
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:464
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -5136,11 +5136,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:463
+#: lxc/init.go:486
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:462
+#: lxc/init.go:485
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 


### PR DESCRIPTION
Rather than replacing them with devices from profile(s).

Found whilst working on https://github.com/lxc/lxd/pull/11157