### PR TITLE
lxd/db: Changed snapshot sort from date to datetime

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -1070,7 +1070,7 @@ SELECT instances_snapshots.name
   JOIN instances ON instances.id = instances_snapshots.instance_id
   JOIN projects ON projects.id = instances.project_id
 WHERE projects.name=? AND instances.name=?
-ORDER BY date(instances_snapshots.creation_date)
+ORDER BY datetime(instances_snapshots.creation_date)
 `
 	inargs := []any{project, name}
 	outfmt := []any{name}


### PR DESCRIPTION
Today I noticed that snapshot names when doing `lxc info <instance name>` are only sorted by _date_ which does not include the timestamp as well. This is quite annoying as then it reverts back to alphabetical when a snapshot has the same date as another. Im currently using `5.0` as well. Any chance this can be backported too? Not sure whats required for that

```
 $ lxd sql global "SELECT instances_snapshots.name, instances_snapshots.creation_date
  FROM instances_snapshots
  JOIN instances ON instances.id = instances_snapshots.instance_id
  JOIN projects ON projects.id = instances.project_id
WHERE instances.name='instance name' ORDER BY date(instances_snapshots.creation_date)"
+----------------------------+--------------------------------+
|            name            |         creation_date          |
+----------------------------+--------------------------------+
| clean                      | 2023-01-09T17:51:05.563210801Z |
| probworking                | 2023-01-09T19:20:10.867780561Z |
| snapshot-test-build        | 2023-01-09T18:51:16.973068416Z |
| snapshot-example3          | 2023-01-10T17:10:48.895137964Z |
+----------------------------+--------------------------------+
```

```
 $ lxd sql global "SELECT instances_snapshots.name, instances_snapshots.creation_date
  FROM instances_snapshots
  JOIN instances ON instances.id = instances_snapshots.instance_id
  JOIN projects ON projects.id = instances.project_id
WHERE instances.name='instance name' ORDER BY datetime(instances_snapshots.creation_date)"
+----------------------------+--------------------------------+
|            name            |         creation_date          |
+----------------------------+--------------------------------+
| clean                      | 2023-01-09T17:51:05.563210801Z |
| snapshot-test-build        | 2023-01-09T18:51:16.973068416Z |
| probworking                | 2023-01-09T19:20:10.867780561Z |
| snapshot-example3          | 2023-01-10T17:10:48.895137964Z |
+----------------------------+--------------------------------+
```

Signed-off-by: MrDaGree <dawsonmax10@gmail.com>