### PR TITLE
Instance: Don't allow manual targeting of a member outside of the allowed groups of a restricted project (stable-5.0)

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2825,7 +2825,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 
 			// Skip migration if no target available.
 			if targetNode == nil {
-				logger.Warn("No migration target available for instance", logger.Ctx{"name": inst.Name(), "project": inst.Project().Name})
+				l.Warn("No migration target available for instance")
 				continue
 			}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2803,7 +2803,12 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 
 			// Find the least loaded cluster member which supports the architecture.
 			err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				candidateMembers, err := tx.GetCandidateMembers(ctx, []int{inst.Architecture()}, "", nil)
+				allMembers, err := tx.GetNodes(ctx)
+				if err != nil {
+					return fmt.Errorf("Failed getting cluster members: %w", err)
+				}
+
+				candidateMembers, err := tx.GetCandidateMembers(ctx, allMembers, []int{inst.Architecture()}, "", nil)
 				if err != nil {
 					return err
 				}

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -14,8 +14,38 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// GetNetworkZones returns the names of existing Network zones.
-func (c *Cluster) GetNetworkZones(project string) ([]string, error) {
+// GetNetworkZones returns the names of existing Network zones mapped to project name.
+func (c *ClusterTx) GetNetworkZones(ctx context.Context) (map[string]string, error) {
+	q := `SELECT networks_zones.name, projects.name AS project_name FROM networks_zones
+		JOIN projects ON projects.id = networks_zones.project_id
+		ORDER BY networks_zones.id
+	`
+
+	var err error
+	zoneProjects := make(map[string]string)
+
+	err = query.Scan(ctx, c.tx, q, func(scan func(dest ...any) error) error {
+		var zoneName string
+		var projectName string
+
+		err := scan(&zoneName, &projectName)
+		if err != nil {
+			return err
+		}
+
+		zoneProjects[zoneName] = projectName
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return zoneProjects, nil
+}
+
+// GetNetworkZonesByProject returns the names of existing Network zones.
+func (c *Cluster) GetNetworkZonesByProject(project string) ([]string, error) {
 	q := `SELECT name FROM networks_zones
 		WHERE project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)
 		ORDER BY id

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -113,40 +113,6 @@ func (c *Cluster) GetNetworkZoneKeys() (map[string]string, error) {
 	return secrets, nil
 }
 
-// GetNetworksForZone returns the names of all networks using the zone and project.
-func (c *Cluster) GetNetworksForZone(projectName string, zoneName string) ([]string, error) {
-	q := `SELECT networks.name FROM networks
-		JOIN projects ON networks.project_id=projects.id
-		JOIN networks_config ON networks_config.network_id=networks.id
-		WHERE
-			networks_config.key IN ('dns.zone.forward', 'dns.zone.reverse.ipv4', 'dns.zone.reverse.ipv6')
-			AND networks_config.value=?
-			AND projects.name=?;
-	`
-
-	var networkNames []string
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
-			var networkName string
-
-			err := scan(&networkName)
-			if err != nil {
-				return err
-			}
-
-			networkNames = append(networkNames, networkName)
-
-			return nil
-		}, zoneName, projectName)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return networkNames, nil
-}
-
 // GetNetworkZone returns the Network zone with the given name.
 func (c *Cluster) GetNetworkZone(name string) (int64, string, *api.NetworkZone, error) {
 	var id int64 = int64(-1)

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -1090,15 +1090,10 @@ func (c *ClusterTx) GetNodeOfflineThreshold(ctx context.Context) (time.Duration,
 // GetCandidateMembers returns cluster members that are online, in created state and don't need manual targeting.
 // It excludes members that do not support any of the targetArchitectures (if non-nil) or not in targetClusterGroup
 // (if non-empty). It also takes into account any restrictions on allowedClusterGroups (if non-nil).
-func (c *ClusterTx) GetCandidateMembers(ctx context.Context, targetArchitectures []int, targetClusterGroup string, allowedClusterGroups []string) ([]NodeInfo, error) {
+func (c *ClusterTx) GetCandidateMembers(ctx context.Context, allMembers []NodeInfo, targetArchitectures []int, targetClusterGroup string, allowedClusterGroups []string) ([]NodeInfo, error) {
 	threshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get offline threshold: %w", err)
-	}
-
-	allMembers, err := c.GetNodes(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get current cluster members: %w", err)
 	}
 
 	var candidateMembers []NodeInfo

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -1087,10 +1087,9 @@ func (c *ClusterTx) GetNodeOfflineThreshold(ctx context.Context) (time.Duration,
 	return threshold, nil
 }
 
-// GetCandidateMembers returns cluster members that are online, not in evacuated state and don't require manual
-// targeting. It will also exclude members that do not support any of the targetArchitectures (if non-nil) or not
-// in targetClusterGroup (if non-empty).
-// It also takes into account any restrictions on allowedClusterGroups (if non-nil).
+// GetCandidateMembers returns cluster members that are online, in created state and don't need manual targeting.
+// It excludes members that do not support any of the targetArchitectures (if non-nil) or not in targetClusterGroup
+// (if non-empty). It also takes into account any restrictions on allowedClusterGroups (if non-nil).
 func (c *ClusterTx) GetCandidateMembers(ctx context.Context, targetArchitectures []int, targetClusterGroup string, allowedClusterGroups []string) ([]NodeInfo, error) {
 	threshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
@@ -1105,8 +1104,8 @@ func (c *ClusterTx) GetCandidateMembers(ctx context.Context, targetArchitectures
 	var candidateMembers []NodeInfo
 
 	for _, member := range allMembers {
-		// Skip evacuated or offline members.
-		if member.State == ClusterMemberStateEvacuated || member.IsOffline(threshold) {
+		// Skip pending, evacuated or offline members.
+		if member.State != ClusterMemberStateCreated || member.IsOffline(threshold) {
 			continue
 		}
 

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -325,9 +325,9 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }
 
 // If there are nodes, and one of them is offline, return the name of the
@@ -356,9 +356,9 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }
 
 // If there are 2 online nodes, and a container is pending on one of them,
@@ -383,9 +383,9 @@ INSERT INTO operations (id, uuid, node_id, type, project_id) VALUES (1, 'abc', 1
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }
 
 // If specific architectures were selected, return only nodes with those
@@ -419,9 +419,9 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.Len(t, members, 1)
 
 	// The local member is returned despite it has more containers.
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "none", name)
+	assert.Equal(t, "none", member.Name)
 }
 
 func TestUpdateNodeFailureDomain(t *testing.T) {
@@ -480,7 +480,7 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
-	name, err := tx.GetNodeWithLeastInstances(context.Background(), members)
+	member, err := tx.GetNodeWithLeastInstances(context.Background(), members)
 	require.NoError(t, err)
-	assert.Equal(t, "buzz", name)
+	assert.Equal(t, "buzz", member.Name)
 }

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -318,7 +318,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, nil, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
@@ -346,7 +349,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 	err = tx.SetNodeHeartbeat("0.0.0.0", time.Now().Add(-time.Minute))
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, nil, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
@@ -370,7 +376,10 @@ INSERT INTO operations (id, uuid, node_id, type, project_id) VALUES (1, 'abc', 1
 `, operationtype.InstanceCreate)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), nil, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, nil, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 2)
 
@@ -402,7 +411,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), []int{localArch}, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, []int{localArch}, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
@@ -461,7 +473,10 @@ INSERT INTO instances (id, node_id, name, architecture, type, project_id, descri
 `, id)
 	require.NoError(t, err)
 
-	members, err := tx.GetCandidateMembers(context.Background(), []int{testArch}, "", nil)
+	allMembers, err := tx.GetNodes(context.Background())
+	require.NoError(t, err)
+
+	members, err := tx.GetCandidateMembers(context.Background(), allMembers, []int{testArch}, "", nil)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -596,7 +597,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 
 	// For migration, an architecture must be specified in the req.
 	if req.Source.Type == "migration" && req.Architecture == "" {
-		return nil, fmt.Errorf("An architecture must be specified in migration requests")
+		return nil, api.StatusErrorf(http.StatusBadRequest, "An architecture must be specified in migration requests")
 	}
 
 	// For none, allow any architecture.
@@ -660,7 +661,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 					return nil, err
 				}
 			} else {
-				return nil, fmt.Errorf("Unsupported remote image server protocol: %s", req.Source.Protocol)
+				return nil, api.StatusErrorf(http.StatusBadRequest, "Unsupported remote image server protocol %q", req.Source.Protocol)
 			}
 
 			// Look for a matching alias.
@@ -695,7 +696,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 	}
 
 	// No other known types
-	return nil, fmt.Errorf("Unknown instance source type: %s", req.Source.Type)
+	return nil, api.StatusErrorf(http.StatusBadRequest, "Unknown instance source type %q", req.Source.Type)
 }
 
 // ValidName validates an instance name. There are different validation rules for instance snapshot names

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -584,7 +584,7 @@ func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, sou
 //
 // An empty list indicates that the request may be handled by any architecture.
 // A nil list indicates that we can't tell at this stage, typically for private images.
-func SuitableArchitectures(ctx context.Context, s *state.State, projectName string, sourceInst *cluster.Instance, sourceImageRef string, req api.InstancesPost) ([]int, error) {
+func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx, projectName string, sourceInst *cluster.Instance, sourceImageRef string, req api.InstancesPost) ([]int, error) {
 	// Handle cases where the architecture is already provided.
 	if shared.StringInSlice(req.Source.Type, []string{"migration", "none"}) && req.Architecture != "" {
 		id, err := osarch.ArchitectureId(req.Architecture)
@@ -614,7 +614,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, projectName stri
 	if req.Source.Type == "image" {
 		// Handle local images.
 		if req.Source.Server == "" {
-			_, img, err := s.DB.Cluster.GetImage(sourceImageRef, cluster.ImageFilter{Project: &projectName})
+			_, img, err := tx.GetImageByFingerprintPrefix(ctx, sourceImageRef, cluster.ImageFilter{Project: &projectName})
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -130,7 +130,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Check if user is allowed to use cluster member targeting
-			err = project.CheckClusterTargetRestriction(tx, r, apiProject, targetNode)
+			err = project.CheckClusterTargetRestriction(r, apiProject, targetNode)
 			if err != nil {
 				return err
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -863,7 +863,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Check manual cluster member targeting restrictions.
-		err = project.CheckClusterTargetRestriction(tx, r, targetProject, target)
+		err = project.CheckClusterTargetRestriction(r, targetProject, target)
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -836,6 +836,10 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	target := queryParam(r, "target")
+	if !clustered && target != "" {
+		return response.BadRequest(fmt.Errorf("Target only allowed when clustered"))
+	}
+
 	var targetMember, targetGroup string
 	if strings.HasPrefix(target, "@") {
 		targetGroup = strings.TrimPrefix(target, "@")

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1059,7 +1059,12 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			candidateMembers, err = tx.GetCandidateMembers(ctx, architectures, targetGroup, clusterGroupsAllowed)
+			allMembers, err := tx.GetNodes(ctx)
+			if err != nil {
+				return fmt.Errorf("Failed getting cluster members: %w", err)
+			}
+
+			candidateMembers, err = tx.GetCandidateMembers(ctx, allMembers, architectures, targetGroup, clusterGroupsAllowed)
 			if err != nil {
 				return err
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -917,7 +917,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				}
 
 				// Check if the target group exists.
-				targetGroupExists, err := dbCluster.ClusterGroupExists(ctx, tx.Tx(), targetGroup)
+				targetGroupExists, err := tx.ClusterGroupExists(targetGroup)
 				if err != nil {
 					return err
 				}

--- a/lxd/network/zone/reverse.go
+++ b/lxd/network/zone/reverse.go
@@ -9,8 +9,7 @@ var ip4Arpa = ".in-addr.arpa"
 var ip6Arpa = ".ip6.arpa"
 
 // reverse takes an IPv4 or IPv6 address and returns the matching ARPA record.
-func reverse(addr string) (arpa string) {
-	ip := net.ParseIP(addr)
+func reverse(ip net.IP) (arpa string) {
 	if ip == nil {
 		return ""
 	}

--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -1,6 +1,7 @@
 package zone
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/cluster/request"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
@@ -297,120 +299,149 @@ func (d *zone) Delete() error {
 
 // Content returns the DNS zone content.
 func (d *zone) Content() (*strings.Builder, error) {
+	var err error
 	records := []map[string]string{}
 
 	// Check if we should include NAT records.
 	includeNAT := shared.IsTrueOrEmpty(d.info.Config["network.nat"])
 
-	// Load all networks for the zone.
-	networks, err := d.state.DB.Cluster.GetNetworksForZone(d.projectName, d.info.Name)
+	// Get all managed networks across all projects.
+	var projectNetworks map[string]map[int64]api.Network
+	var zoneProjects map[string]string
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		projectNetworks, err = tx.GetCreatedNetworks(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to load all networks: %w", err)
+		}
+
+		zoneProjects, err = tx.GetNetworkZones(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to load all network zones: %w", err)
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	for _, netName := range networks {
-		// Load the network.
-		n, err := network.LoadByName(d.state, d.projectName, netName)
-		if err != nil {
-			return nil, err
-		}
-
-		// Load the leases.
-		leases, err := n.Leases(d.projectName, request.ClientTypeNormal)
-		if err != nil {
-			return nil, err
-		}
-
-		// Check whether what records to include.
-		netConfig := n.Config()
-		includeV4 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv4.nat"])
-		includeV6 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv6.nat"])
-
-		// Check if dealing with a reverse zone.
-		isReverse4 := strings.HasSuffix(d.info.Name, ip4Arpa)
-		isReverse6 := strings.HasSuffix(d.info.Name, ip6Arpa)
-		isReverse := isReverse4 || isReverse6
-		forwardZone := n.Config()["dns.zone.forward"]
-
-		genRecord := func(name string, addr string) map[string]string {
-			isV4 := net.ParseIP(addr).To4() != nil
-
-			// Skip disabled families.
-			if isV4 && !includeV4 {
-				return nil
+	for netProjectName, networks := range projectNetworks {
+		for _, netInfo := range networks {
+			if !d.networkUsesZone(netInfo.Config) {
+				continue
 			}
 
-			if !isV4 && !includeV6 {
-				return nil
+			// Load the network.
+			n, err := network.LoadByName(d.state, netProjectName, netInfo.Name)
+			if err != nil {
+				return nil, err
 			}
 
-			record := map[string]string{}
-			record["ttl"] = "300"
-			if !isReverse {
-				if isV4 {
-					record["type"] = "A"
+			// Check whether what records to include.
+			netConfig := n.Config()
+			includeV4 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv4.nat"])
+			includeV6 := includeNAT || shared.IsFalseOrEmpty(netConfig["ipv6.nat"])
+
+			// Check if dealing with a reverse zone.
+			isReverse4 := strings.HasSuffix(d.info.Name, ip4Arpa)
+			isReverse6 := strings.HasSuffix(d.info.Name, ip6Arpa)
+			isReverse := isReverse4 || isReverse6
+
+			genRecord := func(name string, ip net.IP) map[string]string {
+				isV4 := ip.To4() != nil
+
+				// Skip disabled families.
+				if isV4 && !includeV4 {
+					return nil
+				}
+
+				if !isV4 && !includeV6 {
+					return nil
+				}
+
+				record := map[string]string{}
+				record["ttl"] = "300"
+				if !isReverse {
+					if isV4 {
+						record["type"] = "A"
+					} else {
+						record["type"] = "AAAA"
+					}
+
+					record["name"] = name
+					record["value"] = ip.String()
 				} else {
-					record["type"] = "AAAA"
+					// Skip PTR records for wrong family.
+					if isV4 && !isReverse4 {
+						return nil
+					}
+
+					if !isV4 && !isReverse6 {
+						return nil
+					}
+
+					// Get the ARPA record.
+					reverseAddr := reverse(ip)
+					if reverseAddr == "" {
+						return nil
+					}
+
+					record["type"] = "PTR"
+					record["name"] = strings.TrimSuffix(reverseAddr, "."+d.info.Name+".")
+					record["value"] = name + "."
 				}
 
-				record["name"] = name
-				record["value"] = addr
+				return record
+			}
+
+			if isReverse {
+				// Load network leases in correct project context for each forward zone referenced.
+				for _, forwardZoneName := range shared.SplitNTrimSpace(n.Config()["dns.zone.forward"], ",", -1, true) {
+					// Get forward zone's project.
+					forwardZoneProjectName := zoneProjects[forwardZoneName]
+					if forwardZoneProjectName == "" {
+						return nil, fmt.Errorf("Associated project not found for zone %q", forwardZoneName)
+					}
+
+					// Load the leases for the forward zone project.
+					leases, err := n.Leases(forwardZoneProjectName, request.ClientTypeNormal)
+					if err != nil {
+						return nil, err
+					}
+
+					// Convert leases to usable PTR records.
+					for _, lease := range leases {
+						ip := net.ParseIP(lease.Address)
+
+						// Get the record.
+						record := genRecord(fmt.Sprintf("%s.%s", lease.Hostname, forwardZoneName), ip)
+						if record == nil {
+							continue
+						}
+
+						records = append(records, record)
+					}
+				}
 			} else {
-				// Skip PTR records if no forward zone.
-				if forwardZone == "" {
-					return nil
+				// Load the leases in the forward zone's project.
+				leases, err := n.Leases(d.projectName, request.ClientTypeNormal)
+				if err != nil {
+					return nil, err
 				}
 
-				// Skip PTR records for wrong family.
-				if isV4 && !isReverse4 {
-					return nil
+				// Convert leases to usable records.
+				for _, lease := range leases {
+					ip := net.ParseIP(lease.Address)
+
+					// Get the record.
+					record := genRecord(lease.Hostname, ip)
+					if record == nil {
+						continue
+					}
+
+					records = append(records, record)
 				}
-
-				if !isV4 && !isReverse6 {
-					return nil
-				}
-
-				// Get the ARPA record.
-				reverseAddr := reverse(addr)
-				if reverseAddr == "" {
-					return nil
-				}
-
-				record["type"] = "PTR"
-				record["name"] = strings.TrimSuffix(reverseAddr, "."+d.info.Name+".")
-				record["value"] = name + "." + forwardZone + "."
 			}
-
-			return record
-		}
-
-		// Convert leases to usable records.
-		for _, lease := range leases {
-			// Get the record.
-			record := genRecord(lease.Hostname, lease.Address)
-			if record == nil {
-				continue
-			}
-
-			records = append(records, record)
-		}
-
-		// Add gateways.
-		for _, addr := range []string{n.Config()["ipv4.address"], n.Config()["ipv6.address"]} {
-			if addr == "" || addr == "none" {
-				continue
-			}
-
-			// Strip the mask.
-			addr = strings.Split(addr, "/")[0]
-
-			// Get the record.
-			record := genRecord(n.Name()+".gw", addr)
-			if record == nil {
-				continue
-			}
-
-			records = append(records, record)
 		}
 	}
 

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -138,7 +138,7 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
 	// Get list of Network zones.
-	zoneNames, err := d.db.Cluster.GetNetworkZones(projectName)
+	zoneNames, err := d.db.Cluster.GetNetworkZonesByProject(projectName)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1470,7 +1470,7 @@ func projectHasRestriction(project *api.Project, restrictionKey string, blockVal
 }
 
 // CheckClusterTargetRestriction check if user is allowed to use cluster member targeting.
-func CheckClusterTargetRestriction(tx *db.ClusterTx, r *http.Request, project *api.Project, targetFlag string) error {
+func CheckClusterTargetRestriction(r *http.Request, project *api.Project, targetFlag string) error {
 	// Allow server administrators to move instances around even when restricted (node evacuation, ...)
 	if rbac.UserIsAdmin(r) {
 		return nil

--- a/lxd/project/permissions_test.go
+++ b/lxd/project/permissions_test.go
@@ -172,7 +172,7 @@ func TestCheckClusterTargetRestriction_RestrictedTrue(t *testing.T) {
 
 	req := &http.Request{}
 
-	err = project.CheckClusterTargetRestriction(tx, req, p, "n1")
+	err = project.CheckClusterTargetRestriction(req, p, "n1")
 	assert.EqualError(t, err, "This project doesn't allow cluster member targeting")
 }
 
@@ -196,6 +196,6 @@ func TestCheckClusterTargetRestriction_RestrictedFalse(t *testing.T) {
 
 	req := &http.Request{}
 
-	err = project.CheckClusterTargetRestriction(tx, req, p, "n1")
+	err = project.CheckClusterTargetRestriction(req, p, "n1")
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Backports https://github.com/lxc/lxd/pull/11264 to stable-5.0.

Also fixes clustering groups test failures by modifying use of `tx.ClusterGroupExists`

Also backports parts (non user facing changes) of https://github.com/lxc/lxd/pull/11160 to aid with future maintenance.