### PR TITLE
lxd: Use consistent snapshot ordering in API and `lxc info` output

### DIFF
--- a/lxc/info.go
+++ b/lxc/info.go
@@ -625,7 +625,6 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, remote config.Remote, name 
 			snapData = append(snapData, row)
 		}
 
-		sort.Sort(utils.ByName(snapData))
 		snapHeader := []string{
 			i18n.G("Name"),
 			i18n.G("Taken at"),

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -1061,6 +1061,7 @@ func (c *Cluster) UpdateInstanceSnapshotCreationDate(instanceID int, date time.T
 
 // GetInstanceSnapshotsNames returns the names of all snapshots of the instance
 // in the given project with the given name.
+// Returns snapshots slice ordered by when they were created, oldest first.
 func (c *Cluster) GetInstanceSnapshotsNames(project, name string) ([]string, error) {
 	result := []string{}
 
@@ -1070,7 +1071,7 @@ SELECT instances_snapshots.name
   JOIN instances ON instances.id = instances_snapshots.instance_id
   JOIN projects ON projects.id = instances.project_id
 WHERE projects.name=? AND instances.name=?
-ORDER BY datetime(instances_snapshots.creation_date)
+ORDER BY instances_snapshots.creation_date, instances_snapshots.id
 `
 	inargs := []any{project, name}
 	outfmt := []any{name}
@@ -1094,7 +1095,9 @@ SELECT instances_snapshots.name
   FROM instances_snapshots
   JOIN instances ON instances.id = instances_snapshots.instance_id
   JOIN projects ON projects.id = instances.project_id
-WHERE projects.name=? AND instances.name=?`
+WHERE projects.name=? AND instances.name=?
+ORDER BY instances_snapshots.creation_date, instances_snapshots.id
+`
 	var numstr string
 	inargs := []any{project, name}
 	outfmt := []any{numstr}

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -257,8 +257,8 @@ func (c *ClusterTx) GetStoragePoolVolume(ctx context.Context, poolID int64, proj
 func (c *Cluster) GetLocalStoragePoolVolumeSnapshotsWithType(projectName string, volumeName string, volumeType int, poolID int64) ([]StorageVolumeArgs, error) {
 	remoteDrivers := StorageRemoteDriverNames()
 
-	// ORDER BY id is important here as the users of this function can expect that the results
-	// will be returned in the order that the snapshots were created. This is specifically used
+	// ORDER BY creation_date and then id is important here as the users of this function can expect that the
+	// results will be returned in the order that the snapshots were created. This is specifically used
 	// during migration to ensure that the storage engines can re-create snapshots using the
 	// correct deltas.
 	queryStr := fmt.Sprintf(`
@@ -275,7 +275,7 @@ func (c *Cluster) GetLocalStoragePoolVolumeSnapshotsWithType(projectName string,
     AND storage_volumes.name=?
     AND projects.name=?
     AND (storage_volumes.node_id=? OR storage_volumes.node_id IS NULL AND storage_pools.driver IN %s)
-  ORDER BY storage_volumes_snapshots.id`, query.Params(len(remoteDrivers)))
+  ORDER BY storage_volumes_snapshots.creation_date, storage_volumes_snapshots.id`, query.Params(len(remoteDrivers)))
 
 	args := []any{poolID, volumeType, volumeName, projectName, c.nodeID}
 	for _, driver := range remoteDrivers {


### PR DESCRIPTION
Order instance and custom volume snapshots in creation order (oldest first).

Continues changes started in https://github.com/lxc/lxd/pull/11271 and fixes snapshot ordering in `lxc info <instance>` described within that PR.