### PR TITLE
lxd/storage/ceph: Increase OSD map timeout to 30s

### DIFF
--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -1,7 +1,6 @@
 package drivers
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -147,10 +146,7 @@ func (d *ceph) rbdDeleteVolume(vol Volume) error {
 // in the /dev directory and is therefore necessary in order to mount it.
 func (d *ceph) rbdMapVolume(vol Volume) (string, error) {
 	rbdName := d.getRBDVolumeName(vol, "", false, false)
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
-	defer cancel()
-
-	devPath, err := shared.RunCommandContext(ctx,
+	devPath, err := shared.RunCommand(
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],


### PR DESCRIPTION
When working with a slow but fonctional Ceph cluster, the 10s timeout causes a lot of issues as it interrupts the kernel part way through the map operation resulting in a bad state that requires a full reboot to clear.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>