### PR TITLE
doc: add link to Running in production YouTube video

### DIFF
--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: https://www.youtube.com/watch?v=QyXOOE_4cm0
+---
+
 (performance-tuning)=
 # Performance tuning
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://linuxcontainers.org/lxd/getting-started-cli/
+relatedlinks: https://linuxcontainers.org/lxd/getting-started-cli/,https://www.youtube.com/watch?v=QyXOOE_4cm0
 ---
 
 # Getting started


### PR DESCRIPTION
Adding the link as a related link to two pages - the video is a bit all over the place (and in the future, we should maybe have a guide about all steps to consider for a production setup), but for now this will have to do. :)

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>