### PR TITLE
Storage: Use `zfs wait` in ZFS driver's `UnmountVolume` function

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1710,6 +1710,12 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 			return false, ErrInUse
 		}
 
+		d.logger.Debug("Waiting for dataset activity to stop", logger.Ctx{"dev": dataset})
+		_, err = shared.RunCommand("zfs", "wait", dataset)
+		if err != nil {
+			d.logger.Warn("Failed waiting for dataset activity to stop", logger.Ctx{"dev": dataset, "err": err})
+		}
+
 		// Unmount the dataset.
 		err = TryUnmount(mountPath, 0)
 		if err != nil {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1736,7 +1736,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 
 		// For block devices, we make them disappear if active.
 		if !keepBlockDev {
-			current, err := d.getDatasetProperty(d.dataset(vol, false), "volmode")
+			current, err := d.getDatasetProperty(dataset, "volmode")
 			if err != nil {
 				return false, err
 			}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -186,7 +186,7 @@ func TryUnmount(path string, flags int) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to unmount '%s': %w", path, err)
+		return fmt.Errorf("Failed to unmount %q: %w", path, err)
 	}
 
 	return nil

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -471,13 +471,13 @@ migration() {
   lxc_remote start l2:c1
   lxc_remote file pull l2:c1/tmp/foo .
   lxc_remote file pull l2:c1/tmp/bar .
-  lxc_remote stop l2:c1
+  lxc_remote stop l2:c1 -f
 
   lxc_remote restore l2:c1 snap0
   lxc_remote start l2:c1
   lxc_remote file pull l2:c1/tmp/foo .
   ! lxc_remote file pull l2:c1/tmp/bar . ||  false
-  lxc_remote stop l2:c1
+  lxc_remote stop l2:c1 -f
 
   rm foo bar
 


### PR DESCRIPTION
Before trying to unmount wait for ZFS dataset filesystem activity to stop.

Related to `time="2022-12-06T04:53:38-05:00" level=debug msg="Failed to unmount" attempt=0 err="device or resource busy" path=/var/snap/lxd/common/lxd/storage-pools/sp00/virtual-machines/pq_mw2022-qvm-mad01` in https://github.com/lxc/lxd/issues/11089#issuecomment-1339079052

And related to https://github.com/lxc/lxd/issues/11168