### PR TITLE
doc: fix version conflicts for doc tools

### DIFF
--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -20,7 +20,8 @@ extensions = [
     "sphinxext.opengraph",
     "youtube-links",
     "related-links",
-    "custom-rst-roles"
+    "custom-rst-roles",
+    "sphinxcontrib.jquery"
 ]
 
 myst_enable_extensions = [

--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -3,7 +3,7 @@ Babel
 certifi
 charset-normalizer
 colorama
-docutils<0.18
+docutils
 idna
 imagesize
 Jinja2
@@ -24,6 +24,7 @@ sphinxcontrib-htmlhelp
 sphinxcontrib-jsmath
 sphinxcontrib-qthelp
 sphinxcontrib-serializinghtml
+sphinxcontrib-jquery
 tornado
 urllib3
 myst-parser


### PR DESCRIPTION
Docutils <0.18 is incompatible with the latest version of Sphinx. Sphinx 6.0.0 does not include jquery by default anymore, so need to add an extension for it.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>