### PR TITLE
Storage: Improve error when existing zpool isn't empty

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1858,7 +1858,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	if shared.PathExists(logfile) {
 		_ = os.Remove(logfile + ".old")
 		err := os.Rename(logfile, logfile+".old")
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return "", nil, err
 		}
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1009,7 +1009,7 @@ func (d *qemu) Start(stateful bool) error {
 	if shared.PathExists(logfile) {
 		_ = os.Remove(logfile + ".old")
 		err := os.Rename(logfile, logfile+".old")
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			op.Done(err)
 			return err
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3343,7 +3343,7 @@ func (b *lxdBackend) CreateBucket(projectName string, bucket api.StorageBucketsP
 
 		bucketExists, err := s3Client.BucketExists(ctx, bucket.Name)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed checking if bucket exists: %w", err)
 		}
 
 		if bucketExists {

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -315,7 +315,7 @@ func (d *zfs) Create() error {
 		}
 
 		if len(datasets) > 0 {
-			return fmt.Errorf("Provided ZFS pool (or dataset) isn't empty")
+			return fmt.Errorf(`Provided ZFS pool (or dataset) isn't empty, run "sudo zfs list %s" to see existing entries`, d.config["zfs.pool_name"])
 		}
 	}
 

--- a/lxd/storage/s3/miniod/miniod.go
+++ b/lxd/storage/s3/miniod/miniod.go
@@ -306,9 +306,9 @@ func EnsureRunning(s *state.State, bucketVol storageDrivers.Volume) (*Process, e
 		miniosMu.Unlock()
 	}()
 
-	// Wait up to 5s for service to become ready. Pass the minioProc.cancel as parent context so that if the
+	// Wait up to 10s for service to become ready. Pass the minioProc.cancel as parent context so that if the
 	// minio process fails to start then this context will immediately be cancelled.
-	waitReadyCtx, waitReadyCtxCancel := context.WithTimeout(minioProc.cancel, time.Second*5)
+	waitReadyCtx, waitReadyCtxCancel := context.WithTimeout(minioProc.cancel, time.Second*10)
 	defer waitReadyCtxCancel()
 
 	err = minioProc.WaitReady(waitReadyCtx)


### PR DESCRIPTION
Reported from https://discuss.linuxcontainers.org/t/lxd-init-error-message-when-zfs-storage-pool-cannot-be-created-could-be-more-descriptive/15733

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>