### PR TITLE
lxd-generate: Generate boilerplate functions

### DIFF
--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -62,6 +62,60 @@ UPDATE certificates
  WHERE id = ?
 `)
 
+// certificateColumns returns a string of column names to be used with a SELECT statement for the entity.
+// Use this function when building statements to retrieve database entries matching the Certificate entity.
+func certificateColumns() string {
+	return "certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted"
+}
+
+// getCertificates can be used to run handwritten sql.Stmts to return a slice of objects.
+func getCertificates(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Certificate, error) {
+	objects := make([]Certificate, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		c := Certificate{}
+		err := scan(&c.ID, &c.Fingerprint, &c.Type, &c.Name, &c.Certificate, &c.Restricted)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, c)
+
+		return nil
+	}
+
+	err := query.SelectObjects(ctx, stmt, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"certificates\" table: %w", err)
+	}
+
+	return objects, nil
+}
+
+// getCertificates can be used to run handwritten query strings to return a slice of objects.
+func getCertificatesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Certificate, error) {
+	objects := make([]Certificate, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		c := Certificate{}
+		err := scan(&c.ID, &c.Fingerprint, &c.Type, &c.Name, &c.Certificate, &c.Restricted)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, c)
+
+		return nil
+	}
+
+	err := query.Scan(ctx, tx, sql, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"certificates\" table: %w", err)
+	}
+
+	return objects, nil
+}
+
 // GetCertificates returns all available certificates.
 // generator: certificate GetMany
 func GetCertificates(ctx context.Context, tx *sql.Tx, filters ...CertificateFilter) ([]Certificate, error) {
@@ -138,25 +192,12 @@ func GetCertificates(ctx context.Context, tx *sql.Tx, filters ...CertificateFilt
 		}
 	}
 
-	// Dest function for scanning a row.
-	dest := func(scan func(dest ...any) error) error {
-		c := Certificate{}
-		err := scan(&c.ID, &c.Fingerprint, &c.Type, &c.Name, &c.Certificate, &c.Restricted)
-		if err != nil {
-			return err
-		}
-
-		objects = append(objects, c)
-
-		return nil
-	}
-
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
+		objects, err = getCertificates(ctx, sqlStmt, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(ctx, tx, queryStr, dest, args...)
+		objects, err = getCertificatesRaw(ctx, tx, queryStr, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/cluster/config.mapper.go
+++ b/lxd/db/cluster/config.mapper.go
@@ -25,6 +25,60 @@ const configCreate = `INSERT INTO %s_config (%s_id, key, value)
 
 const configDelete = `DELETE FROM %s_config WHERE %s_id = ?`
 
+// configColumns returns a string of column names to be used with a SELECT statement for the entity.
+// Use this function when building statements to retrieve database entries matching the Config entity.
+func configColumns() string {
+	return "%s_config.id, %s_config.%s_id, %s_config.key, %s_config.value"
+}
+
+// getConfig can be used to run handwritten sql.Stmts to return a slice of objects.
+func getConfig(ctx context.Context, stmt *sql.Stmt, parent string, args ...any) ([]Config, error) {
+	objects := make([]Config, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		c := Config{}
+		err := scan(&c.ID, &c.ReferenceID, &c.Key, &c.Value)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, c)
+
+		return nil
+	}
+
+	err := query.SelectObjects(ctx, stmt, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"%s_config\" table: %w", parent, err)
+	}
+
+	return objects, nil
+}
+
+// getConfig can be used to run handwritten query strings to return a slice of objects.
+func getConfigRaw(ctx context.Context, tx *sql.Tx, sql string, parent string, args ...any) ([]Config, error) {
+	objects := make([]Config, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		c := Config{}
+		err := scan(&c.ID, &c.ReferenceID, &c.Key, &c.Value)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, c)
+
+		return nil
+	}
+
+	err := query.Scan(ctx, tx, sql, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"%s_config\" table: %w", parent, err)
+	}
+
+	return objects, nil
+}
+
 // GetConfig returns all available config.
 // generator: config GetMany
 func GetConfig(ctx context.Context, tx *sql.Tx, parent string, filters ...ConfigFilter) (map[int]map[string]string, error) {
@@ -70,22 +124,8 @@ func GetConfig(ctx context.Context, tx *sql.Tx, parent string, filters ...Config
 	}
 
 	queryStr = strings.Join(queryParts, " ORDER BY")
-
-	// Dest function for scanning a row.
-	dest := func(scan func(dest ...any) error) error {
-		c := Config{}
-		err := scan(&c.ID, &c.ReferenceID, &c.Key, &c.Value)
-		if err != nil {
-			return err
-		}
-
-		objects = append(objects, c)
-
-		return nil
-	}
-
 	// Select.
-	err = query.Scan(ctx, tx, queryStr, dest, args...)
+	objects, err = getConfigRaw(ctx, tx, queryStr, parent, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"%s_config\" table: %w", parent, err)
 	}

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -59,21 +59,8 @@ func GetProfileInstances(ctx context.Context, tx *sql.Tx, profileID int) ([]Inst
 
 	args := []any{profileID}
 
-	// Dest function for scanning a row.
-	dest := func(scan func(dest ...any) error) error {
-		i := InstanceProfile{}
-		err := scan(&i.InstanceID, &i.ProfileID, &i.ApplyOrder)
-		if err != nil {
-			return err
-		}
-
-		objects = append(objects, i)
-
-		return nil
-	}
-
 	// Select.
-	err = query.SelectObjects(ctx, sqlStmt, dest, args...)
+	objects, err = getInstanceProfiles(ctx, sqlStmt, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"instances_profiles\" table: %w", err)
 	}
@@ -91,6 +78,60 @@ func GetProfileInstances(ctx context.Context, tx *sql.Tx, profileID int) ([]Inst
 	return result, nil
 }
 
+// instanceProfileColumns returns a string of column names to be used with a SELECT statement for the entity.
+// Use this function when building statements to retrieve database entries matching the InstanceProfile entity.
+func instanceProfileColumns() string {
+	return "instances_profiles.instance_id, instances_profiles.profile_id, instances_profiles.apply_order"
+}
+
+// getInstanceProfiles can be used to run handwritten sql.Stmts to return a slice of objects.
+func getInstanceProfiles(ctx context.Context, stmt *sql.Stmt, args ...any) ([]InstanceProfile, error) {
+	objects := make([]InstanceProfile, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		i := InstanceProfile{}
+		err := scan(&i.InstanceID, &i.ProfileID, &i.ApplyOrder)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, i)
+
+		return nil
+	}
+
+	err := query.SelectObjects(ctx, stmt, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"instances_profiles\" table: %w", err)
+	}
+
+	return objects, nil
+}
+
+// getInstanceProfiles can be used to run handwritten query strings to return a slice of objects.
+func getInstanceProfilesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]InstanceProfile, error) {
+	objects := make([]InstanceProfile, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		i := InstanceProfile{}
+		err := scan(&i.InstanceID, &i.ProfileID, &i.ApplyOrder)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, i)
+
+		return nil
+	}
+
+	err := query.Scan(ctx, tx, sql, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"instances_profiles\" table: %w", err)
+	}
+
+	return objects, nil
+}
+
 // GetInstanceProfiles returns all available Profiles for the Instance.
 // generator: instance_profile GetMany
 func GetInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) ([]Profile, error) {
@@ -106,21 +147,8 @@ func GetInstanceProfiles(ctx context.Context, tx *sql.Tx, instanceID int) ([]Pro
 
 	args := []any{instanceID}
 
-	// Dest function for scanning a row.
-	dest := func(scan func(dest ...any) error) error {
-		i := InstanceProfile{}
-		err := scan(&i.InstanceID, &i.ProfileID, &i.ApplyOrder)
-		if err != nil {
-			return err
-		}
-
-		objects = append(objects, i)
-
-		return nil
-	}
-
 	// Select.
-	err = query.SelectObjects(ctx, sqlStmt, dest, args...)
+	objects, err = getInstanceProfiles(ctx, sqlStmt, args...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch from \"instances_profiles\" table: %w", err)
 	}

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -61,6 +61,60 @@ var operationDeleteByNodeID = RegisterStmt(`
 DELETE FROM operations WHERE node_id = ?
 `)
 
+// operationColumns returns a string of column names to be used with a SELECT statement for the entity.
+// Use this function when building statements to retrieve database entries matching the Operation entity.
+func operationColumns() string {
+	return "operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type"
+}
+
+// getOperations can be used to run handwritten sql.Stmts to return a slice of objects.
+func getOperations(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Operation, error) {
+	objects := make([]Operation, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		o := Operation{}
+		err := scan(&o.ID, &o.UUID, &o.NodeAddress, &o.ProjectID, &o.NodeID, &o.Type)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, o)
+
+		return nil
+	}
+
+	err := query.SelectObjects(ctx, stmt, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"operations\" table: %w", err)
+	}
+
+	return objects, nil
+}
+
+// getOperations can be used to run handwritten query strings to return a slice of objects.
+func getOperationsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Operation, error) {
+	objects := make([]Operation, 0)
+
+	dest := func(scan func(dest ...any) error) error {
+		o := Operation{}
+		err := scan(&o.ID, &o.UUID, &o.NodeAddress, &o.ProjectID, &o.NodeID, &o.Type)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects, o)
+
+		return nil
+	}
+
+	err := query.Scan(ctx, tx, sql, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"operations\" table: %w", err)
+	}
+
+	return objects, nil
+}
+
 // GetOperations returns all available operations.
 // generator: operation GetMany
 func GetOperations(ctx context.Context, tx *sql.Tx, filters ...OperationFilter) ([]Operation, error) {
@@ -161,25 +215,12 @@ func GetOperations(ctx context.Context, tx *sql.Tx, filters ...OperationFilter) 
 		}
 	}
 
-	// Dest function for scanning a row.
-	dest := func(scan func(dest ...any) error) error {
-		o := Operation{}
-		err := scan(&o.ID, &o.UUID, &o.NodeAddress, &o.ProjectID, &o.NodeID, &o.Type)
-		if err != nil {
-			return err
-		}
-
-		objects = append(objects, o)
-
-		return nil
-	}
-
 	// Select.
 	if sqlStmt != nil {
-		err = query.SelectObjects(ctx, sqlStmt, dest, args...)
+		objects, err = getOperations(ctx, sqlStmt, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		err = query.Scan(ctx, tx, queryStr, dest, args...)
+		objects, err = getOperationsRaw(ctx, tx, queryStr, args...)
 	}
 
 	if err != nil {

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -139,6 +139,11 @@ func (m *Method) getMany(buf *file.Buffer) error {
 		return fmt.Errorf("Parse entity struct: %w", err)
 	}
 
+	err = m.getManyTemplateFuncs(buf, mapping)
+	if err != nil {
+		return err
+	}
+
 	if m.config["references"] != "" {
 		refFields := strings.Split(m.config["references"], ",")
 		for _, fieldName := range refFields {
@@ -304,27 +309,24 @@ func (m *Method) getMany(buf *file.Buffer) error {
 		buf.N()
 	}
 
-	buf.N()
-	buf.L("// Dest function for scanning a row.")
-	buf.L("dest := %s", destFunc("objects", typ, mapping.ColumnFields()))
-	buf.N()
 	if mapping.Type == EntityTable {
 		buf.L("// Select.")
 		buf.L("if sqlStmt != nil {")
-		buf.L("err = query.SelectObjects(ctx, sqlStmt, dest, args...)")
+		buf.L("objects, err = get%s(ctx, sqlStmt, args...)", lex.Plural(mapping.Name))
 		buf.L("} else {")
 		buf.L("queryStr := strings.Join(queryParts[:], \"ORDER BY\")")
-		buf.L("err = query.Scan(ctx, tx, queryStr, dest, args...)")
+		buf.L("objects, err = get%sRaw(ctx, tx, queryStr, args...)", lex.Plural(mapping.Name))
 		buf.L("}")
 		buf.N()
 		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	} else if mapping.Type == ReferenceTable || mapping.Type == MapTable {
 		buf.L("// Select.")
-		buf.L("err = query.Scan(ctx, tx, queryStr, dest, args...)")
+		buf.L("objects, err = get%sRaw(ctx, tx, queryStr, parent, args...)", lex.Plural(mapping.Name))
 		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%%s_%s\" table: %%w", parent, err)`, entityTable(m.entity, m.config["table"])))
 	} else {
+		buf.N()
 		buf.L("// Select.")
-		buf.L("err = query.SelectObjects(ctx, sqlStmt, dest, args...)")
+		buf.L("objects, err = get%s(ctx, sqlStmt, args...)", lex.Plural(mapping.Name))
 		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", err)`, entityTable(m.entity, m.config["table"])))
 	}
 
@@ -1446,4 +1448,82 @@ func (m *Method) ifErrNotNil(buf *file.Buffer, newLine bool, rets ...string) {
 
 func (m *Method) end(buf *file.Buffer) {
 	buf.L("}")
+}
+
+// getManyTemplateFuncs returns two functions that can be used to perform generic queries without validation, and return
+// a slice of objects matching the entity. One function will accept pre-registered statements, and the other will accept
+// raw queries.
+func (m *Method) getManyTemplateFuncs(buf *file.Buffer, mapping *Mapping) error {
+	if mapping.Type == AssociationTable {
+		if m.config["struct"] != "" && strings.HasSuffix(mapping.Name, m.config["struct"]) {
+			return nil
+		}
+	}
+
+	tableName := mapping.TableName(m.entity, m.config["table"])
+	// Create a function to get the column names to use with SELECT statements for the entity.
+	buf.L("// %sColumns returns a string of column names to be used with a SELECT statement for the entity.", lex.Minuscule(mapping.Name))
+	buf.L("// Use this function when building statements to retrieve database entries matching the %s entity.", mapping.Name)
+	buf.L("func %sColumns() string {", lex.Minuscule(mapping.Name))
+	columns := make([]string, len(mapping.Fields))
+	for i, field := range mapping.Fields {
+		column, err := field.SelectColumn(mapping, tableName)
+		if err != nil {
+			return err
+		}
+
+		columns[i] = column
+	}
+
+	buf.L("return \"%s\"", strings.Join(columns, ", "))
+	buf.L("}")
+	buf.N()
+
+	// Create a function supporting prepared statements.
+	buf.L("// get%s can be used to run handwritten sql.Stmts to return a slice of objects.", lex.Plural(mapping.Name))
+	if mapping.Type != ReferenceTable && mapping.Type != MapTable {
+		buf.L("func get%s(ctx context.Context, stmt *sql.Stmt, args ...any) ([]%s, error) {", lex.Plural(mapping.Name), mapping.Name)
+	} else {
+		buf.L("func get%s(ctx context.Context, stmt *sql.Stmt, parent string, args ...any) ([]%s, error) {", lex.Plural(mapping.Name), mapping.Name)
+	}
+
+	buf.L("objects := make([]%s, 0)", mapping.Name)
+	buf.N()
+	buf.L("dest := %s", destFunc("objects", lex.Camel(m.entity), mapping.ColumnFields()))
+	buf.N()
+	buf.L("err := query.SelectObjects(ctx, stmt, dest, args...)")
+	if mapping.Type != ReferenceTable && mapping.Type != MapTable {
+		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", err)`, tableName))
+	} else {
+		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", parent, err)`, tableName))
+	}
+
+	buf.L("	return objects, nil")
+	buf.L("}")
+	buf.N()
+
+	// Create a function supporting raw queries.
+	buf.L("// get%s can be used to run handwritten query strings to return a slice of objects.", lex.Plural(mapping.Name))
+	if mapping.Type != ReferenceTable && mapping.Type != MapTable {
+		buf.L("func get%sRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]%s, error) {", lex.Plural(mapping.Name), mapping.Name)
+	} else {
+		buf.L("func get%sRaw(ctx context.Context, tx *sql.Tx, sql string, parent string, args ...any) ([]%s, error) {", lex.Plural(mapping.Name), mapping.Name)
+	}
+
+	buf.L("objects := make([]%s, 0)", mapping.Name)
+	buf.N()
+	buf.L("dest := %s", destFunc("objects", lex.Camel(m.entity), mapping.ColumnFields()))
+	buf.N()
+	buf.L("err := query.Scan(ctx, tx, sql, dest, args...)")
+	if mapping.Type != ReferenceTable && mapping.Type != MapTable {
+		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", err)`, tableName))
+	} else {
+		m.ifErrNotNil(buf, true, "nil", fmt.Sprintf(`fmt.Errorf("Failed to fetch from \"%s\" table: %%w", parent, err)`, tableName))
+	}
+
+	buf.L("	return objects, nil")
+	buf.L("}")
+	buf.N()
+
+	return nil
 }


### PR DESCRIPTION
As discussed in Prague and in #10944, this PR adds more function support for handwritten SQL statements in lxd-generate. 

In particular, 3 new functions are generated per entity on a call to `GetMany`:
* `<entity>Columns()` - returns a string to be used for the columns to retrieve in a SELECT statement, such that the result will map to the `<entity>` struct.
* `get<entities>(ctx context.Context, stmt *sql.Stmt, args ...any)` - executes the given registered statement with the supplied arguments, returning a slice of type `<entity>`.
* `get<entities>Raw(ctx context.Context, tx *sql.Tx, query string, args ...any)` - executes the given query string with the given transaction and the supplied arguments, returning a slice of type `<entity>`. 

Closes  #10944