### PR TITLE
lxd/apparmor: fix AppArmor profile for qemu-img

### DIFF
--- a/lxd/apparmor/qemuimg.go
+++ b/lxd/apparmor/qemuimg.go
@@ -22,6 +22,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 
   capability dac_override,
   capability dac_read_search,
+  capability ipc_lock,
+
+  /sys/devices/**/block/*/queue/max_segments  r,
 
 {{range $index, $element := .allowedCmdPaths}}
   {{$element}} mixr,


### PR DESCRIPTION
qemu-img uses "/sys/devices/virtual/block/{device_name}/queue/max_segments" with ZFS for its purpose, so path "/sys/devices/** r" is added to AppArmor profile to prevent Apparmor denials
see also https://github.com/qemu/qemu/blob/75d30fde55485b965a1168a21d016dd07b50ed32/block/file-posix.c#L1225

ipc_lock capability is added for memory locking used by qemu-img

Fixes #11154

Signed-off-by: Viktor Iakovchuk <viktor@yakovchuk.net>