### PR TITLE
forkdns: Updates serversFileMonitor to only watch for inotify.InMovedTo event

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2072,8 +2072,8 @@ test_clustering_dns() {
   mkdir "${lxdDir}"/networks/lxdtest1/forkdns.servers -p
 
   # Launch forkdns (we expect syslog error about missing servers.conf file)
-  lxd forkdns 127.0.1.1"${ipRand}":1053 lxd lxdtest1 > "${lxdDir}"/forkdns1.log 2>&1 &
-  echo $! > "${lxdDir}"/forkdns1.pid
+  lxd forkdns 127.0.1.1"${ipRand}":1053 lxd lxdtest1 &
+  forkdns_pid1=$!
 
   # Create first dummy interface for forkdns
   ip link add "${prefix}2" type dummy
@@ -2084,13 +2084,11 @@ test_clustering_dns() {
   mkdir "${lxdDir}"/networks/lxdtest2/forkdns.servers -p
 
   # Launch forkdns (we expect syslog error about missing servers.conf file)
-  lxd forkdns 127.0.1.2"${ipRand}":1053 lxd lxdtest2 > "${lxdDir}"/forkdns2.log 2>&1 &
-  echo $! > "${lxdDir}"/forkdns2.pid
+  lxd forkdns 127.0.1.2"${ipRand}":1053 lxd lxdtest2 &
+  forkdns_pid2=$!
 
   # Let the processes come up
   sleep 1
-  forkdns_pid1=$(cat "${lxdDir}/forkdns1.pid")
-  forkdns_pid2=$(cat "${lxdDir}/forkdns2.pid")
 
   # Create servers list file for forkdns1 pointing at forkdns2 (should be live reloaded)
   echo "127.0.1.2${ipRand}" > "${lxdDir}"/networks/lxdtest1/forkdns.servers/servers.conf

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2130,8 +2130,8 @@ test_clustering_dns() {
   fi
 
   # Cleanup
-  kill "${forkdns_pid1}"
-  kill "${forkdns_pid2}"
+  kill -9 "${forkdns_pid1}"
+  kill -9 "${forkdns_pid2}"
   ip link delete "${prefix}1"
   ip link delete "${prefix}2"
 }

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2091,7 +2091,8 @@ test_clustering_dns() {
   sleep 1
 
   # Create servers list file for forkdns1 pointing at forkdns2 (should be live reloaded)
-  echo "127.0.1.2${ipRand}" > "${lxdDir}"/networks/lxdtest1/forkdns.servers/servers.conf
+  echo "127.0.1.2${ipRand}" > "${lxdDir}"/networks/lxdtest1/forkdns.servers/servers.conf.tmp
+  mv "${lxdDir}"/networks/lxdtest1/forkdns.servers/servers.conf.tmp "${lxdDir}"/networks/lxdtest1/forkdns.servers/servers.conf
 
   # Create fake DHCP lease file on forkdns2 network
   echo "$(date +%s) 00:16:3e:98:05:40 10.140.78.145 test1 ff:2b:a8:0a:df:00:02:00:00:ab:11:36:ea:11:e5:37:e0:85:45" > "${lxdDir}"/networks/lxdtest2/dnsmasq.leases

--- a/test/suites/network_zone.sh
+++ b/test/suites/network_zone.sh
@@ -62,8 +62,6 @@ test_network_zone() {
   ! lxc network set "${netName}" dns.zone.reverse.ipv4 "2.0.192.in-addr.arpa, lxd.example.net" || false
   ! lxc network set "${netName}" dns.zone.reverse.ipv6 "0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa, lxd.example.net" || false
 
-
-
   lxc start c1
   lxc start c2 --project foo
 
@@ -90,7 +88,7 @@ test_network_zone() {
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxd.example.net | grep "c1.lxd.example.net.\s\+300\s\+IN\s\+AAAA\s\+"
 
   # Check the c2 instance from project foo isn't in the forward view of lxd.example.net
-  ! dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxd.example.net | grep "c2" || false
+  ! dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxd.example.net | grep "c2.lxd.example.net" || false
 
   # Check the c2 instance is the lxdfoo.example.net zone view, but not the network's gateways.
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxdfoo.example.net
@@ -100,7 +98,7 @@ test_network_zone() {
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxdfoo.example.net | grep "c2.lxdfoo.example.net.\s\+300\s\+IN\s\+AAAA\s\+"
 
   # Check the c1 instance from project default isn't in the forward view of lxdfoo.example.net
-  ! dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxdfoo.example.net | grep "c1" || false
+  ! dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxdfoo.example.net | grep "c1.lxd.example.net" || false
 
   # Check reverse zones include records from both projects associated to the relevant forward zone name.
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 2.0.192.in-addr.arpa | grep -Fc "PTR" | grep -Fx 3


### PR DESCRIPTION
This fixes a regression caused when I moved this to use the inotify package (https://github.com/lxc/lxd/pull/11152) as by watching for all events, this included the open and read events causing a busy event loop and log spam.

This also fixes a small inefficiency that caused the forkdns server to reload its servers file twice because it was triggering both on writes to the servers file and the temporary file that is generated first.

We now only watch for files being renamed to the main servers list file.

This also updates the tests to properly simulate what LXD does (moving a temporary file into position) to properly trigger the watched for event.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>