### PR TITLE
Network: Use `UsedByInstanceDevices` for `checkAddressConflict` and `Leases`

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -239,7 +239,7 @@ func (d *nicOVN) checkAddressConflict() error {
 	}
 
 	// Check if any instance devices use this network.
-	return network.UsedByInstanceDevices(d.state, d.network.Project(), d.network.Name(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+	return network.UsedByInstanceDevices(d.state, d.network.Project(), d.network.Name(), d.network.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 		// Skip our own device. This avoids triggering duplicate device errors during
 		// updates or when making temporary copies of our instance during migrations.
 		if instance.IsSameLogicalInstance(d.inst, &inst) && d.Name() == nicName {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -240,11 +240,6 @@ func (d *nicOVN) checkAddressConflict() error {
 
 	// Check if any instance devices use this network.
 	return network.UsedByInstanceDevices(d.state, d.network.Project(), d.network.Name(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
-		// Skip NICs that specify a NIC type that is not the same as our own.
-		if !shared.StringInSlice(nicConfig["nictype"], []string{"", "ovn"}) {
-			return nil
-		}
-
 		// Skip our own device. This avoids triggering duplicate device errors during
 		// updates or when making temporary copies of our instance during migrations.
 		if instance.IsSameLogicalInstance(d.inst, &inst) && d.Name() == nicName {

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2905,7 +2905,7 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 
 		// Get all the instances in the requested project that are connected to this network.
 		filter := dbCluster.InstanceFilter{Project: &projectName}
-		err = UsedByInstanceDevices(n.state, n.project, n.name, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+		err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 			// Fill in the hwaddr from volatile.
 			if nicConfig["hwaddr"] == "" {
 				nicConfig["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", nicName)]

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -25,7 +25,6 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/warningtype"
-	"github.com/lxc/lxd/lxd/device/nictype"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	firewallDrivers "github.com/lxc/lxd/lxd/firewall/drivers"
@@ -2869,15 +2868,14 @@ func (n *bridge) forwardSetupFirewall() error {
 // Leases returns a list of leases for the bridged network. It will reach out to other cluster members as needed.
 // The projectName passed here refers to the initial project from the API request which may differ from the network's project.
 func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]api.NetworkLease, error) {
+	var err error
+	var projectMacs []string
 	leases := []api.NetworkLease{}
-	projectMacs := []string{}
 
 	// Get all static leases.
 	if clientType == request.ClientTypeNormal {
 		// Get the downstream networks.
 		if n.project == project.Default {
-			var err error
-
 			// Load all the networks.
 			var projectNetworks map[string]map[int64]api.Network
 			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -2910,80 +2908,55 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 			}
 		}
 
-		// Get all the instances in project.
+		// Get all the instances in the requested project that are connected to this network.
 		filter := dbCluster.InstanceFilter{Project: &projectName}
-		err := n.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
-			devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
+		err = UsedByInstanceDevices(n.state, n.project, n.name, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+			// Fill in the hwaddr from volatile.
+			if nicConfig["hwaddr"] == "" {
+				nicConfig["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", nicName)]
+			}
 
-			// Go through all its devices (including profiles).
-			for k, dev := range devices {
-				// Skip uninteresting entries.
-				if dev["type"] != "nic" {
-					continue
-				}
+			// Record the MAC.
+			hwAddr, _ := net.ParseMAC(nicConfig["hwaddr"])
+			if hwAddr != nil {
+				projectMacs = append(projectMacs, hwAddr.String())
+			}
 
-				nicType, err := nictype.NICType(n.state, inst.Project, dev)
-				if err != nil || nicType != "bridged" {
-					continue
-				}
+			// Add the lease.
+			nicIP4 := net.ParseIP(nicConfig["ipv4.address"])
+			if nicIP4 != nil {
+				leases = append(leases, api.NetworkLease{
+					Hostname: inst.Name,
+					Address:  nicIP4.String(),
+					Hwaddr:   hwAddr.String(),
+					Type:     "static",
+					Location: inst.Node,
+				})
+			}
 
-				// Temporarily populate parent from network setting if used.
-				if dev["network"] != "" {
-					dev["parent"] = dev["network"]
-				}
+			nicIP6 := net.ParseIP(nicConfig["ipv6.address"])
+			if nicIP6 != nil {
+				leases = append(leases, api.NetworkLease{
+					Hostname: inst.Name,
+					Address:  nicIP6.String(),
+					Hwaddr:   hwAddr.String(),
+					Type:     "static",
+					Location: inst.Node,
+				})
+			}
 
-				if dev["parent"] != n.name {
-					continue
-				}
-
-				// Fill in the hwaddr from volatile.
-				if dev["hwaddr"] == "" {
-					dev["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", k)]
-				}
-
-				// Record the MAC.
-				if dev["hwaddr"] != "" {
-					projectMacs = append(projectMacs, dev["hwaddr"])
-				}
-
-				// Add the lease.
-				if dev["ipv4.address"] != "" {
+			// Add EUI64 records.
+			_, netIP6, _ := net.ParseCIDR(n.config["ipv6.address"])
+			if netIP6 != nil && hwAddr != nil && shared.IsFalseOrEmpty(n.config["ipv6.dhcp.stateful"]) {
+				eui64IP6, err := eui64.ParseMAC(netIP6.IP, hwAddr)
+				if err == nil {
 					leases = append(leases, api.NetworkLease{
 						Hostname: inst.Name,
-						Address:  dev["ipv4.address"],
-						Hwaddr:   dev["hwaddr"],
-						Type:     "static",
+						Address:  eui64IP6.String(),
+						Hwaddr:   hwAddr.String(),
+						Type:     "dynamic",
 						Location: inst.Node,
 					})
-				}
-
-				if dev["ipv6.address"] != "" {
-					leases = append(leases, api.NetworkLease{
-						Hostname: inst.Name,
-						Address:  dev["ipv6.address"],
-						Hwaddr:   dev["hwaddr"],
-						Type:     "static",
-						Location: inst.Node,
-					})
-				}
-
-				// Add EUI64 records.
-				ipv6Address := n.config["ipv6.address"]
-				if ipv6Address != "" && ipv6Address != "none" && shared.IsFalseOrEmpty(n.config["ipv6.dhcp.stateful"]) {
-					_, netAddress, _ := net.ParseCIDR(ipv6Address)
-					hwAddr, _ := net.ParseMAC(dev["hwaddr"])
-					if netAddress != nil && hwAddr != nil {
-						ipv6, err := eui64.ParseMAC(netAddress.IP, hwAddr)
-						if err == nil {
-							leases = append(leases, api.NetworkLease{
-								Hostname: inst.Name,
-								Address:  ipv6.String(),
-								Hwaddr:   dev["hwaddr"],
-								Type:     "dynamic",
-								Location: inst.Node,
-							})
-						}
-					}
 				}
 			}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -56,11 +56,6 @@ type bridge struct {
 	common
 }
 
-// Type returns the network type.
-func (n *bridge) Type() string {
-	return "bridge"
-}
-
 // DBType returns the network type DB ID.
 func (n *bridge) DBType() db.NetworkType {
 	return db.NetworkTypeBridge

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -254,7 +254,7 @@ func (n *common) Locations() []string {
 
 // IsUsed returns whether the network is used by any instances or profiles.
 func (n *common) IsUsed() (bool, error) {
-	usedBy, err := UsedBy(n.state, n.project, n.id, n.name, true)
+	usedBy, err := UsedBy(n.state, n.project, n.id, n.name, n.netType, true)
 	if err != nil {
 		return false, err
 	}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -82,6 +82,7 @@ type common struct {
 	id          int64
 	project     string
 	name        string
+	netType     string
 	description string
 	config      map[string]string
 	status      string
@@ -95,6 +96,7 @@ func (n *common) init(state *state.State, id int64, projectName string, netInfo 
 	n.id = id
 	n.project = projectName
 	n.name = netInfo.Name
+	n.netType = netInfo.Type
 	n.config = netInfo.Config
 	n.state = state
 	n.description = netInfo.Description
@@ -184,6 +186,11 @@ func (n *common) ID() int64 {
 // Name returns the network name.
 func (n *common) Name() string {
 	return n.name
+}
+
+// Type returns the network type.
+func (n *common) Type() string {
+	return n.netType
 }
 
 // Project returns the network project.

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -16,11 +16,6 @@ type macvlan struct {
 	common
 }
 
-// Type returns the network type.
-func (n *macvlan) Type() string {
-	return "macvlan"
-}
-
 // DBType returns the network type DB ID.
 func (n *macvlan) DBType() db.NetworkType {
 	return db.NetworkTypeMacvlan

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -85,11 +85,6 @@ type ovn struct {
 	common
 }
 
-// Type returns the network type.
-func (n *ovn) Type() string {
-	return "ovn"
-}
-
 // DBType returns the network type DB ID.
 func (n *ovn) DBType() db.NetworkType {
 	return db.NetworkTypeOVN

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1816,7 +1816,7 @@ func (n *ovn) getDHCPv4Reservations() ([]shared.IPRange, error) {
 		dhcpReserveIPv4s = []shared.IPRange{{Start: routerIntPortIPv4}}
 	}
 
-	err = UsedByInstanceDevices(n.state, n.project, n.name, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+	err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 		ip := net.ParseIP(nicConfig["ipv4.address"])
 		if ip != nil {
 			dhcpReserveIPv4s = append(dhcpReserveIPv4s, shared.IPRange{Start: ip})
@@ -2947,7 +2947,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 		var localNICRoutes []net.IPNet
 
 		// Apply ACL changes to running instance NICs that use this network.
-		err = UsedByInstanceDevices(n.state, n.project, n.name, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+		err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 			nicACLs := shared.SplitNTrimSpace(nicConfig["security.acls"], ",", -1, true)
 
 			// Get logical port UUID and name.
@@ -4916,7 +4916,7 @@ func (n *ovn) Leases(projectName string, clientType request.ClientType) ([]api.N
 
 	// Get all the instances in the requested project that are connected to this network.
 	filter := dbCluster.InstanceFilter{Project: &projectName}
-	err = UsedByInstanceDevices(n.state, n.project, n.name, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+	err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 		// Get the instance UUID needed for OVN port name generation.
 		instanceUUID := inst.Config["volatile.uuid"]
 		if instanceUUID == "" {
@@ -5042,7 +5042,7 @@ func (n *ovn) PeerCreate(peer api.NetworkPeersPost) error {
 		var localNICRoutes []net.IPNet
 
 		// Get routes on instance NICs connected to local network to be added as routes to target network.
-		err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+		err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 			instancePortName := n.getInstanceDevicePortName(inst.Config["volatile.uuid"], nicName)
 			_, found := activeLocalNICPorts[instancePortName]
 			if !found {
@@ -5186,7 +5186,7 @@ func (n *ovn) peerSetup(client *openvswitch.OVN, targetOVNNet *ovn, opts openvsw
 	}
 
 	// Get routes on instance NICs connected to target network to be added as routes to local network.
-	err = UsedByInstanceDevices(n.state, targetOVNNet.Project(), targetOVNNet.Name(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+	err = UsedByInstanceDevices(n.state, targetOVNNet.Project(), targetOVNNet.Name(), targetOVNNet.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 		instancePortName := targetOVNNet.getInstanceDevicePortName(inst.Config["volatile.uuid"], nicName)
 		_, found := activeTargetNICPorts[instancePortName]
 		if !found {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1822,11 +1822,6 @@ func (n *ovn) getDHCPv4Reservations() ([]shared.IPRange, error) {
 	}
 
 	err = UsedByInstanceDevices(n.state, n.project, n.name, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
-		// Skip NICs that specify a NIC type that is not the same as our own.
-		if !shared.StringInSlice(nicConfig["nictype"], []string{"", "ovn"}) {
-			return nil
-		}
-
 		ip := net.ParseIP(nicConfig["ipv4.address"])
 		if ip != nil {
 			dhcpReserveIPv4s = append(dhcpReserveIPv4s, shared.IPRange{Start: ip})

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4921,49 +4921,45 @@ func (n *ovn) LoadBalancerDelete(listenAddress string, clientType request.Client
 
 // Leases returns a list of leases for the OVN network. Those are directly extracted from the OVN database.
 func (n *ovn) Leases(projectName string, clientType request.ClientType) ([]api.NetworkLease, error) {
+	var err error
 	leases := []api.NetworkLease{}
 
+	// Get all the instances in the requested project that are connected to this network.
 	filter := dbCluster.InstanceFilter{Project: &projectName}
-	err := n.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
-		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
-
+	err = UsedByInstanceDevices(n.state, n.project, n.name, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 		// Get the instance UUID needed for OVN port name generation.
 		instanceUUID := inst.Config["volatile.uuid"]
 		if instanceUUID == "" {
 			return nil
 		}
 
-		// Get the instances IPs.
-		for devName, dev := range devices {
-			if !isInUseByDevice(n.name, dev) {
-				continue
+		devIPs, err := n.InstanceDevicePortDynamicIPs(instanceUUID, nicName)
+		if err != nil {
+			return nil // There is likely no active port and so no leases.
+		}
+
+		// Fill in the hwaddr from volatile.
+		if nicConfig["hwaddr"] == "" {
+			nicConfig["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", nicName)]
+		}
+
+		// Parse the MAC.
+		hwAddr, _ := net.ParseMAC(nicConfig["hwaddr"])
+
+		// Add the leases.
+		for _, ip := range devIPs {
+			leaseType := "dynamic"
+			if nicConfig["ipv4.address"] == ip.String() || nicConfig["ipv6.address"] == ip.String() {
+				leaseType = "static"
 			}
 
-			devIPs, err := n.InstanceDevicePortDynamicIPs(instanceUUID, devName)
-			if err != nil {
-				continue // There is likely no active port and so no leases.
-			}
-
-			// Fill in the hwaddr from volatile.
-			if dev["hwaddr"] == "" {
-				dev["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", devName)]
-			}
-
-			// Add the leases.
-			for _, ip := range devIPs {
-				leaseType := "dynamic"
-				if dev["ipv4.address"] == ip.String() || dev["ipv6.address"] == ip.String() {
-					leaseType = "static"
-				}
-
-				leases = append(leases, api.NetworkLease{
-					Hostname: inst.Name,
-					Address:  ip.String(),
-					Hwaddr:   dev["hwaddr"],
-					Type:     leaseType,
-					Location: inst.Node,
-				})
-			}
+			leases = append(leases, api.NetworkLease{
+				Hostname: inst.Name,
+				Address:  ip.String(),
+				Hwaddr:   hwAddr.String(),
+				Type:     leaseType,
+				Location: inst.Node,
+			})
 		}
 
 		return nil

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -21,11 +21,6 @@ type physical struct {
 	common
 }
 
-// Type returns the network type.
-func (n *physical) Type() string {
-	return "physical"
-}
-
 // DBType returns the network type DB ID.
 func (n *physical) DBType() db.NetworkType {
 	return db.NetworkTypePhysical

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -16,11 +16,6 @@ type sriov struct {
 	common
 }
 
-// Type returns the network type.
-func (n *sriov) Type() string {
-	return "sriov"
-}
-
 // DBType returns the network type DB ID.
 func (n *sriov) DBType() db.NetworkType {
 	return db.NetworkTypeSriov

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/shared/api"
 )
 
 var drivers = map[string]func() Network{
@@ -32,6 +33,7 @@ func LoadByType(driverType string) (Type, error) {
 	}
 
 	n := driverFunc()
+	n.init(nil, -1, "", &api.Network{Type: driverType}, nil)
 
 	return n, nil
 }

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -72,7 +72,8 @@ func MACDevName(mac net.HardwareAddr) string {
 }
 
 // UsedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
-func UsedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error) error {
+// Accepts optional filter arguments to specify a subset of instances.
+func UsedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error, filters ...cluster.InstanceFilter) error {
 	return s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
@@ -94,7 +95,7 @@ func UsedByInstanceDevices(s *state.State, networkProjectName string, networkNam
 		}
 
 		return nil
-	})
+	}, filters...)
 }
 
 // UsedBy returns list of API resources using network. Accepts firstOnly argument to indicate that only the first

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -73,7 +73,7 @@ func MACDevName(mac net.HardwareAddr) string {
 
 // UsedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 // Accepts optional filter arguments to specify a subset of instances.
-func UsedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error, filters ...cluster.InstanceFilter) error {
+func UsedByInstanceDevices(s *state.State, networkProjectName string, networkName string, networkType string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error, filters ...cluster.InstanceFilter) error {
 	return s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
@@ -86,7 +86,7 @@ func UsedByInstanceDevices(s *state.State, networkProjectName string, networkNam
 		// Look for NIC devices using this network.
 		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 		for devName, devConfig := range devices {
-			if isInUseByDevice(networkName, devConfig) {
+			if isInUseByDevice(networkName, networkType, devConfig) {
 				err := usageFunc(inst, devName, devConfig)
 				if err != nil {
 					return err
@@ -100,7 +100,7 @@ func UsedByInstanceDevices(s *state.State, networkProjectName string, networkNam
 
 // UsedBy returns list of API resources using network. Accepts firstOnly argument to indicate that only the first
 // resource using network should be returned. This can help to quickly check if the network is in use.
-func UsedBy(s *state.State, networkProjectName string, networkID int64, networkName string, firstOnly bool) ([]string, error) {
+func UsedBy(s *state.State, networkProjectName string, networkID int64, networkName string, networkType string, firstOnly bool) ([]string, error) {
 	var err error
 	var usedBy []string
 
@@ -178,7 +178,7 @@ func UsedBy(s *state.State, networkProjectName string, networkID int64, networkN
 				return err
 			}
 
-			inUse, err := usedByProfileDevices(s, profileDevices, apiProfileProject, networkProjectName, networkName)
+			inUse, err := usedByProfileDevices(s, profileDevices, apiProfileProject, networkProjectName, networkName, networkType)
 			if err != nil {
 				return err
 			}
@@ -199,7 +199,7 @@ func UsedBy(s *state.State, networkProjectName string, networkID int64, networkN
 	}
 
 	// Check if any instance devices use this network.
-	err = UsedByInstanceDevices(s, networkProjectName, networkName, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+	err = UsedByInstanceDevices(s, networkProjectName, networkName, networkType, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
 		usedBy = append(usedBy, api.NewURL().Path(version.APIVersion, "instances", inst.Name).Project(inst.Project).String())
 
 		if firstOnly {
@@ -222,7 +222,7 @@ func UsedBy(s *state.State, networkProjectName string, networkID int64, networkN
 
 // usedByProfileDevices indicates if network is referenced by a profile's NIC devices.
 // Checks if the device's parent or network properties match the network name.
-func usedByProfileDevices(s *state.State, profileDevices map[string]cluster.Device, profileProject *api.Project, networkProjectName string, networkName string) (bool, error) {
+func usedByProfileDevices(s *state.State, profileDevices map[string]cluster.Device, profileProject *api.Project, networkProjectName string, networkName string, networkType string) (bool, error) {
 	// Get the translated network project name from the profiles's project.
 
 	// Skip profiles who's translated network project doesn't match the requested network's project.
@@ -233,7 +233,7 @@ func usedByProfileDevices(s *state.State, profileDevices map[string]cluster.Devi
 	}
 
 	for _, d := range deviceConfig.NewDevices(cluster.DevicesToAPI(profileDevices)) {
-		if isInUseByDevice(networkName, d) {
+		if isInUseByDevice(networkName, networkType, d) {
 			return true, nil
 		}
 	}
@@ -242,13 +242,18 @@ func usedByProfileDevices(s *state.State, profileDevices map[string]cluster.Devi
 }
 
 // isInUseByDevices inspects a device's config to find references for a network being used.
-func isInUseByDevice(networkName string, d deviceConfig.Device) bool {
+func isInUseByDevice(networkName string, networkType string, d deviceConfig.Device) bool {
 	if d["type"] != "nic" {
 		return false
 	}
 
 	if d["network"] != "" && d["network"] == networkName {
 		return true
+	}
+
+	// OVN networks can only use managed networks.
+	if networkType == "ovn" {
+		return false
 	}
 
 	if d["parent"] != "" && GetHostDevice(d["parent"], d["vlan"]) == networkName {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -868,7 +868,7 @@ func doNetworkGet(d *Daemon, r *http.Request, allNodes bool, projectName string,
 			networkID = n.ID()
 		}
 
-		usedBy, err := network.UsedBy(d.State(), projectName, networkID, apiNet.Name, false)
+		usedBy, err := network.UsedBy(d.State(), projectName, networkID, apiNet.Name, apiNet.Type, false)
 		if err != nil {
 			return api.Network{}, err
 		}

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -278,7 +278,7 @@ test_config_edit() {
 
     # Check instance name is included in edit screen.
     cmd=$(unset -f lxc; command -v lxc)
-    output=$(EDITOR="cat" "${cmd}" config edit foo)
+    output=$(EDITOR="cat" timeout --foreground 120 "${cmd}" config edit foo)
     echo "${output}" | grep "name: foo"
 
     # Check expanded config isn't included in edit screen.
@@ -368,7 +368,7 @@ test_container_snapshot_config() {
 
     # Check instance name is included in edit screen.
     cmd=$(unset -f lxc; command -v lxc)
-    output=$(EDITOR="cat" "${cmd}" config edit foo/snap0)
+    output=$(EDITOR="cat" timeout --foreground 120 "${cmd}" config edit foo/snap0)
     echo "${output}" | grep "name: snap0"
 
     # Check expanded config isn't included in edit screen.


### PR DESCRIPTION
* Use `UsedByInstanceDevices` helper to avoid logic duplication for what constitutes an instance connected to a network.
* Fixes a bug in `UsedByInstanceDevices` where a `macvlan` NIC could be incorrectly considered connected to an OVN network if it was using `parent` property connected to an unmanaged bridge of the same name as an OVN network in a non-default project. 
* Parse MAC and IPs in `Leases()` so they use their canonical form rather than what is provided from the user.

Related to #11145

