### PR TITLE
VM: Fix `macvlan` NICs losing connectivity when LXD is reloaded

### DIFF
--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -185,12 +185,18 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
+	// Get MAC from VF if not specified.
+	if d.config["hwaddr"] == "" {
+		d.config["hwaddr"] = saveData["last_state.hwaddr"]
+	}
+
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "type", Value: "phys"},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: saveData["host_name"]},
+		{Key: "hwaddr", Value: d.config["hwaddr"]},
 	}
 
 	if d.inst.Type() == instancetype.VM {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3670,7 +3670,7 @@ func (d *qemu) writeNICDevConfig(mtuStr string, devName string, nicName string, 
 	// Parse MAC address to ensure it is in a canonical form (avoiding casing/presentation differences).
 	hw, err := net.ParseMAC(devHwaddr)
 	if err != nil {
-		return fmt.Errorf("Failed parsing MAC: %w", err)
+		return fmt.Errorf("Failed parsing MAC %q: %w", devHwaddr, err)
 	}
 
 	nicConfig := deviceConfig.NICConfig{

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -93,8 +93,23 @@ func (m *Monitor) SendFile(name string, file *os.File) error {
 		return ErrMonitorDisconnect
 	}
 
+	var req struct {
+		Execute   string `json:"execute"`
+		Arguments struct {
+			FDName string `json:"fdname"`
+		} `json:"arguments"`
+	}
+
+	req.Execute = "getfd"
+	req.Arguments.FDName = name
+
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
 	// Query the status.
-	_, err := m.qmp.RunWithFile([]byte(fmt.Sprintf("{'execute': 'getfd', 'arguments': {'fdname': '%s'}}", name)), file)
+	_, err = m.qmp.RunWithFile(reqJSON, file)
 	if err != nil {
 		// Confirm the daemon didn't die.
 		errPing := m.ping()

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -40,12 +40,43 @@ type CPUInstanceProperties struct {
 	ThreadID  int `json:"thread-id,omitempty"`
 }
 
+// CPU contains information about a CPU.
+type CPU struct {
+	Index    int    `json:"cpu-index,omitempty"`
+	QOMPath  string `json:"qom-path,omitempty"`
+	ThreadID int    `json:"thread-id,omitempty"`
+	Target   string `json:"target,omitempty"`
+
+	Props CPUInstanceProperties `json:"props"`
+}
+
 // HotpluggableCPU contains information about a hotpluggable CPU.
 type HotpluggableCPU struct {
-	Type       string                `json:"type"`
-	Props      CPUInstanceProperties `json:"props"`
-	VCPUsCount int                   `json:"vcpus-count"`
-	QOMPath    string                `json:"qom-path,omitempty"`
+	Type       string `json:"type"`
+	VCPUsCount int    `json:"vcpus-count"`
+	QOMPath    string `json:"qom-path,omitempty"`
+
+	Props CPUInstanceProperties `json:"props"`
+}
+
+// QueryCPUs returns a list of CPUs.
+func (m *Monitor) QueryCPUs() ([]CPU, error) {
+	// Check if disconnected
+	if m.disconnected {
+		return nil, ErrMonitorDisconnect
+	}
+
+	// Prepare the response.
+	var resp struct {
+		Return []CPU `json:"return"`
+	}
+
+	err := m.run("query-cpus-fast", nil, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to query CPUs: %w", err)
+	}
+
+	return resp.Return, nil
 }
 
 // QueryHotpluggableCPUs returns a list of hotpluggable CPUs.


### PR DESCRIPTION
Fixes two regressions:

- Fixes macvlan NICs losing connectivity when LXD is reloaded regressed by https://github.com/lxc/lxd/pull/10876
- Fixes multi-queue support for veth and macvlan NICs regressed by https://github.com/lxc/lxd/pull/11075

This PR fixes the issue that `macvlan` NICs lose connectivity when LXD is reloaded by switching to using `monitor.SendFile()` rather than `monitor.SendFileWithFDSet()`, as there appears to be some rather strange behaviour going on with QEMU when used with macvtap NICs.

If you pass the macvtap file handles using `monitor.SendFileWithFDSet()` it will use a separate FD set for each file handle. This works fine, and I can see the correct file handles opened by the QEMU process. But when LXD is restarted (the monitor connection is closed), the file handles are closed by QEMU, causing the connectivity to break.

I have experimented with using the same FD set for all file handles associated to a particular macvtap NIC. 
This didn't fix the issue.

I also tried hard coding the FD set ID to 0. This meant that the macvtap NIC would share an FD set with the root disk device. 

Interestingly this solved the issue. However it made me uncomfortable as the root disk is only configured by referencing
the FD set ID itself, rather than a particular FD inside the set. So I don't think that sharing an FD set with multiple devices is a good idea.

However it got me thinking that perhaps the fact that the root disk is referencing the FD set by ID (i.e using file=/dev/fdset/0 in its config) meant that QEMU somehow realised that the FD set should be persisted even after the monitor has disconnected.

I confirmed that using the same FD set (even if a different ID than 0) for macvtap NICS as the root disk device fixed the issue.

But because of my discomfort at that scenario (explained above) I instead looked for a different solution. Before introducing multi-queue macvlan support for VMs we were using monitor.SendFile() which worked fine. However I had switched to using the
`monitor.SendFileWithFDSet()` function as the former didn't support accessing the specific FD number that was created inside QEMU. I thought we needed this because all the documentation around using multi-queue macvtap devices showed the use of numeric FDs.

However on further exploration it turns out that we can infact use `monitor.SendFile`, and by sending each file handle with a unique name we can then refer to those file handles using the same names in `fds` setting for the macvtap devices.

Note: Because the `fds` list is colon separated one cannot use colons in the file handle names. And I also experienced issues with connectivity when using dashes in the file handle names. So I opted for using full-stops instead.

Fixes #11089

Also while fixing this issue I noticed that multi-queue support had been regressed with the introduction of CPU hotplugging, so this PR fixes that as well.

Associated tests: https://github.com/lxc/lxc-ci/pull/665