### PR TITLE
Instance: Fixes delete of ephemeral VM on stop

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3600,15 +3600,15 @@ func (d *lxc) Delete(force bool) error {
 
 	defer op.Done(nil)
 
+	if d.IsRunning() {
+		return api.StatusErrorf(http.StatusBadRequest, "Instance is running")
+	}
+
 	return d.delete(force)
 }
 
 // Delete deletes the instance without creating an operation lock.
 func (d *lxc) delete(force bool) error {
-	if d.IsRunning() {
-		return api.StatusErrorf(http.StatusBadRequest, "Instance is running")
-	}
-
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5090,15 +5090,15 @@ func (d *qemu) Delete(force bool) error {
 
 	defer op.Done(nil)
 
+	if d.IsRunning() {
+		return api.StatusErrorf(http.StatusBadRequest, "Instance is running")
+	}
+
 	return d.delete(force)
 }
 
 // Delete the instance without creating an operation lock.
 func (d *qemu) delete(force bool) error {
-	if d.IsRunning() {
-		return api.StatusErrorf(http.StatusBadRequest, "Instance is running")
-	}
-
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,


### PR DESCRIPTION
Moves the IsRunning check out of the internal `delete()` function and into the exported `Delete()` function. This avoids failing the the `delete()` call from the `onStop()` function when trying to delete an ephemeral VM on stop.

Although containers were not affected (because their notion of running doesn't include an ongoing Stop operation that VMs do) I've also moved the check in the LXC driver to the same place for consistency.

Fixes #11261

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>