### PR TITLE
Instance: Split cluster member targeting logic to generate candidate members list before selecting least used

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2896,7 +2896,12 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 
 			// Find the least loaded cluster member which supports the architecture.
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				targetNodeName, err = tx.GetNodeWithLeastInstances(ctx, []int{inst.Architecture()}, -1, "", nil)
+				candidateMembers, err := tx.GetCandidateMembers(ctx, []int{inst.Architecture()}, "", nil)
+				if err != nil {
+					return err
+				}
+
+				targetNodeName, err = tx.GetNodeWithLeastInstances(ctx, candidateMembers)
 				if err != nil {
 					return err
 				}

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -318,7 +318,11 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `)
 	require.NoError(t, err)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), nil, -1, "", nil)
+	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	require.NoError(t, err)
+	require.Len(t, members, 2)
+
+	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
 	assert.Equal(t, "buzz", name)
 }
@@ -342,7 +346,11 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	err = tx.SetNodeHeartbeat("0.0.0.0", time.Now().Add(-time.Minute))
 	require.NoError(t, err)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), nil, -1, "", nil)
+	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+
+	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
 	assert.Equal(t, "buzz", name)
 }
@@ -362,7 +370,11 @@ INSERT INTO operations (id, uuid, node_id, type, project_id) VALUES (1, 'abc', 1
 `, operationtype.InstanceCreate)
 	require.NoError(t, err)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), nil, -1, "", nil)
+	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	require.NoError(t, err)
+	require.Len(t, members, 2)
+
+	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
 	assert.Equal(t, "buzz", name)
 }
@@ -390,8 +402,12 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `)
 	require.NoError(t, err)
 
+	members, err := tx.GetCandidateMembers(context.Background(), []int{localArch}, "", nil)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+
 	// The local member is returned despite it has more containers.
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), []int{localArch}, -1, "", nil)
+	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
 	assert.Equal(t, "none", name)
 }
@@ -445,7 +461,11 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `, id)
 	require.NoError(t, err)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), nil, testArch, "", nil)
+	members, err := tx.GetCandidateMembers(context.Background(), []int{testArch}, "", nil)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+
+	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
 	assert.Equal(t, "buzz", name)
 }

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -947,6 +947,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 			// If image has an entry in the database then use its profiles if no override provided.
 			if sourceImage != nil && req.Profiles == nil {
+				req.Architecture = sourceImage.Architecture
 				req.Profiles = sourceImage.Profiles
 			}
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -778,7 +778,8 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	targetProjectName := projectParam(r)
-	logger.Debugf("Responding to instance create")
+
+	logger.Debug("Responding to instance create")
 
 	// If we're getting binary content, process separately
 	if r.Header.Get("Content-Type") == "application/octet-stream" {
@@ -1025,7 +1026,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			logger.Debugf("No name provided for new instance, creating using %q", req.Name)
+			logger.Debug("No name provided for new instance, using auto-generated name", logger.Ctx{"project": targetProjectName, "instance": req.Name})
 		}
 
 		return nil
@@ -1097,7 +1098,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			client = client.UseProject(targetProjectName)
 			client = client.UseTarget(targetNode)
 
-			logger.Debugf("Forward instance post request to %s", address)
+			logger.Debug("Forward instance post request", logger.Ctx{"member": address})
 			op, err := client.CreateInstance(req)
 			if err != nil {
 				return response.SmartError(err)
@@ -1162,7 +1163,7 @@ func instanceFindStoragePool(d *Daemon, projectName string, req *api.InstancesPo
 
 	// If there is just a single pool in the database, use that
 	if storagePool == "" {
-		logger.Debugf("No valid storage pool in the container's local root disk device and profiles found")
+		logger.Debug("No valid storage pool in the container's local root disk device and profiles found")
 		pools, err := d.db.Cluster.GetStoragePoolNames()
 		if err != nil {
 			if response.IsNotFoundError(err) {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1095,7 +1095,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if address != "" {
-			client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), r, false)
+			client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), r, true)
 			if err != nil {
 				return response.SmartError(err)
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -845,6 +845,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	var sourceInst *dbCluster.Instance
 	var sourceImage *api.Image
 	var sourceImageRef string
+	var clusterGroupsAllowed []string
 
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), targetProjectName)
@@ -857,7 +858,22 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
+		// Check manual cluster member targeting restrictions.
+		err = project.CheckClusterTargetRestriction(tx, r, targetProject, targetNode)
+		if err != nil {
+			return err
+		}
+
 		if targetGroup != "" {
+			// Check restricted cluster groups from project.
+			if shared.IsTrue(targetProject.Config["restricted"]) {
+				clusterGroupsAllowed = shared.SplitNTrimSpace(targetProject.Config["restricted.cluster.groups"], ",", -1, true)
+
+				if targetGroup != "" && !shared.StringInSlice(targetGroup, clusterGroupsAllowed) {
+					return api.StatusErrorf(http.StatusForbidden, "Project isn't allowed to use this cluster group")
+				}
+			}
+
 			// Check if the target group exists.
 			targetGroupExists, err := dbCluster.ClusterGroupExists(ctx, tx.Tx(), targetGroup)
 			if err != nil {
@@ -981,12 +997,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		// Check manual targeting restrictions.
-		err = project.CheckClusterTargetRestriction(tx, r, targetProject, targetNode)
-		if err != nil {
-			return err
-		}
-
 		// Check that the project's limits are not violated. Note this check is performed after
 		// automatically generated config values (such as the ones from an InstanceType) have been set.
 		err = project.AllowInstanceCreation(tx, targetProjectName, req)
@@ -1034,18 +1044,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		// since GetNodeWithLeastInstances() will return an empty string.
 		// If the target is a cluster group, find a suitable node within the group.
 
-		// Load restricted groups from project.
-		var allowedGroups []string
-
-		if !isClusterNotification(r) && shared.IsTrue(targetProject.Config["restricted"]) {
-			allowedGroups = shared.SplitNTrimSpace(targetProject.Config["restricted.cluster.groups"], ",", -1, true)
-
-			// Validate restrictions.
-			if targetGroup != "" && !shared.StringInSlice(targetGroup, allowedGroups) {
-				return response.Forbidden(fmt.Errorf("Project isn't allowed to use this cluster group"))
-			}
-		}
-
 		architectures, err := instance.SuitableArchitectures(r.Context(), s, targetProjectName, sourceInst, sourceImageRef, req)
 		if err != nil {
 			return response.BadRequest(err)
@@ -1067,7 +1065,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			targetNode, err = tx.GetNodeWithLeastInstances(ctx, architectures, defaultArchID, targetGroup, allowedGroups)
+			targetNode, err = tx.GetNodeWithLeastInstances(ctx, architectures, defaultArchID, targetGroup, clusterGroupsAllowed)
 			if err != nil {
 				return err
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1050,28 +1050,46 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
+		// If no architectures have been ascertained from the source then use the default architecture
+		// from project or global config if available.
+		if len(architectures) < 1 {
+			defaultArch := targetProject.Config["images.default_architecture"]
+			if defaultArch == "" {
+				defaultArch = s.GlobalConfig.ImagesDefaultArchitecture()
+			}
+
+			if defaultArch != "" {
+				defaultArchID, err := osarch.ArchitectureId(defaultArch)
+				if err != nil {
+					return response.SmartError(err)
+				}
+
+				architectures = append(architectures, defaultArchID)
+			} else {
+				architectures = nil // Don't exclude candidate members based on architecture.
+			}
+		}
+
+		var candidateMembers []db.NodeInfo
+		err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			candidateMembers, err = tx.GetCandidateMembers(ctx, architectures, targetGroup, clusterGroupsAllowed)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+
 		// If no target member was selected yet, pick the member with the least number of instances.
 		// If there's just one member, or if the selected member is the local one, this is effectively a
 		// no-op, since GetNodeWithLeastInstances() will return an empty string.
 		// If the target is a cluster group, find a suitable member within the group.
 		if targetMember == "" {
 			err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-				defaultArch := ""
-				if targetProject.Config["images.default_architecture"] != "" {
-					defaultArch = targetProject.Config["images.default_architecture"]
-				} else {
-					defaultArch = s.GlobalConfig.ImagesDefaultArchitecture()
-				}
-
-				defaultArchID := -1
-				if defaultArch != "" {
-					defaultArchID, err = osarch.ArchitectureId(defaultArch)
-					if err != nil {
-						return err
-					}
-				}
-
-				targetMember, err = tx.GetNodeWithLeastInstances(ctx, architectures, defaultArchID, targetGroup, clusterGroupsAllowed)
+				targetMember, err = tx.GetNodeWithLeastInstances(ctx, candidateMembers)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This is part of the work to accommodate providing candidate members list to the instance placement scriptlet (https://github.com/lxc/lxd/pull/11180).

Also enables the cluster notification header when forwarding an instance creation request to another cluster member, which allows for avoiding running certain checks (and thus DB queries) again on the target member.