### PR TITLE
Instance: Fix VM support and feature detection on s390x and ppc64le

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6391,7 +6391,7 @@ func (d *qemu) Info() instance.Info {
 	return data
 }
 
-func (d *qemu) checkFeatures(qemu string) ([]string, error) {
+func (d *qemu) checkFeatures(qemuPath string) ([]string, error) {
 	pidFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
@@ -6407,8 +6407,8 @@ func (d *qemu) checkFeatures(qemu string) ([]string, error) {
 	defer func() { _ = os.Remove(monitorPath.Name()) }()
 
 	qemuArgs := []string{
-		"qemu",
-		"-S",
+		qemuPath,
+		"-S", // Do not start virtualisation.
 		"-nographic",
 		"-nodefaults",
 		"-daemonize",

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6412,7 +6412,6 @@ func (d *qemu) checkFeatures(qemuPath string) ([]string, error) {
 		"-nographic",
 		"-nodefaults",
 		"-daemonize",
-		"-bios", filepath.Join(d.ovmfPath(), "OVMF_CODE.fd"),
 		"-pidfile", pidFile.Name(),
 		"-chardev", fmt.Sprintf("socket,id=monitor,path=%s,server=on,wait=off", monitorPath.Name()),
 		"-mon", "chardev=monitor,mode=control",

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6404,6 +6404,7 @@ func (d *qemu) checkFeatures(qemuPath string) ([]string, error) {
 		"-S", // Do not start virtualisation.
 		"-nographic",
 		"-nodefaults",
+		"-no-user-config",
 		"-chardev", fmt.Sprintf("socket,id=monitor,path=%s,server=on,wait=off", monitorPath.Name()),
 		"-mon", "chardev=monitor,mode=control",
 	}


### PR DESCRIPTION
The PR https://github.com/lxc/lxd/pull/11147 in LXD 5.9 introduced a change that meant that the `checkFeatures()` QEMU invocation was required to return a non-nil error in order for LXD to consider VMs supported at all on the host.

https://github.com/lxc/lxd/pull/11147/files#diff-87040b4a9b898c058e0f889f869c7a0448135f0a7f02db851824f48290c3a2f5R6428

This exposed a long standing bug in the specific qemu invocation being used, which was the use of the `-bios` flag which is only needed on UEFI platforms (LXD's normal qemu invocation only uses this flag on UEFI platforms).

This caused the following error:

```
qemu-system-s390x: could not find stage1 bootloader
```

The feature check functionality had not been working on s390x since it was introduced in https://github.com/lxc/lxd/commit/d4ac80270e34b1a91f4139a48d59fd49ef628856 in LXD 4.24.

However that specific error was not logged to LXD's log because the qemu stderr output was not captured.

Additionally the qemu invocation was using `-daemonize` which meant using a fork and pid file.
So this PR also avoids the need for using `-daemonize` by using Go routines to detect premature exit of QEMU process.

