### PR TITLE
Instance: Don't allow manual targeting of a member outside of the allowed groups of a restricted project

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2896,7 +2896,12 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 
 			// Find the least loaded cluster member which supports the architecture.
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				candidateMembers, err := tx.GetCandidateMembers(ctx, []int{inst.Architecture()}, "", nil)
+				allMembers, err := tx.GetNodes(ctx)
+				if err != nil {
+					return fmt.Errorf("Failed getting cluster members: %w", err)
+				}
+
+				candidateMembers, err := tx.GetCandidateMembers(ctx, allMembers, []int{inst.Architecture()}, "", nil)
 				if err != nil {
 					return err
 				}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2841,6 +2841,8 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 		metadata := make(map[string]any)
 
 		for _, inst := range instances {
+			l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
+
 			// Check if migratable.
 			migrate, live := inst.CanMigrate()
 
@@ -2874,6 +2876,8 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 				// Start with a clean shutdown.
 				err = inst.Shutdown(time.Duration(val) * time.Second)
 				if err != nil {
+					l.Warn("Failed shutting down instance, forcing stop", logger.Ctx{"err": err})
+
 					// Fallback to forced stop.
 					err = inst.Stop(false)
 					if err != nil && !errors.Is(err, drivers.ErrInstanceIsStopped) {
@@ -2884,7 +2888,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 				// Mark the instance as RUNNING in volatile so its state can be properly restored.
 				err = inst.VolatileSet(map[string]string{"volatile.last_state.power": "RUNNING"})
 				if err != nil {
-					logger.Warn("Failed to set instance state to RUNNING", logger.Ctx{"instance": inst.Name(), "err": err})
+					l.Warn("Failed to set instance state to RUNNING", logger.Ctx{"err": err})
 				}
 			}
 
@@ -2918,7 +2922,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 
 			// Skip migration if no target available.
 			if targetNode == nil {
-				logger.Warn("No migration target available for instance", logger.Ctx{"name": inst.Name(), "project": inst.Project().Name})
+				l.Warn("No migration target available for instance")
 				continue
 			}
 

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -1090,15 +1090,10 @@ func (c *ClusterTx) GetNodeOfflineThreshold(ctx context.Context) (time.Duration,
 // GetCandidateMembers returns cluster members that are online, in created state and don't need manual targeting.
 // It excludes members that do not support any of the targetArchitectures (if non-nil) or not in targetClusterGroup
 // (if non-empty). It also takes into account any restrictions on allowedClusterGroups (if non-nil).
-func (c *ClusterTx) GetCandidateMembers(ctx context.Context, targetArchitectures []int, targetClusterGroup string, allowedClusterGroups []string) ([]NodeInfo, error) {
+func (c *ClusterTx) GetCandidateMembers(ctx context.Context, allMembers []NodeInfo, targetArchitectures []int, targetClusterGroup string, allowedClusterGroups []string) ([]NodeInfo, error) {
 	threshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get offline threshold: %w", err)
-	}
-
-	allMembers, err := c.GetNodes(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get current cluster members: %w", err)
 	}
 
 	var candidateMembers []NodeInfo

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -1087,10 +1087,9 @@ func (c *ClusterTx) GetNodeOfflineThreshold(ctx context.Context) (time.Duration,
 	return threshold, nil
 }
 
-// GetCandidateMembers returns cluster members that are online, not in evacuated state and don't require manual
-// targeting. It will also exclude members that do not support any of the targetArchitectures (if non-nil) or not
-// in targetClusterGroup (if non-empty).
-// It also takes into account any restrictions on allowedClusterGroups (if non-nil).
+// GetCandidateMembers returns cluster members that are online, in created state and don't need manual targeting.
+// It excludes members that do not support any of the targetArchitectures (if non-nil) or not in targetClusterGroup
+// (if non-empty). It also takes into account any restrictions on allowedClusterGroups (if non-nil).
 func (c *ClusterTx) GetCandidateMembers(ctx context.Context, targetArchitectures []int, targetClusterGroup string, allowedClusterGroups []string) ([]NodeInfo, error) {
 	threshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
@@ -1105,8 +1104,8 @@ func (c *ClusterTx) GetCandidateMembers(ctx context.Context, targetArchitectures
 	var candidateMembers []NodeInfo
 
 	for _, member := range allMembers {
-		// Skip evacuated or offline members.
-		if member.State == ClusterMemberStateEvacuated || member.IsOffline(threshold) {
+		// Skip pending, evacuated or offline members.
+		if member.State != ClusterMemberStateCreated || member.IsOffline(threshold) {
 			continue
 		}
 

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -325,9 +325,9 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }
 
 // If there are nodes, and one of them is offline, return the name of the
@@ -356,9 +356,9 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }
 
 // If there are 2 online nodes, and a container is pending on one of them,
@@ -383,9 +383,9 @@ INSERT INTO operations (id, uuid, node_id, type, project_id) VALUES (1, 'abc', 1
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }
 
 // If specific architectures were selected, return only nodes with those
@@ -419,9 +419,9 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.Len(t, members, 1)
 
 	// The local member is returned despite it has more containers.
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "none", name)
+	assert.Equal(t, "none", member.Name)
 }
 
 func TestUpdateNodeFailureDomain(t *testing.T) {
@@ -480,7 +480,7 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -318,7 +318,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, nil, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
@@ -346,7 +349,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	err = tx.SetNodeHeartbeat("0.0.0.0", time.Now().Add(-time.Minute))
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, nil, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
@@ -370,7 +376,10 @@ INSERT INTO operations (id, uuid, node_id, type, project_id) VALUES (1, 'abc', 1
 `, operationtype.InstanceCreate)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, nil, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
@@ -402,7 +411,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), []int{localArch}, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, []int{localArch}, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
@@ -461,7 +473,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `, id)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), []int{testArch}, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, []int{testArch}, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -596,7 +597,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 
 	// For migration, an architecture must be specified in the req.
 	if req.Source.Type == "migration" && req.Architecture == "" {
-		return nil, fmt.Errorf("An architecture must be specified in migration requests")
+		return nil, api.StatusErrorf(http.StatusBadRequest, "An architecture must be specified in migration requests")
 	}
 
 	// For none, allow any architecture.
@@ -660,7 +661,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 					return nil, err
 				}
 			} else {
-				return nil, fmt.Errorf("Unsupported remote image server protocol: %s", req.Source.Protocol)
+				return nil, api.StatusErrorf(http.StatusBadRequest, "Unsupported remote image server protocol %q", req.Source.Protocol)
 			}
 
 			// Look for a matching alias.
@@ -695,7 +696,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 	}
 
 	// No other known types
-	return nil, fmt.Errorf("Unknown instance source type: %s", req.Source.Type)
+	return nil, api.StatusErrorf(http.StatusBadRequest, "Unknown instance source type %q", req.Source.Type)
 }
 
 // ValidName validates an instance name. There are different validation rules for instance snapshot names

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -584,7 +584,7 @@ func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, sou
 //
 // An empty list indicates that the request may be handled by any architecture.
 // A nil list indicates that we can't tell at this stage, typically for private images.
-func SuitableArchitectures(ctx context.Context, s *state.State, projectName string, sourceInst *cluster.Instance, sourceImageRef string, req api.InstancesPost) ([]int, error) {
+func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx, projectName string, sourceInst *cluster.Instance, sourceImageRef string, req api.InstancesPost) ([]int, error) {
 	// Handle cases where the architecture is already provided.
 	if shared.StringInSlice(req.Source.Type, []string{"migration", "none"}) && req.Architecture != "" {
 		id, err := osarch.ArchitectureId(req.Architecture)
@@ -614,7 +614,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 	if req.Source.Type == "image" {
 		// Handle local images.
 		if req.Source.Server == "" {
-			_, img, err := s.DB.Cluster.GetImage(sourceImageRef, cluster.ImageFilter{Project: &projectName})
+			_, img, err := tx.GetImageByFingerprintPrefix(ctx, sourceImageRef, cluster.ImageFilter{Project: &projectName})
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -130,7 +130,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Check if user is allowed to use cluster member targeting
-			err = project.CheckClusterTargetRestriction(tx, r, apiProject, targetNode)
+			err = project.CheckClusterTargetRestriction(r, apiProject, targetNode)
 			if err != nil {
 				return err
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -863,7 +863,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Check manual cluster member targeting restrictions.
-		err = project.CheckClusterTargetRestriction(tx, r, targetProject, target)
+		err = project.CheckClusterTargetRestriction(r, targetProject, target)
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -836,6 +836,10 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	target := queryParam(r, "target")
+	if !clustered && target != "" {
+		return response.BadRequest(fmt.Errorf("Target only allowed when clustered"))
+	}
+
 	var targetMember, targetGroup string
 	if strings.HasPrefix(target, "@") {
 		targetGroup = strings.TrimPrefix(target, "@")

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -849,6 +849,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	var sourceImage *api.Image
 	var sourceImageRef string
 	var clusterGroupsAllowed []string
+	var candidateMembers []db.NodeInfo
 
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), targetProjectName)
@@ -1024,6 +1025,40 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			logger.Debug("No name provided for new instance, using auto-generated name", logger.Ctx{"project": targetProjectName, "instance": req.Name})
 		}
 
+		if clustered && !clusterNotification && targetMember == "" {
+			architectures, err := instance.SuitableArchitectures(ctx, s, tx, targetProjectName, sourceInst, sourceImageRef, req)
+			if err != nil {
+				return err
+			}
+
+			// If no architectures have been ascertained from the source then use the default architecture
+			// from project or global config if available.
+			if len(architectures) < 1 {
+				defaultArch := targetProject.Config["images.default_architecture"]
+				if defaultArch == "" {
+					defaultArch = s.GlobalConfig.ImagesDefaultArchitecture()
+				}
+
+				if defaultArch != "" {
+					defaultArchID, err := osarch.ArchitectureId(defaultArch)
+					if err != nil {
+						return err
+					}
+
+					architectures = append(architectures, defaultArchID)
+				} else {
+					architectures = nil // Don't exclude candidate members based on architecture.
+				}
+			}
+
+			candidateMembers, err = tx.GetCandidateMembers(ctx, architectures, targetGroup, clusterGroupsAllowed)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+
 		if !clusterNotification {
 			// Check that the project's limits are not violated. Note this check is performed after
 			// automatically generated config values (such as ones from an InstanceType) have been set.
@@ -1045,44 +1080,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if clustered && !clusterNotification && targetMember == "" {
-		architectures, err := instance.SuitableArchitectures(r.Context(), s, targetProjectName, sourceInst, sourceImageRef, req)
-		if err != nil {
-			return response.BadRequest(err)
-		}
-
-		// If no architectures have been ascertained from the source then use the default architecture
-		// from project or global config if available.
-		if len(architectures) < 1 {
-			defaultArch := targetProject.Config["images.default_architecture"]
-			if defaultArch == "" {
-				defaultArch = s.GlobalConfig.ImagesDefaultArchitecture()
-			}
-
-			if defaultArch != "" {
-				defaultArchID, err := osarch.ArchitectureId(defaultArch)
-				if err != nil {
-					return response.SmartError(err)
-				}
-
-				architectures = append(architectures, defaultArchID)
-			} else {
-				architectures = nil // Don't exclude candidate members based on architecture.
-			}
-		}
-
-		var candidateMembers []db.NodeInfo
-		err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			candidateMembers, err = tx.GetCandidateMembers(ctx, architectures, targetGroup, clusterGroupsAllowed)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		})
-		if err != nil {
-			return response.SmartError(err)
-		}
-
 		// If no target member was selected yet, pick the member with the least number of instances.
 		// If there's just one member, or if the selected member is the local one, this is effectively a
 		// no-op, since GetNodeWithLeastInstances() will return an empty string.

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1051,7 +1051,12 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			candidateMembers, err = tx.GetCandidateMembers(ctx, architectures, targetGroup, clusterGroupsAllowed)
+			allMembers, err := tx.GetNodes(ctx)
+			if err != nil {
+				return fmt.Errorf("Failed getting cluster members: %w", err)
+			}
+
+			candidateMembers, err = tx.GetCandidateMembers(ctx, allMembers, architectures, targetGroup, clusterGroupsAllowed)
 			if err != nil {
 				return err
 			}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1471,7 +1471,7 @@ func projectHasRestriction(project *api.Project, restrictionKey string, blockVal
 }
 
 // CheckClusterTargetRestriction check if user is allowed to use cluster member targeting.
-func CheckClusterTargetRestriction(tx *db.ClusterTx, r *http.Request, project *api.Project, targetFlag string) error {
+func CheckClusterTargetRestriction(r *http.Request, project *api.Project, targetFlag string) error {
 	// Allow server administrators to move instances around even when restricted (node evacuation, ...)
 	if rbac.UserIsAdmin(r) {
 		return nil

--- a/lxd/project/permissions_test.go
+++ b/lxd/project/permissions_test.go
@@ -172,7 +172,7 @@ func TestCheckClusterTargetRestriction_RestrictedTrue(t *testing.T) {
 
 	req := &http.Request{}
 
-	err = project.CheckClusterTargetRestriction(tx, req, p, "n1")
+	err = project.CheckClusterTargetRestriction(req, p, "n1")
 	assert.EqualError(t, err, "This project doesn't allow cluster member targeting")
 }
 
@@ -196,6 +196,6 @@ func TestCheckClusterTargetRestriction_RestrictedFalse(t *testing.T) {
 
 	req := &http.Request{}
 
-	err = project.CheckClusterTargetRestriction(tx, req, p, "n1")
+	err = project.CheckClusterTargetRestriction(req, p, "n1")
 	assert.NoError(t, err)
 }

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -312,12 +312,11 @@ test_clustering_membership() {
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list-tokens
   ! LXD_DIR="${LXD_TWO_DIR}" lxc cluster list-tokens | grep node7 || false
 
-  # Set cluster token expiry to 10 seconds
-  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.join_token_expiry=10S
+  # Set cluster token expiry to 30 seconds
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.join_token_expiry=30S
 
   # Generate a join token for an eigth and ninth node
   token_valid=$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster add node8 | tail -n 1)
-  token_expired=$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster add node9 | tail -n 1)
 
   # Spawn an eigth node, using join token.
   setup_clustering_netns 8
@@ -330,8 +329,10 @@ test_clustering_membership() {
   spawn_lxd_and_join_cluster "${ns8}" "${bridge}" "${cert}" 8 2 "${LXD_EIGHT_DIR}"
   unset LXD_SECRET
 
-  # This will cause the token to expiry
-  sleep 11
+  # This will cause the token to expire
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.join_token_expiry=5S
+  token_expired=$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster add node9 | tail -n 1)
+  sleep 6
 
   # Spawn a ninth node, using join token.
   setup_clustering_netns 9

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2929,11 +2929,22 @@ test_clustering_evacuation() {
   LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage
 
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c1 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c1 boot.host_shutdown_timeout=5
+
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c2 --target=node1 -c cluster.evacuate=auto -s pool1
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c2 boot.host_shutdown_timeout=5
+
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c3 --target=node1 -c cluster.evacuate=stop
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c3 boot.host_shutdown_timeout=5
+
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c4 --target=node1 -c cluster.evacuate=migrate -s pool1
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c4 boot.host_shutdown_timeout=5
+
   LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c5 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c5 boot.host_shutdown_timeout=5
+
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c6 --target=node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set c6 boot.host_shutdown_timeout=5
 
   # For debugging
   LXD_DIR="${LXD_TWO_DIR}" lxc list

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3373,6 +3373,9 @@ test_clustering_groups() {
   lxc cluster group rename cluster:foobar blah
   [ "$(lxc query cluster:/1.0/cluster/members/node2 | jq 'any(.groups[] == "blah"; .)')" = "true" ]
 
+  lxc cluster group create cluster:foobar2
+  lxc cluster group assign cluster:node3 default,foobar2
+
   # With these settings:
   # - node1 will receive instances unless a different node is directly targeted (not via group)
   # - node2 will receive instances if either targeted by group or directly
@@ -3411,7 +3414,41 @@ test_clustering_groups() {
   lxc info cluster:c5 | grep -q "Location: node3"
 
   # Clean up
-  lxc rm c1 c2 c3 c4 c5
+  lxc rm -f c1 c2 c3 c4 c5
+
+  # Restricted project tests
+  lxc project create foo -c features.images=false -c restricted=true -c restricted.cluster.groups=blah
+  lxc profile show default | lxc profile edit default --project foo
+
+  # Check cannot create instance in restricted project that only allows blah group, when the only member that
+  # exists in the blah group also has scheduler.instance=group set (so it must be targeted via group or directly).
+  ! lxc init testimage cluster:c1 --project foo || false
+
+  # Check cannot create instance in restricted project when targeting a member that isn't in the restricted
+  # project's allowed cluster groups list.
+  ! lxc init testimage cluster:c1 --project foo --target=node1 || false
+  ! lxc init testimage cluster:c1 --project foo --target=@foobar2 || false
+
+  # Check can create instance in restricted project when not targeting any specific member, but that it will only
+  # be created on members within the project's allowed cluster groups list.
+  lxc cluster unset cluster:node2 scheduler.instance
+  lxc init testimage cluster:c1 --project foo
+  lxc init testimage cluster:c2 --project foo
+  lxc info cluster:c1 --project foo | grep -q "Location: node2"
+  lxc info cluster:c2 --project foo | grep -q "Location: node2"
+  lxc delete -f c1 c2 --project foo
+
+  # Check can specify any member or group when restricted.cluster.groups is empty.
+  lxc project unset foo restricted.cluster.groups
+  lxc init testimage cluster:c1 --project foo --target=node1
+  lxc info cluster:c1 --project foo | grep -q "Location: node1"
+
+  lxc init testimage cluster:c2 --project foo --target=@blah
+  lxc info cluster:c2 --project foo | grep -q "Location: node2"
+
+  lxc delete -f c1 c2 --project foo
+
+  lxc project delete foo
 
   LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown


### PR DESCRIPTION
In a restricted project new instances can no longer be targeted at specific cluster members that do not exist in the `restricted.cluster.groups` setting (if set). However if it is not set or is empty, then all cluster members are allowed.

This also changes the behaviour of an empty/unset `restricted.cluster.groups` setting when using cluster group targeting. Previously it would have prevented the use of any targeted cluster groups in a restricted project. 
Now if the setting is empty all cluster groups can be targeted.

Also continues work to reduce unnecessary queries and transactions within the instances_post API endpoint by removing the use of `ResolveTarget` (which would then load all the member info again).

Fixes #11263