### PR TITLE
Networks: Use project.NetworkZoneProject in networkZonesGet

### DIFF
--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -130,7 +130,7 @@ var networkZoneCmd = APIEndpoint{
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZonesGet(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}


### PR DESCRIPTION
Missed one needed use of `project.NetworkZoneProject ` in https://github.com/lxc/lxd/pull/11160

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>