### PR TITLE
lxd: Fix escaping of `lxd sql .dump` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/rs/xid v1.4.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/secure-io/sio-go v0.3.1 // indirect
-	github.com/shirou/gopsutil/v3 v3.22.11 // indirect
+	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -540,8 +540,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/secure-io/sio-go v0.3.1 h1:dNvY9awjabXTYGsTF1PiCySl9Ltofk9GA3VdWlo7rRc=
 github.com/secure-io/sio-go v0.3.1/go.mod h1:+xbkjDzPjwh4Axd07pRKSNriS9SCiYksWnZqdnfpQxs=
-github.com/shirou/gopsutil/v3 v3.22.11 h1:kxsPKS+Eeo+VnEQ2XCaGJepeP6KY53QoRTETx3+1ndM=
-github.com/shirou/gopsutil/v3 v3.22.11/go.mod h1:xl0EeL4vXJ+hQMAGN8B9VFpxukEMA0XdevQOe5MZ1oY=
+github.com/shirou/gopsutil/v3 v3.22.12 h1:oG0ns6poeUSxf78JtOsfygNWuEHYYz8hnnNg7P04TJs=
+github.com/shirou/gopsutil/v3 v3.22.12/go.mod h1:Xd7P1kwZcp5VW52+9XsirIKd/BROzbb2wdX3Kqlz9uI=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/lxd/db/query/dump.go
+++ b/lxd/db/query/dump.go
@@ -80,6 +80,11 @@ func getEntitiesSchemas(ctx context.Context, tx *sql.Tx) (map[string][2]string, 
 			return nil, nil, fmt.Errorf("Could not scan table name and schema: %w", err)
 		}
 
+		// This is based on logic from dump_callback in sqlite source for sqlite3_db_dump function.
+		if strings.HasPrefix(schema, `CREATE TABLE "`) {
+			schema = strings.Replace(schema, "CREATE TABLE", "CREATE TABLE IF NOT EXISTS", 1)
+		}
+
 		names = append(names, name)
 		tablesSchemas[name] = [2]string{kind, schema + ";"}
 	}

--- a/lxd/db/query/dump.go
+++ b/lxd/db/query/dump.go
@@ -130,11 +130,32 @@ func getTableData(ctx context.Context, tx *sql.Tx, table string) ([]string, erro
 			case int64:
 				values[j] = strconv.FormatInt(v, 10)
 			case string:
-				values[j] = fmt.Sprintf("'%s'", v)
+				// This is based on logic from dump_callback in sqlite source for sqlite3_db_dump function.
+				v = fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
+
+				if strings.Contains(v, "\r") {
+					v = "replace(" + strings.ReplaceAll(v, "\r", "\\r") + ",'\\r',char(13))"
+				}
+
+				if strings.Contains(v, "\n") {
+					v = "replace(" + strings.ReplaceAll(v, "\n", "\\n") + ",'\\n',char(10))"
+				}
+
+				values[j] = v
+
 			case []byte:
 				values[j] = fmt.Sprintf("'%s'", string(v))
 			case time.Time:
-				values[j] = strconv.FormatInt(v.Unix(), 10)
+				// Try and match the sqlite3 .dump output format.
+				format := "2006-01-02 15:04:05"
+
+				if v.Nanosecond() > 0 {
+					format = format + ".000000000"
+				}
+
+				format = format + "-07:00"
+
+				values[j] = "'" + v.Format(format) + "'"
 			default:
 				if v != nil {
 					return nil, fmt.Errorf("Bad type in column %q of row %d in table %q", columns[j], i, table)

--- a/lxd/db/query/dump_test.go
+++ b/lxd/db/query/dump_test.go
@@ -23,7 +23,7 @@ CREATE TABLE schema (
     updated_at DATETIME NOT NULL,
     UNIQUE (version)
 );
-INSERT INTO schema VALUES(1,37,1523946366);
+INSERT INTO schema VALUES(1,37,'2018-04-17 06:26:06+00:00');
 CREATE TABLE config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     key VARCHAR(255) NOT NULL,
@@ -36,8 +36,8 @@ CREATE TABLE patches (
     applied_at DATETIME NOT NULL,
     UNIQUE (name)
 );
-INSERT INTO patches VALUES(1,'invalid_profile_names',1523946366);
-INSERT INTO patches VALUES(2,'leftover_profile_config',1523946366);
+INSERT INTO patches VALUES(1,'invalid_profile_names','2018-04-17 06:26:06+00:00');
+INSERT INTO patches VALUES(2,'leftover_profile_config','2018-04-17 06:26:06+00:00');
 CREATE TABLE raft_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     address TEXT NOT NULL,
@@ -65,8 +65,8 @@ func TestDumpTablePatches(t *testing.T) {
 	data, err := query.GetTableData(context.Background(), tx, "patches")
 	require.NoError(t, err)
 	assert.ElementsMatch(t, data, []string{
-		"INSERT INTO patches VALUES(1,'invalid_profile_names',1523946366);",
-		"INSERT INTO patches VALUES(2,'leftover_profile_config',1523946366);",
+		"INSERT INTO patches VALUES(1,'invalid_profile_names','2018-04-17 06:26:06+00:00');",
+		"INSERT INTO patches VALUES(2,'leftover_profile_config','2018-04-17 06:26:06+00:00');",
 	})
 }
 

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -56,7 +56,7 @@ func (c *Cluster) UpsertWarning(nodeName string, projectName string, entityTypeC
 		return fmt.Errorf("Unknown warning type code %d", typeCode)
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		filter := cluster.WarningFilter{
@@ -96,7 +96,7 @@ func (c *Cluster) UpsertWarning(nodeName string, projectName string, entityTypeC
 				Status:         warningtype.StatusNew,
 				FirstSeenDate:  now,
 				LastSeenDate:   now,
-				UpdatedDate:    time.Time{},
+				UpdatedDate:    time.Time{}.UTC(),
 				LastMessage:    message,
 				Count:          1,
 			}


### PR DESCRIPTION
Fixes #11205 and adds some additional changes to try and better align with the output format of `sqlite3 .dump`.