### PR TITLE
Instance: Handle VM guest initiated reboot via SHUTDOWN event

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2929,7 +2929,7 @@ func (d *lxc) onStop(args map[string]string) error {
 		waitTimeout := operationlock.TimeoutShutdown
 		_ = op.ResetTimeout(waitTimeout)
 		err = d.unmount()
-		if err != nil {
+		if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 			err = fmt.Errorf("Failed unmounting instance: %w", err)
 			op.Done(err)
 			return

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -590,7 +590,7 @@ func (d *qemu) onStop(target string) error {
 	// Stop the storage for the instance.
 	_ = op.ResetTimeout(waitTimeout)
 	err = d.unmount()
-	if err != nil {
+	if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 		err = fmt.Errorf("Failed unmounting instance: %w", err)
 		op.Done(err)
 		return err

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -578,6 +578,16 @@ func (m *Monitor) RemoveNIC(netDevID string) error {
 	return nil
 }
 
+// SetAction sets the actions the VM will take for certain scenarios.
+func (m *Monitor) SetAction(actions map[string]string) error {
+	err := m.run("set-action", actions, nil)
+	if err != nil {
+		return fmt.Errorf("Failed setting actions: %w", err)
+	}
+
+	return nil
+}
+
 // Reset VM.
 func (m *Monitor) Reset() error {
 	err := m.run("system_reset", nil, nil)


### PR DESCRIPTION
Rather than using workaround added in https://github.com/lxc/lxd/pull/8793 which required handling the RESET event and then racing the guest to shut it down and restart it from LXD.

This restores the original behaviour we had originally with the `-no-reboot` but using the QMP `set-action` command added in QEMU 6.0.

This allows us to both workaround the QMP `device_add` boot-order bug by resetting the system after adding the devices, yet still set the `reboot` action to `shutdown` afterwards to allow us to more cleanly handled guest initiated reboots.

This PR also includes a change to ignore mount in-use errors when trying to unmount the instance's root disk on stop.
This is because it is possible for another user request to being using the mount as the instance is stopped, and the mount will be cleaned up later once that request is finished.