### PR TITLE
Instance: Fix VM vsock nesting regression

### DIFF
--- a/lxd/endpoints/vsock.go
+++ b/lxd/endpoints/vsock.go
@@ -36,16 +36,15 @@ func createVsockListener(cert *shared.CertInfo) (net.Listener, error) {
 	return nil, fmt.Errorf("Failed finding free listen port for vsock listener")
 }
 
-// VsockAddress returns the network address of the vsock endpoint, or an
-// empty string if there's no vsock endpoint.
-func (e *Endpoints) VsockAddress() string {
+// VsockAddress returns the network address of the vsock endpoint, or nil if there's no vsock endpoint.
+func (e *Endpoints) VsockAddress() net.Addr {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
 	listener := e.listeners[vsock]
 	if listener == nil {
-		return ""
+		return nil
 	}
 
-	return listener.Addr().String()
+	return listener.Addr()
 }

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2394,9 +2394,11 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 		return err
 	}
 
-	err = d.saveConnectionInfo(connInfo)
-	if err != nil {
-		return err
+	if connInfo != nil {
+		err = d.saveConnectionInfo(connInfo)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -28,6 +28,7 @@ import (
 	"github.com/flosch/pongo2"
 	"github.com/gorilla/websocket"
 	"github.com/kballard/go-shellquote"
+	"github.com/mdlayher/vsock"
 	"github.com/pborman/uuid"
 	"github.com/pkg/sftp"
 	"golang.org/x/sys/unix"
@@ -60,7 +61,7 @@ import (
 	"github.com/lxc/lxd/lxd/storage/filesystem"
 	pongoTemplate "github.com/lxc/lxd/lxd/template"
 	"github.com/lxc/lxd/lxd/util"
-	"github.com/lxc/lxd/lxd/vsock"
+	lxdvsock "github.com/lxc/lxd/lxd/vsock"
 	"github.com/lxc/lxd/lxd/warnings"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -337,7 +338,7 @@ func (d *qemu) getAgentClient() (*http.Client, error) {
 		}
 	}
 
-	agent, err := vsock.HTTPClient(vsockID, shared.HTTPSDefaultPort, clientCert, clientKey, agentCert)
+	agent, err := lxdvsock.HTTPClient(vsockID, shared.HTTPSDefaultPort, clientCert, clientKey, agentCert)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,19 +1599,21 @@ func (d *qemu) Start(stateful bool) error {
 // getAgentConnectionInfo returns the connection info the lxd-agent needs to connect to the LXD
 // server.
 func (d *qemu) getAgentConnectionInfo() (*agentAPI.API10Put, error) {
-	req := agentAPI.API10Put{
-		Certificate: string(d.state.Endpoints.NetworkCert().PublicKey()),
-		Devlxd:      shared.IsTrueOrEmpty(d.expandedConfig["security.devlxd"]),
-	}
-
 	addr := d.state.Endpoints.VsockAddress()
-	if addr == "" {
+	if addr == nil {
 		return nil, nil
 	}
 
-	_, err := fmt.Sscanf(addr, "host(%d):%d", &req.CID, &req.Port)
-	if err != nil {
-		return nil, fmt.Errorf("Failed parsing vsock address: %w", err)
+	vsockaddr, ok := addr.(*vsock.Addr)
+	if !ok {
+		return nil, fmt.Errorf("Listen address is not vsock.Addr")
+	}
+
+	req := agentAPI.API10Put{
+		Certificate: string(d.state.Endpoints.NetworkCert().PublicKey()),
+		Devlxd:      shared.IsTrueOrEmpty(d.expandedConfig["security.devlxd"]),
+		CID:         vsockaddr.ContextID,
+		Port:        vsockaddr.Port,
 	}
 
 	return &req, nil


### PR DESCRIPTION
Fixes https://github.com/lxc/lxd/issues/11187 

The output of the vsock's `Addr().String()` was incompatible with `fmt.Sscanf(addr, "host(%d):%d"` pattern when nesting (as the "host" part became "vm").

Rather than account for the various output patterns I just extracted the underlying context ID and port directly using type smuggling.