### PR TITLE
doc/devices: document device option override at creation

### DIFF
--- a/doc/howto/instances_configure.md
+++ b/doc/howto/instances_configure.md
@@ -63,6 +63,11 @@ To configure instance device options for a device that you have added earlier, u
 
     lxc config device set <instance_name> <device_name> <device_option_key>=<device_option_value> <device_option_key>=<device_option_value> ...
 
+```{note}
+You can also specify device options by using the `--device` flag when {ref}`creating an instance <instances-create>`.
+This is useful if you want to override device options for a device that is provided through a {ref}`profile <profiles>`.
+```
+
 To remove a device, use the `lxc config device remove` command.
 See `lxc config device --help` for a full list of available commands.
 

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -26,6 +26,7 @@ Flags
   The most common flags are:
 
   - `--config` to specify a configuration option for the new instance
+  - `--device` to override {ref}`device options <devices>` for a device provided through a profile
   - `--profile` to specify a {ref}`profile <profiles>` to use for the new instance
   - `--network` or `--storage` to make the new instance use a specific network or storage pool
   - `--target` to create the instance on a specific cluster member


### PR DESCRIPTION
You can now specify device options when you create an instance.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>