### PR TITLE
Storage: Fix BTRFS driver `getQGroup` to suport BTRFS >= 6.0.1

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -247,7 +247,8 @@ func (d *btrfs) getQGroup(path string) (string, int64, error) {
 	var qgroup string
 	usage := int64(-1)
 	for _, line := range strings.Split(output, "\n") {
-		if line == "" || strings.HasPrefix(line, "qgroupid") || strings.HasPrefix(line, "---") {
+		// Use case-insensitive field title match because BTRFS tooling changed casing between versions.
+		if line == "" || strings.HasPrefix(strings.ToLower(line), "qgroupid") || strings.HasPrefix(line, "-") {
 			continue
 		}
 

--- a/lxd/storage/s3/miniod/miniod.go
+++ b/lxd/storage/s3/miniod/miniod.go
@@ -132,7 +132,7 @@ func (p *Process) WaitReady(ctx context.Context) error {
 	}
 
 	for {
-		_, err = adminClient.ServerInfo(ctx)
+		_, err = adminClient.GetConfig(ctx)
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
Fixes #11210

Reproduced and tested working on `images:alpine/edge` which has BRRFS 6.1.1

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>