### PR TITLE
Device: Use api.NetworkStatusUnavailable constant

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -474,7 +474,7 @@ func (d *nicBridged) PreStartCheck() error {
 	}
 
 	// If managed network is not available, don't try and start instance.
-	if d.network.LocalStatus() == api.StoragePoolStatusUnvailable {
+	if d.network.LocalStatus() == api.NetworkStatusUnavailable {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -112,7 +112,7 @@ func (d *nicMACVLAN) PreStartCheck() error {
 	}
 
 	// If managed network is not available, don't try and start instance.
-	if d.network.LocalStatus() == api.StoragePoolStatusUnvailable {
+	if d.network.LocalStatus() == api.NetworkStatusUnavailable {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -292,7 +292,7 @@ func (d *nicOVN) PreStartCheck() error {
 	}
 
 	// If managed network is not available, don't try and start instance.
-	if d.network.LocalStatus() == api.StoragePoolStatusUnvailable {
+	if d.network.LocalStatus() == api.NetworkStatusUnavailable {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -115,7 +115,7 @@ func (d *nicSRIOV) PreStartCheck() error {
 	}
 
 	// If managed network is not available, don't try and start instance.
-	if d.network.LocalStatus() == api.StoragePoolStatusUnvailable {
+	if d.network.LocalStatus() == api.NetworkStatusUnavailable {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 


### PR DESCRIPTION
This doesn't change behaviour, but is the correct constant to use for NICs.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>