### PR TITLE
Instance: Fix VM QEMU feature detection on aarch64

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2566,7 +2566,7 @@ func (d *qemu) deviceBootPriorities() (map[string]int, error) {
 func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName string, devConfs []*deviceConfig.RunConfig, fdFiles *[]*os.File) (string, []monitorHook, error) {
 	var monHooks []monitorHook
 
-	cfg := qemuBase(&qemuBaseOpts{d.architectureName})
+	cfg := qemuBase(&qemuBaseOpts{d.Architecture()})
 
 	err := d.addCPUMemoryConfig(&cfg)
 	if err != nil {
@@ -2751,7 +2751,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 			devAddr:       devAddr,
 			multifunction: multi,
 		},
-		architecture: d.architectureName,
+		architecture: d.Architecture(),
 	}
 
 	cfg = append(cfg, qemuGPU(&gpuOpts)...)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6407,6 +6407,7 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) ([]string, error) {
 		"-no-user-config",
 		"-chardev", fmt.Sprintf("socket,id=monitor,path=%s,server=on,wait=off", monitorPath.Name()),
 		"-mon", "chardev=monitor,mode=control",
+		"-machine", qemuMachineType(hostArch),
 	}
 
 	if d.architectureSupportsUEFI(hostArch) {

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -1503,7 +1503,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 						[object "3"]
 						key4 = " value4 "
 						[object "2"]
-						key3 =   value3  
+						key3 =   value3
 						[object "3"]
 						key5 = "value5"`,
 			},
@@ -1552,7 +1552,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 		[global][4]
 		key2 = "val4"
 
-		[global] 
+		[global]
 
 		[global][4]
 		[global][5]

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/lxc/lxd/shared/osarch"
 )
 
 func TestQemuConfigTemplates(t *testing.T) {
@@ -29,7 +31,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			opts     qemuBaseOpts
 			expected string
 		}{{
-			qemuBaseOpts{"x86_64"},
+			qemuBaseOpts{architecture: osarch.ARCH_64BIT_INTEL_X86},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -50,7 +52,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[boot-opts]
 			strict = "on"`,
 		}, {
-			qemuBaseOpts{"aarch64"},
+			qemuBaseOpts{architecture: osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -62,7 +64,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[boot-opts]
 			strict = "on"`,
 		}, {
-			qemuBaseOpts{"ppc64le"},
+			qemuBaseOpts{architecture: osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -74,7 +76,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[boot-opts]
 			strict = "on"`,
 		}, {
-			qemuBaseOpts{"s390x"},
+			qemuBaseOpts{architecture: osarch.ARCH_64BIT_S390_BIG_ENDIAN},
 			`# Machine
 			[machine]
 			graphics = "off"
@@ -306,7 +308,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			opts     qemuGpuOpts
 			expected string
 		}{{
-			qemuGpuOpts{qemuDevOpts{"pci", "qemu_pcie3", "00.0", true}, "x86_64"},
+			qemuGpuOpts{dev: qemuDevOpts{"pci", "qemu_pcie3", "00.0", true}, architecture: osarch.ARCH_64BIT_INTEL_X86},
 			`# GPU
 			[device "qemu_gpu"]
 			driver = "virtio-vga"
@@ -314,20 +316,20 @@ func TestQemuConfigTemplates(t *testing.T) {
 			addr = "00.0"
 			multifunction = "on"`,
 		}, {
-			qemuGpuOpts{qemuDevOpts{"pci", "qemu_pci3", "00.1", false}, "otherArch"},
+			qemuGpuOpts{dev: qemuDevOpts{"pci", "qemu_pci3", "00.1", false}, architecture: osarch.ARCH_UNKNOWN},
 			`# GPU
 			[device "qemu_gpu"]
 			driver = "virtio-gpu-pci"
 			bus = "qemu_pci3"
 			addr = "00.1"`,
 		}, {
-			qemuGpuOpts{qemuDevOpts{"ccw", "devBus", "busAddr", true}, "arch"},
+			qemuGpuOpts{dev: qemuDevOpts{"ccw", "devBus", "busAddr", true}, architecture: osarch.ARCH_UNKNOWN},
 			`# GPU
 			[device "qemu_gpu"]
 			driver = "virtio-gpu-ccw"
 			multifunction = "on"`,
 		}, {
-			qemuGpuOpts{qemuDevOpts{"ccw", "devBus", "busAddr", false}, "x86_64"},
+			qemuGpuOpts{dev: qemuDevOpts{"ccw", "devBus", "busAddr", false}, architecture: osarch.ARCH_64BIT_INTEL_X86},
 			`# GPU
 			[device "qemu_gpu"]
 			driver = "virtio-gpu-ccw"`,


### PR DESCRIPTION
- Fixes detection on aarch64 (fixes #11254).
- Switches to integer architecture constants for config architecture logic.

Tested working in custom sideloaded build of snap package on:

- [x] AMD64
- [x] Aarch64
- [x] S390x