### PR TITLE
Network: Exclude gateway and uplink addresses in leases list when filtering by project other than network's

### DIFF
--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -128,13 +128,11 @@ func (d *proxy) validateConfig(instConf instance.ConfigReader) error {
 			// Default project always has networks feature so don't bother loading the project config
 			// in that case.
 			instProject := d.inst.Project()
-			if instProject.Name != project.Default {
+			if instProject.Name != project.Default && shared.IsTrue(instProject.Config["features.networks"]) {
 				// Prevent use of NAT mode on non-default projects with networks feature.
 				// This is because OVN networks don't allow the host to communicate directly with
 				// instance NICs and so DNAT rules on the host won't work.
-				if shared.IsTrue(instProject.Config["features.networks"]) {
-					return fmt.Errorf("NAT mode cannot be used in projects that have the networks feature")
-				}
+				return fmt.Errorf("NAT mode cannot be used in projects that have the networks feature")
 			}
 		}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2869,9 +2869,9 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 
 	// Get all static leases.
 	if clientType == request.ClientTypeNormal {
-		// Get the downstream networks.
-		if n.project == project.Default {
-			// Load all the networks.
+		// If requested project matches network's project then include downstream uplink IPs.
+		if projectName == n.project {
+			// Include downstream OVN routers using the network as an uplink.
 			var projectNetworks map[string]map[int64]api.Network
 			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				projectNetworks, err = tx.GetCreatedNetworks(ctx)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4914,6 +4914,21 @@ func (n *ovn) Leases(projectName string, clientType request.ClientType) ([]api.N
 	var err error
 	leases := []api.NetworkLease{}
 
+	// If requested project matches network's project then include gateway IPs.
+	if projectName == n.project {
+		// Add our own gateway IPs.
+		for _, addr := range []string{n.config["ipv4.address"], n.config["ipv6.address"]} {
+			ip, _, _ := net.ParseCIDR(addr)
+			if ip != nil {
+				leases = append(leases, api.NetworkLease{
+					Hostname: fmt.Sprintf("%s.gw", n.Name()),
+					Address:  ip.String(),
+					Type:     "gateway",
+				})
+			}
+		}
+	}
+
 	// Get all the instances in the requested project that are connected to this network.
 	filter := dbCluster.InstanceFilter{Project: &projectName}
 	err = UsedByInstanceDevices(n.state, n.Project(), n.Name(), n.Type(), func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {


### PR DESCRIPTION
So we don't add these uplink addresses when viewing leases for other projects where they aren't relevant.

Also adds the network's own gateway IPs to `Leases()` list for consistency (when requesting the network's own project), as we are including OVN router uplink addresses in leases list already.

This will aid with consistency of view between `list-leases` command and DNS zones created within projects.

Related to #11145

E.g.

```
lxc network list-leases lxdbr0
+---------------------+-------------------+----------------------------------------+---------+
|      HOSTNAME       |    MAC ADDRESS    |               IP ADDRESS               |  TYPE   |
+---------------------+-------------------+----------------------------------------+---------+
| c1                  | 00:16:3e:19:6e:de | 10.21.203.2                            | DYNAMIC |
+---------------------+-------------------+----------------------------------------+---------+
| c1                  | 00:16:3e:19:6e:de | fd42:ffdb:caff:baf7:216:3eff:fe19:6ede | DYNAMIC |
+---------------------+-------------------+----------------------------------------+---------+
| cbuild              | 00:16:3e:ea:60:28 | fd42:ffdb:caff:baf7:216:3eff:feea:6028 | DYNAMIC |
+---------------------+-------------------+----------------------------------------+---------+
| default-ovn1.uplink |                   | 10.21.203.11                           | UPLINK  |
+---------------------+-------------------+----------------------------------------+---------+
| default-ovn1.uplink |                   | fd42:ffdb:caff:baf7:216:3eff:febe:538c | UPLINK  |
+---------------------+-------------------+----------------------------------------+---------+
| foo2-ovn1.uplink    |                   | 10.21.203.12                           | UPLINK  |
+---------------------+-------------------+----------------------------------------+---------+
| foo2-ovn1.uplink    |                   | fd42:ffdb:caff:baf7:216:3eff:fe15:2e17 | UPLINK  |
+---------------------+-------------------+----------------------------------------+---------+
| lxdbr0.gw           |                   | 10.21.203.1                            | GATEWAY |
+---------------------+-------------------+----------------------------------------+---------+
| lxdbr0.gw           |                   | fd42:ffdb:caff:baf7::1                 | GATEWAY |
+---------------------+-------------------+----------------------------------------+---------+
```

```
lxc network list-leases lxdbr0 --project=foo
+----------+-------------------+----------------------------------------+---------+
| HOSTNAME |    MAC ADDRESS    |               IP ADDRESS               |  TYPE   |
+----------+-------------------+----------------------------------------+---------+
| c2       | 00:16:3e:c0:62:2d | 10.21.203.3                            | DYNAMIC |
+----------+-------------------+----------------------------------------+---------+
| c2       | 00:16:3e:c0:62:2d | fd42:ffdb:caff:baf7:216:3eff:fec0:622d | DYNAMIC |
+----------+-------------------+----------------------------------------+---------+
```

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>