### PR TITLE
Storage: Don't expect multi-sync for live optimized ceph migration

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -507,7 +507,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 	// is running, and if we are doing a non-optimized transfer (i.e using rsync or raw block transfer) then we
 	// should do a two stage transfer to minimize downtime.
 	instanceRunning := s.live || (respHeader.Criu != nil && *respHeader.Criu == migration.CRIUType_NONE)
-	nonOptimizedMigration := volSourceArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSourceArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC || volSourceArgs.MigrationType.FSType == migration.MigrationFSType_RBD
+	nonOptimizedMigration := volSourceArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSourceArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC
 	if s.instance.Type() == instancetype.Container && instanceRunning && nonOptimizedMigration {
 		// Indicate this info to the storage driver so that it can alter its behaviour if needed.
 		volSourceArgs.MultiSync = true

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -590,13 +590,6 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 		return err
 	}
 
-	if volTargetArgs.Live {
-		err = d.receiveVolume(recvName, conn, wrapper)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Map the RBD volume.
 	devPath, err := d.rbdMapVolume(vol)
 	if err != nil {


### PR DESCRIPTION
This brings ceph storage driver in-line with the behaviour of zfs and btrfs storage drivers that do not expect a multi-stage sync when doing an optimized migration.