### PR TITLE
Metrics: Limits concurrency of instance metrics building to avoid potentially spawning unlimited go routines

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -81,7 +81,7 @@ func ConnectLXD(url string, args *ConnectionArgs) (InstanceServer, error) {
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
 func ConnectLXDWithContext(ctx context.Context, url string, args *ConnectionArgs) (InstanceServer, error) {
-	logger.Debugf("Connecting to a remote LXD over HTTPS")
+	logger.Debug("Connecting to a remote LXD over HTTPS")
 
 	// Cleanup URL
 	url = strings.TrimSuffix(url, "/")
@@ -96,7 +96,7 @@ func ConnectLXDHTTP(args *ConnectionArgs, client *http.Client) (InstanceServer, 
 
 // ConnectLXDHTTPWithContext lets you connect to a VM agent over a VM socket with context.Context.
 func ConnectLXDHTTPWithContext(ctx context.Context, args *ConnectionArgs, client *http.Client) (InstanceServer, error) {
-	logger.Debugf("Connecting to a VM agent over a VM socket")
+	logger.Debug("Connecting to a VM agent over a VM socket")
 
 	// Use empty args if not specified
 	if args == nil {
@@ -154,7 +154,7 @@ func ConnectLXDUnix(path string, args *ConnectionArgs) (InstanceServer, error) {
 // unset $LXD_DIR/unix.socket will be used and if that one isn't set
 // either, then the path will default to /var/lib/lxd/unix.socket.
 func ConnectLXDUnixWithContext(ctx context.Context, path string, args *ConnectionArgs) (InstanceServer, error) {
-	logger.Debugf("Connecting to a local LXD over a Unix socket")
+	logger.Debug("Connecting to a local LXD over a Unix socket")
 
 	// Use empty args if not specified
 	if args == nil {
@@ -229,7 +229,7 @@ func ConnectPublicLXD(url string, args *ConnectionArgs) (ImageServer, error) {
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
 func ConnectPublicLXDWithContext(ctx context.Context, url string, args *ConnectionArgs) (ImageServer, error) {
-	logger.Debugf("Connecting to a remote public LXD over HTTPS")
+	logger.Debug("Connecting to a remote public LXD over HTTPS")
 
 	// Cleanup URL
 	url = strings.TrimSuffix(url, "/")

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -98,6 +99,14 @@ func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
 	// Perform the query
 	resp, _, err := d.RawQuery(c.flagAction, path, data, "")
 	if err != nil {
+		var jsonSyntaxError *json.SyntaxError
+
+		// If not JSON decoding error then fail immediately.
+		if !errors.As(err, &jsonSyntaxError) {
+			return err
+		}
+
+		// If JSON decoding error then try a plain request.
 		cleanErr := err
 
 		// Get the URL prefix

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -179,7 +179,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	hostInterfaces, _ := net.Interfaces()
 
 	var instances []instance.Instance
-	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(r.Context(), func(dbInst db.InstanceArgs, p api.Project) error {
 		inst, err := instance.Load(s, dbInst, p)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -194,7 +194,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Prepare temporary metrics storage.
-	newMetrics := map[string]*metrics.MetricSet{}
+	newMetrics := make(map[string]*metrics.MetricSet, len(projectsToFetch))
 	newMetricsLock := sync.Mutex{}
 
 	// Limit metrics build concurrency to number of instances or number of CPU cores (which ever is less).

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -116,25 +116,32 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Review the cache.
-	metricsCacheLock.Lock()
-	projectMissing := []string{}
-	for _, project := range projectNames {
-		cache, ok := metricsCache[project]
-		if !ok || cache.expiry.Before(time.Now()) {
-			// If missing or expired, record it.
-			projectMissing = append(projectMissing, project)
-			continue
+	// invalidProjects returns project names who are either not in cache or have expired.
+	invalidProjects := func(projectNames []string) []string {
+		metricsCacheLock.Lock()
+		defer metricsCacheLock.Unlock()
+
+		invalidProjects := []string{}
+		for _, projectName := range projectNames {
+			cache, ok := metricsCache[projectName]
+			if !ok || cache.expiry.Before(time.Now()) {
+				// If missing or expired, record it.
+				invalidProjects = append(invalidProjects, projectName)
+				continue
+			}
+
+			// If present and valid, merge the existing data.
+			metricSet.Merge(cache.metrics)
 		}
 
-		// If present and valid, merge the existing data.
-		metricSet.Merge(cache.metrics)
+		return invalidProjects
 	}
 
-	metricsCacheLock.Unlock()
+	// Review the cache for invalid projects.
+	projectsToFetch := invalidProjects(projectNames)
 
 	// If all valid, return immediately.
-	if len(projectMissing) == 0 {
+	if len(projectsToFetch) == 0 {
 		return response.SyncResponsePlain(true, metricSet.String())
 	}
 
@@ -142,25 +149,12 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	metricsLock.Lock()
 	defer metricsLock.Unlock()
 
-	// Check if any of the missing data has been filled in.
-	metricsCacheLock.Lock()
-	toFetch := []string{}
-	for _, project := range projectMissing {
-		cache, ok := metricsCache[project]
-		if !ok || cache.expiry.Before(time.Now()) {
-			// Still missing, queue a re-fetch.
-			toFetch = append(toFetch, project)
-			continue
-		}
-
-		// If present and valid, merge the existing data.
-		metricSet.Merge(cache.metrics)
-	}
-
-	metricsCacheLock.Unlock()
+	// Check if any of the missing data has been filled in since acquiring the lock.
+	// As its possible another request was already populating the cache when we tried to take the lock.
+	projectsToFetch = invalidProjects(projectNames)
 
 	// If all valid, return immediately.
-	if len(toFetch) == 0 {
+	if len(projectsToFetch) == 0 {
 		return response.SyncResponsePlain(true, metricSet.String())
 	}
 
@@ -172,7 +166,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	// Fetch what's missing.
 	wgInstances := sync.WaitGroup{}
-	for _, project := range toFetch {
+	for _, project := range projectsToFetch {
 		// Get the instances.
 		instances, err := instanceLoadNodeProjectAll(d.State(), project, instancetype.Any)
 		if err != nil {

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -91,7 +91,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 		projectNames = []string{projectName}
 	} else {
 		// Get all projects.
-		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err := d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			projects, err := dbCluster.GetProjects(ctx, tx.Tx())
 			if err != nil {
 				return err

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -97,6 +97,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
+			projectNames = make([]string, 0, len(projects))
 			for _, project := range projects {
 				projectNames = append(projectNames, project.Name)
 			}

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/metrics"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared/api"
@@ -25,7 +26,6 @@ type metricsCacheEntry struct {
 
 var metricsCache map[string]metricsCacheEntry
 var metricsCacheLock sync.Mutex
-var metricsLock sync.Mutex
 
 var metricsCmd = APIEndpoint{
 	Path: "metrics",
@@ -153,9 +153,18 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SyncResponsePlain(true, metricSet.String())
 	}
 
+	cacheDuration := time.Duration(8) * time.Second
+
 	// Acquire update lock.
-	metricsLock.Lock()
-	defer metricsLock.Unlock()
+	lockCtx, lockCtxCancel := context.WithTimeout(r.Context(), cacheDuration)
+	defer lockCtxCancel()
+
+	unlock := locking.Lock(lockCtx, "metricsGet")
+	if unlock == nil {
+		return response.SmartError(api.StatusErrorf(http.StatusLocked, "Metrics are currently being built by another request"))
+	}
+
+	defer unlock()
 
 	// Check if any of the missing data has been filled in since acquiring the lock.
 	// As its possible another request was already populating the cache when we tried to take the lock.
@@ -232,7 +241,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	for project, entries := range newMetrics {
 		metricsCache[project] = metricsCacheEntry{
-			expiry:  time.Now().Add(8 * time.Second),
+			expiry:  time.Now().Add(cacheDuration),
 			metrics: entries,
 		}
 

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -197,40 +197,55 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	newMetrics := map[string]*metrics.MetricSet{}
 	newMetricsLock := sync.Mutex{}
 
-	// Fetch what's missing.
-	wgInstances := sync.WaitGroup{}
+	// Limit metrics build concurrency to number of instances or number of CPU cores (which ever is less).
+	var wg sync.WaitGroup
+	instMetricsCh := make(chan instance.Instance)
+	maxConcurrent := runtime.NumCPU()
+	instCount := len(instances)
+	if instCount < maxConcurrent {
+		maxConcurrent = instCount
+	}
 
+	// Start metrics builder routines.
+	for i := 0; i < maxConcurrent; i++ {
+		go func(instMetricsCh <-chan instance.Instance) {
+			for inst := range instMetricsCh {
+				projectName := inst.Project().Name
+				instanceMetrics, err := inst.Metrics(hostInterfaces)
+				if err != nil {
+					logger.Warn("Failed getting instance metrics", logger.Ctx{"instance": inst.Name(), "project": projectName, "err": err})
+				} else {
+					// Add the metrics.
+					newMetricsLock.Lock()
+
+					// Initialise metrics set for project if needed.
+					if newMetrics[projectName] == nil {
+						newMetrics[projectName] = metrics.NewMetricSet(nil)
+					}
+
+					newMetrics[projectName].Merge(instanceMetrics)
+
+					newMetricsLock.Unlock()
+				}
+
+				wg.Done()
+			}
+		}(instMetricsCh)
+	}
+
+	// Fetch what's missing.
 	for _, inst := range instances {
 		// Ignore stopped instances.
 		if !inst.IsRunning() {
 			continue
 		}
 
-		wgInstances.Add(1)
-		go func(inst instance.Instance) {
-			defer wgInstances.Done()
-
-			projectName := inst.Project().Name
-			instanceMetrics, err := inst.Metrics(hostInterfaces)
-			if err != nil {
-				logger.Warn("Failed to get instance metrics", logger.Ctx{"instance": inst.Name(), "project": projectName, "err": err})
-				return
-			}
-
-			// Add the metrics.
-			newMetricsLock.Lock()
-			defer newMetricsLock.Unlock()
-
-			// Initialise metrics set for project if needed.
-			if newMetrics[projectName] == nil {
-				newMetrics[projectName] = metrics.NewMetricSet(nil)
-			}
-
-			newMetrics[projectName].Merge(instanceMetrics)
-		}(inst)
+		wg.Add(1)
+		instMetricsCh <- inst
 	}
 
-	wgInstances.Wait()
+	wg.Wait()
+	close(instMetricsCh)
 
 	// Put the new data in the global cache and in response.
 	metricsCacheLock.Lock()

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -50,7 +51,7 @@ func (d *Daemon) imageOperationLock(fingerprint string) locking.UnlockFunc {
 	l.Debug("Acquiring lock for image")
 	defer l.Debug("Lock acquired for image")
 
-	return locking.Lock(fmt.Sprintf("ImageOperation_%s", fingerprint))
+	return locking.Lock(context.TODO(), fmt.Sprintf("ImageOperation_%s", fingerprint))
 }
 
 // ImageDownload resolves the image fingerprint and if not in the database, downloads it.

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -221,7 +221,7 @@ var ErrInstanceListStop = fmt.Errorf("search stopped")
 
 // InstanceList loads all instances across all projects and for each instance runs the instanceFunc passing in the
 // instance and it's project and profiles. Accepts optional filter arguments to specify a subset of instances.
-func (c *Cluster) InstanceList(instanceFunc func(inst InstanceArgs, project api.Project) error, filters ...cluster.InstanceFilter) error {
+func (c *Cluster) InstanceList(ctx context.Context, instanceFunc func(inst InstanceArgs, project api.Project) error, filters ...cluster.InstanceFilter) error {
 	projectsByName := make(map[string]*api.Project)
 	var instances map[int]InstanceArgs
 
@@ -238,7 +238,7 @@ func (c *Cluster) InstanceList(instanceFunc func(inst InstanceArgs, project api.
 	}
 
 	// Retrieve required info from the database in single transaction for performance.
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+	err := c.Transaction(ctx, func(ctx context.Context, tx *ClusterTx) error {
 		// Get all projects.
 		projects, err := cluster.GetProjects(ctx, tx.tx)
 		if err != nil {

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -265,7 +265,7 @@ func TestInstanceList(t *testing.T) {
 	require.NoError(t, err)
 
 	var instances []db.InstanceArgs
-	err = c.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
+	err = c.InstanceList(context.TODO(), func(dbInst db.InstanceArgs, p api.Project) error {
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -432,7 +432,7 @@ func instanceLoadNodeProjectAll(s *state.State, project string, instanceType ins
 		filter.Node = &s.ServerName
 	}
 
-	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(context.TODO(), func(dbInst db.InstanceArgs, p api.Project) error {
 		inst, err := instance.Load(s, dbInst, p)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5343,7 +5343,7 @@ func (d *lxc) inheritInitPidFd() (int, *os.File) {
 // FileSFTPConn returns a connection to the forkfile handler.
 func (d *lxc) FileSFTPConn() (net.Conn, error) {
 	// Lock to avoid concurrent spawning.
-	spawnUnlock := locking.Lock(fmt.Sprintf("forkfile_%d", d.id))
+	spawnUnlock := locking.Lock(context.TODO(), fmt.Sprintf("forkfile_%d", d.id))
 	defer spawnUnlock()
 
 	// Create any missing directories in case the instance has never been started before.
@@ -5404,7 +5404,7 @@ func (d *lxc) FileSFTPConn() (net.Conn, error) {
 	chReady := make(chan error)
 	go func() {
 		// Lock to avoid concurrent running forkfile.
-		runUnlock := locking.Lock(d.forkfileRunningLockName())
+		runUnlock := locking.Lock(context.TODO(), d.forkfileRunningLockName())
 		defer runUnlock()
 
 		// Mount the filesystem if needed.
@@ -5575,7 +5575,7 @@ func (d *lxc) FileSFTP() (*sftp.Client, error) {
 func (d *lxc) stopForkfile() {
 	// Make sure that when the function exits, no forkfile is running by acquiring the lock (which indicates
 	// that forkfile isn't running and holding the lock) and then releasing it.
-	defer func() { locking.Lock(d.forkfileRunningLockName())() }()
+	defer func() { locking.Lock(context.TODO(), d.forkfileRunningLockName())() }()
 
 	// Try to send SIGINT to forkfile to speed up shutdown.
 	content, err := os.ReadFile(filepath.Join(d.LogPath(), "forkfile.pid"))

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5828,7 +5828,7 @@ func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error
 			// Try and get state info from agent.
 			status, err = d.agentGetState()
 			if err != nil {
-				if err != errQemuAgentOffline {
+				if !errors.Is(err, errQemuAgentOffline) {
 					d.logger.Warn("Could not get VM state from agent", logger.Ctx{"err": err})
 				}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6579,13 +6579,7 @@ func (d *qemu) getNetworkState() (map[string]api.InstanceStateNetwork, error) {
 }
 
 func (d *qemu) agentMetricsEnabled() bool {
-	val := d.expandedConfig["security.agent.metrics"]
-
-	if val == "" || shared.IsTrue(val) {
-		return true
-	}
-
-	return false
+	return shared.IsTrueOrEmpty(d.expandedConfig["security.agent.metrics"])
 }
 
 func (d *qemu) deviceAttachUSB(usbConf deviceConfig.USBDeviceItem) error {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6492,7 +6492,17 @@ func (d *qemu) checkFeatures(qemu string) ([]string, error) {
 
 func (d *qemu) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error) {
 	if d.agentMetricsEnabled() {
-		return d.getAgentMetrics()
+		metrics, err := d.getAgentMetrics()
+		if err != nil {
+			if !errors.Is(err, errQemuAgentOffline) {
+				d.logger.Warn("Could not get VM metrics from agent", logger.Ctx{"err": err})
+			}
+
+			// Fallback data if agent is not reachable.
+			return d.getQemuMetrics()
+		}
+
+		return metrics, nil
 	}
 
 	return d.getQemuMetrics()

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -403,7 +403,7 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 		filter.Node = &s.ServerName
 	}
 
-	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(context.TODO(), func(dbInst db.InstanceArgs, p api.Project) error {
 		inst, err := Load(s, dbInst, p)
 		if err != nil {
 			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -204,7 +204,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 	}
 
 	// Find instances using the ACLs. Most expensive to do.
-	err = s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2439,7 +2439,7 @@ func (n *bridge) bridgeNetworkExternalSubnets(bridgeProjectNetworks map[string][
 func (n *bridge) bridgedNICExternalRoutes(bridgeProjectNetworks map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+	err := n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -2651,7 +2651,7 @@ func (n *bridge) ForwardCreate(forward api.NetworkForwardsPost, clientType reque
 			// If we are the first forward on this bridge, enable hairpin mode on active NIC ports.
 			if len(listenAddresses) <= 1 {
 				filter := dbCluster.InstanceFilter{Node: &n.state.ServerName}
-				err = n.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+				err = n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 					// Get the instance's effective network project name.
 					instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1187,7 +1187,7 @@ func (n *ovn) startUplinkPort() error {
 
 	// Lock uplink network so that if multiple OVN networks are trying to connect to the same uplink we don't
 	// race each other setting up the connection.
-	unlock := locking.Lock(n.uplinkOperationLockName(uplinkNet))
+	unlock := locking.Lock(context.TODO(), n.uplinkOperationLockName(uplinkNet))
 	defer unlock()
 
 	switch uplinkNet.Type() {
@@ -1501,7 +1501,7 @@ func (n *ovn) deleteUplinkPort() error {
 		}
 
 		// Lock uplink network so we don't race each other networks using the OVS uplink bridge.
-		unlock := locking.Lock(n.uplinkOperationLockName(uplinkNet))
+		unlock := locking.Lock(context.TODO(), n.uplinkOperationLockName(uplinkNet))
 		defer unlock()
 
 		switch uplinkNet.Type() {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4106,7 +4106,7 @@ func (n *ovn) ovnNetworkExternalSubnets(ovnProjectNetworksWithOurUplink map[stri
 func (n *ovn) ovnNICExternalRoutes(ovnProjectNetworksWithOurUplink map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+	err := n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
@@ -4224,7 +4224,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
 			// This will restore the l2proxy DNAT_AND_SNAT rules.
-			err = n.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+			err = n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 				// Get the instance's effective network project name.
 				instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -74,7 +74,7 @@ func MACDevName(mac net.HardwareAddr) string {
 // UsedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 // Accepts optional filter arguments to specify a subset of instances.
 func UsedByInstanceDevices(s *state.State, networkProjectName string, networkName string, networkType string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error, filters ...cluster.InstanceFilter) error {
-	return s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+	return s.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -57,7 +57,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	reservedDevices := map[string]struct{}{}
 
 	// Check if any instances are using the VF device.
-	err = s.DB.Cluster.InstanceList(func(dbInst db.InstanceArgs, p api.Project) error {
+	err = s.DB.Cluster.InstanceList(context.TODO(), func(dbInst db.InstanceArgs, p api.Project) error {
 		// Expand configs so we take into account profile devices.
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -404,7 +404,7 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+	return d.State().DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2640,7 +2640,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 
 	// Lock this operation to ensure that the only one snapshot is made at the time.
 	// Other operations will wait for this one to finish.
-	unlock := locking.Lock(drivers.OperationLockName("CreateInstanceSnapshot", b.name, vol.Type(), contentType, src.Name()))
+	unlock := locking.Lock(context.TODO(), drivers.OperationLockName("CreateInstanceSnapshot", b.name, vol.Type(), contentType, src.Name()))
 	defer unlock()
 
 	err = b.driver.CreateVolumeSnapshot(vol, op)
@@ -3015,7 +3015,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 	// We need to lock this operation to ensure that the image is not being created multiple times.
 	// Uses a lock name of "EnsureImage_<fingerprint>" to avoid deadlocking with CreateVolume below that also
 	// establishes a lock on the volume type & name if it needs to mount the volume before filling.
-	unlock := locking.Lock(drivers.OperationLockName("EnsureImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
+	unlock := locking.Lock(context.TODO(), drivers.OperationLockName("EnsureImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
 	defer unlock()
 
 	// Load image info from database.
@@ -3152,7 +3152,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 	defer l.Debug("DeleteImage finished")
 
 	// We need to lock this operation to ensure that the image is not being deleted multiple times.
-	unlock := locking.Lock(drivers.OperationLockName("DeleteImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
+	unlock := locking.Lock(context.TODO(), drivers.OperationLockName("DeleteImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
 	defer unlock()
 
 	// Load the storage volume in order to get the volume config which is needed for some drivers.
@@ -4994,7 +4994,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 
 	// Lock this operation to ensure that the only one snapshot is made at the time.
 	// Other operations will wait for this one to finish.
-	unlock := locking.Lock(drivers.OperationLockName("CreateCustomVolumeSnapshot", b.name, vol.Type(), contentType, volName))
+	unlock := locking.Lock(context.TODO(), drivers.OperationLockName("CreateCustomVolumeSnapshot", b.name, vol.Type(), contentType, volName))
 	defer unlock()
 
 	// Create the snapshot on the storage device.

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -45,7 +45,7 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 	// Get instances on this local server (as the DB helper functions return volumes on local server), also
 	// avoids running the same queries on every cluster member for instances on shared storage.
 	filter := cluster.InstanceFilter{Node: &localNode}
-	err = b.state.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+	err = b.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 		// Check we can convert the instance to the volume type needed.
 		volType, err := InstanceTypeToVolumeType(inst.Type)
 		if err != nil {

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -55,7 +56,7 @@ func (d *lvm) openLoopFile(source string) (string, error) {
 	}
 
 	if filepath.IsAbs(source) && !shared.IsBlockdevPath(source) {
-		unlock := locking.Lock(OperationLockName("openLoopFile", d.name, "", "", ""))
+		unlock := locking.Lock(context.TODO(), OperationLockName("openLoopFile", d.name, "", "", ""))
 		defer unlock()
 
 		loopDeviceName, err := loopDeviceSetup(source)

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -166,7 +167,7 @@ func (v Volume) mountLockName() string {
 
 // MountLock attempts to lock the mount lock for the volume and returns the UnlockFunc.
 func (v Volume) MountLock() locking.UnlockFunc {
-	return locking.Lock(v.mountLockName())
+	return locking.Lock(context.TODO(), v.mountLockName())
 }
 
 // MountRefCountIncrement increments the mount ref counter for the volume and returns the new value.

--- a/lxd/storage/s3/miniod/miniod.go
+++ b/lxd/storage/s3/miniod/miniod.go
@@ -92,7 +92,7 @@ func (p *Process) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	spawnUnlock := locking.Lock(fmt.Sprintf("%s%s", minioLockPrefix, p.bucketName))
+	spawnUnlock := locking.Lock(context.TODO(), fmt.Sprintf("%s%s", minioLockPrefix, p.bucketName))
 	defer spawnUnlock()
 
 	defer p.cancel.Cancel()
@@ -161,7 +161,7 @@ func EnsureRunning(s *state.State, bucketVol storageDrivers.Volume) (*Process, e
 	bucketName := bucketVol.Name()
 
 	// Prevent concurrent spawning of same bucket.
-	spawnUnlock := locking.Lock(fmt.Sprintf("%s%s", minioLockPrefix, bucketName))
+	spawnUnlock := locking.Lock(context.TODO(), fmt.Sprintf("%s%s", minioLockPrefix, bucketName))
 	defer spawnUnlock()
 
 	// Check if there is an existing running minio process for the bucket, and if so return it.
@@ -348,7 +348,7 @@ func EnsureRunning(s *state.State, bucketVol storageDrivers.Volume) (*Process, e
 // Get returns an existing MinIO process if it exists.
 func Get(bucketName string) *Process {
 	// Wait for any ongoing spawn of the bucket process to finish.
-	spawnUnlock := locking.Lock(fmt.Sprintf("%s%s", minioLockPrefix, bucketName))
+	spawnUnlock := locking.Lock(context.TODO(), fmt.Sprintf("%s%s", minioLockPrefix, bucketName))
 	defer spawnUnlock()
 
 	// Check if there is an existing running minio process for the bucket, and if so return it.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -791,7 +791,7 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 		return err
 	}
 
-	return s.DB.Cluster.InstanceList(func(inst db.InstanceArgs, p api.Project) error {
+	return s.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
 		// If the volume has a specific cluster member which is different than the instance then skip as
 		// instance cannot be using this volume.
 		if vol.Location != "" && inst.Node != vol.Location {


### PR DESCRIPTION
This PR aims to fix an issue that @stgraber is experiencing on his own LXD cluster where requests to the `/1.0/metrics` endpoint are piling up and apparently becoming deadlocked.

This PR makes the following improvements:

- Uses VM non-agent metrics if lxd-agent isn't reachable.
- Pre-allocates slices and maps where possible.
- Reduces DB transactions where possible.
- Cancels DB transactions if client request context is cancelled.
- Adds timeout when acquiring the metrics update lock. So that if there is an ongoing metrics build requests do not pile up if they are coming in too frequently.
- Limits concurrency of instance metrics building to avoid potentially spawning unlimited go routines.
- Fixes an issue in `lxc query` where any failed request was retried in plain mode, rather than just when a JSON decode error occurred.