### PR TITLE
lxd: Reduce calls to d.State() and avoid starting a transaction if target is local server in `ResolveTarget()`

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -224,7 +224,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -405,8 +405,10 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func api10Put(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -502,8 +504,10 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func api10Patch(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -361,7 +361,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	fullSrv.Environment = env
 
 	if rbac.UserIsAdmin(r) {
-		fullSrv.Config, err = daemonConfigRender(d.State())
+		fullSrv.Config, err = daemonConfigRender(s)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -456,7 +456,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		return response.EmptySyncResponse
 	}
 
-	render, err := daemonConfigRender(d.State())
+	render, err := daemonConfigRender(s)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -515,7 +515,7 @@ func api10Patch(d *Daemon, r *http.Request) response.Response {
 	// Don't apply changes to settings until daemon is fully started.
 	<-d.waitReady.Done()
 
-	render, err := daemonConfigRender(d.State())
+	render, err := daemonConfigRender(s)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -701,7 +701,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		return response.SmartError(err)
 	}
 
-	d.State().Events.SendLifecycle(project.Default, lifecycle.ConfigUpdated.Event(request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(project.Default, lifecycle.ConfigUpdated.Event(request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2829,8 +2829,10 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	s := d.State()
+
 	// Forward request
-	resp := forwardedResponseToNode(d, r, name)
+	resp := forwardedResponseToNode(s, r, name)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -34,8 +34,10 @@ var metricsCmd = APIEndpoint{
 }
 
 func allowMetrics(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Check if API is wide open.
-	if !d.State().GlobalConfig.MetricsAuthentication() {
+	if !s.GlobalConfig.MetricsAuthentication() {
 		return response.EmptySyncResponse
 	}
 
@@ -74,6 +76,8 @@ func allowMetrics(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func metricsGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	projectName := queryParam(r, "project")
 
 	// Forward if requested.
@@ -84,8 +88,6 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	// Wait until daemon is fully started.
 	<-d.waitReady.Done()
-
-	s := d.State()
 
 	// Prepare response.
 	metricSet := metrics.NewMetricSet(nil)

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -77,7 +77,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	projectName := queryParam(r, "project")
 
 	// Forward if requested.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -13,6 +13,8 @@ import (
 )
 
 func authenticateAgentCert(d *Daemon, r *http.Request) (bool, instance.Instance, error) {
+	s := d.State()
+
 	var vsockID int
 	trusted := false
 
@@ -23,7 +25,7 @@ func authenticateAgentCert(d *Daemon, r *http.Request) (bool, instance.Instance,
 
 	var clusterInst *cluster.Instance
 
-	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		clusterInst, err = tx.GetLocalInstanceWithVsockID(ctx, vsockID)
@@ -37,7 +39,7 @@ func authenticateAgentCert(d *Daemon, r *http.Request) (bool, instance.Instance,
 		return false, nil, err
 	}
 
-	inst, err := instance.LoadByProjectAndName(d.State(), clusterInst.Project, clusterInst.Name)
+	inst, err := instance.LoadByProjectAndName(s, clusterInst.Project, clusterInst.Name)
 	if err != nil {
 		return false, nil, err
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -2039,6 +2039,8 @@ func (d *Daemon) hasMemberStateChanged(heartbeatData *cluster.APIHeartbeat) bool
 
 // heartbeatHandler handles heartbeat requests from other cluster members.
 func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLeader bool, hbData *cluster.APIHeartbeat) {
+	s := d.State()
+
 	var err error
 
 	// Look for time skews.
@@ -2105,7 +2107,7 @@ func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLead
 		return
 	}
 
-	localClusterAddress := d.State().LocalConfig.ClusterAddress()
+	localClusterAddress := s.LocalConfig.ClusterAddress()
 
 	if hbData.FullStateList {
 		// If there is an ongoing heartbeat round (and by implication this is the leader), then this could
@@ -2144,7 +2146,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		return
 	}
 
-	localClusterAddress := d.State().LocalConfig.ClusterAddress()
+	localClusterAddress := s.LocalConfig.ClusterAddress()
 
 	if !heartbeatData.FullStateList || len(heartbeatData.Members) <= 0 {
 		logger.Error("Heartbeat member refresh task called with partial state list", logger.Ctx{"local": localClusterAddress})

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -473,6 +473,7 @@ func (d *Daemon) State() *state.State {
 		GlobalConfig:           globalConfig,
 		LocalConfig:            localConfig,
 		ServerName:             d.serverName,
+		StartTime:              d.startTime,
 	}
 }
 

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -426,6 +426,87 @@ func (c *ClusterTx) storagePoolNodeState(poolID int64, state StoragePoolState) e
 	return nil
 }
 
+// GetStoragePools returns map of Storage Pools keyed on ID and Storage Pool member info keyed on ID and Member ID.
+// Can optionally accept a state filter, if nil, then pools in any state are returned.
+// Can optionally accept one or more poolNames to further filter the returned pools.
+func (c *Cluster) GetStoragePools(ctx context.Context, state *StoragePoolState, poolNames ...string) (map[int64]api.StoragePool, map[int64]map[int64]StoragePoolNode, error) {
+	var q *strings.Builder = &strings.Builder{}
+	var args []any
+
+	q.WriteString("SELECT id, name, driver, description, state FROM storage_pools ")
+
+	if state != nil {
+		q.WriteString("WHERE storage_pools.state = ? ")
+		args = append(args, *state)
+	}
+
+	if len(poolNames) > 0 {
+		verb := "WHERE"
+		if len(args) > 0 {
+			verb = "AND"
+		}
+
+		q.WriteString(fmt.Sprintf("%s storage_pools.name IN %s", verb, query.Params(len(poolNames))))
+		for _, poolName := range poolNames {
+			args = append(args, poolName)
+		}
+	}
+
+	var err error
+	pools := make(map[int64]api.StoragePool)
+	memberInfo := make(map[int64]map[int64]StoragePoolNode)
+
+	err = c.Transaction(ctx, func(ctx context.Context, tx *ClusterTx) error {
+		err = query.Scan(ctx, tx.Tx(), q.String(), func(scan func(dest ...any) error) error {
+			var poolID int64 = int64(-1)
+			var poolState StoragePoolState
+			var pool api.StoragePool
+
+			err := scan(&poolID, &pool.Name, &pool.Driver, &pool.Description, &poolState)
+			if err != nil {
+				return err
+			}
+
+			pool.Status = StoragePoolStateToAPIStatus(poolState)
+
+			pools[poolID] = pool
+
+			return nil
+		}, args...)
+		if err != nil {
+			return err
+		}
+
+		for poolID := range pools {
+			pool := pools[poolID]
+
+			err = c.getStoragePoolConfig(ctx, tx, poolID, &pool)
+			if err != nil {
+				return err
+			}
+
+			memberInfo[poolID], err = tx.storagePoolNodes(ctx, poolID)
+			if err != nil {
+				return err
+			}
+
+			pool.Locations = make([]string, 0, len(memberInfo[poolID]))
+			for _, node := range memberInfo[poolID] {
+				pool.Locations = append(pool.Locations, node.Name)
+			}
+
+			pools[poolID] = pool
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pools, memberInfo, nil
+}
+
 // GetStoragePoolNodeConfigs returns the node-specific configuration of all
 // nodes grouped by node name, for the given poolID.
 //

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -282,7 +282,9 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 			return
 		}
 
-		c, err := findContainerForPid(cred.Pid, d.State())
+		s := d.State()
+
+		c, err := findContainerForPid(cred.Pid, s)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -41,6 +41,8 @@ func (r *eventsServe) String() string {
 }
 
 func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
+	s := d.State()
+
 	// Detect project mode.
 	projectName := queryParam(r, "project")
 	allProjects := shared.IsTrue(queryParam(r, "all-projects"))
@@ -92,7 +94,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 
 	defer func() { _ = conn.Close() }() // Ensure listener below ends when this function ends.
 
-	d.events.SetLocalLocation(d.State().ServerName)
+	d.events.SetLocalLocation(s.ServerName)
 
 	var excludeLocations []string
 	// Get the current local serverName and store it for the events.

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -41,6 +41,7 @@ import (
 	projectutils "github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/lxd/util"
@@ -189,6 +190,8 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
  * exports it as an image.
  */
 func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operations.Operation, builddir string, budget int64) (*api.Image, error) {
+	s := d.State()
+
 	info := api.Image{}
 	info.Properties = map[string]string{}
 	projectName := projectParam(r)
@@ -221,7 +224,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 		info.Public = false
 	}
 
-	c, err := instance.LoadByProjectAndName(d.State(), projectName, name)
+	c, err := instance.LoadByProjectAndName(s, projectName, name)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +301,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 		if p.Config["images.compression_algorithm"] != "" {
 			compress = p.Config["images.compression_algorithm"]
 		} else {
-			compress = d.State().GlobalConfig.ImagesCompressionAlgorithm()
+			compress = s.GlobalConfig.ImagesCompressionAlgorithm()
 		}
 	}
 
@@ -402,7 +405,9 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 		return nil, fmt.Errorf("must specify one of alias or fingerprint for init from image")
 	}
 
-	info, err := d.ImageDownload(r, op, &ImageDownloadArgs{
+	s := d.State()
+
+	info, err := ImageDownload(r, s, op, &ImageDownloadArgs{
 		Server:            req.Source.Server,
 		Protocol:          req.Source.Protocol,
 		Certificate:       req.Source.Certificate,
@@ -458,6 +463,8 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 }
 
 func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
+	s := d.State()
+
 	var err error
 
 	if req.Source.URL == "" {
@@ -505,7 +512,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 	}
 
 	// Import the image
-	info, err := d.ImageDownload(r, op, &ImageDownloadArgs{
+	info, err := ImageDownload(r, s, op, &ImageDownloadArgs{
 		Server:      url,
 		Protocol:    "direct",
 		Alias:       hash,
@@ -518,7 +525,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 		return nil, err
 	}
 
-	id, info, err := d.db.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+	id, info, err := s.DB.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &project})
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +536,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 	}
 
 	if req.Public || req.AutoUpdate || req.Filename != "" || len(req.Properties) > 0 {
-		err = d.db.Cluster.UpdateImage(id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
+		err = s.DB.Cluster.UpdateImage(id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
 		if err != nil {
 			return nil, err
 		}
@@ -783,12 +790,12 @@ func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string,
 // the image. No entry in the images database will be created. This implies that
 // imageCreateinPool() should only be called when an image already exists in the
 // database and hence has already a storage volume in at least one storage pool.
-func imageCreateInPool(d *Daemon, info *api.Image, storagePool string) error {
+func imageCreateInPool(s *state.State, info *api.Image, storagePool string) error {
 	if storagePool == "" {
 		return fmt.Errorf("No storage pool specified")
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), storagePool)
+	pool, err := storagePools.LoadByName(s, storagePool)
 	if err != nil {
 		return err
 	}
@@ -909,6 +916,8 @@ func imageCreateInPool(d *Daemon, info *api.Image, storagePool string) error {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func imagesPost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	trusted := d.checkTrustedClient(r) == nil && allowProjectPermission("images", "manage-images")(d, r) == response.EmptySyncResponse
 
 	secret := r.Header.Get("X-LXD-secret")
@@ -1131,7 +1140,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed syncing image between nodes: %w", err)
 		}
 
-		d.State().Events.SendLifecycle(projectName, lifecycle.ImageCreated.Event(info.Fingerprint, projectName, op.Requestor(), logger.Ctx{"type": info.Type}))
+		s.Events.SendLifecycle(projectName, lifecycle.ImageCreated.Event(info.Fingerprint, projectName, op.Requestor(), logger.Ctx{"type": info.Type}))
 
 		return nil
 	}
@@ -1147,7 +1156,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, operationtype.ImageDownload, nil, metadata, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.ImageDownload, nil, metadata, run, nil, nil, r)
 	if err != nil {
 		cleanup(builddir, post)
 		return response.InternalError(err)
@@ -1552,11 +1561,13 @@ func imagesGet(d *Daemon, r *http.Request) response.Response {
 
 func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
+		s := d.State()
+
 		opRun := func(op *operations.Operation) error {
-			return autoUpdateImages(ctx, d)
+			return autoUpdateImages(ctx, s)
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, operationtype.ImagesUpdate, nil, nil, opRun, nil, nil, nil)
+		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ImagesUpdate, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start image update operation", logger.Ctx{"err": err})
 			return
@@ -1580,10 +1591,10 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	return f, task.Hourly()
 }
 
-func autoUpdateImages(ctx context.Context, d *Daemon) error {
+func autoUpdateImages(ctx context.Context, s *state.State) error {
 	imageMap := make(map[string][]dbCluster.Image)
 
-	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		autoUpdate := true
@@ -1605,7 +1616,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 	for fingerprint, images := range imageMap {
 		skipFingerprint := false
 
-		nodes, err := d.db.Cluster.GetNodesWithImageAndAutoUpdate(fingerprint, true)
+		nodes, err := s.DB.Cluster.GetNodesWithImageAndAutoUpdate(fingerprint, true)
 		if err != nil {
 			logger.Error("Error getting cluster members for image auto-update", logger.Ctx{"fingerprint": fingerprint, "err": err})
 			continue
@@ -1615,7 +1626,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 			var nodeIDs []int64
 
 			for _, node := range nodes {
-				err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 					var err error
 
 					nodeInfo, err := tx.GetNodeByAddress(ctx, node)
@@ -1648,7 +1659,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 
 				// Skip image update if we're not the chosen cluster member.
 				// That way, an image is only updated by a single cluster member.
-				if d.db.Cluster.GetNodeID() != selectedNode {
+				if s.DB.Cluster.GetNodeID() != selectedNode {
 					continue
 				}
 			}
@@ -1663,13 +1674,13 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 				filter.Public = &image.Public
 			}
 
-			_, imageInfo, err := d.db.Cluster.GetImage(image.Fingerprint, filter)
+			_, imageInfo, err := s.DB.Cluster.GetImage(image.Fingerprint, filter)
 			if err != nil {
 				logger.Error("Failed to get image", logger.Ctx{"err": err, "project": image.Project, "fingerprint": image.Fingerprint})
 				continue
 			}
 
-			newInfo, err := autoUpdateImage(ctx, d, nil, image.ID, imageInfo, image.Project, false)
+			newInfo, err := autoUpdateImage(ctx, s, nil, image.ID, imageInfo, image.Project, false)
 			if err != nil {
 				logger.Error("Failed to update image", logger.Ctx{"err": err, "project": image.Project, "fingerprint": image.Fingerprint})
 
@@ -1689,7 +1700,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 
 		if newImage != nil {
 			if len(nodes) > 1 {
-				err := distributeImage(ctx, d, nodes, fingerprint, newImage)
+				err := distributeImage(ctx, s, nodes, fingerprint, newImage)
 				if err != nil {
 					logger.Error("Failed to distribute new image", logger.Ctx{"err": err, "fingerprint": newImage.Fingerprint})
 
@@ -1701,7 +1712,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 
 			for _, ID := range deleteIDs {
 				// Remove the database entry for the image after distributing to cluster members.
-				err = d.db.Cluster.DeleteImage(ID)
+				err = s.DB.Cluster.DeleteImage(ID)
 				if err != nil {
 					logger.Error("Error deleting old image from database", logger.Ctx{"err": err, "fingerprint": fingerprint, "ID": ID})
 				}
@@ -1712,7 +1723,7 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 	return nil
 }
 
-func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerprint string, newImage *api.Image) error {
+func distributeImage(ctx context.Context, s *state.State, nodes []string, oldFingerprint string, newImage *api.Image) error {
 	// Get config of all nodes (incl. own) and check for storage.images_volume.
 	// If the setting is missing, distribute the image to the node.
 	// If the option is set, only distribute the image once to nodes with this
@@ -1723,7 +1734,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	// may be different for each cluster member.
 	var imageVolumes []string
 
-	err := d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+	err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(ctx, tx)
 		if err != nil {
 			return err
@@ -1733,7 +1744,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 		if vol != "" {
 			fields := strings.Split(vol, "/")
 
-			_, pool, _, err := d.db.Cluster.GetStoragePool(fields[0])
+			_, pool, _, err := s.DB.Cluster.GetStoragePool(fields[0])
 			if err != nil {
 				return fmt.Errorf("Failed to get storage pool info: %w", err)
 			}
@@ -1754,18 +1765,18 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 	}
 
 	// Skip own node
-	localClusterAddress := d.State().LocalConfig.ClusterAddress()
+	localClusterAddress := s.LocalConfig.ClusterAddress()
 
 	// Get the IDs of all storage pools on which a storage volume
 	// for the requested image currently exists.
-	poolIDs, err := d.db.Cluster.GetPoolsWithImage(newImage.Fingerprint)
+	poolIDs, err := s.DB.Cluster.GetPoolsWithImage(newImage.Fingerprint)
 	if err != nil {
 		logger.Error("Error getting image storage pools", logger.Ctx{"err": err, "fingerprint": oldFingerprint})
 		return err
 	}
 
 	// Translate the IDs to poolNames.
-	poolNames, err := d.db.Cluster.GetPoolNamesFromIDs(poolIDs)
+	poolNames, err := s.DB.Cluster.GetPoolNamesFromIDs(poolIDs)
 	if err != nil {
 		logger.Error("Error getting image storage pools", logger.Ctx{"err": err, "fingerprint": oldFingerprint})
 		return err
@@ -1777,7 +1788,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 		}
 
 		var nodeInfo db.NodeInfo
-		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
 			nodeInfo, err = tx.GetNodeByAddress(ctx, nodeAddress)
 			return err
@@ -1786,7 +1797,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 			return fmt.Errorf("Failed to retrieve information about cluster member with address %q: %w", nodeAddress, err)
 		}
 
-		client, err := cluster.Connect(nodeAddress, d.endpoints.NetworkCert(), d.serverCert(), nil, true)
+		client, err := cluster.Connect(nodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), nil, true)
 		if err != nil {
 			return fmt.Errorf("Failed to connect to %q for image synchronization: %w", nodeAddress, err)
 		}
@@ -1909,7 +1920,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 // Update a single image.  The operation can be nil, if no progress tracking is needed.
 // Returns whether the image has been updated.
-func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, id int, info *api.Image, projectName string, manual bool) (*api.Image, error) {
+func autoUpdateImage(ctx context.Context, s *state.State, op *operations.Operation, id int, info *api.Image, projectName string, manual bool) (*api.Image, error) {
 	fingerprint := info.Fingerprint
 	var source api.ImageSource
 
@@ -1917,7 +1928,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 		var interval int64
 
 		var project *api.Project
-		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			p, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
 			if err != nil {
 				return err
@@ -1936,7 +1947,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 				return nil, fmt.Errorf("Unable to fetch project configuration: %w", err)
 			}
 		} else {
-			interval = d.State().GlobalConfig.ImagesAutoUpdateIntervalHours()
+			interval = s.GlobalConfig.ImagesAutoUpdateIntervalHours()
 		}
 
 		// Check if we're supposed to auto update at all (0 disables it)
@@ -1945,13 +1956,13 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 		}
 
 		now := time.Now()
-		elapsedHours := int64(math.Round(now.Sub(d.startTime).Hours()))
+		elapsedHours := int64(math.Round(now.Sub(s.StartTime).Hours()))
 		if elapsedHours%interval != 0 {
 			return nil, nil
 		}
 	}
 
-	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		_, source, err = tx.GetImageSource(ctx, id)
 		return err
@@ -1963,14 +1974,14 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 
 	// Get the IDs of all storage pools on which a storage volume
 	// for the requested image currently exists.
-	poolIDs, err := d.db.Cluster.GetPoolsWithImage(fingerprint)
+	poolIDs, err := s.DB.Cluster.GetPoolsWithImage(fingerprint)
 	if err != nil {
 		logger.Error("Error getting image pools", logger.Ctx{"err": err, "fingerprint": fingerprint})
 		return nil, err
 	}
 
 	// Translate the IDs to poolNames.
-	poolNames, err := d.db.Cluster.GetPoolNamesFromIDs(poolIDs)
+	poolNames, err := s.DB.Cluster.GetPoolNamesFromIDs(poolIDs)
 	if err != nil {
 		logger.Error("Error getting image pools", logger.Ctx{"err": err, "fingerprint": fingerprint})
 		return nil, err
@@ -1994,7 +2005,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 
 		// Sent a lifecycle event if the refresh actually happened.
 		if result {
-			d.State().Events.SendLifecycle(projectName, lifecycle.ImageRefreshed.Event(fingerprint, projectName, op.Requestor(), nil))
+			s.Events.SendLifecycle(projectName, lifecycle.ImageRefreshed.Event(fingerprint, projectName, op.Requestor(), nil))
 		}
 	}
 
@@ -2009,7 +2020,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 		default:
 		}
 
-		newInfo, err = d.ImageDownload(nil, op, &ImageDownloadArgs{
+		newInfo, err = ImageDownload(nil, s, op, &ImageDownloadArgs{
 			Server:      source.Server,
 			Protocol:    source.Protocol,
 			Certificate: source.Certificate,
@@ -2032,40 +2043,40 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 			continue
 		}
 
-		newID, _, err := d.db.Cluster.GetImage(hash, dbCluster.ImageFilter{Project: &projectName})
+		newID, _, err := s.DB.Cluster.GetImage(hash, dbCluster.ImageFilter{Project: &projectName})
 		if err != nil {
 			logger.Error("Error loading image", logger.Ctx{"err": err, "fingerprint": hash})
 			continue
 		}
 
 		if info.Cached {
-			err = d.db.Cluster.SetImageCachedAndLastUseDate(projectName, hash, info.LastUsedAt)
+			err = s.DB.Cluster.SetImageCachedAndLastUseDate(projectName, hash, info.LastUsedAt)
 			if err != nil {
 				logger.Error("Error setting cached flag and last use date", logger.Ctx{"err": err, "fingerprint": hash})
 				continue
 			}
 		} else {
-			err = d.db.Cluster.UpdateImageLastUseDate(projectName, hash, info.LastUsedAt)
+			err = s.DB.Cluster.UpdateImageLastUseDate(projectName, hash, info.LastUsedAt)
 			if err != nil {
 				logger.Error("Error setting last use date", logger.Ctx{"err": err, "fingerprint": hash})
 				continue
 			}
 		}
 
-		err = d.db.Cluster.MoveImageAlias(id, newID)
+		err = s.DB.Cluster.MoveImageAlias(id, newID)
 		if err != nil {
 			logger.Error("Error moving aliases", logger.Ctx{"err": err, "fingerprint": hash})
 			continue
 		}
 
-		err = d.db.Cluster.CopyDefaultImageProfiles(id, newID)
+		err = s.DB.Cluster.CopyDefaultImageProfiles(id, newID)
 		if err != nil {
 			logger.Error("Copying default profiles", logger.Ctx{"err": err, "fingerprint": hash})
 		}
 
 		// If we do have optimized pools, make sure we remove the volumes associated with the image.
 		if poolName != "" {
-			pool, err := storagePools.LoadByName(d.State(), poolName)
+			pool, err := storagePools.LoadByName(s, poolName)
 			if err != nil {
 				logger.Error("Error loading storage pool to delete image", logger.Ctx{"err": err, "pool": poolName, "fingerprint": fingerprint})
 				continue
@@ -2086,7 +2097,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 	}
 
 	// Remove main image file.
-	fname := filepath.Join(d.os.VarDir, "images", fingerprint)
+	fname := filepath.Join(s.OS.VarDir, "images", fingerprint)
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
@@ -2095,7 +2106,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 	}
 
 	// Remove the rootfs file for the image.
-	fname = filepath.Join(d.os.VarDir, "images", fingerprint) + ".rootfs"
+	fname = filepath.Join(s.OS.VarDir, "images", fingerprint) + ".rootfs"
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
@@ -2109,11 +2120,13 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 
 func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
+		s := d.State()
+
 		opRun := func(op *operations.Operation) error {
-			return pruneExpiredImages(ctx, d, op)
+			return pruneExpiredImages(ctx, s, op)
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, operationtype.ImagesExpire, nil, nil, opRun, nil, nil, nil)
+		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ImagesExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start expired image operation", logger.Ctx{"err": err})
 			return
@@ -2153,10 +2166,12 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 }
 
 func pruneLeftoverImages(d *Daemon) {
+	s := d.State()
+
 	opRun := func(op *operations.Operation) error {
 		// Check if dealing with shared image storage.
 		var storageImages string
-		err := d.State().DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		err := s.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
 			nodeConfig, err := node.ConfigLoad(ctx, tx)
 			if err != nil {
 				return err
@@ -2178,7 +2193,7 @@ func pruneLeftoverImages(d *Daemon) {
 			}
 
 			// Load the pool.
-			pool, err := storagePools.LoadByName(d.State(), poolName)
+			pool, err := storagePools.LoadByName(s, poolName)
 			if err != nil {
 				return err
 			}
@@ -2225,7 +2240,7 @@ func pruneLeftoverImages(d *Daemon) {
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, operationtype.ImagesPruneLeftover, nil, nil, opRun, nil, nil, nil)
+	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ImagesPruneLeftover, nil, nil, opRun, nil, nil, nil)
 	if err != nil {
 		logger.Error("Failed to start image leftover cleanup operation", logger.Ctx{"err": err})
 		return
@@ -2247,9 +2262,9 @@ func pruneLeftoverImages(d *Daemon) {
 	logger.Infof("Done pruning leftover image files")
 }
 
-func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation) error {
+func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Operation) error {
 	var projects []api.Project
-	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		dbProjects, err := dbCluster.GetProjects(ctx, tx.Tx())
 		if err != nil {
@@ -2273,7 +2288,7 @@ func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation
 	}
 
 	for _, project := range projects {
-		err := pruneExpiredImagesInProject(ctx, d, project, op)
+		err := pruneExpiredImagesInProject(ctx, s, project, op)
 		if err != nil {
 			return fmt.Errorf("Unable to prune images for project %q: %w", project.Name, err)
 		}
@@ -2282,7 +2297,7 @@ func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation
 	return nil
 }
 
-func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Project, op *operations.Operation) error {
+func pruneExpiredImagesInProject(ctx context.Context, s *state.State, project api.Project, op *operations.Operation) error {
 	var expiry int64
 	var err error
 	if project.Config["images.remote_cache_expiry"] != "" {
@@ -2291,7 +2306,7 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 			return fmt.Errorf("Unable to fetch project configuration: %w", err)
 		}
 	} else {
-		expiry = d.State().GlobalConfig.ImagesRemoteCacheExpiryDays()
+		expiry = s.GlobalConfig.ImagesRemoteCacheExpiryDays()
 	}
 
 	// Check if we're supposed to prune at all
@@ -2300,7 +2315,7 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 	}
 
 	// Get the list of expired images.
-	images, err := d.db.Cluster.GetExpiredImagesInProject(expiry, project.Name)
+	images, err := s.DB.Cluster.GetExpiredImagesInProject(expiry, project.Name)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve the list of expired images: %w", err)
 	}
@@ -2318,19 +2333,19 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 
 		// Get the IDs of all storage pools on which a storage volume
 		// for the requested image currently exists.
-		poolIDs, err := d.db.Cluster.GetPoolsWithImage(fingerprint)
+		poolIDs, err := s.DB.Cluster.GetPoolsWithImage(fingerprint)
 		if err != nil {
 			continue
 		}
 
 		// Translate the IDs to poolNames.
-		poolNames, err := d.db.Cluster.GetPoolNamesFromIDs(poolIDs)
+		poolNames, err := s.DB.Cluster.GetPoolNamesFromIDs(poolIDs)
 		if err != nil {
 			continue
 		}
 
 		for _, poolName := range poolNames {
-			pool, err := storagePools.LoadByName(d.State(), poolName)
+			pool, err := storagePools.LoadByName(s, poolName)
 			if err != nil {
 				return fmt.Errorf("Error loading storage pool %q to delete image %q: %w", poolName, fingerprint, err)
 			}
@@ -2342,7 +2357,7 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 		}
 
 		// Remove main image file.
-		fname := filepath.Join(d.os.VarDir, "images", fingerprint)
+		fname := filepath.Join(s.OS.VarDir, "images", fingerprint)
 		if shared.PathExists(fname) {
 			err = os.Remove(fname)
 			if err != nil && !os.IsNotExist(err) {
@@ -2351,7 +2366,7 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 		}
 
 		// Remove the rootfs file for the image.
-		fname = filepath.Join(d.os.VarDir, "images", fingerprint) + ".rootfs"
+		fname = filepath.Join(s.OS.VarDir, "images", fingerprint) + ".rootfs"
 		if shared.PathExists(fname) {
 			err = os.Remove(fname)
 			if err != nil && !os.IsNotExist(err) {
@@ -2359,18 +2374,18 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Pro
 			}
 		}
 
-		imgID, _, err := d.db.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &project.Name})
+		imgID, _, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &project.Name})
 		if err != nil {
 			return fmt.Errorf("Error retrieving image info for fingerprint %q and project %q: %w", fingerprint, project.Name, err)
 		}
 
 		// Remove the database entry for the image.
-		err = d.db.Cluster.DeleteImage(imgID)
+		err = s.DB.Cluster.DeleteImage(imgID)
 		if err != nil {
 			return fmt.Errorf("Error deleting image %q from database: %w", fingerprint, err)
 		}
 
-		d.State().Events.SendLifecycle(project.Name, lifecycle.ImageDeleted.Event(fingerprint, project.Name, op.Requestor(), nil))
+		s.Events.SendLifecycle(project.Name, lifecycle.ImageDeleted.Event(fingerprint, project.Name, op.Requestor(), nil))
 	}
 
 	return nil
@@ -2418,7 +2433,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 	do := func(op *operations.Operation) error {
 		// Lock this operation to ensure that concurrent image operations don't conflict.
 		// Other operations will wait for this one to finish.
-		unlock := d.imageOperationLock(imgInfo.Fingerprint)
+		unlock := imageOperationLock(imgInfo.Fingerprint)
 		defer unlock()
 
 		// Check image still exists and another request hasn't removed it since we resolved the image
@@ -4024,19 +4039,21 @@ func imageRefresh(d *Daemon, r *http.Request) response.Response {
 
 	// Begin background operation
 	run := func(op *operations.Operation) error {
+		s := d.State()
+
 		nodes, err := d.db.Cluster.GetNodesWithImageAndAutoUpdate(fingerprint, true)
 		if err != nil {
 			return fmt.Errorf("Error getting cluster members for refreshing image %q in project %q: %w", fingerprint, projectName, err)
 		}
 
-		newImage, err := autoUpdateImage(d.shutdownCtx, d, op, imageID, imageInfo, projectName, true)
+		newImage, err := autoUpdateImage(d.shutdownCtx, s, op, imageID, imageInfo, projectName, true)
 		if err != nil {
 			return fmt.Errorf("Failed to update image %q in project %q: %w", fingerprint, projectName, err)
 		}
 
 		if newImage != nil {
 			if len(nodes) > 1 {
-				err := distributeImage(d.shutdownCtx, d, nodes, fingerprint, newImage)
+				err := distributeImage(d.shutdownCtx, s, nodes, fingerprint, newImage)
 				if err != nil {
 					return fmt.Errorf("Failed to distribute new image %q: %w", newImage.Fingerprint, err)
 				}

--- a/lxd/network_forwards.go
+++ b/lxd/network_forwards.go
@@ -216,7 +216,9 @@ func networkForwardsGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -292,7 +294,9 @@ func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -379,7 +383,9 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkForwardGet(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -494,7 +500,9 @@ func networkForwardGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkForwardPut(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/network_forwards.go
+++ b/lxd/network_forwards.go
@@ -223,7 +223,7 @@ func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -242,7 +242,7 @@ func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -301,7 +301,7 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -311,7 +311,7 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -337,7 +337,7 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed deleting forward: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkForwardDeleted.Event(n, listenAddress, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.NetworkForwardDeleted.Event(n, listenAddress, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -390,7 +390,7 @@ func networkForwardGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -400,7 +400,7 @@ func networkForwardGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -507,7 +507,7 @@ func networkForwardPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -517,7 +517,7 @@ func networkForwardPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -577,7 +577,7 @@ func networkForwardPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed updating forward: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkForwardUpdated.Event(n, listenAddress, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.NetworkForwardUpdated.Event(n, listenAddress, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/network_load_balancers.go
+++ b/lxd/network_load_balancers.go
@@ -224,7 +224,7 @@ func networkLoadBalancersPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -265,7 +265,7 @@ func networkLoadBalancersPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	lc := lifecycle.NetworkLoadBalancerCreated.Event(n, req.ListenAddress, request.CreateRequestor(r), nil)
-	d.State().Events.SendLifecycle(projectName, lc)
+	s.Events.SendLifecycle(projectName, lc)
 
 	return response.SyncResponseLocation(true, nil, lc.Source)
 }
@@ -302,7 +302,7 @@ func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -312,7 +312,7 @@ func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -338,7 +338,7 @@ func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed deleting load balancer: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkLoadBalancerDeleted.Event(n, listenAddress, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.NetworkLoadBalancerDeleted.Event(n, listenAddress, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -391,7 +391,7 @@ func networkLoadBalancerGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -401,7 +401,7 @@ func networkLoadBalancerGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -508,7 +508,7 @@ func networkLoadBalancerPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -518,7 +518,7 @@ func networkLoadBalancerPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -584,7 +584,7 @@ func networkLoadBalancerPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed updating load balancer: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkLoadBalancerUpdated.Event(n, listenAddress, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.NetworkLoadBalancerUpdated.Event(n, listenAddress, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/network_load_balancers.go
+++ b/lxd/network_load_balancers.go
@@ -217,7 +217,9 @@ func networkLoadBalancersGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkLoadBalancersPost(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -293,7 +295,9 @@ func networkLoadBalancersPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -380,7 +384,9 @@ func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkLoadBalancerGet(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -495,7 +501,9 @@ func networkLoadBalancerGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkLoadBalancerPut(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -216,7 +216,9 @@ func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkPeersPost(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -288,7 +290,9 @@ func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -373,7 +377,9 @@ func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkPeerGet(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -487,7 +493,9 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkPeerPut(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -223,7 +223,7 @@ func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -240,7 +240,7 @@ func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -260,7 +260,7 @@ func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	lc := lifecycle.NetworkPeerCreated.Event(n, req.Name, request.CreateRequestor(r), nil)
-	d.State().Events.SendLifecycle(projectName, lc)
+	s.Events.SendLifecycle(projectName, lc)
 
 	return response.SyncResponseLocation(true, nil, lc.Source)
 }
@@ -297,7 +297,7 @@ func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -307,7 +307,7 @@ func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -331,7 +331,7 @@ func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed deleting peer: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkPeerDeleted.Event(n, peerName, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.NetworkPeerDeleted.Event(n, peerName, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -384,7 +384,7 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -394,7 +394,7 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -413,7 +413,7 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	_, peer, err := d.State().DB.Cluster.GetNetworkPeer(n.ID(), peerName)
+	_, peer, err := s.DB.Cluster.GetNetworkPeer(n.ID(), peerName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -500,7 +500,7 @@ func networkPeerPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -510,7 +510,7 @@ func networkPeerPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -541,7 +541,7 @@ func networkPeerPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed updating peer: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.NetworkPeerUpdated.Event(n, peerName, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.NetworkPeerUpdated.Event(n, peerName, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -750,8 +750,10 @@ func doNetworksCreate(d *Daemon, n network.Network, clientType clusterRequest.Cl
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1163,8 +1165,10 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkPut(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1756,8 +1760,10 @@ func networkRestartOVN(s *state.State) error {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkStateGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -758,7 +758,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1173,7 +1173,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1184,7 +1184,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Get the existing network.
-	n, err := network.LoadByName(d.State(), projectName, networkName)
+	n, err := network.LoadByName(s, projectName, networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
@@ -1768,7 +1768,7 @@ func networkStateGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/resources.go
+++ b/lxd/resources.go
@@ -139,7 +139,7 @@ func storagePoolResourcesGet(d *Daemon, r *http.Request) response.Response {
 
 	var res *api.ResourcesStoragePool
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/resources.go
+++ b/lxd/resources.go
@@ -65,8 +65,10 @@ var storagePoolResourcesCmd = APIEndpoint{
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func api10ResourcesGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -121,8 +123,10 @@ func api10ResourcesGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolResourcesGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/lxc/lxd/lxd/bgp"
 	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
@@ -73,4 +74,7 @@ type State struct {
 
 	// Local server name.
 	ServerName string
+
+	// Local server start time.
+	StartTime time.Time
 }

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -262,7 +262,9 @@ func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -344,7 +346,9 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -483,7 +487,9 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -578,7 +584,9 @@ func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -808,7 +816,9 @@ func storagePoolBucketKeysGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -881,7 +891,9 @@ func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -962,7 +974,9 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1060,7 +1074,9 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -269,7 +269,7 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -279,7 +279,7 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
@@ -297,7 +297,7 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 	memberSpecific := targetMember != ""
 
 	var bucket *db.StorageBucket
-	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		bucket, err = tx.GetStoragePoolBucket(ctx, pool.ID(), bucketProjectName, memberSpecific, bucketName)
 		return err
 	})
@@ -353,7 +353,7 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -370,7 +370,7 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
@@ -399,7 +399,7 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed creating storage bucket admin key: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketCreated.Event(pool, bucketProjectName, req.Name, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketCreated.Event(pool, bucketProjectName, req.Name, request.CreateRequestor(r), nil))
 
 	u := api.NewURL().Path(version.APIVersion, "storage-pools", pool.Name(), "buckets", req.Name)
 
@@ -494,7 +494,7 @@ func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -549,7 +549,7 @@ func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed updating storage bucket: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketUpdated.Event(pool, bucketProjectName, bucketName, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketUpdated.Event(pool, bucketProjectName, bucketName, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -591,7 +591,7 @@ func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -601,7 +601,7 @@ func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
@@ -616,7 +616,7 @@ func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed deleting storage bucket: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketDeleted.Event(pool, bucketProjectName, bucketName, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketDeleted.Event(pool, bucketProjectName, bucketName, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -823,7 +823,7 @@ func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -845,7 +845,7 @@ func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
@@ -856,7 +856,7 @@ func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	lc := lifecycle.StorageBucketKeyCreated.Event(pool, bucketProjectName, pool.Name(), req.Name, request.CreateRequestor(r), nil)
-	d.State().Events.SendLifecycle(bucketProjectName, lc)
+	s.Events.SendLifecycle(bucketProjectName, lc)
 
 	return response.SyncResponseLocation(true, key, lc.Source)
 }
@@ -898,7 +898,7 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -908,7 +908,7 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
@@ -928,7 +928,7 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed deleting storage bucket key: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketKeyDeleted.Event(pool, bucketProjectName, pool.Name(), bucketName, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketKeyDeleted.Event(pool, bucketProjectName, pool.Name(), bucketName, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -981,7 +981,7 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -991,7 +991,7 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
@@ -1014,7 +1014,7 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 	memberSpecific := targetMember != ""
 
 	var bucketKey *db.StorageBucketKey
-	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		bucket, err := tx.GetStoragePoolBucket(ctx, pool.ID(), bucketProjectName, memberSpecific, bucketName)
 		if err != nil {
 			return err
@@ -1081,7 +1081,7 @@ func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
+	bucketProjectName, err := project.StorageBucketProject(r.Context(), s.DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1091,7 +1091,7 @@ func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
@@ -1118,7 +1118,7 @@ func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed updating storage bucket key: %w", err))
 	}
 
-	d.State().Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketKeyUpdated.Event(pool, bucketProjectName, pool.Name(), bucketName, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(bucketProjectName, lifecycle.StorageBucketKeyUpdated.Event(pool, bucketProjectName, pool.Name(), bucketName, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -569,8 +569,10 @@ func storagePoolsPostCluster(d *Daemon, pool *api.StoragePool, req api.StoragePo
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -665,8 +667,10 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolPut(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// If a target was specified, forward the request to the relevant node.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -593,13 +593,13 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Get the existing storage pool.
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	// Get all users of the storage pool.
-	poolUsedBy, err := storagePools.UsedBy(r.Context(), d.State(), pool, false, memberSpecific)
+	poolUsedBy, err := storagePools.UsedBy(r.Context(), s, pool, false, memberSpecific)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -681,7 +681,7 @@ func storagePoolPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Get the existing storage pool.
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -756,7 +756,7 @@ func storagePoolPut(d *Daemon, r *http.Request) response.Response {
 		ctx["target"] = targetNode
 	}
 
-	d.State().Events.SendLifecycle(project.Default, lifecycle.StoragePoolUpdated.Event(pool.Name(), requestor, ctx))
+	s.Events.SendLifecycle(project.Default, lifecycle.StoragePoolUpdated.Event(pool.Name(), requestor, ctx))
 
 	return response
 }

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -323,7 +323,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Retrieve ID of the storage pool (and check if the storage pool exists).
-	poolID, err := d.db.Cluster.GetStoragePoolID(poolName)
+	poolID, err := s.DB.Cluster.GetStoragePoolID(poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -341,7 +341,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	var dbVolumes []*db.StorageVolume
 	var projectImages []string
 
-	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var customVolProjectName string
 
 		if !allProjects {
@@ -536,7 +536,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	projectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
+	projectName, err := project.StorageVolumeProject(s.DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -589,14 +589,14 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Currently not allowed to create storage volumes of type %q", req.Type))
 	}
 
-	poolID, err := d.db.Cluster.GetStoragePoolID(poolName)
+	poolID, err := s.DB.Cluster.GetStoragePoolID(poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	// Check if destination volume exists.
 	var dbVolume *db.StorageVolume
-	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, db.StoragePoolVolumeTypeCustom, req.Name, true)
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
@@ -794,7 +794,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 		req.ContentType = db.StoragePoolVolumeContentTypeNameFS
 	}
 
-	projectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
+	projectName, err := project.StorageVolumeProject(s.DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -811,7 +811,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 
 	// Check if destination volume exists.
 	var dbVolume *db.StorageVolume
-	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, projectName, db.StoragePoolVolumeTypeCustom, req.Name, true)
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
@@ -1008,7 +1008,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Renaming storage volumes of type %q is not allowed", volumeTypeName))
 	}
 
-	projectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
+	projectName, err := project.StorageVolumeProject(s.DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1051,7 +1051,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// This is a migration request so send back requested secrets.
 	if req.Migration {
-		return storagePoolVolumeTypePostMigration(d.State(), r, projectParam(r), projectName, srcPoolName, volumeName, req)
+		return storagePoolVolumeTypePostMigration(s, r, projectParam(r), projectName, srcPoolName, volumeName, req)
 	}
 
 	// Retrieve ID of the storage pool (and check if the storage pool exists).
@@ -1067,7 +1067,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check that the name isn't already in use.
-	_, err = d.db.Cluster.GetStoragePoolNodeVolumeID(targetProjectName, req.Name, volumeType, targetPoolID)
+	_, err = s.DB.Cluster.GetStoragePoolNodeVolumeID(targetProjectName, req.Name, volumeType, targetPoolID)
 	if !response.IsNotFoundError(err) {
 		if err != nil {
 			return response.InternalError(err)
@@ -1087,13 +1087,13 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Load source volume.
-	srcPoolID, err := d.db.Cluster.GetStoragePoolID(srcPoolName)
+	srcPoolID, err := s.DB.Cluster.GetStoragePoolID(srcPoolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	var dbVolume *db.StorageVolume
-	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, srcPoolID, projectName, volumeType, volumeName, true)
 		return err
 	})
@@ -1102,7 +1102,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if a running instance is using it.
-	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, &dbVolume.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(s, srcPoolName, projectName, &dbVolume.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
 		inst, err := instance.Load(d.State(), dbInst, project)
 		if err != nil {
 			return err
@@ -1350,7 +1350,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestProjectName := projectParam(r)
-	volumeProjectName, err := project.StorageVolumeProject(d.State().DB.Cluster, requestProjectName, volumeType)
+	volumeProjectName, err := project.StorageVolumeProject(s.DB.Cluster, requestProjectName, volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1373,7 +1373,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 
 	// Get the storage volume.
 	var dbVolume *db.StorageVolume
-	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, poolID, volumeProjectName, volumeType, volumeName, true)
 		return err
 	})
@@ -1381,7 +1381,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), requestProjectName, poolName, dbVolume)
+	volumeUsedBy, err := storagePoolVolumeUsedByGet(s, requestProjectName, poolName, dbVolume)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1459,7 +1459,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	projectName, err = project.StorageVolumeProject(d.State().DB.Cluster, projectName, volumeType)
+	projectName, err = project.StorageVolumeProject(s.DB.Cluster, projectName, volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1469,7 +1469,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1486,7 +1486,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 
 	// Get the existing storage volume.
 	var dbVolume *db.StorageVolume
-	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volumeType, volumeName, true)
 		return err
 	})
@@ -1528,7 +1528,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 		// the volume's config if only restoring snapshot.
 		if req.Config != nil || req.Restore == "" {
 			// Possibly check if project limits are honored.
-			err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 				return project.AllowVolumeUpdate(tx, projectName, volumeName, req, dbVolume.Config)
 			})
 			if err != nil {
@@ -1638,12 +1638,12 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	projectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectParam(r), volumeType)
+	projectName, err := project.StorageVolumeProject(s.DB.Cluster, projectParam(r), volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1660,7 +1660,7 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 
 	// Get the existing storage volume.
 	var dbVolume *db.StorageVolume
-	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, volumeType, volumeName, true)
 		return err
 	})
@@ -1766,7 +1766,7 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestProjectName := projectParam(r)
-	volumeProjectName, err := project.StorageVolumeProject(d.State().DB.Cluster, requestProjectName, volumeType)
+	volumeProjectName, err := project.StorageVolumeProject(s.DB.Cluster, requestProjectName, volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1791,14 +1791,14 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Get the storage pool the storage volume is supposed to be attached to.
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	// Get the storage volume.
 	var dbVolume *db.StorageVolume
-	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), volumeProjectName, volumeType, volumeName, true)
 		return err
 	})
@@ -1806,7 +1806,7 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), requestProjectName, poolName, dbVolume)
+	volumeUsedBy, err := storagePoolVolumeUsedByGet(s, requestProjectName, poolName, dbVolume)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -282,7 +282,9 @@ var storagePoolVolumeTypeCmd = APIEndpoint{
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -527,6 +529,8 @@ func filterVolumes(volumes []*db.StorageVolume, clauses []filter.Clause, allProj
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	poolName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -537,7 +541,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -749,7 +753,9 @@ func doVolumeCreateOrCopy(d *Daemon, r *http.Request, requestProjectName string,
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	s := d.State()
+
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -955,6 +961,8 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -1025,7 +1033,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	r.Body = shared.BytesReadCloser{Buf: &buf}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1311,6 +1319,8 @@ func storageGetVolumeNameFromURL(r *http.Request) (string, error) {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	volumeTypeName, err := url.PathUnescape(mux.Vars(r)["type"])
 	if err != nil {
 		return response.SmartError(err)
@@ -1345,7 +1355,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1423,6 +1433,8 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	projectName := projectParam(r)
 	volumeTypeName, err := url.PathUnescape(mux.Vars(r)["type"])
 	if err != nil {
@@ -1462,7 +1474,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1592,6 +1604,8 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -1634,7 +1648,7 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1722,6 +1736,8 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -1760,7 +1776,7 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -268,6 +268,8 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -310,7 +312,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -478,6 +480,8 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -518,7 +522,7 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -576,6 +580,8 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -616,7 +622,7 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -700,6 +706,8 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -740,7 +748,7 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -807,6 +815,8 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage volume.
 	volumeName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -847,7 +857,7 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -85,6 +85,8 @@ var storagePoolVolumeSnapshotTypeCmd = APIEndpoint{
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the pool.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])
 	if err != nil {
@@ -143,7 +145,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 	}
 
 	// Forward if needed.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -473,6 +475,8 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage pool the volume is supposed to be attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])
 	if err != nil {
@@ -515,7 +519,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 	}
 
 	// Forward if needed.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -609,6 +613,8 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage pool the volume is supposed to be
 	// attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])
@@ -647,7 +653,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 	}
 
 	// Forward if needed.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -730,6 +736,8 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage pool the volume is supposed to be
 	// attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])
@@ -768,7 +776,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 	}
 
 	// Forward if needed.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -856,6 +864,8 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage pool the volume is supposed to be
 	// attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])
@@ -894,7 +904,7 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 	}
 
 	// Forward if needed.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}
@@ -1010,6 +1020,8 @@ func doStoragePoolVolumeSnapshotUpdate(d *Daemon, r *http.Request, poolName stri
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Get the name of the storage pool the volume is supposed to be attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])
 	if err != nil {
@@ -1052,7 +1064,7 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 	}
 
 	// Forward if needed.
-	resp := forwardedResponseIfTargetIsRemote(d, r)
+	resp := forwardedResponseIfTargetIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -38,10 +38,10 @@ test_storage_volume_snapshots() {
   lxc storage volume show "${storage_pool}" "${storage_volume}/snap0" | grep -q 'description: foo'
 
   # edit volume snapshot expiry date
-  lxc storage volume show "${storage_pool}" "${storage_volume}/snap0" | sed 's/^expires_at:.*/expires_at: 2006-01-02T15:04:05Z/' | lxc storage volume edit "${storage_pool}" "${storage_volume}/snap0"
+  lxc storage volume show "${storage_pool}" "${storage_volume}/snap0" | sed 's/^expires_at:.*/expires_at: 2100-01-02T15:04:05Z/' | lxc storage volume edit "${storage_pool}" "${storage_volume}/snap0"
   # Depending on the timezone of the runner, some values will be different.
-  # Both the year (2006) and the month (01) will be constant though.
-  lxc storage volume show "${storage_pool}" "${storage_volume}/snap0" | grep -q '^expires_at: 2006-01'
+  # Both the year (2100) and the month (01) will be constant though.
+  lxc storage volume show "${storage_pool}" "${storage_volume}/snap0" | grep -q '^expires_at: 2100-01'
   # Reset/remove expiry date
   lxc storage volume show "${storage_pool}" "${storage_volume}/snap0" | sed '/^expires_at:/d' | lxc storage volume edit "${storage_pool}" "${storage_volume}/snap0"
   lxc storage volume show "${storage_pool}" "${storage_volume}/snap0" | grep -q '^expires_at: 0001-01-01T00:00:00Z'


### PR DESCRIPTION
- Reduce calls to d.State() as these require several locks and allocations and there was plenty of unnecessary duplicate calls. There are still more to fix, but I had spent enough time going through it for my immediate needs.
- Avoid starting a transaction if the target is a local server in `forwardedResponseToNode` and `forwardedResponseIfTargetIsRemote` by passing state into it and `ResolveTarget()` and using ` s.ServerName `.
- Adds `GetStoragePools` function that can load an enriched map of all storage pools in a single transaction (will help with https://github.com/lxc/lxd/pull/11180 amongst other places).