### PR TITLE
Networks: Support multiple zones per network and zones associated to their own projects

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2109,3 +2109,23 @@ This adds the `CreatedAt` field to the `StorageVolume` and `StorageVolumeSnapsho
 
 This adds CPU hotplugging for VMs.
 Hotplugging is disabled when using CPU pinning, because this would require hotplugging NUMA devices as well, which is not possible.
+
+## `projects_networks_zones`
+
+This adds support for the `features.networks.zones` project feature, which changes which project network zones are
+associated with when they are created. Previously network zones were tied to the value of `features.networks`,
+meaning they were created in the same project as networks were.
+
+Now this has been decoupled from `features.networks` to allow projects that share a network in the default project
+(i.e those with `features.networks=false`) to have their own project level DNS zones that give a project oriented
+"view" of the addresses on that shared network (which only includes addresses from instances in their project).
+
+This also introduces a change to the network `dns.zone.forward` setting, which now accepts a comma-separated of
+DNS zone names (a maximum of one per project) in order to associate a shared network with multiple zones.
+
+No change to the `dns.zone.reverse.*` settings have been made, they still only allow a single DNS zone to be set.
+However the resulting zone content that is generated now includes `PTR` records covering addresses from all
+projects that are referencing that network via one of their forward zones.
+
+Existing projects that have `features.networks=true` will have `features.networks.zones=true` set automatically,
+but new projects will need to specify this explicitly.

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -29,6 +29,7 @@ Key                                  | Type      | Condition             | Defau
 `backups.compression_algorithm`      | string    | -                     | -                         | Compression algorithm to use for backups (`bzip2`, `gzip`, `lzma`, `xz` or `none`) in the project
 `features.images`                    | bool      | -                     | `true`                    | Separate set of images and image aliases for the project
 `features.networks`                  | bool      | -                     | `false`                   | Separate set of networks for the project
+`features.networks.zones`            | bool      | -                     | `false`                   | Separate set of network zones for the project
 `features.profiles`                  | bool      | -                     | `true`                    | Separate set of profiles for the project
 `features.storage.buckets`           | bool      | -                     | `true`                    | Separate set of storage buckets for the project
 `features.storage.volumes`           | bool      | -                     | `true`                    | Separate set of storage volumes for the project

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -74,7 +74,7 @@ Key                                  | Type      | Condition             | Defau
 `dns.domain`                         | string    | -                     | `lxd`                     | Domain to advertise to DHCP clients and use for DNS resolution
 `dns.mode`                           | string    | -                     | `managed`                 | DNS registration mode: `none` for no DNS record, `managed` for LXD-generated static records or `dynamic` for client-generated records
 `dns.search`                         | string    | -                     | -                         | Full comma-separated domain search list, defaulting to `dns.domain` value
-`dns.zone.forward`                   | string    | -                     | `managed`                 | DNS zone name for forward DNS records
+`dns.zone.forward`                   | string    | -                     | `managed`                 | Comma-separated list of DNS zone names for forward DNS records
 `dns.zone.reverse.ipv4`              | string    | -                     | `managed`                 | DNS zone name for IPv4 reverse DNS records
 `dns.zone.reverse.ipv6`              | string    | -                     | `managed`                 | DNS zone name for IPv6 reverse DNS records
 `fan.overlay_subnet`                 | string    | fan mode              | `240.0.0.0/8`             | Subnet to use as the overlay for the FAN (CIDR)

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -50,7 +50,7 @@ Key                                  | Type      | Condition             | Defau
 `bridge.mtu`                         | integer   | -                     | `1442`                    | Bridge MTU (default allows host to host Geneve tunnels)
 `dns.domain`                         | string    | -                     | `lxd`                     | Domain to advertise to DHCP clients and use for DNS resolution
 `dns.search`                         | string    | -                     | -                         | Full comma-separated domain search list, defaulting to `dns.domain` value
-`dns.zone.forward`                   | string    | -                     | -                         | DNS zone name for forward DNS records
+`dns.zone.forward`                   | string    | -                     | -                         | Comma-separated list of DNS zone names for forward DNS records
 `dns.zone.reverse.ipv4`              | string    | -                     | -                         | DNS zone name for IPv4 reverse DNS records
 `dns.zone.reverse.ipv6`              | string    | -                     | -                         | DNS zone name for IPv6 reverse DNS records
 `ipv4.address`                       | string    | standard mode         | `auto` (on create only)   | IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -462,13 +462,18 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 			networks = i18n.G("YES")
 		}
 
+		networkZones := i18n.G("NO")
+		if shared.IsTrue(project.Config["features.networks.zones"]) {
+			networkZones = i18n.G("YES")
+		}
+
 		name := project.Name
 		if name == currentProject {
 			name = fmt.Sprintf("%s (%s)", name, i18n.G("current"))
 		}
 
 		strUsedBy := fmt.Sprintf("%d", len(project.UsedBy))
-		data = append(data, []string{name, images, profiles, storageVolumes, storageBuckets, networks, project.Description, strUsedBy})
+		data = append(data, []string{name, images, profiles, storageVolumes, storageBuckets, networks, networkZones, project.Description, strUsedBy})
 	}
 
 	sort.Sort(utils.ByName(data))
@@ -480,6 +485,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("STORAGE VOLUMES"),
 		i18n.G("STORAGE BUCKETS"),
 		i18n.G("NETWORKS"),
+		i18n.G("NETWORK ZONES"),
 		i18n.G("DESCRIPTION"),
 		i18n.G("USED BY"),
 	}

--- a/lxd-user/lxd.go
+++ b/lxd-user/lxd.go
@@ -193,6 +193,7 @@ func lxdSetupUser(uid uint32) error {
 				Config: map[string]string{
 					"features.images":               "true",
 					"features.networks":             "false",
+					"features.networks.zones":       "true",
 					"features.profiles":             "true",
 					"features.storage.volumes":      "true",
 					"features.storage.buckets":      "true",

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -276,10 +276,10 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 		project.Config = map[string]string{}
 	}
 
-	for _, feature := range cluster.ProjectFeaturesDefaults {
-		_, ok := project.Config[feature]
-		if !ok {
-			project.Config[feature] = "true"
+	for featureName, featureInfo := range cluster.ProjectFeatures {
+		_, ok := project.Config[featureName]
+		if !ok && featureInfo.DefaultEnabled {
+			project.Config[featureName] = "true"
 		}
 	}
 

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1073,6 +1073,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		"features.storage.volumes":             validate.Optional(validate.IsBool),
 		"features.storage.buckets":             validate.Optional(validate.IsBool),
 		"features.networks":                    validate.Optional(validate.IsBool),
+		"features.networks.zones":              validate.Optional(validate.IsBool),
 		"images.auto_update_cached":            validate.Optional(validate.IsBool),
 		"images.auto_update_interval":          validate.Optional(validate.IsInt64),
 		"images.compression_algorithm":         validate.IsCompressionAlgorithm,

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -190,8 +190,9 @@ INSERT INTO nodes(id, name, address, schema, api_extensions, arch, description) 
 			var defaultProjectStmt strings.Builder
 			_, _ = defaultProjectStmt.WriteString("INSERT INTO projects (name, description) VALUES ('default', 'Default LXD project');")
 
-			for _, key := range ProjectFeatures {
-				_, _ = defaultProjectStmt.WriteString(fmt.Sprintf("INSERT INTO projects_config (project_id, key, value) VALUES (1, '%s', 'true');", key))
+			// Enable all features for default project.
+			for featureName := range ProjectFeatures {
+				_, _ = defaultProjectStmt.WriteString(fmt.Sprintf("INSERT INTO projects_config (project_id, key, value) VALUES (1, '%s', 'true');", featureName))
 			}
 
 			_, err = tx.Exec(defaultProjectStmt.String())

--- a/lxd/db/cluster/projects.go
+++ b/lxd/db/cluster/projects.go
@@ -34,13 +34,36 @@ import (
 //go:generate mapper method -i -e project Rename
 //go:generate mapper method -i -e project DeleteOne-by-Name
 
-// ProjectFeaturesDefaults are the features enabled by default on new projects.
-// The features.networks won't be enabled by default until it becomes clear whether it is practical to run OVN on
-// every system.
-var ProjectFeaturesDefaults = []string{"features.images", "features.profiles", "features.storage.volumes", "features.storage.buckets"}
+// ProjectFeature indicates the behaviour of a project feature.
+type ProjectFeature struct {
+	// DefaultEnabled
+	// Whether the feature should be enabled by default on new projects.
+	DefaultEnabled bool
 
-// ProjectFeatures are the features available to projects.
-var ProjectFeatures = append(ProjectFeaturesDefaults, "features.networks")
+	// CanEnableNonEmpty
+	// Whether or not the feature can be changed to enabled on a non-empty project.
+	CanEnableNonEmpty bool
+}
+
+// ProjectFeatures lists available project features and their behaviours.
+var ProjectFeatures = map[string]ProjectFeature{
+	"features.images": {
+		DefaultEnabled: true,
+	},
+	"features.profiles": {
+		DefaultEnabled: true,
+	},
+	"features.storage.volumes": {
+		DefaultEnabled: true,
+	},
+	"features.storage.buckets": {
+		DefaultEnabled: true,
+	},
+	"features.networks": {},
+	"features.networks.zones": {
+		CanEnableNonEmpty: true,
+	},
+}
 
 // Project represents a LXD project.
 type Project struct {

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -621,5 +621,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (67, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (68, strftime("%s"))
 `

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -14,8 +14,38 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// GetNetworkZones returns the names of existing Network zones.
-func (c *Cluster) GetNetworkZones(project string) ([]string, error) {
+// GetNetworkZones returns the names of existing Network zones mapped to project name.
+func (c *ClusterTx) GetNetworkZones(ctx context.Context) (map[string]string, error) {
+	q := `SELECT networks_zones.name, projects.name AS project_name FROM networks_zones
+		JOIN projects ON projects.id = networks_zones.project_id
+		ORDER BY networks_zones.id
+	`
+
+	var err error
+	zoneProjects := make(map[string]string)
+
+	err = query.Scan(ctx, c.tx, q, func(scan func(dest ...any) error) error {
+		var zoneName string
+		var projectName string
+
+		err := scan(&zoneName, &projectName)
+		if err != nil {
+			return err
+		}
+
+		zoneProjects[zoneName] = projectName
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return zoneProjects, nil
+}
+
+// GetNetworkZonesByProject returns the names of existing Network zones.
+func (c *Cluster) GetNetworkZonesByProject(project string) ([]string, error) {
 	q := `SELECT name FROM networks_zones
 		WHERE project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)
 		ORDER BY id

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -113,40 +113,6 @@ func (c *Cluster) GetNetworkZoneKeys() (map[string]string, error) {
 	return secrets, nil
 }
 
-// GetNetworksForZone returns the names of all networks using the zone and project.
-func (c *Cluster) GetNetworksForZone(projectName string, zoneName string) ([]string, error) {
-	q := `SELECT networks.name FROM networks
-		JOIN projects ON networks.project_id=projects.id
-		JOIN networks_config ON networks_config.network_id=networks.id
-		WHERE
-			networks_config.key IN ('dns.zone.forward', 'dns.zone.reverse.ipv4', 'dns.zone.reverse.ipv6')
-			AND networks_config.value=?
-			AND projects.name=?;
-	`
-
-	var networkNames []string
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
-			var networkName string
-
-			err := scan(&networkName)
-			if err != nil {
-				return err
-			}
-
-			networkNames = append(networkNames, networkName)
-
-			return nil
-		}, zoneName, projectName)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return networkNames, nil
-}
-
 // GetNetworkZone returns the Network zone with the given name.
 func (c *Cluster) GetNetworkZone(name string) (int64, string, *api.NetworkZone, error) {
 	var id int64 = int64(-1)

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -128,13 +128,11 @@ func (d *proxy) validateConfig(instConf instance.ConfigReader) error {
 			// Default project always has networks feature so don't bother loading the project config
 			// in that case.
 			instProject := d.inst.Project()
-			if instProject.Name != project.Default {
+			if instProject.Name != project.Default && shared.IsTrue(instProject.Config["features.networks"]) {
 				// Prevent use of NAT mode on non-default projects with networks feature.
 				// This is because OVN networks don't allow the host to communicate directly with
 				// instance NICs and so DNAT rules on the host won't work.
-				if shared.IsTrue(instProject.Config["features.networks"]) {
-					return fmt.Errorf("NAT mode cannot be used in projects that have the networks feature")
-				}
+				return fmt.Errorf("NAT mode cannot be used in projects that have the networks feature")
 			}
 		}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2869,9 +2869,9 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 
 	// Get all static leases.
 	if clientType == request.ClientTypeNormal {
-		// Get the downstream networks.
-		if n.project == project.Default {
-			// Load all the networks.
+		// If requested project matches network's project then include downstream uplink IPs.
+		if projectName == n.project {
+			// Include downstream OVN routers using the network as an uplink.
 			var projectNetworks map[string]map[int64]api.Network
 			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				projectNetworks, err = tx.GetCreatedNetworks(ctx)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -261,9 +261,9 @@ func (n *bridge) Validate(config map[string]string) error {
 		"dns.domain":                           validate.IsAny,
 		"dns.mode":                             validate.Optional(validate.IsOneOf("dynamic", "managed", "none")),
 		"dns.search":                           validate.IsAny,
-		"dns.zone.forward":                     validate.Optional(n.validateZoneName),
-		"dns.zone.reverse.ipv4":                validate.Optional(n.validateZoneName),
-		"dns.zone.reverse.ipv6":                validate.Optional(n.validateZoneName),
+		"dns.zone.forward":                     validate.IsAny,
+		"dns.zone.reverse.ipv4":                validate.IsAny,
+		"dns.zone.reverse.ipv6":                validate.IsAny,
 		"raw.dnsmasq":                          validate.IsAny,
 		"maas.subnet.ipv4":                     validate.IsAny,
 		"maas.subnet.ipv6":                     validate.IsAny,
@@ -329,6 +329,12 @@ func (n *bridge) Validate(config map[string]string) error {
 	}
 
 	// Peform composite key checks after per-key validation.
+
+	// Validate DNS zone names.
+	err = n.validateZoneNames(config)
+	if err != nil {
+		return err
+	}
 
 	// Validate network name when used in fan mode.
 	bridgeMode := config["bridge.mode"]

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -375,9 +375,9 @@ func (n *ovn) Validate(config map[string]string) error {
 		"ipv6.nat.address":                     validate.Optional(validate.IsNetworkAddressV6),
 		"dns.domain":                           validate.IsAny,
 		"dns.search":                           validate.IsAny,
-		"dns.zone.forward":                     validate.Optional(n.validateZoneName),
-		"dns.zone.reverse.ipv4":                validate.Optional(n.validateZoneName),
-		"dns.zone.reverse.ipv6":                validate.Optional(n.validateZoneName),
+		"dns.zone.forward":                     validate.IsAny,
+		"dns.zone.reverse.ipv4":                validate.IsAny,
+		"dns.zone.reverse.ipv6":                validate.IsAny,
 		"security.acls":                        validate.IsAny,
 		"security.acls.default.ingress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
 		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),
@@ -390,6 +390,14 @@ func (n *ovn) Validate(config map[string]string) error {
 	}
 
 	err := n.validate(config, rules)
+	if err != nil {
+		return err
+	}
+
+	// Peform composite key checks after per-key validation.
+
+	// Validate DNS zone names.
+	err = n.validateZoneNames(config)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4914,6 +4914,21 @@ func (n *ovn) Leases(projectName string, clientType request.ClientType) ([]api.N
 	var err error
 	leases := []api.NetworkLease{}
 
+	// If requested project matches network's project then include gateway IPs.
+	if projectName == n.project {
+		// Add our own gateway IPs.
+		for _, addr := range []string{n.config["ipv4.address"], n.config["ipv6.address"]} {
+			ip, _, _ := net.ParseCIDR(addr)
+			if ip != nil {
+				leases = append(leases, api.NetworkLease{
+					Hostname: fmt.Sprintf("%s.gw", n.Name()),
+					Address:  ip.String(),
+					Type:     "gateway",
+				})
+			}
+		}
+	}
+
 	// Get all the instances in the requested project that are connected to this network.
 	filter := dbCluster.InstanceFilter{Project: &projectName}
 	err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {

--- a/lxd/network/zone/reverse.go
+++ b/lxd/network/zone/reverse.go
@@ -9,8 +9,7 @@ var ip4Arpa = ".in-addr.arpa"
 var ip6Arpa = ".ip6.arpa"
 
 // reverse takes an IPv4 or IPv6 address and returns the matching ARPA record.
-func reverse(addr string) (arpa string) {
-	ip := net.ParseIP(addr)
+func reverse(ip net.IP) (arpa string) {
 	if ip == nil {
 		return ""
 	}

--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -1,6 +1,7 @@
 package zone
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/cluster/request"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
@@ -297,120 +299,149 @@ func (d *zone) Delete() error {
 
 // Content returns the DNS zone content.
 func (d *zone) Content() (*strings.Builder, error) {
+	var err error
 	records := []map[string]string{}
 
 	// Check if we should include NAT records.
 	includeNAT := shared.IsTrueOrEmpty(d.info.Config["network.nat"])
 
-	// Load all networks for the zone.
-	networks, err := d.state.DB.Cluster.GetNetworksForZone(d.projectName, d.info.Name)
+	// Get all managed networks across all projects.
+	var projectNetworks map[string]map[int64]api.Network
+	var zoneProjects map[string]string
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		projectNetworks, err = tx.GetCreatedNetworks(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to load all networks: %w", err)
+		}
+
+		zoneProjects, err = tx.GetNetworkZones(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to load all network zones: %w", err)
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	for _, netName := range networks {
-		// Load the network.
-		n, err := network.LoadByName(d.state, d.projectName, netName)
-		if err != nil {
-			return nil, err
-		}
-
-		// Load the leases.
-		leases, err := n.Leases(d.projectName, request.ClientTypeNormal)
-		if err != nil {
-			return nil, err
-		}
-
-		// Check whether what records to include.
-		netConfig := n.Config()
-		includeV4 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv4.nat"])
-		includeV6 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv6.nat"])
-
-		// Check if dealing with a reverse zone.
-		isReverse4 := strings.HasSuffix(d.info.Name, ip4Arpa)
-		isReverse6 := strings.HasSuffix(d.info.Name, ip6Arpa)
-		isReverse := isReverse4 || isReverse6
-		forwardZone := n.Config()["dns.zone.forward"]
-
-		genRecord := func(name string, addr string) map[string]string {
-			isV4 := net.ParseIP(addr).To4() != nil
-
-			// Skip disabled families.
-			if isV4 && !includeV4 {
-				return nil
+	for netProjectName, networks := range projectNetworks {
+		for _, netInfo := range networks {
+			if !d.networkUsesZone(netInfo.Config) {
+				continue
 			}
 
-			if !isV4 && !includeV6 {
-				return nil
+			// Load the network.
+			n, err := network.LoadByName(d.state, netProjectName, netInfo.Name)
+			if err != nil {
+				return nil, err
 			}
 
-			record := map[string]string{}
-			record["ttl"] = "300"
-			if !isReverse {
-				if isV4 {
-					record["type"] = "A"
+			// Check whether what records to include.
+			netConfig := n.Config()
+			includeV4 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv4.nat"])
+			includeV6 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv6.nat"])
+
+			// Check if dealing with a reverse zone.
+			isReverse4 := strings.HasSuffix(d.info.Name, ip4Arpa)
+			isReverse6 := strings.HasSuffix(d.info.Name, ip6Arpa)
+			isReverse := isReverse4 || isReverse6
+
+			genRecord := func(name string, ip net.IP) map[string]string {
+				isV4 := ip.To4() != nil
+
+				// Skip disabled families.
+				if isV4 && !includeV4 {
+					return nil
+				}
+
+				if !isV4 && !includeV6 {
+					return nil
+				}
+
+				record := map[string]string{}
+				record["ttl"] = "300"
+				if !isReverse {
+					if isV4 {
+						record["type"] = "A"
+					} else {
+						record["type"] = "AAAA"
+					}
+
+					record["name"] = name
+					record["value"] = ip.String()
 				} else {
-					record["type"] = "AAAA"
+					// Skip PTR records for wrong family.
+					if isV4 && !isReverse4 {
+						return nil
+					}
+
+					if !isV4 && !isReverse6 {
+						return nil
+					}
+
+					// Get the ARPA record.
+					reverseAddr := reverse(ip)
+					if reverseAddr == "" {
+						return nil
+					}
+
+					record["type"] = "PTR"
+					record["name"] = strings.TrimSuffix(reverseAddr, "."+d.info.Name+".")
+					record["value"] = name + "."
 				}
 
-				record["name"] = name
-				record["value"] = addr
+				return record
+			}
+
+			if isReverse {
+				// Load network leases in correct project context for each forward zone referenced.
+				for _, forwardZoneName := range shared.SplitNTrimSpace(n.Config()["dns.zone.forward"], ",", -1, true) {
+					// Get forward zone's project.
+					forwardZoneProjectName := zoneProjects[forwardZoneName]
+					if forwardZoneProjectName == "" {
+						return nil, fmt.Errorf("Associated project not found for zone %q", forwardZoneName)
+					}
+
+					// Load the leases for the forward zone project.
+					leases, err := n.Leases(forwardZoneProjectName, request.ClientTypeNormal)
+					if err != nil {
+						return nil, err
+					}
+
+					// Convert leases to usable PTR records.
+					for _, lease := range leases {
+						ip := net.ParseIP(lease.Address)
+
+						// Get the record.
+						record := genRecord(fmt.Sprintf("%s.%s", lease.Hostname, forwardZoneName), ip)
+						if record == nil {
+							continue
+						}
+
+						records = append(records, record)
+					}
+				}
 			} else {
-				// Skip PTR records if no forward zone.
-				if forwardZone == "" {
-					return nil
+				// Load the leases in the forward zone's project.
+				leases, err := n.Leases(d.projectName, request.ClientTypeNormal)
+				if err != nil {
+					return nil, err
 				}
 
-				// Skip PTR records for wrong family.
-				if isV4 && !isReverse4 {
-					return nil
+				// Convert leases to usable records.
+				for _, lease := range leases {
+					ip := net.ParseIP(lease.Address)
+
+					// Get the record.
+					record := genRecord(lease.Hostname, ip)
+					if record == nil {
+						continue
+					}
+
+					records = append(records, record)
 				}
-
-				if !isV4 && !isReverse6 {
-					return nil
-				}
-
-				// Get the ARPA record.
-				reverseAddr := reverse(addr)
-				if reverseAddr == "" {
-					return nil
-				}
-
-				record["type"] = "PTR"
-				record["name"] = strings.TrimSuffix(reverseAddr, "."+d.info.Name+".")
-				record["value"] = name + "." + forwardZone + "."
 			}
-
-			return record
-		}
-
-		// Convert leases to usable records.
-		for _, lease := range leases {
-			// Get the record.
-			record := genRecord(lease.Hostname, lease.Address)
-			if record == nil {
-				continue
-			}
-
-			records = append(records, record)
-		}
-
-		// Add gateways.
-		for _, addr := range []string{n.Config()["ipv4.address"], n.Config()["ipv6.address"]} {
-			if addr == "" || addr == "none" {
-				continue
-			}
-
-			// Strip the mask.
-			addr = strings.Split(addr, "/")[0]
-
-			// Get the record.
-			record := genRecord(n.Name()+".gw", addr)
-			if record == nil {
-				continue
-			}
-
-			records = append(records, record)
 		}
 	}
 

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -147,7 +147,7 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 	resultMap := []api.NetworkZone{}
 	for _, zoneName := range zoneNames {
 		if !recursion {
-			resultString = append(resultString, fmt.Sprintf("/%s/network-zones/%s", version.APIVersion, zoneName))
+			resultString = append(resultString, api.NewURL().Path(version.APIVersion, "network-zones", zoneName).String())
 		} else {
 			netzone, err := zone.LoadByNameAndProject(d.State(), projectName, zoneName)
 			if err != nil {

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -138,7 +138,7 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
 	// Get list of Network zones.
-	zoneNames, err := d.db.Cluster.GetNetworkZones(projectName)
+	zoneNames, err := d.db.Cluster.GetNetworkZonesByProject(projectName)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -201,7 +201,7 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZonesPost(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -261,7 +261,7 @@ func networkZonesPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -327,7 +327,7 @@ func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZoneGet(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -421,7 +421,7 @@ func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZonePut(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/network_zones_records.go
+++ b/lxd/network_zones_records.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -158,7 +157,7 @@ func networkZoneRecordsGet(d *Daemon, r *http.Request) response.Response {
 	resultMap := []api.NetworkZoneRecord{}
 	for _, record := range records {
 		if !recursion {
-			resultString = append(resultString, fmt.Sprintf("/%s/network-zones/%s/records/%s", version.APIVersion, zoneName, record.Name))
+			resultString = append(resultString, api.NewURL().Path(version.APIVersion, "network-zones", zoneName, "records", record.Name).String())
 		} else {
 			resultMap = append(resultMap, record)
 		}

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -275,3 +275,41 @@ func ProfileProjectFromRecord(p *api.Project) string {
 
 	return Default
 }
+
+// NetworkZoneProject returns the effective project name to use for network zone based on the requested project.
+// If the requested project has the "features.networks.zones" flag enabled then the requested project's name is
+// returned, otherwise the default project name is returned.
+// The second return value is always the requested project's info.
+func NetworkZoneProject(c *db.Cluster, projectName string) (string, *api.Project, error) {
+	var p *api.Project
+	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return err
+		}
+
+		p, err = dbProject.ToAPI(ctx, tx.Tx())
+
+		return err
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("Failed to load project %q: %w", projectName, err)
+	}
+
+	effectiveProjectName := NetworkZoneProjectFromRecord(p)
+
+	return effectiveProjectName, p, nil
+}
+
+// NetworkZoneProjectFromRecord returns the project name to use for the network zone based on the supplied project.
+// If the project supplied has the "features.networks.zones" flag enabled then the project name is returned,
+// otherwise the default project name is returned.
+func NetworkZoneProjectFromRecord(p *api.Project) string {
+	// Network zones only use the project specified if the project has the features.networks.zones feature
+	// enabled, otherwise the legacy behaviour of using the default project for network zones is used.
+	if shared.IsTrue(p.Config["features.networks.zones"]) {
+		return p.Name
+	}
+
+	return Default
+}

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -160,8 +160,9 @@ func StorageBucketProjectFromRecord(p *api.Project) string {
 }
 
 // NetworkProject returns the effective project name to use for the network based on the requested project.
-// If the requested project has the "features.networks" flag enabled then the requested project's info is returned,
-// otherwise the default project name is returned. The second return value is always the requested project's info.
+// If the requested project has the "features.networks" flag enabled then the requested project's name is returned,
+// otherwise the default project name is returned.
+// The second return value is always the requested project's info.
 func NetworkProject(c *db.Cluster, projectName string) (string, *api.Project, error) {
 	var p *api.Project
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1654,7 +1654,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1848,8 +1848,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2512,7 +2512,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2571,7 +2571,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2705,7 +2705,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -3016,7 +3016,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4000,13 +4000,17 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -4020,7 +4024,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -4314,7 +4318,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4500,7 +4504,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4565,7 +4569,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4610,7 +4614,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -4769,7 +4773,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4924,7 +4928,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4932,7 +4936,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5127,12 +5131,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5313,7 +5317,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5556,7 +5560,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5830,7 +5834,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5842,12 +5846,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5984,7 +5988,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -6135,7 +6139,7 @@ msgstr "Zustand des laufenden Containers sichern oder nicht"
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -7172,8 +7176,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -7181,7 +7185,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -7189,7 +7193,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -7197,7 +7201,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -7322,7 +7326,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -1342,7 +1342,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1530,8 +1530,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2156,7 +2156,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2214,7 +2214,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2639,7 +2639,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3433,7 +3433,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3553,13 +3553,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3573,7 +3577,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3863,7 +3867,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4042,7 +4046,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4103,7 +4107,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4147,7 +4151,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4442,7 +4446,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4450,7 +4454,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4640,11 +4644,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4816,7 +4820,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5046,7 +5050,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5308,7 +5312,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5320,12 +5324,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5457,7 +5461,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5595,7 +5599,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6123,20 +6127,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6196,7 +6200,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1599,7 +1599,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1788,8 +1788,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2421,7 +2421,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2479,7 +2479,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2609,7 +2609,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3721,7 +3721,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -3845,13 +3845,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3865,7 +3869,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -4153,7 +4157,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4336,7 +4340,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4441,7 +4445,7 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4592,7 +4596,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4742,7 +4746,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4750,7 +4754,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4940,11 +4944,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5116,7 +5120,7 @@ msgstr "Perfil %s creado"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5347,7 +5351,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5614,7 +5618,7 @@ msgstr "Expira: %s"
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5626,12 +5630,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5763,7 +5767,7 @@ msgstr "Perfil %s creado"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5902,7 +5906,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6547,23 +6551,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6638,7 +6642,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1676,7 +1676,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1875,8 +1875,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2547,7 +2547,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2605,7 +2605,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2743,7 +2743,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -3058,7 +3058,7 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3955,7 +3955,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4087,13 +4087,17 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -4107,7 +4111,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr "NON"
 
@@ -4413,7 +4417,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -4601,7 +4605,7 @@ msgstr "Profil %s créé"
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -4665,7 +4669,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
@@ -4713,7 +4717,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -4872,7 +4876,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -5045,7 +5049,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5054,7 +5058,7 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5252,12 +5256,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5442,7 +5446,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
@@ -5688,7 +5692,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5969,7 +5973,7 @@ msgstr "Expire : %s"
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5981,12 +5985,12 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -6125,7 +6129,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6274,7 +6278,7 @@ msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr "OUI"
 
@@ -7404,8 +7408,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -7413,7 +7417,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -7421,7 +7425,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -7429,7 +7433,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -7569,7 +7573,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1521,8 +1521,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2138,7 +2138,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3509,13 +3509,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3529,7 +3533,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3817,7 +3821,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3995,7 +3999,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4056,7 +4060,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4100,7 +4104,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4244,7 +4248,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4389,7 +4393,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4581,11 +4585,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4749,7 +4753,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4977,7 +4981,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5239,7 +5243,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5251,12 +5255,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5379,7 +5383,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5516,7 +5520,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6044,20 +6048,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1590,7 +1590,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1779,8 +1779,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2411,7 +2411,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2598,7 +2598,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2900,7 +2900,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3714,7 +3714,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -3837,13 +3837,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3857,7 +3861,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4328,7 +4332,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4390,7 +4394,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4434,7 +4438,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -4586,7 +4590,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4736,7 +4740,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4744,7 +4748,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4932,11 +4936,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5108,7 +5112,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5341,7 +5345,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5607,7 +5611,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5619,12 +5623,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5755,7 +5759,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5895,7 +5899,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6542,23 +6546,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
@@ -6633,7 +6637,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1613,7 +1613,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1797,8 +1797,8 @@ msgstr "警告を削除します"
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2463,7 +2463,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2521,7 +2521,7 @@ msgstr "すべてのコマンドに対する man ページを作成します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
@@ -2643,7 +2643,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -2956,7 +2956,7 @@ msgstr "LAST SEEN"
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr "LIMIT"
 
@@ -3888,7 +3888,7 @@ msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -4025,13 +4025,18 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr "NAME"
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+#, fuzzy
+msgid "NETWORK ZONES"
+msgstr "NETWORKS"
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -4045,7 +4050,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr "NO"
 
@@ -4336,7 +4341,7 @@ msgstr "PORTS"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr "PROFILES"
 
@@ -4516,7 +4521,7 @@ msgstr "プロジェクト %s を作成しました"
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
@@ -4577,7 +4582,7 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
@@ -4621,7 +4626,7 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4765,7 +4770,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -4917,7 +4922,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
@@ -4925,7 +4930,7 @@ msgstr "STORAGE BUCKETS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
@@ -5149,11 +5154,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5334,7 +5339,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
@@ -5562,7 +5567,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -5850,7 +5855,7 @@ msgstr "タイプ: %s"
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -5862,12 +5867,12 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr "USED BY"
@@ -5990,7 +5995,7 @@ msgstr "ネットワークゾーンレコードの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
@@ -6134,7 +6139,7 @@ msgstr "インスタンスの稼動状態のスナップショットを取得す
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr "YES"
 
@@ -6676,20 +6681,20 @@ msgstr "[<remote>:]<profile> <new-name>"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
@@ -6749,7 +6754,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr "現在値"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2022-11-25 09:28+0000\n"
+        "POT-Creation-Date: 2022-11-29 14:07+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1248,7 +1248,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059 lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964 lxc/network_acl.go:149 lxc/network_forward.go:146 lxc/network_load_balancer.go:149 lxc/network_peer.go:141 lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164 lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619 lxc/storage_bucket.go:496 lxc/storage_bucket.go:791 lxc/storage_volume.go:1459
+#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059 lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964 lxc/network_acl.go:149 lxc/network_forward.go:146 lxc/network_load_balancer.go:149 lxc/network_peer.go:141 lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164 lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619 lxc/storage_bucket.go:496 lxc/storage_bucket.go:791 lxc/storage_volume.go:1459
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1360,7 +1360,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203 lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380 lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713 lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072 lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616 lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32 lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1270 lxc/storage_volume.go:1354 lxc/storage_volume.go:1560 lxc/storage_volume.go:1593 lxc/storage_volume.go:1706 lxc/storage_volume.go:1794 lxc/storage_volume.go:1893 lxc/storage_volume.go:1927 lxc/storage_volume.go:2024 lxc/storage_volume.go:2091 lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203 lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380 lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713 lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072 lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1270 lxc/storage_volume.go:1354 lxc/storage_volume.go:1560 lxc/storage_volume.go:1593 lxc/storage_volume.go:1706 lxc/storage_volume.go:1794 lxc/storage_volume.go:1893 lxc/storage_volume.go:1927 lxc/storage_volume.go:2024 lxc/storage_volume.go:2091 lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1921,7 +1921,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561 lxc/storage_bucket.go:443 lxc/storage_bucket.go:734 lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561 lxc/storage_bucket.go:443 lxc/storage_bucket.go:734 lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -1977,7 +1977,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
@@ -2099,7 +2099,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid   "IMAGES"
 msgstr  ""
 
@@ -2389,7 +2389,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid   "LIMIT"
 msgstr  ""
 
@@ -3085,7 +3085,7 @@ msgstr  ""
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368 lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368 lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid   "Missing project name"
 msgstr  ""
 
@@ -3193,11 +3193,15 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566 lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1458
+#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566 lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1458
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid   "NETWORK ZONES"
+msgstr  ""
+
+#: lxc/project.go:487
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -3209,7 +3213,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440 lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440 lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid   "NO"
 msgstr  ""
 
@@ -3495,7 +3499,7 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid   "PROFILES"
 msgstr  ""
 
@@ -3665,7 +3669,7 @@ msgstr  ""
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
@@ -3726,7 +3730,7 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid   "RESOURCE"
 msgstr  ""
 
@@ -3770,7 +3774,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895 lxc/remote.go:933
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895 lxc/remote.go:933
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -3912,7 +3916,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid   "Rename projects"
 msgstr  ""
 
@@ -4054,7 +4058,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
@@ -4062,7 +4066,7 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
@@ -4226,11 +4230,11 @@ msgid   "Set profile configuration keys\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4386,7 +4390,7 @@ msgstr  ""
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid   "Show project options"
 msgstr  ""
 
@@ -4614,7 +4618,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -4862,7 +4866,7 @@ msgstr  ""
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -4874,11 +4878,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141 lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620 lxc/storage_volume.go:1461
+#: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141 lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620 lxc/storage_volume.go:1461
 msgid   "USED BY"
 msgstr  ""
 
@@ -4999,7 +5003,7 @@ msgstr  ""
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid   "Unset project configuration keys"
 msgstr  ""
 
@@ -5128,7 +5132,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442 lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442 lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462 lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid   "YES"
 msgstr  ""
 
@@ -5624,19 +5628,19 @@ msgstr  ""
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643 lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649 lxc/project.go:702
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -5696,7 +5700,7 @@ msgstr  ""
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid   "current"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -1553,7 +1553,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1737,8 +1737,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2354,7 +2354,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2412,7 +2412,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2830,7 +2830,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3606,7 +3606,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3725,13 +3725,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3745,7 +3749,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -4033,7 +4037,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4211,7 +4215,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4272,7 +4276,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4316,7 +4320,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4460,7 +4464,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4605,7 +4609,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4613,7 +4617,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4797,11 +4801,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4965,7 +4969,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5193,7 +5197,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5455,7 +5459,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5467,12 +5471,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5595,7 +5599,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5732,7 +5736,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6260,20 +6264,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6333,7 +6337,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1587,7 +1587,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1771,8 +1771,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2388,7 +2388,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2446,7 +2446,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2568,7 +2568,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3640,7 +3640,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3759,13 +3759,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3779,7 +3783,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -4067,7 +4071,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4245,7 +4249,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4306,7 +4310,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4350,7 +4354,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4494,7 +4498,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4639,7 +4643,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4647,7 +4651,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4831,11 +4835,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4999,7 +5003,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5227,7 +5231,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5501,12 +5505,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5629,7 +5633,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5766,7 +5770,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6294,20 +6298,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6367,7 +6371,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1631,7 +1631,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1827,8 +1827,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2466,7 +2466,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2524,7 +2524,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2658,7 +2658,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3773,7 +3773,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3895,13 +3895,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3915,7 +3919,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -4203,7 +4207,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4387,7 +4391,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4449,7 +4453,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4493,7 +4497,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4649,7 +4653,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4803,7 +4807,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4811,7 +4815,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5005,12 +5009,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5189,7 +5193,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5422,7 +5426,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5691,7 +5695,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5703,12 +5707,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5846,7 +5850,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -5987,7 +5991,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6565,21 +6569,21 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6648,7 +6652,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1622,7 +1622,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1815,8 +1815,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2454,7 +2454,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2512,7 +2512,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2642,7 +2642,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3772,7 +3772,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -3897,13 +3897,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3917,7 +3921,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -4209,7 +4213,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4449,7 +4453,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4495,7 +4499,7 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4647,7 +4651,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4800,7 +4804,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4808,7 +4812,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4998,11 +5002,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5177,7 +5181,7 @@ msgstr "Копирование образа: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5414,7 +5418,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5677,7 +5681,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5689,12 +5693,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5826,7 +5830,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5966,7 +5970,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6966,8 +6970,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -6975,7 +6979,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -6983,7 +6987,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -6991,7 +6995,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -7111,7 +7115,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1521,8 +1521,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2138,7 +2138,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3509,13 +3509,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3529,7 +3533,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3817,7 +3821,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3995,7 +3999,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4056,7 +4060,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4100,7 +4104,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4244,7 +4248,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4389,7 +4393,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4581,11 +4585,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4749,7 +4753,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4977,7 +4981,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5239,7 +5243,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5251,12 +5255,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5379,7 +5383,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5516,7 +5520,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6044,20 +6048,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1521,8 +1521,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2138,7 +2138,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3509,13 +3509,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3529,7 +3533,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3817,7 +3821,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3995,7 +3999,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4056,7 +4060,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4100,7 +4104,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4244,7 +4248,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4389,7 +4393,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4581,11 +4585,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4749,7 +4753,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4977,7 +4981,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5239,7 +5243,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5251,12 +5255,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5379,7 +5383,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5516,7 +5520,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6044,20 +6048,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1333,7 +1333,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1517,8 +1517,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2134,7 +2134,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2192,7 +2192,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2314,7 +2314,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2610,7 +2610,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3386,7 +3386,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3505,13 +3505,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3525,7 +3529,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3813,7 +3817,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3991,7 +3995,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4052,7 +4056,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4096,7 +4100,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4240,7 +4244,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4385,7 +4389,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4393,7 +4397,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4577,11 +4581,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4745,7 +4749,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4973,7 +4977,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5235,7 +5239,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5247,12 +5251,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5375,7 +5379,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5512,7 +5516,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6040,20 +6044,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6113,7 +6117,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1521,8 +1521,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2138,7 +2138,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3509,13 +3509,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3529,7 +3533,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3817,7 +3821,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3995,7 +3999,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4056,7 +4060,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4100,7 +4104,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4244,7 +4248,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4389,7 +4393,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4397,7 +4401,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4581,11 +4585,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4749,7 +4753,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4977,7 +4981,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5239,7 +5243,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5251,12 +5255,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5379,7 +5383,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5516,7 +5520,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6044,20 +6048,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1450,7 +1450,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1634,8 +1634,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2251,7 +2251,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2431,7 +2431,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2727,7 +2727,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3503,7 +3503,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3622,13 +3622,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3642,7 +3646,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3930,7 +3934,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -4108,7 +4112,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4213,7 +4217,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4357,7 +4361,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4502,7 +4506,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4510,7 +4514,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4694,11 +4698,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4862,7 +4866,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -5090,7 +5094,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5352,7 +5356,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5364,12 +5368,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5492,7 +5496,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5629,7 +5633,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6157,20 +6161,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6230,7 +6234,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2022-11-25 09:28+0000\n"
+"POT-Creation-Date: 2022-11-29 14:07+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -1336,7 +1336,7 @@ msgstr ""
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:483 lxc/storage.go:619
+#: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1459
 msgid "DESCRIPTION"
@@ -1520,8 +1520,8 @@ msgstr ""
 #: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
 #: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
 #: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:501 lxc/project.go:556 lxc/project.go:616
-#: lxc/project.go:645 lxc/project.go:698 lxc/project.go:757 lxc/publish.go:32
+#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
+#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
 #: lxc/query.go:32 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
 #: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
 #: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
@@ -2137,7 +2137,7 @@ msgstr ""
 #: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
-#: lxc/project.go:759 lxc/remote.go:665 lxc/storage.go:561
+#: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
 #: lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:756 lxc/project.go:757
+#: lxc/project.go:762 lxc/project.go:763
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:478
+#: lxc/project.go:483
 msgid "IMAGES"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:818
+#: lxc/project.go:824
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:119 lxc/project.go:188 lxc/project.go:266 lxc/project.go:368
-#: lxc/project.go:525 lxc/project.go:583 lxc/project.go:669 lxc/project.go:782
+#: lxc/project.go:531 lxc/project.go:589 lxc/project.go:675 lxc/project.go:788
 msgid "Missing project name"
 msgstr ""
 
@@ -3508,13 +3508,17 @@ msgstr ""
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:477 lxc/remote.go:726 lxc/storage.go:611
+#: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1458
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:482
+#: lxc/project.go:488
+msgid "NETWORK ZONES"
+msgstr ""
+
+#: lxc/project.go:487
 msgid "NETWORKS"
 msgstr ""
 
@@ -3528,7 +3532,7 @@ msgstr ""
 
 #: lxc/network.go:936 lxc/operation.go:146 lxc/project.go:440
 #: lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460
-#: lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
+#: lxc/project.go:465 lxc/remote.go:682 lxc/remote.go:687 lxc/remote.go:692
 msgid "NO"
 msgstr ""
 
@@ -3816,7 +3820,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:479
+#: lxc/list.go:569 lxc/project.go:484
 msgid "PROFILES"
 msgstr ""
 
@@ -3994,7 +3998,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:540
+#: lxc/project.go:546
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4055,7 +4059,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:817
+#: lxc/project.go:823
 msgid "RESOURCE"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:724 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
+#: lxc/project.go:730 lxc/remote.go:769 lxc/remote.go:841 lxc/remote.go:895
 #: lxc/remote.go:933
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4243,7 +4247,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:500 lxc/project.go:501
+#: lxc/project.go:506 lxc/project.go:507
 msgid "Rename projects"
 msgstr ""
 
@@ -4388,7 +4392,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:481
+#: lxc/project.go:486
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -4396,7 +4400,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:480
+#: lxc/project.go:485
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -4580,11 +4584,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:555
+#: lxc/project.go:561
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:556
+#: lxc/project.go:562
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:644 lxc/project.go:645
+#: lxc/project.go:650 lxc/project.go:651
 msgid "Show project options"
 msgstr ""
 
@@ -4976,7 +4980,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:697 lxc/project.go:698
+#: lxc/project.go:703 lxc/project.go:704
 msgid "Switch the current project"
 msgstr ""
 
@@ -5238,7 +5242,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:795
+#: lxc/project.go:801
 msgid "UNLIMITED"
 msgstr ""
 
@@ -5250,12 +5254,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:819 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1462
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:484 lxc/storage.go:620
+#: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
 #: lxc/storage_volume.go:1461
 msgid "USED BY"
 msgstr ""
@@ -5378,7 +5382,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:615 lxc/project.go:616
+#: lxc/project.go:621 lxc/project.go:622
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -5515,7 +5519,7 @@ msgstr ""
 
 #: lxc/network.go:938 lxc/operation.go:148 lxc/project.go:442
 #: lxc/project.go:447 lxc/project.go:452 lxc/project.go:457 lxc/project.go:462
-#: lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:467 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "YES"
 msgstr ""
 
@@ -6043,20 +6047,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:643
-#: lxc/project.go:696
+#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:649
+#: lxc/project.go:702
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:342 lxc/project.go:614 lxc/project.go:755
+#: lxc/project.go:342 lxc/project.go:620 lxc/project.go:761
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:554
+#: lxc/project.go:560
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:498
+#: lxc/project.go:504
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6116,7 +6120,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:467 lxc/remote.go:717
+#: lxc/project.go:472 lxc/remote.go:717
 msgid "current"
 msgstr ""
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -355,6 +355,7 @@ var APIExtensions = []string{
 	"init_preseed",
 	"storage_volumes_created_at",
 	"cpu_hotplug",
+	"projects_networks_zones",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This adds support for the `features.networks.zones` project feature, which changes which project network zones are
associated with when they are created. Previously network zones were tied to the value of `features.networks`,
meaning they were created in the same project as networks were.

Now this has been decoupled from `features.networks` to allow projects that share a network in the default project
(i.e those with `features.networks=false`) to have their own project level DNS zones that give a project oriented
"view" of the addresses on that shared network (which only includes addresses from instances in their project).

This PR also introduces the concept of project features that can be enabled on non-empty projects, and this is what the `features.networks.zones` feature is configured as.

This also introduces a change to the network `dns.zone.forward` setting, which now accepts a comma-separated of
DNS zone names (a maximum of one per project) in order to associate a shared network with multiple zones.

No change to the `dns.zone.reverse.*` settings have been made, they still only allow a single DNS zone to be set.
However the resulting zone content that is generated now includes PTR records covering addresses from all projects
that are referencing that network via one of their forward zones.

E.g. The PTR records for a zone that show the IP addresses resolving to names in multiple forward zones across projects:

```
10.in-addr.arpa.	3600	IN	SOA	10.in-addr.arpa. ns1.lxd2.private. 1669650976 120 60 86400 30
10.in-addr.arpa.	300	IN	NS	ns1.lxd2.private.
1.203.21.10.in-addr.arpa. 300	IN	PTR	lxdbr0.gw.lxd2.private.
12.203.21.10.in-addr.arpa. 300	IN	PTR	foo2-ovn1.uplink.lxd2.private.
11.203.21.10.in-addr.arpa. 300	IN	PTR	default-ovn1.uplink.lxd2.private.
10.203.21.10.in-addr.arpa. 300	IN	PTR	cbuild.lxd2.private.
2.203.21.10.in-addr.arpa. 300	IN	PTR	c1.lxd2.private.
3.203.21.10.in-addr.arpa. 300	IN	PTR	c2.lxdfoo.private.
1.118.17.10.in-addr.arpa. 300	IN	PTR	ovn1.gw.foo2.private.
2.118.17.10.in-addr.arpa. 300	IN	PTR	c1.foo2.private.
10.in-addr.arpa.	3600	IN	SOA	10.in-addr.arpa. ns1.lxd2.private. 1669650976 120 60 86400 30
```

Existing projects that have `features.networks=true` will have `features.networks.zones=true` set automatically,
but new projects will need to specify this explicitly.

Fixes #11145