### PR TITLE
Instance: Don't mask unexpected VM monitor QMP response errors with sentinel

### DIFF
--- a/lxd/instance/drivers/qmp/errors.go
+++ b/lxd/instance/drivers/qmp/errors.go
@@ -7,8 +7,5 @@ import (
 // ErrMonitorDisconnect is returned when interacting with a disconnected Monitor.
 var ErrMonitorDisconnect = fmt.Errorf("Monitor is disconnected")
 
-// ErrMonitorBadReturn is returned when the QMP data cannot be deserialized.
-var ErrMonitorBadReturn = fmt.Errorf("Monitor returned invalid data")
-
 // ErrMonitorBadConsole is retuned when the requested console doesn't exist.
 var ErrMonitorBadConsole = fmt.Errorf("Requested console couldn't be found")

--- a/lxd/instance/drivers/qmp/monitor.go
+++ b/lxd/instance/drivers/qmp/monitor.go
@@ -183,7 +183,7 @@ func (m *Monitor) run(cmd string, args any, resp any) error {
 				return errPing
 			}
 
-			return ErrMonitorBadReturn
+			return fmt.Errorf("Unexpected monitor response: %w (%q)", err, string(out))
 		}
 	}
 


### PR DESCRIPTION


Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>