### PR TITLE
lxd Add support for setting txqueuelen on veth based NICs

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2129,3 +2129,7 @@ projects that are referencing that network via one of their forward zones.
 
 Existing projects that have `features.networks=true` will have `features.networks.zones=true` set automatically,
 but new projects will need to specify this explicitly.
+
+## `instance_nic_txqueuelength`
+
+Adds a `txqueuelen` key to control the `txqueuelen` parameter of the NIC device.

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -43,6 +43,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		"ipv6.host_address":                    validate.Optional(validate.IsNetworkAddressV6),
 		"ipv4.host_table":                      validate.Optional(validate.IsUint32),
 		"ipv6.host_table":                      validate.Optional(validate.IsUint32),
+		"queue.tx.length":                      validate.Optional(validate.IsUint32),
 		"ipv4.routes.external":                 validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
 		"ipv6.routes.external":                 validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
 		"security.acls":                        validate.IsAny,

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -69,6 +69,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		"network",
 		"parent",
 		"mtu",
+		"queue.tx.length",
 		"hwaddr",
 		"host_name",
 		"limits.ingress",

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -29,6 +29,7 @@ func (d *nicP2P) validateConfig(instConf instance.ConfigReader) error {
 	optionalFields := []string{
 		"name",
 		"mtu",
+		"queue.tx.length",
 		"hwaddr",
 		"host_name",
 		"limits.ingress",

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -62,6 +62,7 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		"name",
 		"parent",
 		"mtu",
+		"queue.tx.length",
 		"hwaddr",
 		"host_name",
 		"vlan",

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -77,6 +77,16 @@ func (l *Link) SetMTU(mtu string) error {
 	return nil
 }
 
+// SetTXQueueLength sets the txqueuelen of the link device.
+func (l *Link) SetTXQueueLength(queueLength uint32) error {
+	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "txqueuelen", fmt.Sprintf("%d", queueLength))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // SetAddress sets the address of the link device.
 func (l *Link) SetAddress(address string) error {
 	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "address", address)

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -279,6 +279,22 @@ func GetDevMTU(devName string) (uint32, error) {
 	return uint32(mtu), nil
 }
 
+// GetTXQueueLength retrieves the current txqlen setting for a named network device.
+func GetTXQueueLength(devName string) (uint32, error) {
+	content, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/tx_queue_len", devName))
+	if err != nil {
+		return 0, err
+	}
+
+	// Parse value
+	txqlen, err := strconv.ParseUint(strings.TrimSpace(string(content)), 10, 32)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(txqlen), nil
+}
+
 // DefaultGatewaySubnetV4 returns subnet of default gateway interface.
 func DefaultGatewaySubnetV4() (*net.IPNet, string, error) {
 	file, err := os.Open("/proc/net/route")

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -356,6 +356,7 @@ var APIExtensions = []string{
 	"storage_volumes_created_at",
 	"cpu_hotplug",
 	"projects_networks_zones",
+	"network_txqueuelen",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -38,6 +38,7 @@ test_container_devices_nic_bridged() {
   lxc profile device set "${ctName}" eth0 limits.egress 2Mbit
   lxc profile device set "${ctName}" eth0 host_name "${vethHostName}"
   lxc profile device set "${ctName}" eth0 mtu "1400"
+  lxc profile device set "${ctName}" eth0 queue.tx.length "1200"
   lxc profile device set "${ctName}" eth0 hwaddr "${ctMAC}"
 
   lxc init testimage "${ctName}" -p "${ctName}"
@@ -91,6 +92,18 @@ test_container_devices_nic_bridged() {
   # Check profile custom MTU is applied on host side of veth.
   if ! grep "1400" /sys/class/net/"${vethHostName}"/mtu ; then
     echo "host veth mtu invalid"
+    false
+  fi
+
+  # Check profile custom txqueuelen is applied in container on boot.
+  if ! lxc exec "${ctName}" -- grep "1200" /sys/class/net/eth0/tx_queue_len ; then
+    echo "container veth txqueuelen invalid"
+    false
+  fi
+
+  # Check profile custom txqueuelen is applied on host side of veth.
+  if ! grep "1200" /sys/class/net/"${vethHostName}"/tx_queue_len ; then
+    echo "host veth txqueuelen invalid"
     false
   fi
 


### PR DESCRIPTION
Add possibility to change txqueuelen on veth devices using `lxc config device set c1 eth0 txqueuelen=100`

fix lxc#11198

Signed-off-by: Viktor Iakovchuk <viktor@yakovchuk.net>