### PR TITLE
Storage: Don't attempt multi-sync mode optimized transfers

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4142,7 +4142,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		_, oldRootDev, oldErr := shared.GetRootDiskDevice(oldExpandedDevices.CloneNative())
 		_, newRootDev, newErr := shared.GetRootDiskDevice(d.expandedDevices.CloneNative())
 		if oldErr == nil && newErr == nil && oldRootDev["pool"] != newRootDev["pool"] {
-			return fmt.Errorf("Cannot update root disk device pool name")
+			return fmt.Errorf("Cannot update root disk device pool name to %q", newRootDev["pool"])
 		}
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4635,7 +4635,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		_, oldRootDev, oldErr := shared.GetRootDiskDevice(oldExpandedDevices.CloneNative())
 		_, newRootDev, newErr := shared.GetRootDiskDevice(d.expandedDevices.CloneNative())
 		if oldErr == nil && newErr == nil && oldRootDev["pool"] != newRootDev["pool"] {
-			return fmt.Errorf("Cannot update root disk device pool name")
+			return fmt.Errorf("Cannot update root disk device pool name to %q", newRootDev["pool"])
 		}
 	}
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1222,9 +1222,9 @@ func (d *btrfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *m
 	}
 
 	// Handle btrfs send/receive migration.
-	if volSrcArgs.FinalSync {
+	if volSrcArgs.MultiSync || volSrcArgs.FinalSync {
 		// This is not needed if the migration is performed using btrfs send/receive.
-		return nil
+		return fmt.Errorf("MultiSync should not be used with optimized migration")
 	}
 
 	var snapshots []string

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1868,9 +1868,9 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 	}
 
 	// Handle zfs send/receive migration.
-	if volSrcArgs.FinalSync {
+	if volSrcArgs.MultiSync || volSrcArgs.FinalSync {
 		// This is not needed if the migration is performed using zfs send/receive.
-		return nil
+		return fmt.Errorf("MultiSync should not be used with optimized migration")
 	}
 
 	var srcMigrationHeader *ZFSMetaDataHeader

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1740,7 +1740,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 
 		// For block devices, we make them disappear if active.
 		if !keepBlockDev {
-			current, err := d.getDatasetProperty(d.dataset(vol, false), "volmode")
+			current, err := d.getDatasetProperty(dataset, "volmode")
 			if err != nil {
 				return false, err
 			}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -186,7 +186,7 @@ func TryUnmount(path string, flags int) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to unmount '%s': %w", path, err)
+		return fmt.Errorf("Failed to unmount %q: %w", path, err)
 	}
 
 	return nil

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -471,13 +471,13 @@ migration() {
   lxc_remote start l2:c1
   lxc_remote file pull l2:c1/tmp/foo .
   lxc_remote file pull l2:c1/tmp/bar .
-  lxc_remote stop l2:c1
+  lxc_remote stop l2:c1 -f
 
   lxc_remote restore l2:c1 snap0
   lxc_remote start l2:c1
   lxc_remote file pull l2:c1/tmp/foo .
   ! lxc_remote file pull l2:c1/tmp/bar . ||  false
-  lxc_remote stop l2:c1
+  lxc_remote stop l2:c1 -f
 
   rm foo bar
 


### PR DESCRIPTION
The ZFS and BTRFS storage drivers were already not doing optimised transfers in the final stage of multi-sync mode (just returning nil). Which causes ZFS temporary snapshots to be left behind. So make this invocation type an error, and detect the use of non-optimized transfer mode earlier to avoid using MultiSync=true in the first place.

This then resolves the issue of the temporary snapshots not being cleaned up on the source.

Instead of https://github.com/lxc/lxd/pull/11193

Fixes #11194