### PR TITLE
lxd-migrate: Fix usage string

### DIFF
--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -36,7 +36,7 @@ type cmdMigrate struct {
 
 func (c *cmdMigrate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = "lxd-migrate <target URL> <instance name> <filesystem root|raw image> [<filesystem mounts>...]"
+	cmd.Use = "lxd-migrate"
 	cmd.Short = "Physical to instance migration tool"
 	cmd.Long = `Description:
   Physical to instance migration tool


### PR DESCRIPTION
This changes the usage string to clarify that lxd-migrate is an
interactive tool, and doesn't use positional arguments.

Resolves #11231.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
