### PR TITLE
ceph: Drop unnecessary volume.block.* config keys

### DIFF
--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -258,18 +258,16 @@ func (d *ceph) Delete(op *operations.Operation) error {
 // Validate checks that all provide keys are supported and that no conflicting or missing configuration is present.
 func (d *ceph) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"ceph.cluster_name":          validate.IsAny,
-		"ceph.osd.force_reuse":       validate.Optional(validate.IsBool), // Deprecated, should not be used.
-		"ceph.osd.pg_num":            validate.IsAny,
-		"ceph.osd.pool_name":         validate.IsAny,
-		"ceph.osd.data_pool_name":    validate.IsAny,
-		"ceph.rbd.clone_copy":        validate.Optional(validate.IsBool),
-		"ceph.rbd.du":                validate.Optional(validate.IsBool),
-		"ceph.rbd.features":          validate.IsAny,
-		"ceph.user.name":             validate.IsAny,
-		"volatile.pool.pristine":     validate.IsAny,
-		"volume.block.filesystem":    validate.Optional(validate.IsOneOf(cephAllowedFilesystems...)),
-		"volume.block.mount_options": validate.IsAny,
+		"ceph.cluster_name":       validate.IsAny,
+		"ceph.osd.force_reuse":    validate.Optional(validate.IsBool), // Deprecated, should not be used.
+		"ceph.osd.pg_num":         validate.IsAny,
+		"ceph.osd.pool_name":      validate.IsAny,
+		"ceph.osd.data_pool_name": validate.IsAny,
+		"ceph.rbd.clone_copy":     validate.Optional(validate.IsBool),
+		"ceph.rbd.du":             validate.Optional(validate.IsBool),
+		"ceph.rbd.features":       validate.IsAny,
+		"ceph.user.name":          validate.IsAny,
+		"volatile.pool.pristine":  validate.IsAny,
 	}
 
 	return d.validatePool(config, rules, d.commonVolumeRules())


### PR DESCRIPTION
This removes the unnecessary volume.block.* config keys from the
Validate() function as they already exist in commonVolumeRules().

Removing these config keys will _not_ change anything, they will
still be validated correctly.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
